### PR TITLE
Refactor  homeassistant.util.slugify to homeassistant.util.string.slugify

### DIFF
--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 DOMAIN = "aprs"
 

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import callback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -26,8 +26,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify
 
 from .const import (
     ATTRIBUTION,

--- a/homeassistant/components/climacell/sensor.py
+++ b/homeassistant/components/climacell/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_VERSION, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import ClimaCellDataUpdateCoordinator, ClimaCellEntity
 from .const import (

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import CONF_ANGLE, CONF_GESTURE, LOGGER
 from .deconz_device import DeconzBase

--- a/homeassistant/components/decora/light.py
+++ b/homeassistant/components/decora/light.py
@@ -8,7 +8,6 @@ from bluepy.btle import BTLEException  # pylint: disable=import-error
 import decora  # pylint: disable=import-error
 import voluptuous as vol
 
-from homeassistant import util
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     PLATFORM_SCHEMA,
@@ -17,6 +16,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_NAME
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ def _name_validator(config):
     config = copy.deepcopy(config)
     for address, device_config in config[CONF_DEVICES].items():
         if CONF_NAME not in device_config:
-            device_config[CONF_NAME] = util.slugify(address)
+            device_config[CONF_NAME] = slugify(address)
 
     return config
 

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, GPSType, StateType
 from homeassistant.setup import async_prepare_setup_platform, async_start_setup
 from homeassistant.util import dt as dt_util
+from homeassistant.util.string import slugify
 from homeassistant.util.yaml import dump
 
 from .const import (
@@ -492,7 +493,7 @@ class DeviceTracker:
         if mac is not None:
             mac = str(mac).upper()
             if (device := self.mac_to_dev.get(mac)) is None:
-                dev_id = util.slugify(host_name or "") or util.slugify(mac)
+                dev_id = slugify(host_name or "") or slugify(mac)
         else:
             dev_id = cv.slug(str(dev_id).lower())
             device = self.devices.get(dev_id)

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -22,7 +22,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
+from homeassistant.util.string import slugify
 
 from .const import (
     CONF_EVENTS,

--- a/homeassistant/components/dsmr_reader/sensor.py
+++ b/homeassistant/components/dsmr_reader/sensor.py
@@ -2,7 +2,7 @@
 from homeassistant.components import mqtt
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import callback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .definitions import SENSORS, DSMRReaderSensorEntityDescription
 

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import async_wait_for_elk_to_sync
 from .const import CONF_AUTO_CONFIGURE, DOMAIN

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -22,7 +22,8 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import convert, slugify
+from homeassistant.util import convert
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -35,13 +35,13 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv, event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.sun import get_astral_event_date
-from homeassistant.util import slugify
 from homeassistant.util.color import (
     color_RGB_to_xy_brightness,
     color_temperature_kelvin_to_mired,
     color_temperature_to_rgb,
 )
 from homeassistant.util.dt import as_local, utcnow as dt_utcnow
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import (
     API_VERSION,

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .common import (
     FritzBoxBaseEntity,

--- a/homeassistant/components/geofency/__init__.py
+++ b/homeassistant/components/geofency/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_entry_flow
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import DOMAIN
 

--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -22,7 +22,8 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/gtfs/sensor.py
+++ b/homeassistant/components/gtfs/sensor.py
@@ -26,8 +26,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homeworks/__init__.py
+++ b/homeassistant/components/homeworks/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/v1/hue_event.py
+++ b/homeassistant/components/hue/v1/hue_event.py
@@ -10,7 +10,8 @@ from aiohue.v1.sensors import (
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.core import callback
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
+from homeassistant.util.string import slugify
 
 from ..const import ATTR_HUE_EVENT
 from .sensor_device import GenericHueDevice

--- a/homeassistant/components/hue/v2/hue_event.py
+++ b/homeassistant/components/hue/v2/hue_event.py
@@ -9,7 +9,7 @@ from aiohue.v2.models.button import Button
 from homeassistant.const import CONF_DEVICE_ID, CONF_ID, CONF_TYPE, CONF_UNIQUE_ID
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from ..const import ATTR_HUE_EVENT, CONF_SUBTYPE, DOMAIN as DOMAIN
 

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import (
     get_hyperion_device_id,

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, ServiceDataType
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .account import IcloudAccount
 from .const import (

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -22,10 +22,10 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.helpers.storage import Store
-from homeassistant.util import slugify
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.dt import utcnow
 from homeassistant.util.location import distance
+from homeassistant.util.string import slugify
 
 from .const import (
     DEVICE_BATTERY_LEVEL,

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     PRESSURE_BAR,
     TEMP_CELSIUS,
 )
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import DOMAIN, IncomfortChild
 

--- a/homeassistant/components/lovelace/const.py
+++ b/homeassistant/components/lovelace/const.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.const import CONF_ICON, CONF_MODE, CONF_TYPE, CONF_URL
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 DOMAIN = "lovelace"
 EVENT_LOVELACE_UPDATED = "lovelace_updated"

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.const import ATTR_ID, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 DOMAIN = "lutron"
 

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -10,8 +10,8 @@ from librouteros.login import plain as login_plain, token as login_token
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify
 
 from .const import (
     ARP,

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -14,7 +14,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.const import ATTR_DEVICE_ID, CONF_WEBHOOK_ID
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import (
     ATTR_APP_DATA,

--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -18,7 +18,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import dt, slugify
+from homeassistant.util import dt
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mysensors/device_tracker.py
+++ b/homeassistant/components/mysensors/device_tracker.py
@@ -14,7 +14,7 @@ from homeassistant.components.mysensors.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .helpers import on_unload
 

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.loader import async_get_integration, bind_hass
 from homeassistant.setup import async_prepare_setup_platform, async_start_setup
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 from homeassistant.util.yaml import load_yaml
 
 from .const import (

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -24,8 +24,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import slugify as util_slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify as util_slugify
 
 from .const import DOMAIN
 

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -11,7 +11,8 @@ from homeassistant.components.device_tracker import (
     SOURCE_TYPE_GPS,
 )
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_HOME
-from homeassistant.util import decorator, slugify
+from homeassistant.util import decorator
+from homeassistant.util.string import slugify
 
 from .helper import supports_encryption
 

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -16,8 +16,8 @@ from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.template import Template, is_template_string
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
-from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify
 
 ATTR_CREATED_AT = "created_at"
 ATTR_MESSAGE = "message"

--- a/homeassistant/components/repetier/__init__.py
+++ b/homeassistant/components/repetier/__init__.py
@@ -24,7 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import track_time_interval
-from homeassistant.util import slugify as util_slugify
+from homeassistant.util.string import slugify as util_slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/screenlogic/const.py
+++ b/homeassistant/components/screenlogic/const.py
@@ -1,7 +1,7 @@
 """Constants for the ScreenLogic integration."""
 from screenlogicpy.const import CIRCUIT_FUNCTION, COLOR_MODE
 
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 DOMAIN = "screenlogic"
 DEFAULT_SCAN_INTERVAL = 30

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -17,7 +17,8 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util import Throttle, slugify
+from homeassistant.util import Throttle
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import BlockDeviceWrapper, RpcDeviceWrapper
 from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC

--- a/homeassistant/components/smhi/config_flow.py
+++ b/homeassistant/components/smhi/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import DOMAIN, HOME_LOCATION_NAME
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -40,7 +40,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util import Throttle, slugify
+from homeassistant.util import Throttle
+from homeassistant.util.string import slugify
 
 from .const import (
     ATTR_SMHI_CLOUDINESS,

--- a/homeassistant/components/solaredge/config_flow.py
+++ b/homeassistant/components/solaredge/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import CONF_SITE_ID, DEFAULT_NAME, DOMAIN
 

--- a/homeassistant/components/solarlog/config_flow.py
+++ b/homeassistant/components/solarlog/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import DEFAULT_HOST, DEFAULT_NAME, DOMAIN
 

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -46,8 +46,8 @@ from homeassistant.helpers.entity_component import DEFAULT_SCAN_INTERVAL
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -30,7 +30,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import DOMAIN, TRACKER_UPDATE
 from .const import (

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .const import DOMAIN
 

--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -26,8 +26,9 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import convert, slugify
+from homeassistant.util import convert
 from homeassistant.util.dt import utc_from_timestamp
+from homeassistant.util.string import slugify
 
 from .common import (
     ControllerData,

--- a/homeassistant/components/vera/scene.py
+++ b/homeassistant/components/vera/scene.py
@@ -9,7 +9,7 @@ from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .common import ControllerData, get_controller_data
 from .const import VERA_ID_FORMAT

--- a/homeassistant/components/volvooncall/device_tracker.py
+++ b/homeassistant/components/volvooncall/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for tracking a Volvo."""
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import DATA_KEY, SIGNAL_STATE_UPDATED
 

--- a/homeassistant/components/waterfurnace/sensor.py
+++ b/homeassistant/components/waterfurnace/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import callback
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import DOMAIN as WF_DOMAIN, UPDATE_TOPIC
 

--- a/homeassistant/components/withings/config_flow.py
+++ b/homeassistant/components/withings/config_flow.py
@@ -9,7 +9,7 @@ from withings_api.common import AuthScope
 from homeassistant.components.withings import const
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.helpers import config_entry_oauth2_flow
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 
 class WithingsFlowHandler(

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -10,7 +10,7 @@ import attr
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.loader import bind_hass
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .typing import UNDEFINED, UndefinedType
 

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.storage import Store
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 STORAGE_VERSION = 1
 SAVE_DELAY = 10

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -79,8 +79,9 @@ from homeassistant.helpers import (
     script_variables as script_variables_helper,
     template as template_helper,
 )
-from homeassistant.util import raise_if_invalid_path, slugify as util_slugify
+from homeassistant.util import raise_if_invalid_path
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify as util_slugify
 
 # pylint: disable=invalid-name
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -42,8 +42,9 @@ from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.event import Event, async_track_entity_registry_updated_event
 from homeassistant.helpers.typing import StateType
 from homeassistant.loader import bind_hass
-from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
+from homeassistant.util import dt as dt_util, ensure_unique_string
 from homeassistant.util.enum import StrEnum
+from homeassistant.util.string import slugify
 
 _LOGGER = logging.getLogger(__name__)
 SLOW_UPDATE_WARNING = 10

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -41,8 +41,9 @@ from homeassistant.helpers import device_registry as dr, storage
 from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
 from homeassistant.helpers.frame import report
 from homeassistant.loader import bind_hass
-from homeassistant.util import slugify, uuid as uuid_util
+from homeassistant.util import uuid as uuid_util
 from homeassistant.util.enum import StrEnum
+from homeassistant.util.string import slugify
 from homeassistant.util.yaml import load_yaml
 
 from .typing import UNDEFINED, UndefinedType

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -73,8 +73,8 @@ from homeassistant.helpers.trigger import (
     async_validate_trigger_config,
 )
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify
 from homeassistant.util.dt import utcnow
+from homeassistant.util.string import slugify
 
 from .trace import (
     TraceElement,

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -13,8 +13,6 @@ import threading
 from types import MappingProxyType
 from typing import Any, TypeVar
 
-import slugify as unicode_slug
-
 from .dt import as_local, utcnow
 
 T = TypeVar("T")
@@ -43,14 +41,6 @@ def raise_if_invalid_path(path: str) -> None:
     """
     if RE_SANITIZE_PATH.sub("", path) != path:
         raise ValueError(f"{path} is not a safe path")
-
-
-def slugify(text: str | None, *, separator: str = "_") -> str:
-    """Slugify a given text."""
-    if text == "" or text is None:
-        return ""
-    slug = unicode_slug.slugify(text, separator=separator)
-    return "unknown" if slug == "" else slug
 
 
 def repr_helper(inp: Any) -> str:

--- a/homeassistant/util/string.py
+++ b/homeassistant/util/string.py
@@ -1,0 +1,12 @@
+"""String related helper methods for various modules."""
+from __future__ import annotations
+
+import slugify as unicode_slug
+
+
+def slugify(text: str | None, *, separator: str = "_") -> str:
+    """Slugify a given text."""
+    if text == "" or text is None:
+        return ""
+    slug = unicode_slug.slugify(text, separator=separator)
+    return "unknown" if slug == "" else slug

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 from script.translations import upload
 
 from .model import Config, Integration

--- a/script/scaffold/gather_info.py
+++ b/script/scaffold/gather_info.py
@@ -1,7 +1,7 @@
 """Gather info for scaffolding."""
 import json
 
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 from script.hassfest.manifest import SUPPORTED_IOT_CLASSES
 
 from .const import COMPONENT_DIR

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -20,8 +20,8 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import slugify
 from homeassistant.util.dt import utcnow
+from homeassistant.util.string import slugify
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -11,7 +11,8 @@ from homeassistant.components.device_tracker.const import (
 )
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
+from homeassistant.util.string import slugify
 
 from tests.common import async_fire_time_changed
 

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
 )
 from homeassistant.setup import async_setup_component
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 HOME_LATITUDE = 37.239622
 HOME_LONGITUDE = -115.815811

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -20,8 +20,8 @@ from homeassistant.components.google import (
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.setup import async_setup_component
-from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+from homeassistant.util.string import slugify
 
 from tests.common import async_mock_service
 

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -22,7 +22,8 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt, slugify
+from homeassistant.util import dt
+from homeassistant.util.string import slugify
 
 from . import (
     TEST_CONFIG_ENTRY_ID,

--- a/tests/components/nws/test_sensor.py
+++ b/tests/components/nws/test_sensor.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.nws.const import ATTRIBUTION, DOMAIN, SENSOR_TYPES
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNKNOWN
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
 from tests.common import MockConfigEntry

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.subaru.sensor import (
     SENSOR_FIELD,
     SENSOR_TYPE,
 )
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from .api_responses import (

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -13,7 +13,8 @@ from homeassistant.components.switcher_kis.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt, slugify
+from homeassistant.util import dt
+from homeassistant.util.string import slugify
 
 from . import init_integration
 from .consts import DUMMY_SWITCHER_DEVICES, YAML_CONFIG

--- a/tests/components/switcher_kis/test_sensor.py
+++ b/tests/components/switcher_kis/test_sensor.py
@@ -3,7 +3,7 @@ import pytest
 
 from homeassistant.components.switcher_kis.const import DATA_DEVICE, DOMAIN
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import init_integration
 from .consts import DUMMY_PLUG_DEVICE, DUMMY_SWITCHER_DEVICES, DUMMY_WATER_HEATER_DEVICE

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -15,7 +15,7 @@ from homeassistant.components.switcher_kis.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.helpers.config_validation import time_period_str
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import init_integration
 from .consts import (

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 from . import init_integration
 from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PIN,
 )
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 NAME = "Vizio"
 NAME2 = "Vizio2"

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -7,7 +7,7 @@ import zigpy.zcl
 import zigpy.zcl.foundation as zcl_f
 
 import homeassistant.components.zha.core.const as zha_const
-from homeassistant.util import slugify
+from homeassistant.util.string import slugify
 
 
 def patch_cluster(cluster):

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -36,31 +36,6 @@ def test_raise_if_invalid_path():
         assert util.raise_if_invalid_path("~/../test/path")
 
 
-def test_slugify():
-    """Test slugify."""
-    assert util.slugify("T-!@#$!#@$!$est") == "t_est"
-    assert util.slugify("Test More") == "test_more"
-    assert util.slugify("Test_(More)") == "test_more"
-    assert util.slugify("Tèst_Mörê") == "test_more"
-    assert util.slugify("B8:27:EB:00:00:00") == "b8_27_eb_00_00_00"
-    assert util.slugify("test.com") == "test_com"
-    assert util.slugify("greg_phone - exp_wayp1") == "greg_phone_exp_wayp1"
-    assert (
-        util.slugify("We are, we are, a... Test Calendar")
-        == "we_are_we_are_a_test_calendar"
-    )
-    assert util.slugify("Tèst_äöüß_ÄÖÜ") == "test_aouss_aou"
-    assert util.slugify("影師嗎") == "ying_shi_ma"
-    assert util.slugify("けいふぉんと") == "keihuonto"
-    assert util.slugify("$") == "unknown"
-    assert util.slugify("Ⓐ") == "unknown"
-    assert util.slugify("ⓑ") == "unknown"
-    assert util.slugify("$$$") == "unknown"
-    assert util.slugify("$something") == "something"
-    assert util.slugify("") == ""
-    assert util.slugify(None) == ""
-
-
 def test_repr_helper():
     """Test repr_helper."""
     assert util.repr_helper("A") == "A"

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -1,0 +1,26 @@
+"""Test Home Assistant string util methods."""
+from homeassistant.util.string import slugify
+
+
+def test_slugify():
+    """Test slugify."""
+    assert slugify("T-!@#$!#@$!$est") == "t_est"
+    assert slugify("Test More") == "test_more"
+    assert slugify("Test_(More)") == "test_more"
+    assert slugify("Tèst_Mörê") == "test_more"
+    assert slugify("B8:27:EB:00:00:00") == "b8_27_eb_00_00_00"
+    assert slugify("test.com") == "test_com"
+    assert slugify("greg_phone - exp_wayp1") == "greg_phone_exp_wayp1"
+    assert (
+        slugify("We are, we are, a... Test Calendar") == "we_are_we_are_a_test_calendar"
+    )
+    assert slugify("Tèst_äöüß_ÄÖÜ") == "test_aouss_aou"
+    assert slugify("影師嗎") == "ying_shi_ma"
+    assert slugify("けいふぉんと") == "keihuonto"
+    assert slugify("$") == "unknown"
+    assert slugify("Ⓐ") == "unknown"
+    assert slugify("ⓑ") == "unknown"
+    assert slugify("$$$") == "unknown"
+    assert slugify("$something") == "something"
+    assert slugify("") == ""
+    assert slugify(None) == ""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the `__init__` of the util module has third party dependencies, thus we can not move the `Platform` StrEnum to `homeassistant.const` due to dependency errors during setup.

Original Platform PR: https://github.com/home-assistant/core/pull/60857
Revert Platform PR with error message: https://github.com/home-assistant/core/pull/60875

Note: This has to be repeated for:

- `homeassistant.util.Throttle` - uses the dt module that also has 3rd party deps
- `homeassistant.util.repr_helper` - uses the dt module that also has 3rd party deps


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
