### PR TITLE
Add audio input format sensor to Sonos HT devices

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -144,6 +144,7 @@ PLAYABLE_MEDIA_TYPES = [
 
 SONOS_CHECK_ACTIVITY = "sonos_check_activity"
 SONOS_CREATE_ALARM = "sonos_create_alarm"
+SONOS_CREATE_AUDIO_FORMAT_SENSOR = "sonos_create_audio_format_sensor"
 SONOS_CREATE_BATTERY = "sonos_create_battery"
 SONOS_CREATE_SWITCHES = "sonos_create_switches"
 SONOS_CREATE_LEVELS = "sonos_create_levels"

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -98,7 +98,7 @@ class SonosAudioInputFormatSensorEntity(SonosEntity, SensorEntity):
         return f"{self.speaker.zone_name} Audio Input Format"
 
     @property
-    def state(self) -> str:
+    def native_value(self) -> str:
         """Return the current state of the text sensor."""
         return self.speaker.soundbar_audio_input_format
 

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -19,8 +19,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Sonos from a config entry."""
 
     @callback
-    def _async_create_audio_format_entity(speaker: SonosSpeaker) -> None:
-        entity = SonosAudioInputFormatSensorEntity(speaker)
+    def _async_create_audio_format_entity(
+        speaker: SonosSpeaker, audio_format: str
+    ) -> None:
+        entity = SonosAudioInputFormatSensorEntity(speaker, audio_format)
         async_add_entities([entity])
 
     @callback
@@ -87,24 +89,16 @@ class SonosAudioInputFormatSensorEntity(SonosEntity, SensorEntity):
     _attr_icon = "mdi:import"
     _attr_should_poll = True
 
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID of the sensor."""
-        return f"{self.soco.uid}-audio-format"
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.speaker.zone_name} Audio Input Format"
-
-    @property
-    def native_value(self) -> str:
-        """Return the current state of the text sensor."""
-        return self.speaker.soundbar_audio_input_format
+    def __init__(self, speaker: SonosSpeaker, audio_format: str) -> None:
+        """Initialize the audio input format sensor."""
+        super().__init__(speaker)
+        self._attr_unique_id = f"{self.soco.uid}-audio-format"
+        self._attr_name = f"{self.speaker.zone_name} Audio Input Format"
+        self._attr_native_value = audio_format
 
     def update(self) -> None:
         """Poll the device for the current state."""
-        self.speaker.soundbar_audio_input_format = self.soco.soundbar_audio_input_format
+        self._attr_native_value = self.soco.soundbar_audio_input_format
 
     async def _async_poll(self) -> None:
         """Provide a stub for required ABC method."""

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -199,7 +199,6 @@ class SonosSpeaker:
         self.treble: int | None = None
         self.sub_enabled: bool | None = None
         self.surround_enabled: bool | None = None
-        self.soundbar_audio_input_format: str | None = None
 
         # Misc features
         self.buttons_enabled: bool | None = None
@@ -244,7 +243,9 @@ class SonosSpeaker:
 
         if audio_format := self.soco.soundbar_audio_input_format:
             self.soundbar_audio_input_format = audio_format
-            dispatcher_send(self.hass, SONOS_CREATE_AUDIO_FORMAT_SENSOR, self)
+            dispatcher_send(
+                self.hass, SONOS_CREATE_AUDIO_FORMAT_SENSOR, self, audio_format
+            )
 
         if battery_info := fetch_battery_info_or_none(self.soco):
             self.battery_info = battery_info

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -46,6 +46,7 @@ from .const import (
     SCAN_INTERVAL,
     SONOS_CHECK_ACTIVITY,
     SONOS_CREATE_ALARM,
+    SONOS_CREATE_AUDIO_FORMAT_SENSOR,
     SONOS_CREATE_BATTERY,
     SONOS_CREATE_LEVELS,
     SONOS_CREATE_MEDIA_PLAYER,
@@ -198,6 +199,7 @@ class SonosSpeaker:
         self.treble: int | None = None
         self.sub_enabled: bool | None = None
         self.surround_enabled: bool | None = None
+        self.soundbar_audio_input_format: str | None = None
 
         # Misc features
         self.buttons_enabled: bool | None = None
@@ -239,6 +241,10 @@ class SonosSpeaker:
         future.result(timeout=10)
 
         dispatcher_send(self.hass, SONOS_CREATE_LEVELS, self)
+
+        if audio_format := self.soco.soundbar_audio_input_format:
+            self.soundbar_audio_input_format = audio_format
+            dispatcher_send(self.hass, SONOS_CREATE_AUDIO_FORMAT_SENSOR, self)
 
         if battery_info := fetch_battery_info_or_none(self.soco):
             self.battery_info = battery_info

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -242,7 +242,6 @@ class SonosSpeaker:
         dispatcher_send(self.hass, SONOS_CREATE_LEVELS, self)
 
         if audio_format := self.soco.soundbar_audio_input_format:
-            self.soundbar_audio_input_format = audio_format
             dispatcher_send(
                 self.hass, SONOS_CREATE_AUDIO_FORMAT_SENSOR, self, audio_format
             )

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -74,6 +74,7 @@ def soco_fixture(music_library, speaker_info, battery_info, alarm_clock):
         mock_soco.treble = -1
         mock_soco.sub_enabled = False
         mock_soco.surround_enabled = True
+        mock_soco.soundbar_audio_input_format = "Dolby 5.1"
         mock_soco.get_battery_info.return_value = battery_info
         mock_soco.all_zones = [mock_soco]
         yield mock_soco

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -123,3 +123,14 @@ async def test_device_payload_without_battery_and_ignored_keys(
     await hass.async_block_till_done()
 
     assert ignored_payload not in caplog.text
+
+
+async def test_audio_input_sensor(hass, config_entry, config, soco):
+    """Test sonos device with battery state."""
+    await setup_platform(hass, config_entry, config)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    audio_input_sensor = entity_registry.entities["sensor.zone_a_audio_input_format"]
+    audio_input_state = hass.states.get(audio_input_sensor.entity_id)
+    assert audio_input_state.state == "Dolby 5.1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposes a new `sensor` which reports the audio input format received by a home theater Sonos device.

![image](https://user-images.githubusercontent.com/1203111/144535185-0089bdd4-ebc3-41ea-b05e-3c44a7a85c22.png)

Is dependent on a future release of `soco` and will be rebased when available.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20555

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
