### PR TITLE
Add Sonos subwoofer and surround on/off controls

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -196,6 +196,8 @@ class SonosSpeaker:
         self.cross_fade: bool | None = None
         self.bass: int | None = None
         self.treble: int | None = None
+        self.sub_enabled: bool | None = None
+        self.surround_enabled: bool | None = None
 
         # Misc features
         self.buttons_enabled: bool | None = None

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -38,6 +38,8 @@ ATTR_CROSSFADE = "cross_fade"
 ATTR_NIGHT_SOUND = "night_mode"
 ATTR_SPEECH_ENHANCEMENT = "dialog_mode"
 ATTR_STATUS_LIGHT = "status_light"
+ATTR_SUB_ENABLED = "sub_enabled"
+ATTR_SURROUND_ENABLED = "surround_enabled"
 ATTR_TOUCH_CONTROLS = "buttons_enabled"
 
 ALL_FEATURES = (
@@ -45,6 +47,8 @@ ALL_FEATURES = (
     ATTR_CROSSFADE,
     ATTR_NIGHT_SOUND,
     ATTR_SPEECH_ENHANCEMENT,
+    ATTR_SUB_ENABLED,
+    ATTR_SURROUND_ENABLED,
     ATTR_STATUS_LIGHT,
 )
 
@@ -60,6 +64,8 @@ FRIENDLY_NAMES = {
     ATTR_NIGHT_SOUND: "Night Sound",
     ATTR_SPEECH_ENHANCEMENT: "Speech Enhancement",
     ATTR_STATUS_LIGHT: "Status Light",
+    ATTR_SUB_ENABLED: "Subwoofer Enabled",
+    ATTR_SURROUND_ENABLED: "Surround Enabled",
     ATTR_TOUCH_CONTROLS: "Touch Controls",
 }
 
@@ -68,6 +74,8 @@ FEATURE_ICONS = {
     ATTR_SPEECH_ENHANCEMENT: "mdi:ear-hearing",
     ATTR_CROSSFADE: "mdi:swap-horizontal",
     ATTR_STATUS_LIGHT: "mdi:led-on",
+    ATTR_SUB_ENABLED: "mdi:dog",
+    ATTR_SURROUND_ENABLED: "mdi:surround-sound",
     ATTR_TOUCH_CONTROLS: "mdi:gesture-tap",
 }
 

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -72,6 +72,8 @@ def soco_fixture(music_library, speaker_info, battery_info, alarm_clock):
         mock_soco.volume = 19
         mock_soco.bass = 1
         mock_soco.treble = -1
+        mock_soco.sub_enabled = False
+        mock_soco.surround_enabled = True
         mock_soco.get_battery_info.return_value = battery_info
         mock_soco.all_zones = [mock_soco]
         yield mock_soco

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -14,7 +14,7 @@ from homeassistant.components.sonos.switch import (
     ATTR_VOLUME,
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
-from homeassistant.const import ATTR_TIME, STATE_ON
+from homeassistant.const import ATTR_TIME, STATE_OFF, STATE_ON
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
@@ -42,6 +42,8 @@ async def test_entity_registry(hass, config_entry, config):
     assert "switch.sonos_zone_a_status_light" in entity_registry.entities
     assert "switch.sonos_zone_a_night_sound" in entity_registry.entities
     assert "switch.sonos_zone_a_speech_enhancement" in entity_registry.entities
+    assert "switch.sonos_zone_a_subwoofer_enabled" in entity_registry.entities
+    assert "switch.sonos_zone_a_surround_enabled" in entity_registry.entities
     assert "switch.sonos_zone_a_touch_controls" in entity_registry.entities
 
 
@@ -82,6 +84,14 @@ async def test_switch_attributes(hass, config_entry, config, soco):
 
     touch_controls = entity_registry.entities["switch.sonos_zone_a_touch_controls"]
     assert hass.states.get(touch_controls.entity_id) is None
+
+    sub_switch = entity_registry.entities["switch.sonos_zone_a_subwoofer_enabled"]
+    sub_switch_state = hass.states.get(sub_switch.entity_id)
+    assert sub_switch_state.state == STATE_OFF
+
+    surround_switch = entity_registry.entities["switch.sonos_zone_a_surround_enabled"]
+    surround_switch_state = hass.states.get(surround_switch.entity_id)
+    assert surround_switch_state.state == STATE_ON
 
     # Enable disabled switches
     for entity in (status_light, touch_controls):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds new switches to control an attached subwoofer and surround speakers in a home theater setup. Sub control is also available if paired to a single speaker or stereo pair.

![image](https://user-images.githubusercontent.com/1203111/144622274-b4221e04-101f-4d99-81f4-12debde3fb04.png)

These switches coincide with these switches in the Sonos app:
![image](https://user-images.githubusercontent.com/1203111/144622850-361b7f66-ffff-4f3e-aa9f-c9c80fff5d80.png)
![image](https://user-images.githubusercontent.com/1203111/144622868-585a8687-37b5-4936-bd7d-574ebabb15ca.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20555

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
