### PR TITLE
Revert "Temporarily disable CI concurrency"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,9 @@ env:
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   SQLALCHEMY_WARN_20: 1
 
-# Temporary disabled: https://github.com/actions/runner/issues/1532
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:


### PR DESCRIPTION
Reverts home-assistant/core#60926

Based on https://github.com/actions/runner/issues/1532#issuecomment-985711846

Seems to work in this PR as well.