### PR TITLE
Fix BMW Connected Drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -35,7 +35,6 @@ from .const import (
     CONF_ACCOUNT,
     CONF_ALLOWED_REGIONS,
     CONF_READ_ONLY,
-    CONF_USE_LOCATION,
     DATA_ENTRIES,
     DATA_HASS_CONFIG,
 )
@@ -115,9 +114,6 @@ def _async_migrate_options_from_data_if_missing(
     if CONF_READ_ONLY in data or list(options) != list(DEFAULT_OPTIONS):
         options = dict(DEFAULT_OPTIONS, **options)
         options[CONF_READ_ONLY] = data.pop(CONF_READ_ONLY, False)
-
-        # Remove CONF_USE_LOCATION as we have to use it by default
-        options.pop(CONF_USE_LOCATION, None)
 
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -117,6 +117,9 @@ def _async_migrate_options_from_data_if_missing(
         options = dict(DEFAULT_OPTIONS, **options)
         options[CONF_READ_ONLY] = data.pop(CONF_READ_ONLY, False)
 
+        # Remove CONF_USE_LOCATION as we have to use it by default
+        options.pop(CONF_USE_LOCATION, None)
+
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 
 
@@ -215,13 +218,10 @@ def setup_account(
     password: str = entry.data[CONF_PASSWORD]
     region: str = entry.data[CONF_REGION]
     read_only: bool = entry.options[CONF_READ_ONLY]
-    use_location: bool = entry.options[CONF_USE_LOCATION]
 
     _LOGGER.debug("Adding new account %s", name)
 
-    pos = (
-        (hass.config.latitude, hass.config.longitude) if use_location else (None, None)
-    )
+    pos = (hass.config.latitude, hass.config.longitude)
     cd_account = BMWConnectedDriveAccount(
         username, password, region, name, read_only, *pos
     )

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -65,7 +65,6 @@ SERVICE_SCHEMA = vol.Schema(
 
 DEFAULT_OPTIONS = {
     CONF_READ_ONLY: False,
-    CONF_USE_LOCATION: False,
 }
 
 PLATFORMS = [

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -258,6 +258,13 @@ def setup_account(
         function_call = getattr(vehicle.remote_services, function_name)
         function_call()
 
+        if call.service in [
+            "find_vehicle",
+            "activate_air_conditioning",
+            "deactivate_air_conditioning",
+        ]:
+            cd_account.update()
+
     if not read_only:
         # register the remote services
         for service in _SERVICE_MAP:

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from . import DOMAIN
-from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_USE_LOCATION
+from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -114,10 +114,6 @@ class BMWConnectedDriveOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_READ_ONLY,
                         default=self.config_entry.options.get(CONF_READ_ONLY, False),
-                    ): bool,
-                    vol.Optional(
-                        CONF_USE_LOCATION,
-                        default=self.config_entry.options.get(CONF_USE_LOCATION, False),
                     ): bool,
                 }
             ),

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
 
     for vehicle in account.account.vehicles:
         entities.append(BMWDeviceTracker(account, vehicle))
-        if not vehicle.status.is_vehicle_tracking_enabled:
+        if not vehicle.is_vehicle_tracking_enabled:
             _LOGGER.info(
                 "Tracking is (currently) disabled for vehicle %s (%s), defaulting to unknown",
                 vehicle.name,
@@ -83,6 +83,6 @@ class BMWDeviceTracker(BMWConnectedDriveBaseEntity, TrackerEntity):
         self._attr_extra_state_attributes = self._attrs
         self._location = (
             self._vehicle.status.gps_position
-            if self._vehicle.status.is_vehicle_tracking_enabled
+            if self._vehicle.is_vehicle_tracking_enabled
             else None
         )

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bmw_connected_drive",
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
-  "requirements": ["bimmer_connected==0.8.2"],
+  "requirements": ["bimmer_connected==0.8.5"],
   "codeowners": ["@gerard33", "@rikroe"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -1,10 +1,10 @@
 """Support for reading vehicle status from BMW connected drive portal."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import logging
-from typing import Any, Mapping, cast
+from typing import Any, cast
 
 from bimmer_connected.vehicle import ConnectedDriveVehicle
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -1,10 +1,10 @@
 """Support for reading vehicle status from BMW connected drive portal."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any, cast
+from typing import cast
 
 from bimmer_connected.vehicle import ConnectedDriveVehicle
 
@@ -13,7 +13,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_UNIT_SYSTEM_IMPERIAL,
     DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_TIMESTAMP,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
     PERCENTAGE,
@@ -43,7 +42,6 @@ class BMWSensorEntityDescription(SensorEntityDescription):
     unit_metric: str | None = None
     unit_imperial: str | None = None
     value: Callable = lambda x, y: x
-    extra_attributes: dict | None = None
 
 
 SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
@@ -53,12 +51,6 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
         icon="mdi:update",
         unit_metric=TIME_HOURS,
         unit_imperial=TIME_HOURS,
-    ),
-    "charging_end_time": BMWSensorEntityDescription(
-        key="charging_end_time",
-        icon="mdi:update",
-        device_class=DEVICE_CLASS_TIMESTAMP,
-        extra_attributes={"original_value": "charging_end_time_original"},
     ),
     "charging_status": BMWSensorEntityDescription(
         key="charging_status",
@@ -179,13 +171,3 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, SensorEntity):
         """Return the state."""
         state = getattr(self._vehicle.status, self.entity_description.key)
         return cast(StateType, self.entity_description.value(state, self.hass))
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return the attributes."""
-        if self.entity_description.extra_attributes:
-            return {
-                k: getattr(self._vehicle.status, v)
-                for k, v in self.entity_description.extra_attributes.items()
-            }
-        return None

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -21,8 +21,7 @@
     "step": {
       "account_options": {
         "data": {
-          "read_only": "Read-only (only sensors and notify, no execution of services, no lock)",
-          "use_location": "Use Home Assistant location for car location polls (required for non i3/i8 vehicles produced before 7/2014)"
+          "read_only": "Read-only (only sensors and notify, no execution of services, no lock)"
         }
       }
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -387,7 +387,7 @@ beautifulsoup4==4.10.0
 bellows==0.29.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.2
+bimmer_connected==0.8.5
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -257,7 +257,7 @@ base36==0.1.1
 bellows==0.29.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.2
+bimmer_connected==0.8.5
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.3

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -3,10 +3,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.bmw_connected_drive.config_flow import DOMAIN
-from homeassistant.components.bmw_connected_drive.const import (
-    CONF_READ_ONLY,
-    CONF_USE_LOCATION,
-)
+from homeassistant.components.bmw_connected_drive.const import CONF_READ_ONLY
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
 
 from tests.common import MockConfigEntry
@@ -28,7 +25,7 @@ FIXTURE_CONFIG_ENTRY = {
         CONF_PASSWORD: FIXTURE_USER_INPUT[CONF_PASSWORD],
         CONF_REGION: FIXTURE_USER_INPUT[CONF_REGION],
     },
-    "options": {CONF_READ_ONLY: False, CONF_USE_LOCATION: False},
+    "options": {CONF_READ_ONLY: False},
     "source": config_entries.SOURCE_USER,
     "unique_id": f"{FIXTURE_USER_INPUT[CONF_REGION]}-{FIXTURE_USER_INPUT[CONF_REGION]}",
 }
@@ -137,14 +134,13 @@ async def test_options_flow_implementation(hass):
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
-            user_input={CONF_READ_ONLY: False, CONF_USE_LOCATION: False},
+            user_input={CONF_READ_ONLY: False},
         )
         await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"] == {
             CONF_READ_ONLY: False,
-            CONF_USE_LOCATION: False,
         }
 
         assert len(mock_setup.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `find_vehicle` service will **always** send the location of your HA instance to BMW. See the [docs](https://www.home-assistant.io/integrations/bmw_connected_drive/#vehicle-finder) for details.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR contains a bugfixes to #59881.

* Upgrade to `bimmer_connected==0.8.5`
  * Release notes:
    * https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.8.3
    * https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.8.4
    * https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.8.5
  * Full diff (most of the commits were due to changing CI to Github actions): https://github.com/bimmerconnected/bimmer_connected/compare/0.8.2...0.8.5
* `find_vehicle` now returns & stores the position of the vehicle, however needs to send a location (using HA location)
* Add check if vehicle tracking is enabled again
* Issues with the BMW API should now be handled more gracefully

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: tracked in library repository
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20570

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
