### PR TITLE
Change the way the button works and implemented in Tuya Button

### DIFF
--- a/homeassistant/components/tuya/button.py
+++ b/homeassistant/components/tuya/button.py
@@ -24,33 +24,78 @@ BUTTONS: dict[str, tuple[ButtonEntityDescription, ...]] = {
     "sd": (
         ButtonEntityDescription(
             key=DPCode.RESET_DUSTER_CLOTH,
+            action=DPCode.RESET_DUSTER_CLOTH,
+            action_value=True,
             name="Reset Duster Cloth",
             icon="mdi:restart",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_EDGE_BRUSH,
+            action=DPCode.RESET_EDGE_BRUSH,
+            action_value=True,
             name="Reset Edge Brush",
             icon="mdi:restart",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_FILTER,
+            action=DPCode.RESET_FILTER,
+            action_value=True,
             name="Reset Filter",
             icon="mdi:air-filter",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_MAP,
+            action=DPCode.RESET_MAP,
+            action_value=True,
             name="Reset Map",
             icon="mdi:map-marker-remove",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_ROLL_BRUSH,
+            action=DPCode.RESET_ROLL_BRUSH,
+            action_value=True,
             name="Reset Roll Brush",
             icon="mdi:restart",
             entity_category=EntityCategory.CONFIG,
+        ),
+        ButtonEntityDescription(
+            key=DPCode.DIRECTION_CONTROL,
+            action=DPCode.DIRECTION_CONTROL,
+            action_value="forward",
+            name="Direction Forward",
+            icon="mdi:arrow-up",
+        ),
+        ButtonEntityDescription(
+            key=DPCode.DIRECTION_CONTROL,
+            action=DPCode.DIRECTION_CONTROL,
+            action_value="backward",
+            name="Direction Backward",
+            icon="mdi:arrow-down",
+        ),
+        ButtonEntityDescription(
+            key=DPCode.DIRECTION_CONTROL,
+            action=DPCode.DIRECTION_CONTROL,
+            action_value="turn_left",
+            name="Direction Left",
+            icon="mdi:arrow-u-down-left",
+        ),
+        ButtonEntityDescription(
+            key=DPCode.DIRECTION_CONTROL,
+            action=DPCode.DIRECTION_CONTROL,
+            action_value="turn_right",
+            name="Direction Right",
+            icon="mdi:arrow-u-down-right",
+        ),
+        ButtonEntityDescription(
+            key=DPCode.DIRECTION_CONTROL,
+            action=DPCode.DIRECTION_CONTROL,
+            action_value="stop",
+            name="Direction Stop",
+            icon="mdi:stop",
         ),
     ),
 }
@@ -98,8 +143,15 @@ class TuyaButtonEntity(TuyaEntity, ButtonEntity):
         """Init Tuya button."""
         super().__init__(device, device_manager)
         self.entity_description = description
-        self._attr_unique_id = f"{super().unique_id}{description.key}"
+        self._attr_unique_id = f"{super().unique_id}{description.key}{description.name}"
 
     def press(self, **kwargs: Any) -> None:
         """Press the button."""
-        self._send_command([{"code": self.entity_description.key, "value": True}])
+        self._send_command(
+            [
+                {
+                    "code": self.entity_description.action,
+                    "value": self.entity_description.action_value,
+                }
+            ]
+        )

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -174,6 +174,7 @@ class DPCode(str, Enum):
     DECIBEL_SENSITIVITY = "decibel_sensitivity"
     DECIBEL_SWITCH = "decibel_switch"
     DEHUMIDITY_SET_VALUE = "dehumidify_set_value"
+    DIRECTION_CONTROL = "direction_control"
     DO_NOT_DISTURB = "do_not_disturb"
     DOORCONTACT_STATE = "doorcontact_state"  # Status of door window sensor
     DOORCONTACT_STATE_2 = "doorcontact_state_2"

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -215,6 +215,9 @@ class EntityDescription:
     name: str | None = None
     unit_of_measurement: str | None = None
 
+    action: str | None = None
+    action_value: Any | None = None
+
 
 class Entity(ABC):
     """An abstract class for Home Assistant entities."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The initial idea of this change was due to the user's difficulty using a select to control the robot vacuum device.

Studying this case, I noticed that the implementation of the button in Tuya was just sending a `True` value for a given `code`. This can limit the use of the button entity if the required change is something other than `True`.

To create the possibility of using the button for any action, it was necessary to include two variables in the `EntityDescription` class: `action` and `action_value`.

With this it was possible to define for each button an `action` (`code` in Tuya's case) and an `action_value` (`value` in Tuya's case).

This PR is intended to demonstrate the functionality of this implementation to be evaluated for newly created button entity.

Example of implementation of buttons on the robot vacuum:
![image](https://user-images.githubusercontent.com/31328123/144692931-e5dd529d-3ff9-4435-a410-5b1b871dbdc1.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
