### PR TITLE
Upgrade netdata to 1.0.1

### DIFF
--- a/homeassistant/components/netdata/manifest.json
+++ b/homeassistant/components/netdata/manifest.json
@@ -2,7 +2,7 @@
   "domain": "netdata",
   "name": "Netdata",
   "documentation": "https://www.home-assistant.io/integrations/netdata",
-  "requirements": ["netdata==0.2.0"],
+  "requirements": ["netdata==1.0.1"],
   "codeowners": ["@fabaff"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
     PERCENTAGE,
 )
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
@@ -61,8 +60,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     port = config.get(CONF_PORT)
     resources = config.get(CONF_RESOURCES)
 
-    session = async_get_clientsession(hass)
-    netdata = NetdataData(Netdata(host, hass.loop, session, port=port))
+    netdata = NetdataData(Netdata(host, port=port))
     await netdata.async_update()
 
     if netdata.api.metrics is None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1050,7 +1050,7 @@ ndms2_client==0.1.1
 nessclient==0.9.15
 
 # homeassistant.components.netdata
-netdata==0.2.0
+netdata==1.0.1
 
 # homeassistant.components.discovery
 netdisco==3.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Upgrades `netdata` to 1.0.1

Release notes: <https://github.com/home-assistant-ecosystem/python-netdata/releases/tag/1.0.1>

Fixes this report from #beta on Discord:

```
2021-12-03 15:41:01 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue for netdata using this method at homeassistant/components/netdata/sensor.py, line 223: await self.api.get_allmetrics()
2021-12-03 15:41:01 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue for netdata using this method at homeassistant/components/netdata/sensor.py, line 224: await self.api.get_alarms()
```

Example configuration:

```yaml
sensor:
  - platform: netdata
    host: "10.10.10.11"
    port: "19999"
    name: "ContainerShip.local"
    resources:
      system_load:
        data_group: system.load
        element: load15
      core0_freq:
        data_group: "cpu.cpufreq"
        element: "cpu0"
        icon: mdi:chip
```

![image](https://user-images.githubusercontent.com/195327/144702522-08cbb963-bdc1-44aa-acc7-68c758ca6be9.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
