### PR TITLE
Revert metoffice weather daytime

### DIFF
--- a/homeassistant/components/metoffice/const.py
+++ b/homeassistant/components/metoffice/const.py
@@ -24,8 +24,6 @@ DOMAIN = "metoffice"
 DEFAULT_NAME = "Met Office"
 ATTRIBUTION = "Data provided by the Met Office"
 
-ATTR_FORECAST_DAYTIME = "daytime"
-
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=15)
 
 METOFFICE_COORDINATES = "metoffice_coordinates"

--- a/homeassistant/components/metoffice/weather.py
+++ b/homeassistant/components/metoffice/weather.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import get_device_info
 from .const import (
-    ATTR_FORECAST_DAYTIME,
     ATTRIBUTION,
     CONDITION_CLASSES,
     DEFAULT_NAME,
@@ -47,7 +46,7 @@ async def async_setup_entry(
     )
 
 
-def _build_forecast_data(timestep, use_3hourly):
+def _build_forecast_data(timestep):
     data = {}
     data[ATTR_FORECAST_TIME] = timestep.date.isoformat()
     if timestep.weather:
@@ -60,9 +59,6 @@ def _build_forecast_data(timestep, use_3hourly):
         data[ATTR_FORECAST_WIND_BEARING] = timestep.wind_direction.value
     if timestep.wind_speed:
         data[ATTR_FORECAST_WIND_SPEED] = timestep.wind_speed.value
-    if not use_3hourly:
-        # if it's close to noon, mark as Day, otherwise as Night
-        data[ATTR_FORECAST_DAYTIME] = abs(timestep.date.hour - 12) < 6
     return data
 
 
@@ -86,7 +82,6 @@ class MetOfficeWeather(CoordinatorEntity, WeatherEntity):
         )
         self._attr_name = f"{DEFAULT_NAME} {hass_data[METOFFICE_NAME]} {mode_label}"
         self._attr_unique_id = hass_data[METOFFICE_COORDINATES]
-        self._use_3hourly = use_3hourly
         if not use_3hourly:
             self._attr_unique_id = f"{self._attr_unique_id}_{MODE_DAILY}"
 
@@ -160,7 +155,7 @@ class MetOfficeWeather(CoordinatorEntity, WeatherEntity):
         if self.coordinator.data.forecast is None:
             return None
         return [
-            _build_forecast_data(timestep, self._use_3hourly)
+            _build_forecast_data(timestep)
             for timestep in self.coordinator.data.forecast
         ]
 

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -181,13 +181,6 @@ async def test_one_weather_site_running(hass, requests_mock, legacy_patchable_ti
     assert weather.attributes.get("forecast")[7]["temperature"] == 13
     assert weather.attributes.get("forecast")[7]["wind_speed"] == 13
     assert weather.attributes.get("forecast")[7]["wind_bearing"] == "SE"
-    assert weather.attributes.get("forecast")[7]["daytime"] is True
-
-    # Check that night entry is correctly marked as Night
-    assert (
-        weather.attributes.get("forecast")[6]["datetime"] == "2020-04-29T00:00:00+00:00"
-    )
-    assert weather.attributes.get("forecast")[6]["daytime"] is False
 
 
 @patch(
@@ -263,7 +256,6 @@ async def test_two_weather_sites_running(hass, requests_mock, legacy_patchable_t
     assert weather.attributes.get("forecast")[18]["temperature"] == 9
     assert weather.attributes.get("forecast")[18]["wind_speed"] == 4
     assert weather.attributes.get("forecast")[18]["wind_bearing"] == "NW"
-    assert "daytime" not in weather.attributes.get("forecast")[18]
 
     # Wavertree daily weather platform expected results
     weather = hass.states.get("weather.met_office_wavertree_daily")
@@ -287,7 +279,6 @@ async def test_two_weather_sites_running(hass, requests_mock, legacy_patchable_t
     assert weather.attributes.get("forecast")[7]["temperature"] == 13
     assert weather.attributes.get("forecast")[7]["wind_speed"] == 13
     assert weather.attributes.get("forecast")[7]["wind_bearing"] == "SE"
-    assert weather.attributes.get("forecast")[7]["daytime"] is True
 
     # King's Lynn 3-hourly weather platform expected results
     weather = hass.states.get("weather.met_office_king_s_lynn_3_hourly")
@@ -312,7 +303,6 @@ async def test_two_weather_sites_running(hass, requests_mock, legacy_patchable_t
     assert weather.attributes.get("forecast")[18]["temperature"] == 10
     assert weather.attributes.get("forecast")[18]["wind_speed"] == 7
     assert weather.attributes.get("forecast")[18]["wind_bearing"] == "SE"
-    assert "daytime" not in weather.attributes.get("forecast")[18]
 
     # King's Lynn daily weather platform expected results
     weather = hass.states.get("weather.met_office_king_s_lynn_daily")
@@ -336,4 +326,3 @@ async def test_two_weather_sites_running(hass, requests_mock, legacy_patchable_t
     assert weather.attributes.get("forecast")[5]["temperature"] == 11
     assert weather.attributes.get("forecast")[5]["wind_speed"] == 7
     assert weather.attributes.get("forecast")[5]["wind_bearing"] == "ESE"
-    assert weather.attributes.get("forecast")[5]["daytime"] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Revert #58679 which added a non standard forecast item not following our weather entity design.
- https://github.com/home-assistant/core/pull/58679#discussion_r760738776

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
