### PR TITLE
Add encoding support for template callback function async_render_with_possible_json_value

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from ast import literal_eval
 import asyncio
 import base64
+from codecs import encode
 import collections.abc
 from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager, suppress
@@ -538,7 +539,11 @@ class Template:
 
     @callback
     def async_render_with_possible_json_value(
-        self, value, error_value=_SENTINEL, variables=None
+        self,
+        value,
+        error_value=_SENTINEL,
+        variables=None,
+        encoding="utf-8",
     ):
         """Render template with value exposed.
 
@@ -559,9 +564,12 @@ class Template:
             variables["value_json"] = json.loads(value)
 
         try:
-            return _render_with_context(
-                self.template, self._compiled, **variables
-            ).strip()
+            return _ensure_encoding(
+                _render_with_context(
+                    self.template, self._compiled, **variables
+                ).strip(),
+                encoding,
+            )
         except jinja2.TemplateError as ex:
             if error_value is _SENTINEL:
                 _LOGGER.error(
@@ -1754,6 +1762,27 @@ def set_template(template_str: str, action: str) -> Generator:
         yield
     finally:
         template_cv.set(None)
+
+
+def _ensure_encoding(
+    rendered_value: str, encoding: str | None = "utf-8"
+) -> str | bytes:
+    """Ensure correct encoding or pass-through as a binary object if no encoding is set."""
+    if encoding is None:
+        try:
+            native_object = literal_eval(rendered_value)
+            if isinstance(native_object, bytes) and encoding is None:
+                return native_object
+
+        except (ValueError, TypeError, SyntaxError, MemoryError):
+            pass
+        _LOGGER.warning(
+            "Unable to encode '%s' with no encoding set, expected 'bytes', got 'str'",
+            rendered_value,
+        )
+        return rendered_value
+
+    return rendered_value if encoding == "utf-8" else encode(rendered_value, encoding)
 
 
 def _render_with_context(

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -1,7 +1,9 @@
 """Helper methods for various modules."""
 from __future__ import annotations
 
+from ast import literal_eval
 import asyncio
+from codecs import encode
 from collections.abc import Callable, Coroutine, Iterable, KeysView
 from datetime import datetime, timedelta
 import enum
@@ -74,6 +76,26 @@ def convert(
     except (ValueError, TypeError):
         # If value could not be converted
         return default
+
+
+def ensure_encoding(rendered_value: str, encoding: str | None = "utf-8") -> str | bytes:
+    """Ensure correct encoding or pass-through as a binary object if no encoding is None.
+
+    If encoding is not set to utf-8, the encoded to bytes to ensure the correct encoding.
+    If encoding is None, and rendered_value is a literal bytes string, rendered_value will casted to bytes.
+    Default action is to return rendered_value as a string.
+    """
+    if encoding is None:
+        try:
+            native_object = literal_eval(rendered_value)
+            if isinstance(native_object, bytes) and encoding is None:
+                return native_object
+
+        except (ValueError, TypeError, SyntaxError, MemoryError):
+            pass
+        return rendered_value
+
+    return rendered_value if encoding == "utf-8" else encode(rendered_value, encoding)
 
 
 def ensure_unique_string(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1054,8 +1054,8 @@ def test_render_with_possible_json_value_raw_encoding(hass):
     assert tpl.async_render_with_possible_json_value(value, encoding=None) == expected
 
 
-def test_render_with_possible_json_value_raw_encoding_warning(hass, caplog):
-    """Render with possible JSON value with raw encoding and invalid input."""
+def test_render_with_possible_json_value_raw_encoding_flag(hass, caplog):
+    """Render with possible JSON value with raw encoding set and utf-8 pass-through."""
     tpl = template.Template(
         """
 {{ value }}
@@ -1068,11 +1068,6 @@ def test_render_with_possible_json_value_raw_encoding_warning(hass, caplog):
     expected = value
     assert (
         tpl.async_render_with_possible_json_value(value, encoding=encoding) == expected
-    )
-
-    assert (
-        "Unable to encode 'àáäèëéèëéòöóùüú' with no encoding set, expected 'bytes', got 'str'"
-        in caplog.text
     )
 
 
@@ -1091,10 +1086,6 @@ def test_render_with_possible_json_value_alternative_encoding(hass):
     assert (
         tpl.async_render_with_possible_json_value(value, encoding=encoding) == expected
     )
-
-    # b'\xe0\xe1\xe4\xe8\xeb\xe9\xe8\xeb\xe9\xf2\xf6\xf3\xf9\xfc\xfa' (latin_1)
-    # b'\xc3\xa0\xc3\xa1\xc3\xa4\xc3\xa8\xc3\xab\xc3\xa9\xc3\xa8\xc3\xab\xc3\xa9\xc3\xb2\xc3\xb6\xc3\xb3\xc3\xb9\xc3\xbc\xc3\xba' (utf-8)
-    # 'àáäèëéèëéòöóùüú' (str)
 
 
 def test_if_state_exists(hass):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1041,6 +1041,62 @@ def test_render_with_possible_json_value_non_string_value(hass):
     assert tpl.async_render_with_possible_json_value(value) == expected
 
 
+def test_render_with_possible_json_value_raw_encoding(hass):
+    """Render with possible JSON value with raw encoding."""
+    tpl = template.Template(
+        """
+{{ value | pack('b') }}
+        """,
+        hass,
+    )
+    value = 16
+    expected = b"\x10"
+    assert tpl.async_render_with_possible_json_value(value, encoding=None) == expected
+
+
+def test_render_with_possible_json_value_raw_encoding_warning(hass, caplog):
+    """Render with possible JSON value with raw encoding and invalid input."""
+    tpl = template.Template(
+        """
+{{ value }}
+        """,
+        hass,
+    )
+    value = "àáäèëéèëéòöóùüú"
+
+    encoding = None
+    expected = value
+    assert (
+        tpl.async_render_with_possible_json_value(value, encoding=encoding) == expected
+    )
+
+    assert (
+        "Unable to encode 'àáäèëéèëéòöóùüú' with no encoding set, expected 'bytes', got 'str'"
+        in caplog.text
+    )
+
+
+def test_render_with_possible_json_value_alternative_encoding(hass):
+    """Render with possible JSON value with alternative encoding."""
+    tpl = template.Template(
+        """
+{{ value }}
+        """,
+        hass,
+    )
+    value = "àáäèëéèëéòöóùüú"
+
+    encoding = "latin_1"
+    expected = b"\xe0\xe1\xe4\xe8\xeb\xe9\xe8\xeb\xe9\xf2\xf6\xf3\xf9\xfc\xfa"
+    assert (
+        tpl.async_render_with_possible_json_value(value, encoding=encoding) == expected
+    )
+
+    # b'\xe0\xe1\xe4\xe8\xeb\xe9\xe8\xeb\xe9\xf2\xf6\xf3\xf9\xfc\xfa' (latin_1)
+    # b'\xc3\xa0\xc3\xa1\xc3\xa4\xc3\xa8\xc3\xab\xc3\xa9\xc3\xa8\xc3\xab\xc3\xa9\xc3\xb2\xc3\xb6\xc3\xb3\xc3\xb9\xc3\xbc\xc3\xba' (utf-8)
+    # 'àáäèëéèëéòöóùüú' (str)
+
+
 def test_if_state_exists(hass):
     """Test if state exists works."""
     hass.states.async_set("test.object", "available")

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -82,6 +82,38 @@ def test_convert():
     assert util.convert(object, int, 1) == 1
 
 
+def test_ensure_unique_encoding():
+    """Test ensure_unique_encoding."""
+    encoding = "latin_1"
+    value = "àáäèëéèëéòöóùüú"
+    expected = b"\xe0\xe1\xe4\xe8\xeb\xe9\xe8\xeb\xe9\xf2\xf6\xf3\xf9\xfc\xfa"
+    assert util.ensure_encoding(value, encoding) == expected
+
+    encoding = None
+    value = "àáäèëéèëéòöóùüú"
+    expected = value
+    assert util.ensure_encoding(value, encoding) == expected
+
+    encoding = None
+    value = (
+        "b'\\xe0\\xe1\\xe4\\xe8\\xeb\\xe9\\xe8\\xeb\\xe9\\xf2\\xf6\\xf3\\xf9\\xfc\\xfa'"
+    )
+    expected = b"\xe0\xe1\xe4\xe8\xeb\xe9\xe8\xeb\xe9\xf2\xf6\xf3\xf9\xfc\xfa"
+    assert util.ensure_encoding(value, encoding) == expected
+
+    encoding = "utf-8"
+    value = "àáäèëéèëéòöóùüú"
+    expected = value
+    assert util.ensure_encoding(value, encoding) == expected
+
+    encoding = "utf-8"
+    value = (
+        "b'\\xe0\\xe1\\xe4\\xe8\\xeb\\xe9\\xe8\\xeb\\xe9\\xf2\\xf6\\xf3\\xf9\\xfc\\xfa'"
+    )
+    expected = value
+    assert util.ensure_encoding(value, encoding) == expected
+
+
 def test_ensure_unique_string():
     """Test ensure_unique_string."""
     assert util.ensure_unique_string("Beer", ["Beer", "Beer_2"]) == "Beer_3"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable a custom encoding to be used for the `async_render_with_possible_json_value` callback function.
This is  a prerequisite to support alternative (and raw) encoding for the MQTT integration. `async_render_with_possible_json_value` is called to render command_templates and value_templates.
With raw encoding set (encoding=None) `async_render_with_possible_json_value` will enable to pass-through raw `bytes`.
With an alternate encoding set (e.g. `latin_1`). The custom output encoding will be ensured.

A new method `ensure_encoding` is introduced. This method will be used later for rendering MQTT payloads to ensure the encoding when no template is set. Now `lambda value: value` is used as empty function wrapper.

Relevant documentation page that needs to be updated:
http://dev-docs.home-assistant.io/en/master/api/util.html

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
