### PR TITLE
Fix panasonic_viera tests

### DIFF
--- a/tests/components/panasonic_viera/test_config_flow.py
+++ b/tests/components/panasonic_viera/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_flow_non_encrypted(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "create_entry"
@@ -65,7 +65,7 @@ async def test_flow_not_connected_error(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "form"
@@ -89,7 +89,7 @@ async def test_flow_unknown_abort(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "abort"
@@ -114,7 +114,7 @@ async def test_flow_encrypted_not_connected_pin_code_request(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "abort"
@@ -139,7 +139,7 @@ async def test_flow_encrypted_unknown_pin_code_request(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "abort"
@@ -168,7 +168,7 @@ async def test_flow_encrypted_valid_pin_code(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "form"
@@ -206,7 +206,7 @@ async def test_flow_encrypted_invalid_pin_code_error(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "form"
@@ -244,7 +244,7 @@ async def test_flow_encrypted_not_connected_abort(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "form"
@@ -277,7 +277,7 @@ async def test_flow_encrypted_unknown_abort(hass):
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            MOCK_BASIC_DATA,
+            {**MOCK_BASIC_DATA},
         )
 
     assert result["type"] == "form"
@@ -304,7 +304,7 @@ async def test_flow_non_encrypted_already_configured_abort(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
-        data=MOCK_BASIC_DATA,
+        data={**MOCK_BASIC_DATA},
     )
 
     assert result["type"] == "abort"
@@ -323,7 +323,7 @@ async def test_flow_encrypted_already_configured_abort(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
-        data=MOCK_BASIC_DATA,
+        data={**MOCK_BASIC_DATA},
     )
 
     assert result["type"] == "abort"
@@ -342,7 +342,7 @@ async def test_imported_flow_non_encrypted(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "create_entry"
@@ -366,7 +366,7 @@ async def test_imported_flow_encrypted_valid_pin_code(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "form"
@@ -398,7 +398,7 @@ async def test_imported_flow_encrypted_invalid_pin_code_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "form"
@@ -430,7 +430,7 @@ async def test_imported_flow_encrypted_not_connected_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "form"
@@ -457,7 +457,7 @@ async def test_imported_flow_encrypted_unknown_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "form"
@@ -482,7 +482,7 @@ async def test_imported_flow_not_connected_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "form"
@@ -500,7 +500,7 @@ async def test_imported_flow_unknown_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_CONFIG_DATA,
+            data={**MOCK_CONFIG_DATA},
         )
 
     assert result["type"] == "abort"
@@ -519,7 +519,7 @@ async def test_imported_flow_non_encrypted_already_configured_abort(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
-        data=MOCK_BASIC_DATA,
+        data={**MOCK_BASIC_DATA},
     )
 
     assert result["type"] == "abort"
@@ -538,7 +538,7 @@ async def test_imported_flow_encrypted_already_configured_abort(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
-        data=MOCK_BASIC_DATA,
+        data={**MOCK_BASIC_DATA},
     )
 
     assert result["type"] == "abort"

--- a/tests/components/panasonic_viera/test_init.py
+++ b/tests/components/panasonic_viera/test_init.py
@@ -130,7 +130,7 @@ async def test_setup_entry_unencrypted_missing_device_info(hass, mock_remote):
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=MOCK_CONFIG_DATA[CONF_HOST],
-        data=MOCK_CONFIG_DATA,
+        data={**MOCK_CONFIG_DATA},
     )
 
     mock_entry.add_to_hass(hass)
@@ -156,7 +156,7 @@ async def test_setup_entry_unencrypted_missing_device_info_none(hass):
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=MOCK_CONFIG_DATA[CONF_HOST],
-        data=MOCK_CONFIG_DATA,
+        data={**MOCK_CONFIG_DATA},
     )
 
     mock_entry.add_to_hass(hass)
@@ -207,7 +207,9 @@ async def test_setup_config_flow_initiated(hass):
 async def test_setup_unload_entry(hass, mock_remote):
     """Test if config entry is unloaded."""
     mock_entry = MockConfigEntry(
-        domain=DOMAIN, unique_id=MOCK_DEVICE_INFO[ATTR_UDN], data=MOCK_CONFIG_DATA
+        domain=DOMAIN,
+        unique_id=MOCK_DEVICE_INFO[ATTR_UDN],
+        data={**MOCK_CONFIG_DATA},
     )
 
     mock_entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
Tests should not modify global test variables. The tests failed if executed in the wrong order.
Likely undetected until now as tests have been split up into multiple test groups.

Failed CI run from #60943: https://github.com/home-assistant/core/runs/4413501519?check_suite_focus=true

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
