### PR TITLE
Don't use ConfigEntry update listener for Fronius

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -42,8 +42,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = solar_net
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-    # reload on config_entry update
-    entry.async_on_unload(entry.add_update_listener(async_update_entry))
     return True
 
 
@@ -56,11 +54,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             solar_net.cleanup_callbacks.pop()()
 
     return unload_ok
-
-
-async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update a given config entry."""
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class FroniusSolarNet:

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 import logging
-from typing import TypeVar
+from typing import Final, TypeVar
 
 from pyfronius import Fronius, FroniusError
 
@@ -27,8 +27,8 @@ from .coordinator import (
     FroniusStorageUpdateCoordinator,
 )
 
-_LOGGER = logging.getLogger(__name__)
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+_LOGGER: Final = logging.getLogger(__name__)
+PLATFORMS: Final = [Platform.SENSOR]
 
 FroniusCoordinatorType = TypeVar("FroniusCoordinatorType", bound=FroniusCoordinatorBase)
 

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, FroniusConfigEntryData
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: Final = logging.getLogger(__name__)
 
 DHCP_REQUEST_DELAY: Final = 60
 

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -102,9 +102,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         else:
             await self.async_set_unique_id(unique_id, raise_on_progress=False)
-            self._abort_if_unique_id_configured(
-                updates=dict(info), reload_on_update=False
-            )
+            self._abort_if_unique_id_configured(updates=dict(info))
+
             return self.async_create_entry(title=create_title(info), data=info)
 
         return self.async_show_form(
@@ -132,9 +131,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="invalid_host")
 
         await self.async_set_unique_id(unique_id, raise_on_progress=False)
-        self._abort_if_unique_id_configured(
-            updates=dict(self.info), reload_on_update=False
-        )
+        self._abort_if_unique_id_configured(updates=dict(self.info))
 
         return await self.async_step_confirm_discovery()
 

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import voluptuous as vol
 
@@ -48,11 +48,11 @@ if TYPE_CHECKING:
         FroniusStorageUpdateCoordinator,
     )
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: Final = logging.getLogger(__name__)
 
-ELECTRIC_CHARGE_AMPERE_HOURS = "Ah"
-ENERGY_VOLT_AMPERE_REACTIVE_HOUR = "varh"
-POWER_VOLT_AMPERE_REACTIVE = "var"
+ELECTRIC_CHARGE_AMPERE_HOURS: Final = "Ah"
+ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"
+POWER_VOLT_AMPERE_REACTIVE: Final = "var"
 
 PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend(

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -21,6 +21,17 @@ from . import MOCK_HOST, mock_responses
 
 from tests.common import MockConfigEntry
 
+
+@pytest.fixture(autouse=True)
+def no_setup():
+    """Disable setting up the whole integration in config_flow tests."""
+    with patch(
+        "homeassistant.components.fronius.async_setup_entry",
+        return_value=True,
+    ):
+        yield
+
+
 INVERTER_INFO_RETURN_VALUE = {
     "inverters": [
         {
@@ -37,17 +48,7 @@ MOCK_DHCP_DATA = DhcpServiceInfo(
 )
 
 
-@pytest.fixture()
-def no_setup():
-    """Disable setting up the whole integration."""
-    with patch(
-        "homeassistant.components.fronius.async_setup_entry",
-        return_value=True,
-    ):
-        yield
-
-
-async def test_form_with_logger(no_setup, hass: HomeAssistant) -> None:
+async def test_form_with_logger(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -79,7 +80,7 @@ async def test_form_with_logger(no_setup, hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_with_inverter(no_setup, hass: HomeAssistant) -> None:
+async def test_form_with_inverter(hass: HomeAssistant) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -114,7 +115,7 @@ async def test_form_with_inverter(no_setup, hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(no_setup, hass: HomeAssistant) -> None:
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -138,7 +139,7 @@ async def test_form_cannot_connect(no_setup, hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_no_device(no_setup, hass: HomeAssistant) -> None:
+async def test_form_no_device(hass: HomeAssistant) -> None:
     """Test we handle no device found error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -162,7 +163,7 @@ async def test_form_no_device(no_setup, hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unexpected(no_setup, hass: HomeAssistant) -> None:
+async def test_form_unexpected(hass: HomeAssistant) -> None:
     """Test we handle unexpected error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -183,7 +184,7 @@ async def test_form_unexpected(no_setup, hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_already_existing(no_setup, hass: HomeAssistant) -> None:
+async def test_form_already_existing(hass: HomeAssistant) -> None:
     """Test existing entry."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -254,7 +255,7 @@ async def test_form_updates_host(hass, aioclient_mock):
     }
 
 
-async def test_import(no_setup, hass, aioclient_mock):
+async def test_import(hass, aioclient_mock):
     """Test import step."""
     mock_responses(aioclient_mock)
     assert await async_setup_component(
@@ -280,7 +281,7 @@ async def test_import(no_setup, hass, aioclient_mock):
     }
 
 
-async def test_dhcp(no_setup, hass, aioclient_mock):
+async def test_dhcp(hass, aioclient_mock):
     """Test starting a flow from discovery."""
     with patch(
         "homeassistant.components.fronius.config_flow.DHCP_REQUEST_DELAY", 0
@@ -305,7 +306,7 @@ async def test_dhcp(no_setup, hass, aioclient_mock):
     }
 
 
-async def test_dhcp_already_configured(no_setup, hass, aioclient_mock):
+async def test_dhcp_already_configured(hass, aioclient_mock):
     """Test starting a flow from discovery."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -324,7 +325,7 @@ async def test_dhcp_already_configured(no_setup, hass, aioclient_mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_dhcp_invalid(no_setup, hass, aioclient_mock):
+async def test_dhcp_invalid(hass, aioclient_mock):
     """Test starting a flow from discovery."""
     with patch(
         "homeassistant.components.fronius.config_flow.DHCP_REQUEST_DELAY", 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- don't use config_entry update listener anymore
- disable `async_setup_entry` in Fronius config_flow tests.
See https://github.com/home-assistant/core/pull/60806#discussion_r762421220


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
