### PR TITLE
Add missing local_ip to KNX config flow and options flow

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -390,6 +390,7 @@ class KNXModule:
                 connection_type=ConnectionType.TUNNELING,
                 gateway_ip=self.config[CONF_HOST],
                 gateway_port=self.config[CONF_PORT],
+                local_ip=self.config.get(ConnectionSchema.CONF_KNX_LOCAL_IP),
                 route_back=self.config.get(ConnectionSchema.CONF_KNX_ROUTE_BACK, False),
                 auto_reconnect=True,
             )

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -121,6 +121,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ConnectionSchema.CONF_KNX_ROUTE_BACK: user_input[
                         ConnectionSchema.CONF_KNX_ROUTE_BACK
                     ],
+                    ConnectionSchema.CONF_KNX_LOCAL_IP: user_input.get(
+                        ConnectionSchema.CONF_KNX_LOCAL_IP
+                    ),
                     CONF_KNX_CONNECTION_TYPE: CONF_KNX_TUNNELING,
                 },
             )
@@ -134,6 +137,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(
                 ConnectionSchema.CONF_KNX_ROUTE_BACK, default=False
             ): vol.Coerce(bool),
+            vol.Optional(ConnectionSchema.CONF_KNX_LOCAL_IP): str,
         }
 
         return self.async_show_form(
@@ -243,6 +247,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     **DEFAULT_ENTRY_DATA,
                     CONF_HOST: config[CONF_KNX_TUNNELING][CONF_HOST],
                     CONF_PORT: config[CONF_KNX_TUNNELING][CONF_PORT],
+                    ConnectionSchema.CONF_KNX_LOCAL_IP: config[CONF_KNX_TUNNELING].get(
+                        ConnectionSchema.CONF_KNX_LOCAL_IP
+                    ),
                     ConnectionSchema.CONF_KNX_ROUTE_BACK: config[CONF_KNX_TUNNELING][
                         ConnectionSchema.CONF_KNX_ROUTE_BACK
                     ],
@@ -299,6 +306,7 @@ class KNXOptionsFlowHandler(OptionsFlow):
                         vol.Required(
                             CONF_PORT, default=self.current_config.get(CONF_PORT, 3671)
                         ): cv.port,
+                        vol.Optional(ConnectionSchema.CONF_KNX_LOCAL_IP): str,
                         vol.Required(
                             ConnectionSchema.CONF_KNX_ROUTE_BACK,
                             default=self.current_config.get(

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -19,7 +19,8 @@
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
           "individual_address": "Individual address for the connection",
-          "route_back": "Route Back / NAT Mode"
+          "route_back": "Route Back / NAT Mode",
+          "local_ip": "Local IP"
         }
       },
       "routing": {
@@ -55,7 +56,8 @@
         "data": {
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
-          "route_back": "Route Back / NAT Mode"
+          "route_back": "Route Back / NAT Mode",
+          "local_ip": "Local IP"
         }
       }
     }

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -20,7 +20,7 @@
           "host": "[%key:common::config_flow::data::host%]",
           "individual_address": "Individual address for the connection",
           "route_back": "Route Back / NAT Mode",
-          "local_ip": "Local IP"
+          "local_ip": "Local IP (leave empty if unsure)"
         }
       },
       "routing": {
@@ -57,7 +57,7 @@
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
           "route_back": "Route Back / NAT Mode",
-          "local_ip": "Local IP"
+          "local_ip": "Local IP (leave empty if unsure)"
         }
       }
     }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -12,7 +12,7 @@
                 "data": {
                     "host": "Host",
                     "individual_address": "Individual address for the connection",
-                    "local_ip": "Local IP",
+                    "local_ip": "Local IP (leave empty if unsure)",
                     "port": "Port",
                     "route_back": "Route Back / NAT Mode"
                 },
@@ -55,7 +55,7 @@
             "tunnel": {
                 "data": {
                     "host": "Host",
-                    "local_ip": "Local IP",
+                    "local_ip": "Local IP (leave empty if unsure)",
                     "port": "Port",
                     "route_back": "Route Back / NAT Mode"
                 }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -12,6 +12,7 @@
                 "data": {
                     "host": "Host",
                     "individual_address": "Individual address for the connection",
+                    "local_ip": "Local IP",
                     "port": "Port",
                     "route_back": "Route Back / NAT Mode"
                 },
@@ -54,6 +55,7 @@
             "tunnel": {
                 "data": {
                     "host": "Host",
+                    "local_ip": "Local IP",
                     "port": "Port",
                     "route_back": "Route Back / NAT Mode"
                 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the missing `local_ip` setting to the KNX config and options flow. 

Normally you don't need this, but in complex network setups it might still be required.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
