### PR TITLE
Improve nest media source event timestamp display

### DIFF
--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -46,7 +46,7 @@ from homeassistant.components.nest.const import DATA_SUBSCRIBER, DOMAIN
 from homeassistant.components.nest.device_info import NestDeviceInfo
 from homeassistant.components.nest.events import MEDIA_SOURCE_EVENT_TITLE_MAP
 from homeassistant.core import HomeAssistant
-import homeassistant.util.dt as dt_util
+from homeassistant.helpers.template import DATE_STR_FORMAT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -250,7 +250,7 @@ def _browse_event(
         media_content_type=MEDIA_TYPE_IMAGE,
         title=CLIP_TITLE_FORMAT.format(
             event_name=MEDIA_SOURCE_EVENT_TITLE_MAP.get(event.event_type, "Event"),
-            event_time=dt_util.as_local(event.timestamp),
+            event_time=event.timestamp.strftime(DATE_STR_FORMAT),
         ),
         can_play=True,
         can_expand=False,

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -17,6 +17,7 @@ from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.components.media_source import const
 from homeassistant.components.media_source.error import Unresolvable
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.template import DATE_STR_FORMAT
 import homeassistant.util.dt as dt_util
 
 from .common import async_setup_sdm_platform
@@ -211,7 +212,7 @@ async def test_camera_event(hass, auth, hass_client):
     assert len(browse.children) == 1
     assert browse.children[0].domain == DOMAIN
     assert browse.children[0].identifier == f"{device.id}/{event_id}"
-    event_timestamp_string = event_timestamp.isoformat(timespec="seconds", sep=" ")
+    event_timestamp_string = event_timestamp.strftime(DATE_STR_FORMAT)
     assert browse.children[0].title == f"Person @ {event_timestamp_string}"
     assert not browse.children[0].can_expand
     assert len(browse.children[0].children) == 0
@@ -291,7 +292,7 @@ async def test_event_order(hass, auth):
     assert len(browse.children) == 2
     assert browse.children[0].domain == DOMAIN
     assert browse.children[0].identifier == f"{device.id}/{event_id2}"
-    event_timestamp_string = event_timestamp2.isoformat(timespec="seconds", sep=" ")
+    event_timestamp_string = event_timestamp2.strftime(DATE_STR_FORMAT)
     assert browse.children[0].title == f"Motion @ {event_timestamp_string}"
     assert not browse.children[0].can_expand
 
@@ -299,7 +300,7 @@ async def test_event_order(hass, auth):
     assert browse.children[1].domain == DOMAIN
 
     assert browse.children[1].identifier == f"{device.id}/{event_id1}"
-    event_timestamp_string = event_timestamp1.isoformat(timespec="seconds", sep=" ")
+    event_timestamp_string = event_timestamp1.strftime(DATE_STR_FORMAT)
     assert browse.children[1].title == f"Person @ {event_timestamp_string}"
     assert not browse.children[1].can_expand
 
@@ -435,7 +436,7 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
     assert len(browse.children) == 1
     assert browse.children[0].domain == DOMAIN
     actual_event_id = browse.children[0].identifier
-    event_timestamp_string = event_timestamp.isoformat(timespec="seconds", sep=" ")
+    event_timestamp_string = event_timestamp.strftime(DATE_STR_FORMAT)
     assert browse.children[0].title == f"Event @ {event_timestamp_string}"
     assert not browse.children[0].can_expand
     assert len(browse.children[0].children) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop subsecond text from the nest media source event timestamp display, using a common date/time
template string.

Before:

<img width="841" alt="Screen Shot 2021-12-04 at 3 42 40 PM" src="https://user-images.githubusercontent.com/6026418/144727986-66f5b8dd-6b74-42fc-80b3-f9412ee9db36.png">

After:

<img width="546" alt="Screen Shot 2021-12-04 at 3 43 03 PM" src="https://user-images.githubusercontent.com/6026418/144727988-c2a56322-1304-4249-85ca-ecc3064defd0.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
