### PR TITLE
Clean up state class and device class usage in ZHA

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -2,14 +2,7 @@
 import functools
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_GAS,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_MOVING,
-    DEVICE_CLASS_OCCUPANCY,
-    DEVICE_CLASS_OPENING,
-    DEVICE_CLASS_SMOKE,
-    DEVICE_CLASS_VIBRATION,
+    BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.const import STATE_ON, Platform
@@ -33,12 +26,12 @@ from .entity import ZhaEntity
 
 # Zigbee Cluster Library Zone Type to Home Assistant device class
 CLASS_MAPPING = {
-    0x000D: DEVICE_CLASS_MOTION,
-    0x0015: DEVICE_CLASS_OPENING,
-    0x0028: DEVICE_CLASS_SMOKE,
-    0x002A: DEVICE_CLASS_MOISTURE,
-    0x002B: DEVICE_CLASS_GAS,
-    0x002D: DEVICE_CLASS_VIBRATION,
+    0x000D: BinarySensorDeviceClass.MOTION,
+    0x0015: BinarySensorDeviceClass.OPENING,
+    0x0028: BinarySensorDeviceClass.SMOKE,
+    0x002A: BinarySensorDeviceClass.MOISTURE,
+    0x002B: BinarySensorDeviceClass.GAS,
+    0x002D: BinarySensorDeviceClass.VIBRATION,
 }
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.BINARY_SENSOR)
@@ -62,13 +55,11 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
     """ZHA BinarySensor."""
 
     SENSOR_ATTR = None
-    DEVICE_CLASS = None
 
     def __init__(self, unique_id, zha_device, channels, **kwargs):
         """Initialize the ZHA binary sensor."""
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel = channels[0]
-        self._device_class = self.DEVICE_CLASS
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
@@ -89,11 +80,6 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
         if self._state is None:
             return False
         return self._state
-
-    @property
-    def device_class(self) -> str:
-        """Return device class from component DEVICE_CLASSES."""
-        return self._device_class
 
     @callback
     def async_set_state(self, attr_id, attr_name, value):
@@ -117,7 +103,7 @@ class Accelerometer(BinarySensor):
     """ZHA BinarySensor."""
 
     SENSOR_ATTR = "acceleration"
-    DEVICE_CLASS = DEVICE_CLASS_MOVING
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.MOVING
 
 
 @STRICT_MATCH(channel_names=CHANNEL_OCCUPANCY)
@@ -125,7 +111,7 @@ class Occupancy(BinarySensor):
     """ZHA BinarySensor."""
 
     SENSOR_ATTR = "occupancy"
-    DEVICE_CLASS = DEVICE_CLASS_OCCUPANCY
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.OCCUPANCY
 
 
 @STRICT_MATCH(channel_names=CHANNEL_ON_OFF)
@@ -133,7 +119,7 @@ class Opening(BinarySensor):
     """ZHA BinarySensor."""
 
     SENSOR_ATTR = "on_off"
-    DEVICE_CLASS = DEVICE_CLASS_OPENING
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.OPENING
 
 
 @STRICT_MATCH(channel_names=CHANNEL_BINARY_INPUT)
@@ -159,7 +145,7 @@ class Motion(BinarySensor):
     """ZHA BinarySensor."""
 
     SENSOR_ATTR = "on_off"
-    DEVICE_CLASS = DEVICE_CLASS_MOTION
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.MOTION
 
 
 @STRICT_MATCH(channel_names=CHANNEL_ZONE)

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -10,8 +10,7 @@ from zigpy.zcl.foundation import Status
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
-    DEVICE_CLASS_DAMPER,
-    DEVICE_CLASS_SHADE,
+    CoverDeviceClass,
     CoverEntity,
 )
 from homeassistant.const import (
@@ -182,7 +181,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
 class Shade(ZhaEntity, CoverEntity):
     """ZHA Shade."""
 
-    _attr_device_class = DEVICE_CLASS_SHADE
+    _attr_device_class = CoverDeviceClass.SHADE
 
     def __init__(
         self,
@@ -291,7 +290,7 @@ class Shade(ZhaEntity, CoverEntity):
 class KeenVent(Shade):
     """Keen vent cover."""
 
-    _attr_device_class = DEVICE_CLASS_DAMPER
+    _attr_device_class = CoverDeviceClass.DAMPER
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -13,25 +13,15 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_OFF,
 )
 from homeassistant.components.sensor import (
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_CO,
-    DEVICE_CLASS_CO2,
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_TEMPERATURE,
-    STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING,
+    SensorDeviceClass,
     SensorEntity,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
-    DEVICE_CLASS_ENERGY,
     ELECTRIC_CURRENT_AMPERE,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
@@ -129,10 +119,8 @@ class Sensor(ZhaEntity, SensorEntity):
 
     SENSOR_ATTR: int | str | None = None
     _decimals: int = 1
-    _device_class: str | None = None
     _divisor: int = 1
     _multiplier: int = 1
-    _state_class: str | None = None
     _unit: str | None = None
 
     def __init__(
@@ -170,16 +158,6 @@ class Sensor(ZhaEntity, SensorEntity):
         self.async_accept_signal(
             self._channel, SIGNAL_ATTR_UPDATED, self.async_set_state
         )
-
-    @property
-    def device_class(self) -> str:
-        """Return device class from component DEVICE_CLASSES."""
-        return self._device_class
-
-    @property
-    def state_class(self) -> str | None:
-        """Return the state class of this entity, from STATE_CLASSES, if any."""
-        return self._state_class
 
     @property
     def native_unit_of_measurement(self) -> str | None:
@@ -226,8 +204,8 @@ class Battery(Sensor):
     """Battery sensor of power configuration cluster."""
 
     SENSOR_ATTR = "battery_percentage_remaining"
-    _device_class = DEVICE_CLASS_BATTERY
-    _state_class = STATE_CLASS_MEASUREMENT
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.BATTERY
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _unit = PERCENTAGE
     _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
@@ -277,8 +255,8 @@ class ElectricalMeasurement(Sensor):
     """Active power measurement."""
 
     SENSOR_ATTR = "active_power"
-    _device_class = DEVICE_CLASS_POWER
-    _state_class = STATE_CLASS_MEASUREMENT
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _unit = POWER_WATT
     _div_mul_prefix = "ac_power"
 
@@ -323,7 +301,7 @@ class ElectricalMeasurementApparentPower(
     """Apparent power measurement."""
 
     SENSOR_ATTR = "apparent_power"
-    _device_class = DEVICE_CLASS_POWER
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
     _unit = POWER_VOLT_AMPERE
     _div_mul_prefix = "ac_power"
 
@@ -338,7 +316,7 @@ class ElectricalMeasurementRMSCurrent(ElectricalMeasurement, id_suffix="rms_curr
     """RMS current measurement."""
 
     SENSOR_ATTR = "rms_current"
-    _device_class = DEVICE_CLASS_CURRENT
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.CURRENT
     _unit = ELECTRIC_CURRENT_AMPERE
     _div_mul_prefix = "ac_current"
 
@@ -353,7 +331,7 @@ class ElectricalMeasurementRMSVoltage(ElectricalMeasurement, id_suffix="rms_volt
     """RMS Voltage measurement."""
 
     SENSOR_ATTR = "rms_voltage"
-    _device_class = DEVICE_CLASS_CURRENT
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.CURRENT
     _unit = ELECTRIC_POTENTIAL_VOLT
     _div_mul_prefix = "ac_voltage"
 
@@ -369,9 +347,9 @@ class Humidity(Sensor):
     """Humidity sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_HUMIDITY
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.HUMIDITY
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _divisor = 100
-    _state_class = STATE_CLASS_MEASUREMENT
     _unit = PERCENTAGE
 
 
@@ -380,9 +358,9 @@ class SoilMoisture(Sensor):
     """Soil Moisture sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_HUMIDITY
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.HUMIDITY
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _divisor = 100
-    _state_class = STATE_CLASS_MEASUREMENT
     _unit = PERCENTAGE
 
 
@@ -391,9 +369,9 @@ class LeafWetness(Sensor):
     """Leaf Wetness sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_HUMIDITY
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.HUMIDITY
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _divisor = 100
-    _state_class = STATE_CLASS_MEASUREMENT
     _unit = PERCENTAGE
 
 
@@ -402,7 +380,7 @@ class Illuminance(Sensor):
     """Illuminance Sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_ILLUMINANCE
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.ILLUMINANCE
     _unit = LIGHT_LUX
 
     @staticmethod
@@ -416,8 +394,8 @@ class SmartEnergyMetering(Sensor):
     """Metering sensor."""
 
     SENSOR_ATTR: int | str = "instantaneous_demand"
-    _device_class: str | None = DEVICE_CLASS_POWER
-    _state_class: str | None = STATE_CLASS_MEASUREMENT
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     unit_of_measure_map = {
         0x00: POWER_WATT,
@@ -460,8 +438,8 @@ class SmartEnergySummation(SmartEnergyMetering, id_suffix="summation_delivered")
     """Smart Energy Metering summation sensor."""
 
     SENSOR_ATTR: int | str = "current_summ_delivered"
-    _device_class: str | None = DEVICE_CLASS_ENERGY
-    _state_class: str = STATE_CLASS_TOTAL_INCREASING
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.ENERGY
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
 
     unit_of_measure_map = {
         0x00: ENERGY_KILO_WATT_HOUR,
@@ -493,9 +471,9 @@ class Pressure(Sensor):
     """Pressure sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_PRESSURE
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.PRESSURE
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _decimals = 0
-    _state_class = STATE_CLASS_MEASUREMENT
     _unit = PRESSURE_HPA
 
 
@@ -504,9 +482,9 @@ class Temperature(Sensor):
     """Temperature Sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_TEMPERATURE
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.TEMPERATURE
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _divisor = 100
-    _state_class = STATE_CLASS_MEASUREMENT
     _unit = TEMP_CELSIUS
 
 
@@ -515,7 +493,8 @@ class CarbonDioxideConcentration(Sensor):
     """Carbon Dioxide Concentration sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_CO2
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.CO2
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _decimals = 0
     _multiplier = 1e6
     _unit = CONCENTRATION_PARTS_PER_MILLION
@@ -526,7 +505,8 @@ class CarbonMonoxideConcentration(Sensor):
     """Carbon Monoxide Concentration sensor."""
 
     SENSOR_ATTR = "measured_value"
-    _device_class = DEVICE_CLASS_CO
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.CO
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _decimals = 0
     _multiplier = 1e6
     _unit = CONCENTRATION_PARTS_PER_MILLION
@@ -538,6 +518,8 @@ class VOCLevel(Sensor):
     """VOC Level sensor."""
 
     SENSOR_ATTR = "measured_value"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _decimals = 0
     _multiplier = 1e6
     _unit = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
@@ -548,6 +530,8 @@ class PPBVOCLevel(Sensor):
     """VOC Level sensor."""
 
     SENSOR_ATTR = "measured_value"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _decimals = 0
     _multiplier = 1
     _unit = CONCENTRATION_PARTS_PER_BILLION
@@ -558,6 +542,7 @@ class FormaldehydeConcentration(Sensor):
     """Formaldehyde Concentration sensor."""
 
     SENSOR_ATTR = "measured_value"
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _decimals = 0
     _multiplier = 1e6
     _unit = CONCENTRATION_PARTS_PER_MILLION

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -301,7 +301,6 @@ class ElectricalMeasurementApparentPower(
     """Apparent power measurement."""
 
     SENSOR_ATTR = "apparent_power"
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
     _unit = POWER_VOLT_AMPERE
     _div_mul_prefix = "ac_power"
 
@@ -381,6 +380,7 @@ class Illuminance(Sensor):
 
     SENSOR_ATTR = "measured_value"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.ILLUMINANCE
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _unit = LIGHT_LUX
 
     @staticmethod

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     ELECTRIC_CURRENT_AMPERE,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
-    ENTITY_CATEGORY_DIAGNOSTIC,
     LIGHT_LUX,
     PERCENTAGE,
     POWER_VOLT_AMPERE,
@@ -44,6 +43,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -207,7 +207,7 @@ class Battery(Sensor):
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.BATTERY
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _unit = PERCENTAGE
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @classmethod
     def create_entity(

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -8,6 +8,7 @@ import zigpy.zcl.clusters.homeautomation as homeautomation
 import zigpy.zcl.clusters.measurement as measurement
 import zigpy.zcl.clusters.smartenergy as smartenergy
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.zha.core.const import ZHA_CHANNEL_READS_PER_REQ
 import homeassistant.config as config_util
 from homeassistant.const import (
@@ -16,7 +17,6 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM,
     CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM_METRIC,
-    DEVICE_CLASS_ENERGY,
     ELECTRIC_CURRENT_AMPERE,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
@@ -149,7 +149,8 @@ async def async_test_smart_energy_summation(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["status"] == "NO_ALARMS"
     assert hass.states.get(entity_id).attributes["device_type"] == "Electric Metering"
     assert (
-        hass.states.get(entity_id).attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
+        hass.states.get(entity_id).attributes[ATTR_DEVICE_CLASS]
+        == SensorDeviceClass.ENERGY
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR cleans up sensor class and device class in ZHA and leverages the new enums.

~~**NEEDS REBASE after merging: #61016**~~

~~**I am going to leave this in draft until after the beta so that we can avoid conflicts if something needs to be patched**~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
