### PR TITLE
Add timeout support to tradfri

### DIFF
--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any
 
-from pytradfri import Gateway, PytradfriError, RequestError
+from pytradfri import Gateway, PytradfriError
 from pytradfri.api.aiocoap_api import APIFactory
 from pytradfri.command import Command
 from pytradfri.device import Device
@@ -206,15 +206,17 @@ async def async_setup_entry(
 
         gw_status = True
         try:
-            await api(gateway.get_gateway_info())
-        except RequestError:
+            await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
+        except PytradfriError:
             _LOGGER.error("Keep-alive failed")
             gw_status = False
 
         async_dispatcher_send(hass, SIGNAL_GW, gw_status)
 
     listeners.append(
-        async_track_time_interval(hass, async_keep_alive, timedelta(seconds=60))
+        async_track_time_interval(
+            hass, async_keep_alive, timedelta(seconds=2 * TIMEOUT_API)
+        )
     )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_KEY,
     DOMAIN,
     KEY_SECURITY_CODE,
+    TIMEOUT_API,
 )
 
 
@@ -202,7 +203,7 @@ async def get_gateway_info(
 
         api = factory.request
         gateway = Gateway()
-        gateway_info_result = await api(gateway.get_gateway_info())
+        gateway_info_result = await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
 
         await factory.shutdown()
     except (OSError, RequestError) as err:

--- a/homeassistant/components/tradfri/const.py
+++ b/homeassistant/components/tradfri/const.py
@@ -2,10 +2,7 @@
 from typing import Final
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_TRANSITION
-from homeassistant.const import (  # noqa: F401 pylint: disable=unused-import
-    CONF_HOST,
-    Platform,
-)
+from homeassistant.const import CONF_HOST  # noqa: F401 pylint: disable=unused-import
 
 ATTR_AUTO = "Auto"
 ATTR_DIMMER = "dimmer"
@@ -30,13 +27,7 @@ SIGNAL_GW = "tradfri.gw_status"
 KEY_SECURITY_CODE = "security_code"
 SUPPORTED_GROUP_FEATURES = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 SUPPORTED_LIGHT_FEATURES = SUPPORT_TRANSITION
-PLATFORMS = [
-    Platform.COVER,
-    Platform.FAN,
-    Platform.LIGHT,
-    Platform.SENSOR,
-    Platform.SWITCH,
-]
+PLATFORMS = ["cover", "fan", "light", "sensor", "switch"]
 TIMEOUT_API = 30
 ATTR_MAX_FAN_STEPS = 49
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is the combination of a couple of old PR´s. It adds timeout control to the gateway communication and secures in many (but not all cases) an automatic restart of the communication.

This is still needed with the coap lib.

For those not willing to wait for this PR to get merged (if it  gets merged), a Custom Component with the same content is available at:

https://github.com/janiversen/custom_components/releases/tag/0.3

this is ready to be copied into config/custom_components and reuse the existing configuration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I was asked to re-submit these changes, so it is hereby done.

- This PR fixes or closes issue: fixes #
fixes #59708
fixes #59392
fixes #56141
fixes #56439
fixes #56141 
fixes #40612 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
