### PR TITLE
Fix regression in nest event media player with multiple devices

### DIFF
--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["ffmpeg", "http", "media_source"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
-  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.4.2"],
+  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.4.3"],
   "codeowners": ["@allenporter"],
   "quality_scale": "platinum",
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.4.2
+google-nest-sdm==0.4.3
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -461,7 +461,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.4.2
+google-nest-sdm==0.4.3
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .common import FakeDeviceManager, FakeSubscriber, MockConfigEntry
+from .common import FakeSubscriber, MockConfigEntry
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -43,15 +43,9 @@ APP_REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob"
 
 
 @pytest.fixture
-def device_manager() -> FakeDeviceManager:
-    """Create FakeDeviceManager."""
-    return FakeDeviceManager(devices={}, structures={})
-
-
-@pytest.fixture
-def subscriber(device_manager: FakeDeviceManager) -> FakeSubscriber:
+def subscriber() -> FakeSubscriber:
     """Create FakeSubscriber."""
-    return FakeSubscriber(device_manager)
+    return FakeSubscriber()
 
 
 def get_config_entry(hass):

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -81,7 +81,7 @@ async def async_setup_devices(hass, auth, device_type, traits={}, events=[]):
     return subscriber
 
 
-def create_event(event_id, event_type, timestamp=None):
+def create_event(event_id, event_type, timestamp=None, device_id=None):
     """Create an EventMessage for a single event type."""
     if not timestamp:
         timestamp = dt_util.now()
@@ -91,17 +91,19 @@ def create_event(event_id, event_type, timestamp=None):
             "eventId": event_id,
         },
     }
-    return create_event_message(event_id, event_data, timestamp)
+    return create_event_message(event_id, event_data, timestamp, device_id=device_id)
 
 
-def create_event_message(event_id, event_data, timestamp):
+def create_event_message(event_id, event_data, timestamp, device_id=None):
     """Create an EventMessage for a single event type."""
+    if device_id is None:
+        device_id = DEVICE_ID
     return EventMessage(
         {
             "eventId": f"{event_id}-{timestamp}",
             "timestamp": timestamp.isoformat(timespec="seconds"),
             "resourceUpdate": {
-                "name": DEVICE_ID,
+                "name": device_id,
                 "events": event_data,
             },
         },
@@ -568,3 +570,75 @@ async def test_media_permission_unauthorized(hass, auth, hass_client, hass_admin
     assert response.status == HTTPStatus.UNAUTHORIZED, (
         "Response not matched: %s" % response
     )
+
+
+async def test_multiple_devices(hass, auth, hass_client):
+    """Test events received for multiple devices."""
+    device_id1 = f"{DEVICE_ID}-1"
+    device_id2 = f"{DEVICE_ID}-2"
+
+    devices = {
+        device_id1: Device.MakeDevice(
+            {
+                "name": device_id1,
+                "type": CAMERA_DEVICE_TYPE,
+                "traits": CAMERA_TRAITS,
+            },
+            auth=auth,
+        ),
+        device_id2: Device.MakeDevice(
+            {
+                "name": device_id2,
+                "type": CAMERA_DEVICE_TYPE,
+                "traits": CAMERA_TRAITS,
+            },
+            auth=auth,
+        ),
+    }
+    subscriber = await async_setup_sdm_platform(hass, PLATFORM, devices=devices)
+
+    device_registry = dr.async_get(hass)
+    device1 = device_registry.async_get_device({(DOMAIN, device_id1)})
+    assert device1
+    device2 = device_registry.async_get_device({(DOMAIN, device_id2)})
+    assert device2
+
+    # Very no events have been received yet
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device1.id}"
+    )
+    assert len(browse.children) == 0
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device2.id}"
+    )
+    assert len(browse.children) == 0
+
+    # Send events for device #1
+    for i in range(0, 5):
+        await subscriber.async_receive_event(
+            create_event(f"event-id-{i}", PERSON_EVENT, device_id=device_id1)
+        )
+
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device1.id}"
+    )
+    assert len(browse.children) == 5
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device2.id}"
+    )
+    assert len(browse.children) == 0
+
+    # Send events for device #2
+    for i in range(0, 3):
+        await subscriber.async_receive_event(
+            create_event(f"other-id-{i}", PERSON_EVENT, device_id=device_id2)
+        )
+
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device1.id}"
+    )
+    assert len(browse.children) == 5
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device2.id}"
+    )
+    assert len(browse.children) == 3


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix a bug where events were associated with multiple devices, rendering
incorrectly in the media player UI. Changes are:

- Bump google-nest-sdm to 0.4.3 which includes a fix. See [changelog](https://github.com/allenporter/python-google-nest-sdm/compare/0.4.2...0.4.3)
- Simplify test setup by using a real DeviceManager implementation rather than a fake, which ensures the shared event store is wired up how it is in production
- Add a test that explicitly exercises the media source using events with multiple deviecs. The test fails on 0.4.2 and passes on 0.4.3

Future follow up PRs will reduce test boiler plate and increase coverage for
event fetch cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
