### PR TITLE
Add zones support to flux_led

### DIFF
--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -62,6 +62,7 @@ TRANSITION_STROBE: Final = "strobe"
 CONF_COLORS: Final = "colors"
 CONF_SPEED_PCT: Final = "speed_pct"
 CONF_TRANSITION: Final = "transition"
+CONF_EFFECT: Final = "effect"
 
 
 EFFECT_SPEED_SUPPORT_MODES: Final = {COLOR_MODE_RGB, COLOR_MODE_RGBW, COLOR_MODE_RGBWW}

--- a/homeassistant/components/flux_led/services.yaml
+++ b/homeassistant/components/flux_led/services.yaml
@@ -36,3 +36,44 @@ set_custom_effect:
             - "gradual"
             - "jump"
             - "strobe"
+set_zones:
+  description: Set strip zones for Addressable v3 controllers (0xA3).
+  target:
+    entity:
+      integration: flux_led
+      domain: light
+  fields:
+    colors:
+      description: List of colors for each zone (RGB). The length of each zone is the number of pixels per segment divided by the number of colors. (Max 2048 Colors)
+      example: |
+        - [255,0,0]
+        - [0,255,0]
+        - [0,0,255]
+        - [255,255,255]
+      required: true
+      selector:
+        object:
+    speed_pct:
+      description: Effect speed for the custom effect (0-100)
+      example: 80
+      default: 50
+      required: false
+      selector:
+        number:
+          min: 1
+          step: 1
+          max: 100
+          unit_of_measurement: "%"
+    effect:
+      description: Effect
+      example: 'running_water'
+      default: 'static'
+      required: false
+      selector:
+        select:
+          options:
+            - "static"
+            - "running_water"
+            - "strobe"
+            - "jump"
+            - "breathing"

--- a/homeassistant/components/flux_led/util.py
+++ b/homeassistant/components/flux_led/util.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from flux_led.aio import AIOWifiLedBulb
-from flux_led.const import COLOR_MODE_DIM as FLUX_COLOR_MODE_DIM
+from flux_led.const import COLOR_MODE_DIM as FLUX_COLOR_MODE_DIM, MultiColorEffects
 
 from homeassistant.components.light import (
     COLOR_MODE_BRIGHTNESS,
@@ -34,3 +34,12 @@ def _flux_color_mode_to_hass(
 def _effect_brightness(brightness: int) -> int:
     """Convert hass brightness to effect brightness."""
     return round(brightness / 255 * 100)
+
+
+def _str_to_multi_color_effect(effect_str: str) -> MultiColorEffects:
+    """Convert an multicolor effect string to MultiColorEffects."""
+    for effect in MultiColorEffects:
+        if effect.name.lower() == effect_str:
+            return effect
+    # unreachable due to schema validation
+    assert False  # pragma: no cover

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -10,6 +10,7 @@ from flux_led.const import (
     COLOR_MODE_RGBW as FLUX_COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW as FLUX_COLOR_MODE_RGBWW,
     COLOR_MODES_RGB_W as FLUX_COLOR_MODES_RGB_W,
+    MultiColorEffects,
 )
 import pytest
 
@@ -19,6 +20,7 @@ from homeassistant.components.flux_led.const import (
     CONF_CUSTOM_EFFECT_COLORS,
     CONF_CUSTOM_EFFECT_SPEED_PCT,
     CONF_CUSTOM_EFFECT_TRANSITION,
+    CONF_EFFECT,
     CONF_SPEED_PCT,
     CONF_TRANSITION,
     DOMAIN,
@@ -1118,6 +1120,36 @@ async def test_rgb_light_custom_effect_via_service(
         [(0, 0, 255), (255, 0, 0)], 30, "jump"
     )
     bulb.async_set_custom_pattern.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_zones",
+        {
+            ATTR_ENTITY_ID: entity_id,
+            CONF_COLORS: [[0, 0, 255], [255, 0, 0]],
+            CONF_EFFECT: "running_water",
+        },
+        blocking=True,
+    )
+    bulb.async_set_zones.assert_called_with(
+        [(0, 0, 255), (255, 0, 0)], 50, MultiColorEffects.RUNNING_WATER
+    )
+    bulb.async_set_zones.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_zones",
+        {
+            ATTR_ENTITY_ID: entity_id,
+            CONF_COLORS: [[0, 0, 255], [255, 0, 0]],
+            CONF_SPEED_PCT: 30,
+        },
+        blocking=True,
+    )
+    bulb.async_set_zones.assert_called_with(
+        [(0, 0, 255), (255, 0, 0)], 30, MultiColorEffects.STATIC
+    )
+    bulb.async_set_zones.reset_mock()
 
 
 async def test_addressable_light(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add zones support to flux_led

The Addressable v3 (0xA3) models allow setting a color effect per zone. The length of each zone is the number of pixels per segment divided by the number of colors.

| Service data attribute | Description |
| ---------------------- | ----------- |
| `entity_id` | The entity_id of the LED light to set the effect on. |
| `colors` | List of colors for each zone (RGB). (Max 2048 Colors) |
| `speed_pct` | The speed of the effect in % (0-100. Default 50) |
| `effect` | The effect you would like. Valid options are `static`, `running_water`, `strobe`, `jump`, or `breathing`. (Default `static`) |


Example
```
service: flux_led.set_zones
target:
  entity_id:
    - light.addressable_v3_8e2f7f
    - light.addressable_v3_8ebdeb
data:
  colors:
    - - 255
      - 0
      - 0
    - - 0
      - 255
      - 0
    - - 0
      - 0
      - 255
    - - 255
      - 255
      - 255
  speed_pct: 80
  effect: running_water
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20584

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
