### PR TITLE
Deprecate `system_id` parameter in SimpliSafe service calls

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -145,57 +145,86 @@ SERVICES = (
     SERVICE_NAME_SET_SYSTEM_PROPERTIES,
 )
 
-
-SERVICE_REMOVE_PIN_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Required(ATTR_PIN_LABEL_OR_VALUE): cv.string,
-    }
+SERVICE_CLEAR_NOTIFICATIONS_SCHEMA = vol.All(
+    cv.deprecated(ATTR_SYSTEM_ID),
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_SYSTEM_ID): cv.string,
+        }
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_SYSTEM_ID),
 )
 
-SERVICE_SET_PIN_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Required(ATTR_PIN_LABEL): cv.string,
-        vol.Required(ATTR_PIN_VALUE): cv.string,
-    }
+SERVICE_REMOVE_PIN_SCHEMA = vol.All(
+    cv.deprecated(ATTR_SYSTEM_ID),
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_SYSTEM_ID): cv.string,
+            vol.Required(ATTR_PIN_LABEL_OR_VALUE): cv.string,
+        }
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_SYSTEM_ID),
 )
 
-SERVICE_SET_SYSTEM_PROPERTIES_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Optional(ATTR_ALARM_DURATION): vol.All(
-            cv.time_period,
-            lambda value: value.total_seconds(),
-            vol.Range(min=MIN_ALARM_DURATION, max=MAX_ALARM_DURATION),
-        ),
-        vol.Optional(ATTR_ALARM_VOLUME): vol.All(vol.In(VOLUME_MAP), VOLUME_MAP.get),
-        vol.Optional(ATTR_CHIME_VOLUME): vol.All(vol.In(VOLUME_MAP), VOLUME_MAP.get),
-        vol.Optional(ATTR_ENTRY_DELAY_AWAY): vol.All(
-            cv.time_period,
-            lambda value: value.total_seconds(),
-            vol.Range(min=MIN_ENTRY_DELAY_AWAY, max=MAX_ENTRY_DELAY_AWAY),
-        ),
-        vol.Optional(ATTR_ENTRY_DELAY_HOME): vol.All(
-            cv.time_period,
-            lambda value: value.total_seconds(),
-            vol.Range(max=MAX_ENTRY_DELAY_HOME),
-        ),
-        vol.Optional(ATTR_EXIT_DELAY_AWAY): vol.All(
-            cv.time_period,
-            lambda value: value.total_seconds(),
-            vol.Range(min=MIN_EXIT_DELAY_AWAY, max=MAX_EXIT_DELAY_AWAY),
-        ),
-        vol.Optional(ATTR_EXIT_DELAY_HOME): vol.All(
-            cv.time_period,
-            lambda value: value.total_seconds(),
-            vol.Range(max=MAX_EXIT_DELAY_HOME),
-        ),
-        vol.Optional(ATTR_LIGHT): cv.boolean,
-        vol.Optional(ATTR_VOICE_PROMPT_VOLUME): vol.All(
-            vol.In(VOLUME_MAP), VOLUME_MAP.get
-        ),
-    }
+SERVICE_SET_PIN_SCHEMA = vol.All(
+    cv.deprecated(ATTR_SYSTEM_ID),
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_SYSTEM_ID): cv.string,
+            vol.Required(ATTR_PIN_LABEL): cv.string,
+            vol.Required(ATTR_PIN_VALUE): cv.string,
+        },
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_SYSTEM_ID),
+)
+
+SERVICE_SET_SYSTEM_PROPERTIES_SCHEMA = vol.All(
+    cv.deprecated(ATTR_SYSTEM_ID),
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_SYSTEM_ID): cv.string,
+            vol.Optional(ATTR_ALARM_DURATION): vol.All(
+                cv.time_period,
+                lambda value: value.total_seconds(),
+                vol.Range(min=MIN_ALARM_DURATION, max=MAX_ALARM_DURATION),
+            ),
+            vol.Optional(ATTR_ALARM_VOLUME): vol.All(
+                vol.In(VOLUME_MAP), VOLUME_MAP.get
+            ),
+            vol.Optional(ATTR_CHIME_VOLUME): vol.All(
+                vol.In(VOLUME_MAP), VOLUME_MAP.get
+            ),
+            vol.Optional(ATTR_ENTRY_DELAY_AWAY): vol.All(
+                cv.time_period,
+                lambda value: value.total_seconds(),
+                vol.Range(min=MIN_ENTRY_DELAY_AWAY, max=MAX_ENTRY_DELAY_AWAY),
+            ),
+            vol.Optional(ATTR_ENTRY_DELAY_HOME): vol.All(
+                cv.time_period,
+                lambda value: value.total_seconds(),
+                vol.Range(max=MAX_ENTRY_DELAY_HOME),
+            ),
+            vol.Optional(ATTR_EXIT_DELAY_AWAY): vol.All(
+                cv.time_period,
+                lambda value: value.total_seconds(),
+                vol.Range(min=MIN_EXIT_DELAY_AWAY, max=MAX_EXIT_DELAY_AWAY),
+            ),
+            vol.Optional(ATTR_EXIT_DELAY_HOME): vol.All(
+                cv.time_period,
+                lambda value: value.total_seconds(),
+                vol.Range(max=MAX_EXIT_DELAY_HOME),
+            ),
+            vol.Optional(ATTR_LIGHT): cv.boolean,
+            vol.Optional(ATTR_VOICE_PROMPT_VOLUME): vol.All(
+                vol.In(VOLUME_MAP), VOLUME_MAP.get
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_SYSTEM_ID),
 )
 
 WEBSOCKET_EVENTS_REQUIRING_SERIAL = [EVENT_LOCK_LOCKED, EVENT_LOCK_UNLOCKED]
@@ -217,6 +246,15 @@ def _async_get_system_for_service_call(
     hass: HomeAssistant, call: ServiceCall
 ) -> SystemType:
     """Get the SimpliSafe system related to a service call (by device ID)."""
+    if ATTR_SYSTEM_ID in call.data:
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            simplisafe = hass.data[DOMAIN][entry.entry_id]
+            if (
+                system := simplisafe.systems.get(int(call.data[ATTR_SYSTEM_ID]))
+            ) is None:
+                continue
+            return cast(SystemType, system)
+
     device_id = call.data[ATTR_DEVICE_ID]
     device_registry = dr.async_get(hass)
 
@@ -366,7 +404,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     for service, method, schema in (
-        (SERVICE_NAME_CLEAR_NOTIFICATIONS, async_clear_notifications, None),
+        (
+            SERVICE_NAME_CLEAR_NOTIFICATIONS,
+            async_clear_notifications,
+            SERVICE_CLEAR_NOTIFICATIONS_SCHEMA,
+        ),
         (SERVICE_NAME_REMOVE_PIN, async_remove_pin, SERVICE_REMOVE_PIN_SCHEMA),
         (SERVICE_NAME_SET_PIN, async_set_pin, SERVICE_SET_PIN_SCHEMA),
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/58722, this PR re-adds support for the "old" schema for SimpliSafe service calls (in which systems were specified by a `system_id` parameter). This will ease the transition for users to the new service schema.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
