### PR TITLE
Coalesce nest media source preview clips by session and bump google-nest-sdm

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -198,7 +198,7 @@ class SignalUpdateCallback:
                 "device_id": device_entry.id,
                 "type": event_type,
                 "timestamp": event_message.timestamp,
-                "nest_event_id": image_event.event_id,
+                "nest_event_id": image_event.event_session_id,
             }
             self._hass.bus.async_fire(NEST_EVENT, message)
 

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["ffmpeg", "http", "media_source"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
-  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.4.3"],
+  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.4.4"],
   "codeowners": ["@allenporter"],
   "quality_scale": "platinum",
   "dhcp": [

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -181,7 +181,7 @@ class NestMediaSource(MediaSource):
             browse_device.children = []
             events = await _get_events(device)
             for child_event in events.values():
-                event_id = MediaId(media_id.device_id, child_event.event_id)
+                event_id = MediaId(media_id.device_id, child_event.event_session_id)
                 browse_device.children.append(
                     _browse_event(event_id, device, child_event)
                 )
@@ -203,7 +203,7 @@ class NestMediaSource(MediaSource):
 async def _get_events(device: Device) -> Mapping[str, ImageEventBase]:
     """Return relevant events for the specified device."""
     events = await device.event_media_manager.async_events()
-    return {e.event_id: e for e in events}
+    return {e.event_session_id: e for e in events}
 
 
 def _browse_root() -> BrowseMediaSource:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.4.3
+google-nest-sdm==0.4.4
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -464,7 +464,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.4.3
+google-nest-sdm==0.4.4
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -117,7 +117,7 @@ async def test_doorbell_chime_event(hass):
         "device_id": entry.device_id,
         "type": "doorbell_chime",
         "timestamp": event_time,
-        "nest_event_id": EVENT_ID,
+        "nest_event_id": EVENT_SESSION_ID,
     }
 
 
@@ -145,7 +145,7 @@ async def test_camera_motion_event(hass):
         "device_id": entry.device_id,
         "type": "camera_motion",
         "timestamp": event_time,
-        "nest_event_id": EVENT_ID,
+        "nest_event_id": EVENT_SESSION_ID,
     }
 
 
@@ -173,7 +173,7 @@ async def test_camera_sound_event(hass):
         "device_id": entry.device_id,
         "type": "camera_sound",
         "timestamp": event_time,
-        "nest_event_id": EVENT_ID,
+        "nest_event_id": EVENT_SESSION_ID,
     }
 
 
@@ -201,7 +201,7 @@ async def test_camera_person_event(hass):
         "device_id": entry.device_id,
         "type": "camera_person",
         "timestamp": event_time,
-        "nest_event_id": EVENT_ID,
+        "nest_event_id": EVENT_SESSION_ID,
     }
 
 
@@ -238,13 +238,13 @@ async def test_camera_multiple_event(hass):
         "device_id": entry.device_id,
         "type": "camera_motion",
         "timestamp": event_time,
-        "nest_event_id": EVENT_ID,
+        "nest_event_id": EVENT_SESSION_ID,
     }
     assert events[1].data == {
         "device_id": entry.device_id,
         "type": "camera_person",
         "timestamp": event_time,
-        "nest_event_id": EVENT_ID,
+        "nest_event_id": EVENT_SESSION_ID,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite events to use the event session id so that related events
are grouped together when fetching media. This fixes the association
between the events and the clip so that event media is fetched correctly (it was sometimes trying to fetch images instead).  The  home assistant events are now published with the session id as the `nest_event_id`, and all the APIs  (e.g. media download api paths) work using that id.

The test `test_camera_event_clip_preview` now exercises an event message with multiple events for the same session, published similar to how some events look in practice, to exercise this case.

The python library contains other event fixes for expiration, and a breaking change to also fetch media by the session id as well, so everything is updated in lockstep.

https://github.com/allenporter/python-google-nest-sdm/compare/0.4.3...0.4.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
