### PR TITLE
Support publishing MQTT messages with raw bytes payloads

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -251,6 +251,36 @@ MQTT_PUBLISH_SCHEMA = vol.All(
 SubscribePayloadType = Union[str, bytes]  # Only bytes if encoding is None
 
 
+class MqttCommandTemplate:
+    """Class for rendering MQTT payload with command templates."""
+
+    def __init__(
+        self,
+        command_template: template.Template,
+        hass: HomeAssistant | None = None,
+        variables: template.TemplateVarsType = None,
+    ) -> None:
+        """Instantiate a command template."""
+        if hass is not None:
+            command_template.hass = hass
+        self.template = command_template
+        self.variables = variables
+
+    @callback
+    def async_render(
+        self, value: PublishPayloadType, variables: template.TemplateVarsType = None
+    ) -> PublishPayloadType:
+        """Render the command template with given value or variables."""
+        values = {"value": value}
+        if self.variables is not None:
+            values.update(self.variables)
+        if variables is not None:
+            values.update(variables)
+        return render_outgoing_payload(
+            self.template.async_render(values, parse_result=False)
+        )
+
+
 @dataclass
 class MqttServiceInfo(BaseServiceInfo):
     """Prepared info from mqtt entries."""

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -297,10 +297,12 @@ def publish(hass: HomeAssistant, topic, payload, qos=0, retain=False) -> None:
 
 
 def prepare_publish_payload(payload: PublishPayloadType) -> str | bytes:
-    """Ensure correct payload type for publishing."""
+    """Ensure correct MQTT payload type for publishing."""
+    # pass-through for bytes type object
     if isinstance(payload, bytes):
         return payload
 
+    # cast bytes literal string to bytes type object
     if isinstance(payload, str):
         try:
             native_object = literal_eval(payload)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -296,8 +296,8 @@ def publish(hass: HomeAssistant, topic, payload, qos=0, retain=False) -> None:
     hass.add_job(async_publish, hass, topic, payload, qos, retain)
 
 
-def prepare_publish_payload(payload: PublishPayloadType) -> str | bytes:
-    """Ensure correct MQTT payload type for publishing."""
+def render_outgoing_payload(payload: PublishPayloadType) -> PublishPayloadType:
+    """Ensure correct raw MQTT payload is passed as bytes for publishing."""
     # pass-through for bytes type object
     if isinstance(payload, bytes):
         return payload
@@ -313,7 +313,7 @@ def prepare_publish_payload(payload: PublishPayloadType) -> str | bytes:
             pass
         return payload
 
-    return str(payload)
+    return payload
 
 
 async def async_publish(
@@ -321,7 +321,7 @@ async def async_publish(
 ) -> None:
     """Publish message to an MQTT topic."""
     await hass.data[DATA_MQTT].async_publish(
-        topic, prepare_publish_payload(payload), qos, retain
+        topic, str(payload) if not isinstance(payload, bytes) else payload, qos, retain
     )
 
 
@@ -564,7 +564,7 @@ async def async_setup_entry(hass, entry):
                 return
 
         await hass.data[DATA_MQTT].async_publish(
-            msg_topic, prepare_publish_payload(payload), qos, retain
+            msg_topic, render_outgoing_payload(payload), qos, retain
         )
 
     hass.services.async_register(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -257,7 +257,7 @@ class MqttCommandTemplate:
     def __init__(
         self,
         command_template: template.Template | None,
-        hass: HomeAssistant | None = None,
+        hass: HomeAssistant,
         variables: template.TemplateVarsType = None,
     ) -> None:
         """Instantiate a command template."""
@@ -265,8 +265,7 @@ class MqttCommandTemplate:
         if command_template is None:
             return
 
-        if hass is not None:
-            command_template.hass = hass
+        command_template.hass = hass
         self.variables = variables
 
     @callback
@@ -589,7 +588,7 @@ async def async_setup_entry(hass, entry):
         if payload_template is not None:
             try:
                 payload = MqttCommandTemplate(
-                    template.Template(payload_template, hass)
+                    template.Template(payload_template), hass
                 ).async_render()
             except (template.jinja2.TemplateError, TemplateError) as exc:
                 _LOGGER.error(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -278,10 +278,6 @@ class MqttCommandTemplate:
             payload: PublishPayloadType,
         ) -> PublishPayloadType:
             """Ensure correct raw MQTT payload is passed as bytes for publishing."""
-            # pass-through for bytes type object
-            if isinstance(payload, bytes):
-                return payload
-
             # cast bytes literal string to bytes type object
             if isinstance(payload, str):
                 try:
@@ -291,7 +287,6 @@ class MqttCommandTemplate:
 
                 except (ValueError, TypeError, SyntaxError, MemoryError):
                     pass
-                return payload
 
             return payload
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -278,7 +278,6 @@ class MqttCommandTemplate:
             payload: PublishPayloadType,
         ) -> PublishPayloadType:
             """Ensure correct raw MQTT payload is passed as bytes for publishing."""
-            # cast bytes literal string to bytes type object
             if isinstance(payload, str):
                 try:
                     native_object = literal_eval(payload)

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -34,7 +34,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, render_outgoing_payload, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -312,7 +312,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
         await mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],
-            payload,
+            render_outgoing_payload(payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -152,7 +152,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
             value_template.hass = self.hass
         self.command_template = MqttCommandTemplate(
             self._config[CONF_COMMAND_TEMPLATE], self.hass
-        )
+        ).async_render
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -308,7 +308,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
     async def _publish(self, code, action):
         """Publish via mqtt."""
         variables = {"action": action, "code": code}
-        payload = self.command_template.async_render(None, variables=variables)
+        payload = self.command_template(None, variables=variables)
         await mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -150,7 +150,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
         value_template = self._config.get(CONF_VALUE_TEMPLATE)
         if value_template is not None:
             value_template.hass = self.hass
-        self.command_template = MqttCommandTemplate(
+        self._command_template = MqttCommandTemplate(
             self._config[CONF_COMMAND_TEMPLATE], self.hass
         ).async_render
 
@@ -308,7 +308,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
     async def _publish(self, code, action):
         """Publish via mqtt."""
         variables = {"action": action, "code": code}
-        payload = self.command_template(None, variables=variables)
+        payload = self._command_template(None, variables=variables)
         await mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -52,7 +52,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
-from . import MQTT_BASE_PLATFORM_SCHEMA, PLATFORMS, subscription
+from . import (
+    MQTT_BASE_PLATFORM_SCHEMA,
+    PLATFORMS,
+    render_outgoing_payload,
+    subscription,
+)
 from .. import mqtt
 from .const import CONF_QOS, CONF_RETAIN, DOMAIN
 from .debug_info import log_messages
@@ -690,7 +695,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
                 or self._current_operation != HVAC_MODE_OFF
             ):
                 payload = self._command_templates[cmnd_template](temp)
-                await self._publish(cmnd_topic, payload)
+                await self._publish(cmnd_topic, render_outgoing_payload(payload))
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
@@ -731,7 +736,9 @@ class MqttClimate(MqttEntity, ClimateEntity):
             payload = self._command_templates[CONF_SWING_MODE_COMMAND_TEMPLATE](
                 swing_mode
             )
-            await self._publish(CONF_SWING_MODE_COMMAND_TOPIC, payload)
+            await self._publish(
+                CONF_SWING_MODE_COMMAND_TOPIC, render_outgoing_payload(payload)
+            )
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
             self._current_swing_mode = swing_mode
@@ -741,7 +748,9 @@ class MqttClimate(MqttEntity, ClimateEntity):
         """Set new target temperature."""
         if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
             payload = self._command_templates[CONF_FAN_MODE_COMMAND_TEMPLATE](fan_mode)
-            await self._publish(CONF_FAN_MODE_COMMAND_TOPIC, payload)
+            await self._publish(
+                CONF_FAN_MODE_COMMAND_TOPIC, render_outgoing_payload(payload)
+            )
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = fan_mode
@@ -757,7 +766,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
             )
 
         payload = self._command_templates[CONF_MODE_COMMAND_TEMPLATE](hvac_mode)
-        await self._publish(CONF_MODE_COMMAND_TOPIC, payload)
+        await self._publish(CONF_MODE_COMMAND_TOPIC, render_outgoing_payload(payload))
 
         if self._topic[CONF_MODE_STATE_TOPIC] is None:
             self._current_operation = hvac_mode
@@ -822,7 +831,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
         payload = self._command_templates[CONF_HOLD_COMMAND_TEMPLATE](
             hold_mode or "off"
         )
-        await self._publish(CONF_HOLD_COMMAND_TOPIC, payload)
+        await self._publish(CONF_HOLD_COMMAND_TOPIC, render_outgoing_payload(payload))
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is not None:
             return False

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -377,12 +377,10 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         command_templates = {}
         for key in COMMAND_TEMPLATE_KEYS:
-            command_templates[key] = lambda value: value
-
-        for key in COMMAND_TEMPLATE_KEYS & config.keys():
             command_templates[key] = MqttCommandTemplate(
                 config[key], self.hass
             ).async_render
+
         self._command_templates = command_templates
 
     async def _subscribe_topics(self):  # noqa: C901

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -378,7 +378,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
         command_templates = {}
         for key in COMMAND_TEMPLATE_KEYS:
             command_templates[key] = MqttCommandTemplate(
-                config[key], self.hass
+                config.get(key), self.hass
             ).async_render
 
         self._command_templates = command_templates

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -36,7 +36,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, render_outgoing_payload, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -630,7 +630,7 @@ class MqttCover(MqttEntity, CoverEntity):
         await mqtt.async_publish(
             self.hass,
             self._config.get(CONF_TILT_COMMAND_TOPIC),
-            tilt,
+            render_outgoing_payload(tilt),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -36,7 +36,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, render_outgoing_payload, subscription
+from . import PLATFORMS, MqttCommandTemplate, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -625,12 +625,12 @@ class MqttCover(MqttEntity, CoverEntity):
                 "tilt_min": self._config[CONF_TILT_MIN],
                 "tilt_max": self._config[CONF_TILT_MAX],
             }
-            tilt = template.async_render(parse_result=False, variables=variables)
+            tilt = MqttCommandTemplate(template).async_render(None, variables=variables)
 
         await mqtt.async_publish(
             self.hass,
             self._config.get(CONF_TILT_COMMAND_TOPIC),
-            render_outgoing_payload(tilt),
+            tilt,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -654,7 +654,9 @@ class MqttCover(MqttEntity, CoverEntity):
                 "tilt_min": self._config[CONF_TILT_MIN],
                 "tilt_max": self._config[CONF_TILT_MAX],
             }
-            position = template.async_render(parse_result=False, variables=variables)
+            position = MqttCommandTemplate(template).async_render(
+                None, variables=variables
+            )
 
         await mqtt.async_publish(
             self.hass,

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -615,16 +615,15 @@ class MqttCover(MqttEntity, CoverEntity):
         percentage_tilt = tilt
         tilt = self.find_in_range_from_percent(tilt)
         # Handover the tilt after calculated from percent would make it more consistent with receiving templates
-        if self._config.get(CONF_TILT_COMMAND_TEMPLATE) is not None:
-            variables = {
-                "tilt_position": percentage_tilt,
-                "entity_id": self.entity_id,
-                "position_open": self._config[CONF_POSITION_OPEN],
-                "position_closed": self._config[CONF_POSITION_CLOSED],
-                "tilt_min": self._config[CONF_TILT_MIN],
-                "tilt_max": self._config[CONF_TILT_MAX],
-            }
-            tilt = self._set_tilt_template(None, variables=variables)
+        variables = {
+            "tilt_position": percentage_tilt,
+            "entity_id": self.entity_id,
+            "position_open": self._config.get(CONF_POSITION_OPEN),
+            "position_closed": self._config.get(CONF_POSITION_CLOSED),
+            "tilt_min": self._config.get(CONF_TILT_MIN),
+            "tilt_max": self._config.get(CONF_TILT_MAX),
+        }
+        tilt = self._set_tilt_template(tilt, variables=variables)
 
         await mqtt.async_publish(
             self.hass,
@@ -643,16 +642,15 @@ class MqttCover(MqttEntity, CoverEntity):
         position = kwargs[ATTR_POSITION]
         percentage_position = position
         position = self.find_in_range_from_percent(position, COVER_PAYLOAD)
-        if self._config.get(CONF_SET_POSITION_TEMPLATE) is not None:
-            variables = {
-                "position": percentage_position,
-                "entity_id": self.entity_id,
-                "position_open": self._config[CONF_POSITION_OPEN],
-                "position_closed": self._config[CONF_POSITION_CLOSED],
-                "tilt_min": self._config[CONF_TILT_MIN],
-                "tilt_max": self._config[CONF_TILT_MAX],
-            }
-            position = self._set_position_template(None, variables=variables)
+        variables = {
+            "position": percentage_position,
+            "entity_id": self.entity_id,
+            "position_open": self._config[CONF_POSITION_OPEN],
+            "position_closed": self._config[CONF_POSITION_CLOSED],
+            "tilt_min": self._config[CONF_TILT_MIN],
+            "tilt_max": self._config[CONF_TILT_MAX],
+        }
+        position = self._set_position_template(position, variables=variables)
 
         await mqtt.async_publish(
             self.hass,

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -36,7 +36,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, render_outgoing_payload, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -524,7 +524,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -545,7 +545,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -565,7 +565,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_PERCENTAGE_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -588,7 +588,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_PRESET_MODE_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -614,7 +614,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_OSCILLATION_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -36,7 +36,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from . import PLATFORMS, render_outgoing_payload, subscription
+from . import PLATFORMS, MqttCommandTemplate, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -332,13 +332,19 @@ class MqttFan(MqttEntity, FanEntity):
         if self._feature_preset_mode:
             self._supported_features |= SUPPORT_PRESET_MODE
 
-        for tpl_dict in (self._command_templates, self._value_templates):
-            for key, tpl in tpl_dict.items():
-                if tpl is None:
-                    tpl_dict[key] = lambda value: value
-                else:
-                    tpl.hass = self.hass
-                    tpl_dict[key] = tpl.async_render_with_possible_json_value
+        for key, tpl in self._command_templates.items():
+            if tpl is None:
+                self._command_templates[key] = lambda value: value
+            else:
+                tpl.hass = self.hass
+                self._command_templates[key] = MqttCommandTemplate(tpl).async_render
+
+        for key, tpl in self._value_templates.items():
+            if tpl is None:
+                self._value_templates[key] = lambda value: value
+            else:
+                tpl.hass = self.hass
+                self._value_templates[key] = tpl.async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -524,7 +530,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_COMMAND_TOPIC],
-            render_outgoing_payload(mqtt_payload),
+            mqtt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -545,7 +551,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_COMMAND_TOPIC],
-            render_outgoing_payload(mqtt_payload),
+            mqtt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -565,7 +571,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_PERCENTAGE_COMMAND_TOPIC],
-            render_outgoing_payload(mqtt_payload),
+            mqtt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -588,7 +594,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_PRESET_MODE_COMMAND_TOPIC],
-            render_outgoing_payload(mqtt_payload),
+            mqtt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -614,7 +620,7 @@ class MqttFan(MqttEntity, FanEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_OSCILLATION_COMMAND_TOPIC],
-            render_outgoing_payload(mqtt_payload),
+            mqtt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -333,11 +333,9 @@ class MqttFan(MqttEntity, FanEntity):
             self._supported_features |= SUPPORT_PRESET_MODE
 
         for key, tpl in self._command_templates.items():
-            if tpl is None:
-                self._command_templates[key] = lambda value: value
-            else:
-                tpl.hass = self.hass
-                self._command_templates[key] = MqttCommandTemplate(tpl).async_render
+            self._command_templates[key] = MqttCommandTemplate(
+                tpl, self.hass
+            ).async_render
 
         for key, tpl in self._value_templates.items():
             if tpl is None:

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -27,7 +27,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, render_outgoing_payload, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -389,7 +389,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -406,7 +406,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -423,7 +423,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_TARGET_HUMIDITY_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -446,7 +446,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         await mqtt.async_publish(
             self.hass,
             self._topic[CONF_MODE_COMMAND_TOPIC],
-            mqtt_payload,
+            render_outgoing_payload(mqtt_payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -238,11 +238,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         self._optimistic_mode = optimistic or self._topic[CONF_MODE_STATE_TOPIC] is None
 
         for key, tpl in self._command_templates.items():
-            if tpl is None:
-                self._command_templates[key] = lambda value: value
-            else:
-                tpl.hass = self.hass
-                self._command_templates[key] = MqttCommandTemplate(tpl).async_render
+            self._command_templates[key] = MqttCommandTemplate(tpl).async_render
 
         for key, tpl in self._value_templates.items():
             if tpl is None:

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -238,7 +238,9 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
         self._optimistic_mode = optimistic or self._topic[CONF_MODE_STATE_TOPIC] is None
 
         for key, tpl in self._command_templates.items():
-            self._command_templates[key] = MqttCommandTemplate(tpl).async_render
+            self._command_templates[key] = MqttCommandTemplate(
+                tpl, self.hass
+            ).async_render
 
         for key, tpl in self._value_templates.items():
             if tpl is None:

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, render_outgoing_payload, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -241,7 +241,7 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
         await mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],
-            payload,
+            render_outgoing_payload(payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, render_outgoing_payload, subscription
+from . import PLATFORMS, MqttCommandTemplate, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -141,12 +141,23 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
             CONF_COMMAND_TEMPLATE: config.get(CONF_COMMAND_TEMPLATE),
             CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
         }
-        for key, tpl in self._templates.items():
-            if tpl is None:
-                self._templates[key] = lambda value: value
-            else:
-                tpl.hass = self.hass
-                self._templates[key] = tpl.async_render_with_possible_json_value
+
+        command_template = self._templates[CONF_COMMAND_TEMPLATE]
+        if command_template is None:
+            self._templates[CONF_COMMAND_TEMPLATE] = lambda value: value
+        else:
+            self._templates[CONF_COMMAND_TEMPLATE] = MqttCommandTemplate(
+                command_template, self.hass
+            ).async_render
+
+        value_template = self._templates[CONF_VALUE_TEMPLATE]
+        if value_template is None:
+            self._templates[CONF_VALUE_TEMPLATE] = lambda value: value
+        else:
+            value_template.hass = self.hass
+            self._templates[
+                CONF_VALUE_TEMPLATE
+            ] = value_template.async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -241,7 +252,7 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
         await mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],
-            render_outgoing_payload(payload),
+            payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -139,7 +139,7 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
 
         self._templates = {
             CONF_COMMAND_TEMPLATE: MqttCommandTemplate(
-                self._templates[CONF_COMMAND_TEMPLATE], self.hass
+                config.get(CONF_COMMAND_TEMPLATE), self.hass
             ).async_render,
             CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
         }

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -138,17 +138,11 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
         self._optimistic = config[CONF_OPTIMISTIC]
 
         self._templates = {
-            CONF_COMMAND_TEMPLATE: config.get(CONF_COMMAND_TEMPLATE),
+            CONF_COMMAND_TEMPLATE: MqttCommandTemplate(
+                self._templates[CONF_COMMAND_TEMPLATE], self.hass
+            ).async_render,
             CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
         }
-
-        command_template = self._templates[CONF_COMMAND_TEMPLATE]
-        if command_template is None:
-            self._templates[CONF_COMMAND_TEMPLATE] = lambda value: value
-        else:
-            self._templates[CONF_COMMAND_TEMPLATE] = MqttCommandTemplate(
-                command_template, self.hass
-            ).async_render
 
         value_template = self._templates[CONF_VALUE_TEMPLATE]
         if value_template is None:

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, render_outgoing_payload, subscription
 from .. import mqtt
 from .const import CONF_COMMAND_TOPIC, CONF_QOS, CONF_RETAIN, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -165,7 +165,7 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
         await mqtt.async_publish(
             self.hass,
             self._config[CONF_COMMAND_TOPIC],
-            payload,
+            render_outgoing_payload(payload),
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -102,17 +102,11 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
         self._attr_options = config[CONF_OPTIONS]
 
         self._templates = {
-            CONF_COMMAND_TEMPLATE: config.get(CONF_COMMAND_TEMPLATE),
+            CONF_COMMAND_TEMPLATE: MqttCommandTemplate(
+                config.get(CONF_COMMAND_TEMPLATE), self.hass
+            ).async_render,
             CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
         }
-
-        command_template = self._templates[CONF_COMMAND_TEMPLATE]
-        if command_template is None:
-            self._templates[CONF_COMMAND_TEMPLATE] = lambda value: value
-        else:
-            self._templates[CONF_COMMAND_TEMPLATE] = MqttCommandTemplate(
-                command_template, self.hass
-            ).async_render
 
         value_template = self._templates[CONF_VALUE_TEMPLATE]
         if value_template is None:

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -296,6 +296,20 @@ async def test_service_call_with_template_payload_renders_template(hass, mqtt_mo
     )
     assert mqtt_mock.async_publish.called
     assert mqtt_mock.async_publish.call_args[0][1] == "8"
+    mqtt_mock.reset_mock()
+
+    await hass.services.async_call(
+        mqtt.DOMAIN,
+        mqtt.SERVICE_PUBLISH,
+        {
+            mqtt.ATTR_TOPIC: "test/topic",
+            mqtt.ATTR_PAYLOAD_TEMPLATE: "{{ (4+4) | pack('B') }}",
+        },
+        blocking=True,
+    )
+    assert mqtt_mock.async_publish.called
+    assert mqtt_mock.async_publish.call_args[0][1] == b"\x08"
+    mqtt_mock.reset_mock()
 
 
 async def test_service_call_with_bad_template(hass, mqtt_mock):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -91,7 +91,7 @@ async def test_mqtt_disconnects_on_home_assistant_stop(hass, mqtt_mock):
     assert mqtt_mock.async_disconnect.called
 
 
-async def test_publish_(hass, mqtt_mock):
+async def test_publish(hass, mqtt_mock):
     """Test the publish function."""
     await mqtt.async_publish(hass, "test-topic", "test-payload")
     await hass.async_block_till_done()
@@ -155,23 +155,14 @@ async def test_publish_(hass, mqtt_mock):
     )
     mqtt_mock.reset_mock()
 
-    # test binary literal string conversion to bytes
-    mqtt.publish(
-        hass,
-        "test-topic3",
-        "b'\\xde\\xad\\xbe\\xef'",
-        0,
-        False,
+
+async def test_render_outgoing_payload(hass):
+    """Test the rendering of outgoing MQTT payloads."""
+    assert mqtt.render_outgoing_payload(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
+
+    assert (
+        mqtt.render_outgoing_payload("b'\\xde\\xad\\xbe\\xef'") == b"\xde\xad\xbe\xef"
     )
-    await hass.async_block_till_done()
-    assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0] == (
-        "test-topic3",
-        b"\xde\xad\xbe\xef",
-        0,
-        False,
-    )
-    mqtt_mock.reset_mock()
 
 
 async def test_service_call_without_topic_does_not_publish(hass, mqtt_mock):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -137,6 +137,42 @@ async def test_publish_(hass, mqtt_mock):
     )
     mqtt_mock.reset_mock()
 
+    # test binary pass-through
+    mqtt.publish(
+        hass,
+        "test-topic3",
+        b"\xde\xad\xbe\xef",
+        0,
+        False,
+    )
+    await hass.async_block_till_done()
+    assert mqtt_mock.async_publish.called
+    assert mqtt_mock.async_publish.call_args[0] == (
+        "test-topic3",
+        b"\xde\xad\xbe\xef",
+        0,
+        False,
+    )
+    mqtt_mock.reset_mock()
+
+    # test binary literal string conversion to bytes
+    mqtt.publish(
+        hass,
+        "test-topic3",
+        "b'\\xde\\xad\\xbe\\xef'",
+        0,
+        False,
+    )
+    await hass.async_block_till_done()
+    assert mqtt_mock.async_publish.called
+    assert mqtt_mock.async_publish.call_args[0] == (
+        "test-topic3",
+        b"\xde\xad\xbe\xef",
+        0,
+        False,
+    )
+    mqtt_mock.reset_mock()
+
 
 async def test_service_call_without_topic_does_not_publish(hass, mqtt_mock):
     """Test the service call if topic is missing."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -164,6 +164,12 @@ async def test_render_outgoing_payload(hass):
         mqtt.render_outgoing_payload("b'\\xde\\xad\\xbe\\xef'") == b"\xde\xad\xbe\xef"
     )
 
+    assert mqtt.render_outgoing_payload(1234) == 1234
+
+    assert mqtt.render_outgoing_payload(1234.56) == 1234.56
+
+    assert mqtt.render_outgoing_payload(None) is None
+
 
 async def test_command_template_value(hass):
     """Test the rendering of MQTT command template."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -158,7 +158,7 @@ async def test_publish(hass, mqtt_mock):
 
 async def test_convert_outgoing_payload(hass):
     """Test the converting of outgoing MQTT payloads without template."""
-    command_template = mqtt.MqttCommandTemplate(None)
+    command_template = mqtt.MqttCommandTemplate(None, hass)
     assert command_template.async_render(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
 
     assert (

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -162,7 +162,8 @@ async def test_convert_outgoing_payload(hass):
     assert command_template.async_render(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
 
     assert (
-        command_template.async_render("b'\\xde\\xad\\xbe\\xef'") == b"\xde\xad\xbe\xef"
+        command_template.async_render("b'\\xde\\xad\\xbe\\xef'")
+        == "b'\\xde\\xad\\xbe\\xef'"
     )
 
     assert command_template.async_render(1234) == 1234
@@ -176,27 +177,16 @@ async def test_command_template_value(hass):
     """Test the rendering of MQTT command template."""
 
     variables = {"id": 1234, "some_var": "beer"}
-    variables2 = {"color": "yellow"}
 
     # test rendering value
     tpl = template.Template("{{ value + 1 }}", hass)
     cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass)
     assert cmd_tpl.async_render(4321) == "4322"
 
-    # test rendering initial variables
-    tpl = template.Template("{{ id + 1 }}", hass)
-    cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass, variables=variables)
-    assert cmd_tpl.async_render(None) == "1235"
-
     # test variables at rendering
     tpl = template.Template("{{ some_var }}", hass)
     cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass)
     assert cmd_tpl.async_render(None, variables=variables) == "beer"
-
-    # test combination
-    tpl = template.Template("{{ value }} {{ color }} {{ some_var }}", hass)
-    cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass, variables=variables2)
-    assert cmd_tpl.async_render(1234, variables=variables) == "1234 yellow beer"
 
 
 async def test_service_call_without_topic_does_not_publish(hass, mqtt_mock):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -156,19 +156,20 @@ async def test_publish(hass, mqtt_mock):
     mqtt_mock.reset_mock()
 
 
-async def test_render_outgoing_payload(hass):
-    """Test the rendering of outgoing MQTT payloads."""
-    assert mqtt.render_outgoing_payload(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
+async def test_convert_outgoing_payload(hass):
+    """Test the converting of outgoing MQTT payloads without template."""
+    command_template = mqtt.MqttCommandTemplate(None)
+    assert command_template.async_render(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
 
     assert (
-        mqtt.render_outgoing_payload("b'\\xde\\xad\\xbe\\xef'") == b"\xde\xad\xbe\xef"
+        command_template.async_render("b'\\xde\\xad\\xbe\\xef'") == b"\xde\xad\xbe\xef"
     )
 
-    assert mqtt.render_outgoing_payload(1234) == 1234
+    assert command_template.async_render(1234) == 1234
 
-    assert mqtt.render_outgoing_payload(1234.56) == 1234.56
+    assert command_template.async_render(1234.56) == 1234.56
 
-    assert mqtt.render_outgoing_payload(None) is None
+    assert command_template.async_render(None) is None
 
 
 async def test_command_template_value(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support publishing MQTT messages with raw `bytes` payloads

MQTT supports publishing types of `PublishPayloadType` = `[str, bytes, int, float, None]` to MQTT topics.
The previous code however stringified all payloads before publishing.

This PR introduces two changes:
- A `bytes` payload will not be stringified before publishing
- A helper class `MqttCommandTemplate` which attempts to evaluate the template output as bytes
  - A template output such as `"b'\\xde\\xad\\xbe\\xef'"` will be converted to `b'\\xde\\xad\\xbe\\xef'`
  - Any other template output will be treated as a string

The `MqttCommandTemplate` class is also used as an output converter when no template is defined, this simplifies code where we want to be able to call the template with a value, or values.

This is applicable for MQTT platforms that publish using command templates and for the MQTT publish service with payload_template` set.

Example:
- Publishing with `payload_template` set to `{{ (4+4) | pack('B') }}` will result in sending payload `b'\x08'`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
