### PR TITLE
Drop deprecated CONF_NAMES from onewire

### DIFF
--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from homeassistant.const import Platform
 
 CONF_MOUNT_DIR = "mount_dir"
-CONF_NAMES = "names"
 
 CONF_TYPE_OWSERVER = "OWServer"
 CONF_TYPE_SYSBUS = "SysBus"

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -37,7 +37,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import (
-    CONF_NAMES,
     CONF_TYPE_OWSERVER,
     CONF_TYPE_SYSBUS,
     DOMAIN,
@@ -363,10 +362,6 @@ def get_entities(
         return []
 
     entities: list[SensorEntity] = []
-    device_names = {}
-    if CONF_NAMES in config and isinstance(config[CONF_NAMES], dict):
-        device_names = config[CONF_NAMES]
-
     conf_type = config[CONF_TYPE]
     # We have an owserver on a remote(or local) host/port
     if conf_type == CONF_TYPE_OWSERVER:
@@ -405,7 +400,7 @@ def get_entities(
                 device_file = os.path.join(
                     os.path.split(device.path)[0], description.key
                 )
-                name = f"{device_names.get(device_id, device_id)} {description.name}"
+                name = f"{device_id} {description.name}"
                 entities.append(
                     OneWireProxySensor(
                         description=description,
@@ -428,7 +423,7 @@ def get_entities(
             device_info = device.device_info
             description = SIMPLE_TEMPERATURE_SENSOR_DESCRIPTION
             device_file = f"/sys/bus/w1/devices/{device_id}/w1_slave"
-            name = f"{device_names.get(device_id, device_id)} {description.name}"
+            name = f"{device_id} {description.name}"
             entities.append(
                 OneWireDirectSensor(
                     description=description,

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 from homeassistant.components.onewire.const import (
     CONF_MOUNT_DIR,
-    CONF_NAMES,
     CONF_TYPE_OWSERVER,
     CONF_TYPE_SYSBUS,
     DEFAULT_SYSBUS_MOUNT_DIR,
@@ -37,9 +36,6 @@ def get_config_entry(hass: HomeAssistant) -> ConfigEntry:
             CONF_TYPE: CONF_TYPE_OWSERVER,
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 1234,
-            CONF_NAMES: {
-                "10.111111111111": "My DS18B20",
-            },
         },
         options={},
         entry_id="2",
@@ -57,9 +53,6 @@ def get_sysbus_config_entry(hass: HomeAssistant) -> ConfigEntry:
         data={
             CONF_TYPE: CONF_TYPE_SYSBUS,
             CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
-            CONF_NAMES: {
-                "10-111111111111": "My DS18B20",
-            },
         },
         unique_id=f"{CONF_TYPE_SYSBUS}:{DEFAULT_SYSBUS_MOUNT_DIR}",
         options={},

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -91,7 +91,7 @@ MOCK_OWPROXY_DEVICES = {
         Platform.SENSOR: [
             {
                 ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
-                ATTR_ENTITY_ID: "sensor.my_ds18b20_temperature",
+                ATTR_ENTITY_ID: "sensor.10_111111111111_temperature",
                 ATTR_INJECT_READS: b"    25.123",
                 ATTR_STATE: "25.1",
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
@@ -895,7 +895,7 @@ MOCK_SYSBUS_DEVICES = {
         Platform.SENSOR: [
             {
                 ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
-                ATTR_ENTITY_ID: "sensor.my_ds18b20_temperature",
+                ATTR_ENTITY_ID: "sensor.10_111111111111_temperature",
                 ATTR_INJECT_READS: 25.123,
                 ATTR_STATE: "25.1",
                 ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During the YAML to ConfigFlow migration, CONF_NAMES was automatically migrated for compatibility.
Now that all entities have unique ids, this isn't needed anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
