### PR TITLE
Fix migration of entities of Hue integration

### DIFF
--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -123,7 +123,7 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
             if hass_dev_id is None:
                 # can be safely ignored, this device does not exist in current config
                 LOGGER.debug(
-                    "Ignoring device %s (%s) as it does not (yet) exist in the device registry.",
+                    "Ignoring device %s (%s) as it does not (yet) exist in the device registry",
                     hue_dev.metadata.name,
                     hue_dev.id,
                 )

--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -92,84 +92,87 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
             DEVICE_CLASS_TEMPERATURE: ResourceTypes.TEMPERATURE,
         }
 
-        # handle entities attached to device
+        # migrate entities attached to a device
         for hue_dev in api.devices:
             zigbee = api.devices.get_zigbee_connectivity(hue_dev.id)
             if not zigbee or not zigbee.mac_address:
                 # not a zigbee device or invalid mac
                 continue
             # get/update existing device by V1 identifier (mac address)
-            # the device will now have both the old and the new identifier
-            identifiers = {(DOMAIN, hue_dev.id), (DOMAIN, zigbee.mac_address)}
+            # the device will now have both the old and the new identifier(s)
+            identifiers = {
+                (DOMAIN, hue_dev.id),
+                (DOMAIN, zigbee.mac_address),
+                (DOMAIN, f"{zigbee.mac_address}-0b"),
+            }
             hass_dev = dev_reg.async_get_or_create(
                 config_entry_id=entry.entry_id, identifiers=identifiers
             )
             dev_name = hass_dev.name or hue_dev.metadata.name
             LOGGER.info("Migrated device %s (%s)", dev_name, hass_dev.id)
-            # loop through al entities for device and find match
+
+            # loop through all entities for device and find match
             for ent in async_entries_for_device(ent_reg, hass_dev.id, True):
-                # migrate light
+
                 if ent.entity_id.startswith("light"):
+                    # migrate light
                     # should always return one lightid here
-                    new_unique_id = next(iter(hue_dev.lights))
-                    if ent.unique_id == new_unique_id:
-                        continue  # just in case
-                    LOGGER.info(
-                        "Migrating %s from unique id %s to %s",
-                        ent.entity_id,
-                        ent.unique_id,
-                        new_unique_id,
+                    new_unique_id = next(iter(hue_dev.lights), None)
+                else:
+                    # migrate sensors
+                    matched_dev_class = sensor_class_mapping.get(
+                        ent.original_device_class or "unknown"
                     )
-                    ent_reg.async_update_entity(
-                        ent.entity_id, new_unique_id=new_unique_id
+                    new_unique_id = next(
+                        (
+                            sensor.id
+                            for sensor in api.devices.get_sensors(hue_dev.id)
+                            if sensor.type == matched_dev_class
+                        ),
+                        None,
                     )
-                    continue
-                # migrate sensors
-                matched_dev_class = sensor_class_mapping.get(
-                    ent.original_device_class or "unknown"
-                )
-                if matched_dev_class is None:
+
+                if new_unique_id is None:
                     # this may happen if we're looking at orphaned or unsupported entity
                     LOGGER.warning(
                         "Skip migration of %s because it no longer exists on the bridge",
                         ent.entity_id,
                     )
                     continue
-                for sensor in api.devices.get_sensors(hue_dev.id):
-                    if sensor.type != matched_dev_class:
-                        continue
-                    new_unique_id = sensor.id
-                    if ent.unique_id == new_unique_id:
-                        break  # just in case
+
+                try:
+                    ent_reg.async_update_entity(
+                        ent.entity_id, new_unique_id=new_unique_id
+                    )
+                except ValueError:
+                    # assume edge case where the entity was already migrated in a previous run
+                    # which got aborted somehow and we do not want
+                    # to crash the entire integration init
+                    LOGGER.warning(
+                        "Skip migration of %s because it already exists",
+                        ent.entity_id,
+                    )
+                else:
                     LOGGER.info(
-                        "Migrating %s from unique id %s to %s",
+                        "Migrated entity %s from unique id %s to %s",
                         ent.entity_id,
                         ent.unique_id,
                         new_unique_id,
                     )
-                    try:
-                        ent_reg.async_update_entity(
-                            ent.entity_id, new_unique_id=sensor.id
-                        )
-                    except ValueError:
-                        # assume edge case where the entity was already migrated in a previous run
-                        # which got aborted somehow and we do not want
-                        # to crash the entire integration init
-                        LOGGER.warning(
-                            "Skip migration of %s because it already exists",
-                            ent.entity_id,
-                        )
-                    break
 
         # migrate entities that are not connected to a device (groups)
         for ent in entities_for_config_entry(ent_reg, entry.entry_id):
             if ent.device_id is not None:
                 continue
-            v1_id = f"/groups/{ent.unique_id}"
-            hue_group = api.groups.room.get_by_v1_id(v1_id)
-            if hue_group is None or hue_group.grouped_light is None:
-                # try again with zone
-                hue_group = api.groups.zone.get_by_v1_id(v1_id)
+            if "-" in ent.unique_id:
+                # handle case where unique id is v2-id of group/zone
+                hue_group = api.groups.get(ent.unique_id)
+            else:
+                # handle case where the unique id is just the v1 id
+                v1_id = f"/groups/{ent.unique_id}"
+                hue_group = api.groups.room.get_by_v1_id(
+                    v1_id
+                ) or api.groups.zone.get_by_v1_id(v1_id)
             if hue_group is None or hue_group.grouped_light is None:
                 # this may happen if we're looking at some orphaned entity
                 LOGGER.warning(

--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -104,7 +104,8 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
             hass_dev = dev_reg.async_get_or_create(
                 config_entry_id=entry.entry_id, identifiers=identifiers
             )
-            LOGGER.info("Migrated device %s (%s)", hass_dev.name, hass_dev.id)
+            dev_name = hass_dev.name or hue_dev.metadata.name
+            LOGGER.info("Migrated device %s (%s)", dev_name, hass_dev.id)
             # loop through al entities for device and find match
             for ent in async_entries_for_device(ent_reg, hass_dev.id, True):
                 # migrate light

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -59,7 +59,7 @@ async def test_light_entity_migration(
     ent_reg.async_get_or_create(
         "light",
         hue.DOMAIN,
-        "00:17:88:01:09:aa:bb:65-b0",
+        "00:17:88:01:09:aa:bb:65-0b",
         suggested_object_id="migrated_light_1",
         device_id=device.id,
     )

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -78,9 +78,7 @@ async def test_light_entity_migration(
     migrated_device = dev_reg.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
-        (hue.DOMAIN, "0b216218-d811-4c95-8c55-bbcda50f9d50"),
-        (hue.DOMAIN, "00:17:88:01:09:aa:bb:65"),
-        (hue.DOMAIN, "00:17:88:01:09:aa:bb:65-0b"),
+        (hue.DOMAIN, "0b216218-d811-4c95-8c55-bbcda50f9d50")
     }
     # the entity should have the new identifier (guid)
     migrated_entity = ent_reg.async_get("light.migrated_light_1")
@@ -136,9 +134,7 @@ async def test_sensor_entity_migration(
     migrated_device = dev_reg.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
-        (hue.DOMAIN, "2330b45d-6079-4c6e-bba6-1b68afb1a0d6"),
-        (hue.DOMAIN, device_mac),
-        (hue.DOMAIN, f"{device_mac}-0b"),
+        (hue.DOMAIN, "2330b45d-6079-4c6e-bba6-1b68afb1a0d6")
     }
     # the entities should have the correct V2 identifier (guid)
     for dev_class, platform, new_id in sensor_mappings:

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -54,12 +54,12 @@ async def test_light_entity_migration(
     # create device/entity with V1 schema in registry
     device = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers={(hue.DOMAIN, "00:17:88:01:09:aa:bb:65")},
+        identifiers={(hue.DOMAIN, "00:17:88:01:09:aa:bb:65-0b")},
     )
     ent_reg.async_get_or_create(
         "light",
         hue.DOMAIN,
-        "00:17:88:01:09:aa:bb:65",
+        "00:17:88:01:09:aa:bb:65-b0",
         suggested_object_id="migrated_light_1",
         device_id=device.id,
     )
@@ -80,6 +80,7 @@ async def test_light_entity_migration(
     assert migrated_device.identifiers == {
         (hue.DOMAIN, "0b216218-d811-4c95-8c55-bbcda50f9d50"),
         (hue.DOMAIN, "00:17:88:01:09:aa:bb:65"),
+        (hue.DOMAIN, "00:17:88:01:09:aa:bb:65-0b"),
     }
     # the entity should have the new identifier (guid)
     migrated_entity = ent_reg.async_get("light.migrated_light_1")
@@ -137,6 +138,7 @@ async def test_sensor_entity_migration(
     assert migrated_device.identifiers == {
         (hue.DOMAIN, "2330b45d-6079-4c6e-bba6-1b68afb1a0d6"),
         (hue.DOMAIN, device_mac),
+        (hue.DOMAIN, f"{device_mac}-0b"),
     }
     # the entities should have the correct V2 identifier (guid)
     for dev_class, platform, new_id in sensor_mappings:
@@ -147,7 +149,7 @@ async def test_sensor_entity_migration(
         assert migrated_entity.unique_id == new_id
 
 
-async def test_group_entity_migration(
+async def test_group_entity_migration_with_v1_id(
     hass, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
 ):
     """Test if entity schema for grouped_lights migrates from v1 to v2."""
@@ -156,10 +158,44 @@ async def test_group_entity_migration(
     ent_reg = er.async_get(hass)
 
     # create (deviceless) entity with V1 schema in registry
+    # using the legacy style group id as unique id
     ent_reg.async_get_or_create(
         "light",
         hue.DOMAIN,
         "3",
+        suggested_object_id="hue_migrated_grouped_light",
+        config_entry=config_entry,
+    )
+
+    # now run the migration and check results
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.hue.migration.HueBridgeV2",
+        return_value=mock_bridge_v2.api,
+    ):
+        await hue.migration.handle_v2_migration(hass, config_entry)
+
+    # the entity should have the new identifier (guid)
+    migrated_entity = ent_reg.async_get("light.hue_migrated_grouped_light")
+    assert migrated_entity is not None
+    assert migrated_entity.unique_id == "e937f8db-2f0e-49a0-936e-027e60e15b34"
+
+
+async def test_group_entity_migration_with_v2_group_id(
+    hass, mock_bridge_v2, mock_config_entry_v2, v2_resources_test_data
+):
+    """Test if entity schema for grouped_lights migrates from v1 to v2."""
+    config_entry = mock_bridge_v2.config_entry = mock_config_entry_v2
+
+    ent_reg = er.async_get(hass)
+
+    # create (deviceless) entity with V1 schema in registry
+    # using the V2 group id as unique id
+    ent_reg.async_get_or_create(
+        "light",
+        hue.DOMAIN,
+        "6ddc9066-7e7d-4a03-a773-c73937968296",
         suggested_object_id="hue_migrated_grouped_light",
         config_entry=config_entry,
     )

--- a/tests/components/hue/test_migration.py
+++ b/tests/components/hue/test_migration.py
@@ -74,13 +74,13 @@ async def test_light_entity_migration(
     ):
         await hue.migration.handle_v2_migration(hass, config_entry)
 
-    # migrated device should have new identifier (guid) and old style (mac)
+    # migrated device should now have the new identifier (guid) instead of old style (mac)
     migrated_device = dev_reg.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
         (hue.DOMAIN, "0b216218-d811-4c95-8c55-bbcda50f9d50")
     }
-    # the entity should have the new identifier (guid)
+    # the entity should have the new unique_id (guid)
     migrated_entity = ent_reg.async_get("light.migrated_light_1")
     assert migrated_entity is not None
     assert migrated_entity.unique_id == "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1"
@@ -130,13 +130,13 @@ async def test_sensor_entity_migration(
     ):
         await hue.migration.handle_v2_migration(hass, config_entry)
 
-    # migrated device should have new identifier (guid) and old style (mac)
+    # migrated device should now have the new identifier (guid) instead of old style (mac)
     migrated_device = dev_reg.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {
         (hue.DOMAIN, "2330b45d-6079-4c6e-bba6-1b68afb1a0d6")
     }
-    # the entities should have the correct V2 identifier (guid)
+    # the entities should have the correct V2 unique_id (guid)
     for dev_class, platform, new_id in sensor_mappings:
         migrated_entity = ent_reg.async_get(
             f"{platform}.hue_migrated_{dev_class}_sensor"


### PR DESCRIPTION
## Proposed change
There was a small oversight in the migration code for the new V2 implementation, regarding to the (unique) id of devices and entities.

This fix will handle all scenarios and it will prevent entities being recreated.
It will not recover from an already failed migration. A user should restore the backup and re-install the 2021.12beta update to profit from this fix. If they skip that step, they'll have to manually cleanup the orphaned entities and re-do renaming etc.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
       closes #61051 
       closes #61042 
       closes #61000 
       closes #61040
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
