### PR TITLE
Change check for existence of options flow

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -366,13 +366,14 @@ async def ignore_config_flow(hass, connection, msg):
 def entry_json(entry: config_entries.ConfigEntry) -> dict:
     """Return JSON value of a config entry."""
     handler = config_entries.HANDLERS.get(entry.domain)
-    supports_options = (
-        # Guard in case handler is no longer registered (custom component etc)
-        handler is not None
-        # pylint: disable=comparison-with-callable
-        and handler.async_get_options_flow
-        != config_entries.ConfigFlow.async_get_options_flow
-    )
+    # work out if handler has support for options flow
+    supports_options = False
+    if handler is not None:
+        try:
+            handler.async_get_options_flow(entry)
+            supports_options = True
+        except data_entry_flow.UnknownHandler:
+            pass
     return {
         "entry_id": entry.entry_id,
         "domain": entry.domain,

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -367,14 +367,9 @@ def entry_json(entry: config_entries.ConfigEntry) -> dict:
     """Return JSON value of a config entry."""
     handler = config_entries.HANDLERS.get(entry.domain)
     # work out if handler has support for options flow
-    supports_options = False
-    if handler is not None:
-        try:
-            handler.async_get_options_flow(entry)
-        except data_entry_flow.UnknownHandler:
-            supports_options = False
-        else:
-            supports_options = True
+    supports_options = handler is not None and handler.async_supports_options_flow(
+        entry
+    )
 
     return {
         "entry_id": entry.entry_id,

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -371,9 +371,11 @@ def entry_json(entry: config_entries.ConfigEntry) -> dict:
     if handler is not None:
         try:
             handler.async_get_options_flow(entry)
-            supports_options = True
         except data_entry_flow.UnknownHandler:
-            pass
+            supports_options = False
+        else:
+            supports_options = True
+
     return {
         "entry_id": entry.entry_id,
         "domain": entry.domain,

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -12,7 +12,7 @@ import async_timeout
 import slugify as unicode_slug
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import ssdp, zeroconf
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import callback
@@ -48,10 +48,15 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> HueOptionsFlowHandler:
         """Get the options flow for this handler."""
-        if config_entry.data.get(CONF_API_VERSION, 1) == 1:
-            # Options for Hue are only applicable to V1 bridges.
-            return HueOptionsFlowHandler(config_entry)
-        raise data_entry_flow.UnknownHandler
+        return HueOptionsFlowHandler(config_entry)
+
+    @classmethod
+    @callback
+    def async_supports_options_flow(
+        cls, config_entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Return options flow support for this handler."""
+        return config_entry.data.get(CONF_API_VERSION, 1) == 1
 
     def __init__(self) -> None:
         """Initialize the Hue flow."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1163,6 +1163,13 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         """Get the options flow for this handler."""
         raise data_entry_flow.UnknownHandler
 
+    @classmethod
+    @callback
+    def async_supports_options_flow(cls, config_entry: ConfigEntry) -> bool:
+        """Return options flow support for this handler."""
+        # pylint: disable=comparison-with-callable
+        return cls.async_get_options_flow != ConfigFlow.async_get_options_flow
+
     @callback
     def _async_abort_entries_match(
         self, match_dict: dict[str, Any] | None = None

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1167,8 +1167,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     @callback
     def async_supports_options_flow(cls, config_entry: ConfigEntry) -> bool:
         """Return options flow support for this handler."""
-        # pylint: disable=comparison-with-callable
-        return cls.async_get_options_flow != ConfigFlow.async_get_options_flow
+        return cls.async_get_options_flow is not ConfigFlow.async_get_options_flow
 
     @callback
     def _async_abort_entries_match(

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -51,6 +51,12 @@ async def test_get_entries(hass, client):
                 """Get options flow."""
                 pass
 
+            @classmethod
+            @callback
+            def async_supports_options_flow(cls, config_entry):
+                """Return options flow support for this handler."""
+                return True
+
         hass.helpers.config_entry_flow.register_discovery_flow(
             "comp2", "Comp 2", lambda: None
         )

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -47,7 +47,7 @@ async def test_get_entries(hass, client):
 
             @staticmethod
             @callback
-            def async_get_options_flow(config, options):
+            def async_get_options_flow(config_entry):
                 """Get options flow."""
                 pass
 

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -7,7 +7,7 @@ from aiohue.errors import LinkButtonNotPressed
 import pytest
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.hue import config_flow, const
 from homeassistant.components.hue.errors import CannotConnect
@@ -706,8 +706,7 @@ async def test_options_flow_v2(hass):
     )
     entry.add_to_hass(hass)
 
-    with pytest.raises(data_entry_flow.UnknownHandler):
-        await hass.config_entries.options.async_init(entry.entry_id)
+    assert config_flow.HueFlowHandler.async_supports_options_flow(entry) is False
 
 
 async def test_bridge_zeroconf(hass, aioclient_mock):


### PR DESCRIPTION
## Proposed change
The check if a config entry flow supports options was a bit strange, only checking if the method was overridden.
This doesn't catch the situation where an integration want to conditionally provide support for the Options flow, depending on the configured device, bridge, api version etc.

The check that was there only checked if the method was overridden.
I've changed it to actually looking if the method throws an UnknownHandler exception at runtime.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #61156
- This PR is related to issue:  
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
