### PR TITLE
Replace deprecated DEVICE_CLASS constants with new enums in Hue integration

### DIFF
--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -8,16 +8,10 @@ from aiohue.v2.models.device import DeviceArchetypes
 from aiohue.v2.models.resource import ResourceTypes
 
 from homeassistant import core
-from homeassistant.components.binary_sensor import DEVICE_CLASS_MOTION
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_USERNAME,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
-)
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_USERNAME
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.device_registry import (
     async_entries_for_config_entry as devices_for_config_entries,
@@ -102,10 +96,10 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
     async with HueBridgeV2(host, api_key, websession) as api:
 
         sensor_class_mapping = {
-            DEVICE_CLASS_BATTERY: ResourceTypes.DEVICE_POWER,
-            DEVICE_CLASS_MOTION: ResourceTypes.MOTION,
-            DEVICE_CLASS_ILLUMINANCE: ResourceTypes.LIGHT_LEVEL,
-            DEVICE_CLASS_TEMPERATURE: ResourceTypes.TEMPERATURE,
+            SensorDeviceClass.BATTERY.value: ResourceTypes.DEVICE_POWER,
+            BinarySensorDeviceClass.MOTION.value: ResourceTypes.MOTION,
+            SensorDeviceClass.ILLUMINANCE.value: ResourceTypes.LIGHT_LEVEL,
+            SensorDeviceClass.TEMPERATURE.value: ResourceTypes.TEMPERATURE,
         }
 
         # migrate entities attached to a device

--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -8,7 +8,7 @@ from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.sensors import LightLevelController, MotionController
 from aiohue.v2.models.resource import SensingService
 
-from homeassistant.components.switch import DEVICE_CLASS_SWITCH, SwitchEntity
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant, callback
@@ -63,7 +63,7 @@ class HueSensingServiceEnabledEntity(HueBaseEntity, SwitchEntity):
     """Representation of a Switch entity from Hue SensingService."""
 
     _attr_entity_category = ENTITY_CATEGORY_CONFIG
-    _attr_device_class = DEVICE_CLASS_SWITCH
+    _attr_device_class = SwitchDeviceClass.SWITCH
 
     def __init__(
         self,

--- a/homeassistant/components/hue/v1/binary_sensor.py
+++ b/homeassistant/components/hue/v1/binary_sensor.py
@@ -2,7 +2,7 @@
 from aiohue.v1.sensors import TYPE_ZLL_PRESENCE
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_MOTION,
+    BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class HuePresence(GenericZLLSensor, BinarySensorEntity):
     """The presence sensor entity for a Hue motion sensor device."""
 
-    _attr_device_class = DEVICE_CLASS_MOTION
+    _attr_device_class = BinarySensorDeviceClass.MOTION
 
     @property
     def is_on(self):

--- a/homeassistant/components/hue/v1/sensor.py
+++ b/homeassistant/components/hue/v1/sensor.py
@@ -6,11 +6,12 @@ from aiohue.v1.sensors import (
     TYPE_ZLL_TEMPERATURE,
 )
 
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    SensorDeviceClass,
+    SensorEntity,
+)
 from homeassistant.const import (
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
     ENTITY_CATEGORY_DIAGNOSTIC,
     LIGHT_LUX,
     PERCENTAGE,
@@ -42,7 +43,7 @@ class GenericHueGaugeSensorEntity(GenericZLLSensor, SensorEntity):
 class HueLightLevel(GenericHueGaugeSensorEntity):
     """The light level sensor entity for a Hue motion sensor device."""
 
-    _attr_device_class = DEVICE_CLASS_ILLUMINANCE
+    _attr_device_class = SensorDeviceClass.ILLUMINANCE
     _attr_native_unit_of_measurement = LIGHT_LUX
 
     @property
@@ -77,7 +78,7 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
 class HueTemperature(GenericHueGaugeSensorEntity):
     """The temperature sensor entity for a Hue motion sensor device."""
 
-    _attr_device_class = DEVICE_CLASS_TEMPERATURE
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = STATE_CLASS_MEASUREMENT
     _attr_native_unit_of_measurement = TEMP_CELSIUS
 
@@ -93,7 +94,7 @@ class HueTemperature(GenericHueGaugeSensorEntity):
 class HueBattery(GenericHueSensor, SensorEntity):
     """Battery class for when a batt-powered device is only represented as an event."""
 
-    _attr_device_class = DEVICE_CLASS_BATTERY
+    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_state_class = STATE_CLASS_MEASUREMENT
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -14,8 +14,7 @@ from aiohue.v2.models.entertainment import (
 from aiohue.v2.models.motion import Motion
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_RUNNING,
+    BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -80,7 +79,7 @@ class HueBinarySensorBase(HueBaseEntity, BinarySensorEntity):
 class HueMotionSensor(HueBinarySensorBase):
     """Representation of a Hue Motion sensor."""
 
-    _attr_device_class = DEVICE_CLASS_MOTION
+    _attr_device_class = BinarySensorDeviceClass.MOTION
 
     @property
     def is_on(self) -> bool | None:
@@ -96,7 +95,7 @@ class HueMotionSensor(HueBinarySensorBase):
 class HueEntertainmentActiveSensor(HueBinarySensorBase):
     """Representation of a Hue Entertainment Configuration as binary sensor."""
 
-    _attr_device_class = DEVICE_CLASS_RUNNING
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/hue/v2/sensor.py
+++ b/homeassistant/components/hue/v2/sensor.py
@@ -17,13 +17,14 @@ from aiohue.v2.models.device_power import DevicePower
 from aiohue.v2.models.light_level import LightLevel
 from aiohue.v2.models.temperature import Temperature
 
-from homeassistant.components.binary_sensor import DEVICE_CLASS_CONNECTIVITY
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    SensorDeviceClass,
+    SensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
     ENTITY_CATEGORY_DIAGNOSTIC,
     LIGHT_LUX,
     PERCENTAGE,
@@ -101,7 +102,7 @@ class HueTemperatureSensor(HueSensorBase):
     """Representation of a Hue Temperature sensor."""
 
     _attr_native_unit_of_measurement = TEMP_CELSIUS
-    _attr_device_class = DEVICE_CLASS_TEMPERATURE
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
 
     @property
     def native_value(self) -> float:
@@ -118,7 +119,7 @@ class HueLightLevelSensor(HueSensorBase):
     """Representation of a Hue LightLevel (illuminance) sensor."""
 
     _attr_native_unit_of_measurement = LIGHT_LUX
-    _attr_device_class = DEVICE_CLASS_ILLUMINANCE
+    _attr_device_class = SensorDeviceClass.ILLUMINANCE
 
     @property
     def native_value(self) -> int:
@@ -142,7 +143,7 @@ class HueBatterySensor(HueSensorBase):
     """Representation of a Hue Battery sensor."""
 
     _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_device_class = DEVICE_CLASS_BATTERY
+    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
     @property
@@ -159,7 +160,7 @@ class HueBatterySensor(HueSensorBase):
 class HueZigbeeConnectivitySensor(HueSensorBase):
     """Representation of a Hue ZigbeeConnectivity sensor."""
 
-    _attr_device_class = DEVICE_CLASS_CONNECTIVITY
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
 


### PR DESCRIPTION
## Proposed change

Replace the now deprecated DEVICE_CLASS constants with the new StringEnums.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
