### PR TITLE
Fix uncaught exception in bond config flow

### DIFF
--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -87,7 +87,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return
 
         self._discovered[CONF_ACCESS_TOKEN] = token
-        _, hub_name = await _validate_input(self.hass, self._discovered)
+        try:
+            _, hub_name = await _validate_input(self.hass, self._discovered)
+        except InputValidationError:
+            return
         self._discovered[CONF_NAME] = hub_name
 
     async def async_step_zeroconf(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- If the wifi is flakey the device can drop the connection
  after getting the token.  This is fine as getting the hub name
  is optional and only happens if we have the token anyways 
  so we can still setup, but we need to keep moving forward.

Fixes
```

2021-12-06 16:49:21 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved:   File "/Users/bdraco/home-assistant/venv/bin/hass", line 8, in <module>
    sys.exit(main())
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/__main__.py", line 318, in main
    exit_code = runner.run(runtime_conf)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/runner.py", line 121, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1882, in _run_once
    handle._run()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/components/zeroconf/__init__.py", line 457, in _process_service_update
    discovery_flow.async_create_flow(
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/helpers/discovery_flow.py", line 25, in async_create_flow
    hass.async_create_task(init_coro)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/core.py", line 393, in async_create_task
    task: asyncio.Task = self.loop.create_task(target)
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/components/bond/config_flow.py", line 51, in _validate_input
    await hub.setup(max_devices=1)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/components/bond/utils.py", line 152, in setup
    responses = await gather_with_concurrency(MAX_REQUESTS, *tasks)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/util/async_.py", line 172, in gather_with_concurrency
    return await gather(
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/util/async_.py", line 170, in sem_task
    return await task
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/bond_api/bond.py", line 52, in device_properties
    return await self.__get(f"/v2/devices/{device_id}/properties")
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/bond_api/bond.py", line 93, in __get
    return await self.__call(get)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/bond_api/bond.py", line 101, in __call
    return await handler(self._session)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/bond_api/bond.py", line 87, in get
    async with session.get(
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiohttp/client.py", line 1138, in __aenter__
    self._resp = await self._coro
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiohttp/client.py", line 559, in _request
    await resp.start(conn)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 898, in start
    message, payload = await protocol.read()  # type: ignore[union-attr]
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiohttp/streams.py", line 616, in read
    await self._waiter
aiohttp.client_exceptions.ClientOSError: [Errno 54] Connection reset by peer

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/data_entry_flow.py", line 203, in async_init
    flow, result = await task
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/data_entry_flow.py", line 230, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data, init_done)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/data_entry_flow.py", line 325, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/components/bond/config_flow.py", line 120, in async_step_zeroconf
    await self._async_try_automatic_configure()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/components/bond/config_flow.py", line 90, in _async_try_automatic_configure
    _, hub_name = await _validate_input(self.hass, self._discovered)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/homeassistant/components/bond/config_flow.py", line 53, in _validate_input
    raise InputValidationError("cannot_connect") from error
homeassistant.components.bond.config_flow.InputValidationError

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
