### PR TITLE
Attempt to fix flaky prometheus test

### DIFF
--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -45,11 +45,11 @@ async def prometheus_client(hass, hass_client, namespace):
     await async_setup_component(
         hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
     )
-    await hass.async_block_till_done()
 
     await async_setup_component(
         hass, humidifier.DOMAIN, {"humidifier": [{"platform": "demo"}]}
     )
+    await hass.async_block_till_done()
 
     sensor1 = DemoSensor(
         None, "Television Energy", 74, None, None, ENERGY_KILO_WATT_HOUR, None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Attempt to fix flaky prometheus test

The test `tests/components/prometheus/test_init.py::test_view_empty_namespace` sometimes fails, probably because the humidifier is not done setting up before the Prometheus API has been called:

```
DEBUG:homeassistant.components.http.view:Serving /api/prometheus to 127.0.0.1 (auth: True)
DEBUG:homeassistant.components.prometheus:Received Prometheus metrics request
DEBUG:homeassistant.components.prometheus:Handling state update for humidifier.humidifier
```

Full log:
```
=================================== FAILURES ===================================
______________________ test_view_empty_namespace[pyloop] _______________________
[gw1] linux -- Python 3.9.0 /__w/core/core/venv/bin/python3

hass = <homeassistant.core.HomeAssistant object at 0x7fddbdb51a60>
hass_client = <function hass_client.<locals>.auth_client at 0x7fdddb6d73a0>

    async def test_view_empty_namespace(hass, hass_client):
        """Test prometheus metrics view."""
        client = await prometheus_client(hass, hass_client, "")
        resp = await client.get(prometheus.API_ENDPOINT)
    
        assert resp.status == HTTPStatus.OK
        assert resp.headers["content-type"] == CONTENT_TYPE_TEXT_PLAIN
        body = await resp.text()
        body = body.split("\n")
    
        assert len(body) > 3
    
        assert "# HELP python_info Python platform information" in body
        assert (
            "# HELP python_gc_objects_collected_total "
            "Objects collected during gc" in body
        )
    
        assert (
            'sensor_temperature_celsius{domain="sensor",'
            'entity="sensor.outside_temperature",'
            'friendly_name="Outside Temperature"} 15.6' in body
        )
    
        assert (
            'battery_level_percent{domain="sensor",'
            'entity="sensor.outside_temperature",'
            'friendly_name="Outside Temperature"} 12.0' in body
        )
    
        assert (
            'climate_current_temperature_celsius{domain="climate",'
            'entity="climate.heatpump",'
            'friendly_name="HeatPump"} 25.0' in body
        )
    
        assert (
            'climate_target_temperature_celsius{domain="climate",'
            'entity="climate.heatpump",'
            'friendly_name="HeatPump"} 20.0' in body
        )
    
        assert (
            'climate_target_temperature_low_celsius{domain="climate",'
            'entity="climate.ecobee",'
            'friendly_name="Ecobee"} 21.0' in body
        )
    
        assert (
            'climate_target_temperature_high_celsius{domain="climate",'
            'entity="climate.ecobee",'
            'friendly_name="Ecobee"} 24.0' in body
        )
    
>       assert (
            'humidifier_target_humidity_percent{domain="humidifier",'
            'entity="humidifier.humidifier",'
            'friendly_name="Humidifier"} 68.0' in body
        )
E       assert 'humidifier_target_humidity_percent{domain="humidifier",entity="humidifier.humidifier",friendly_name="Humidifier"} 68.0' in ['# HELP python_gc_objects_collected_total Objects collected during gc', '# TYPE python_gc_objects_collected_total cou...eneration="2"} 4.678307e+06', '# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC', ...]

tests/components/prometheus/test_init.py:186: AssertionError
---------------------------- Captured stderr setup -----------------------------
DEBUG:asyncio:Using selector: EpollSelector
------------------------------ Captured log setup ------------------------------
DEBUG    asyncio:selector_events.py:59 Using selector: EpollSelector
----------------------------- Captured stderr call -----------------------------
INFO:homeassistant.loader:Loaded prometheus from homeassistant.components.prometheus
INFO:homeassistant.loader:Loaded http from homeassistant.components.http
DEBUG:homeassistant.setup:Dependency prometheus will wait for dependencies ['http']
INFO:homeassistant.setup:Setting up http
DEBUG:homeassistant.components.network.network:Adapters: [{'name': 'lo', 'index': 1, 'enabled': False, 'auto': False, 'default': False, 'ipv4': [{'address': '127.0.0.1', 'network_prefix': 8}], 'ipv6': []}, {'name': 'eth0', 'index': 5, 'enabled': True, 'auto': True, 'default': False, 'ipv4': [{'address': '172.18.0.2', 'network_prefix': 16}], 'ipv6': []}]
INFO:homeassistant.setup:Setup of domain http took 0.0 seconds
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=http>
INFO:homeassistant.setup:Setting up prometheus
INFO:homeassistant.setup:Setup of domain prometheus took 0.0 seconds
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=prometheus>
INFO:homeassistant.loader:Loaded sensor from homeassistant.components.sensor
INFO:homeassistant.loader:Loaded demo from homeassistant.components.demo
INFO:homeassistant.setup:Setting up sensor
INFO:homeassistant.setup:Setup of domain sensor took 0.0 seconds
DEBUG:homeassistant.setup:Dependency demo will wait for dependencies ['conversation', 'group', 'zone']
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=sensor>
INFO:homeassistant.loader:Loaded conversation from homeassistant.components.conversation
INFO:homeassistant.loader:Loaded group from homeassistant.components.group
INFO:homeassistant.loader:Loaded zone from homeassistant.components.zone
INFO:homeassistant.setup:Setting up conversation
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=conversation, service=process>
INFO:homeassistant.setup:Setup of domain conversation took 0.0 seconds
INFO:homeassistant.setup:Setting up group
INFO:homeassistant.loader:Loaded climate from homeassistant.components.climate
INFO:homeassistant.setup:Setting up zone
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=conversation>
INFO:homeassistant.setup:Setting up climate
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=turn_on>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=turn_off>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_hvac_mode>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_preset_mode>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_aux_heat>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_temperature>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_humidity>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_fan_mode>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=climate, service=set_swing_mode>
INFO:homeassistant.setup:Setup of domain climate took 0.0 seconds
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=group, service=reload>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=group, service=set>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=group, service=remove>
INFO:homeassistant.setup:Setup of domain group took 0.0 seconds
DEBUG:homeassistant.setup:Dependency demo will wait for dependencies ['group', 'zone']
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=climate>
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=group>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=zone, service=reload>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=zone.home, old_state=None, new_state=<state zone.home=zoning; latitude=32.87336, longitude=-117.22743, radius=100, passive=False, editable=True, icon=mdi:home, friendly_name=test home @ 2021-12-08T09:38:26.805210+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for zone.home
INFO:homeassistant.setup:Setup of domain zone took 0.0 seconds
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=zone>
INFO:homeassistant.setup:Setting up demo
INFO:homeassistant.setup:Setup of domain demo took 0.0 seconds
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=demo>
INFO:homeassistant.components.sensor:Setting up sensor.demo
INFO:homeassistant.components.climate:Setting up climate.demo
INFO:homeassistant.helpers.entity_registry:Registered new sensor.demo entity: sensor.outside_temperature
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.outside_temperature>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.outside_temperature, old_state=None, new_state=<state sensor.outside_temperature=15.6; state_class=measurement, battery_level=12, unit_of_measurement=°C, device_class=temperature, friendly_name=Outside Temperature @ 2021-12-08T09:38:26.809014+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new sensor.demo entity: sensor.outside_humidity
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.outside_temperature
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.outside_humidity>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.outside_humidity, old_state=None, new_state=<state sensor.outside_humidity=54; state_class=measurement, unit_of_measurement=%, device_class=humidity, friendly_name=Outside Humidity @ 2021-12-08T09:38:26.810600+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new sensor.demo entity: sensor.carbon_monoxide
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.outside_humidity
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.carbon_monoxide>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.carbon_monoxide, old_state=None, new_state=<state sensor.carbon_monoxide=54; state_class=measurement, unit_of_measurement=ppm, device_class=carbon_monoxide, friendly_name=Carbon monoxide @ 2021-12-08T09:38:26.811751+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new sensor.demo entity: sensor.carbon_dioxide
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.carbon_monoxide
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.carbon_dioxide>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.carbon_dioxide, old_state=None, new_state=<state sensor.carbon_dioxide=54; state_class=measurement, battery_level=14, unit_of_measurement=ppm, device_class=carbon_dioxide, friendly_name=Carbon dioxide @ 2021-12-08T09:38:26.813049+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new sensor.demo entity: sensor.power_consumption
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.carbon_dioxide
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.power_consumption>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.power_consumption, old_state=None, new_state=<state sensor.power_consumption=100; state_class=measurement, unit_of_measurement=W, device_class=power, friendly_name=Power consumption @ 2021-12-08T09:38:26.814348+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new sensor.demo entity: sensor.today_energy
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.power_consumption
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=sensor.today_energy>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.today_energy, old_state=None, new_state=<state sensor.today_energy=15; state_class=measurement, unit_of_measurement=kWh, device_class=energy, friendly_name=Today energy @ 2021-12-08T09:38:26.815616+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new climate.demo entity: climate.heatpump
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.today_energy
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=climate.heatpump>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=climate.heatpump, old_state=None, new_state=<state climate.heatpump=heat; hvac_modes=['heat', 'off'], min_temp=7.0, max_temp=35.0, current_temperature=25.0, temperature=20.0, hvac_action=heating, friendly_name=HeatPump, supported_features=1 @ 2021-12-08T09:38:26.816929+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new climate.demo entity: climate.hvac
DEBUG:homeassistant.components.prometheus:Handling state update for climate.heatpump
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=climate.hvac>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=climate.hvac, old_state=None, new_state=<state climate.hvac=cool; hvac_modes=['off', 'heat', 'cool', 'auto', 'dry', 'fan_only'], min_temp=7, max_temp=35, min_humidity=30, max_humidity=99, fan_modes=['On Low', 'On High', 'Auto Low', 'Auto High', 'Off'], swing_modes=['Auto', '1', '2', '3', 'Off'], current_temperature=22, temperature=21, target_temp_high=None, target_temp_low=None, current_humidity=54, humidity=67, fan_mode=On High, hvac_action=cooling, swing_mode=Off, aux_heat=off, friendly_name=Hvac, supported_features=111 @ 2021-12-08T09:38:26.818580+00:00>>
INFO:homeassistant.helpers.entity_registry:Registered new climate.demo entity: climate.ecobee
DEBUG:homeassistant.components.prometheus:Handling state update for climate.hvac
DEBUG:homeassistant.core:Bus:Handling <Event entity_registry_updated[L]: action=create, entity_id=climate.ecobee>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=climate.ecobee, old_state=None, new_state=<state climate.ecobee=heat_cool; hvac_modes=['heat_cool', 'cool', 'heat'], min_temp=7, max_temp=35, fan_modes=['On Low', 'On High', 'Auto Low', 'Auto High', 'Off'], preset_modes=['home', 'eco'], swing_modes=['Auto', '1', '2', '3', 'Off'], current_temperature=23, target_temp_high=24, target_temp_low=21, fan_mode=Auto Low, preset_mode=home, swing_mode=Auto, friendly_name=Ecobee, supported_features=58 @ 2021-12-08T09:38:26.819968+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for climate.ecobee
INFO:homeassistant.loader:Loaded humidifier from homeassistant.components.humidifier
INFO:homeassistant.setup:Setting up humidifier
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=humidifier, service=turn_on>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=humidifier, service=turn_off>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=humidifier, service=toggle>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=humidifier, service=set_mode>
DEBUG:homeassistant.core:Bus:Handling <Event service_registered[L]: domain=humidifier, service=set_humidity>
INFO:homeassistant.setup:Setup of domain humidifier took 0.0 seconds
INFO:homeassistant.components.humidifier:Setting up humidifier.demo
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=humidifier>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.television_energy, old_state=None, new_state=<state sensor.television_energy=74; unit_of_measurement=kWh, friendly_name=Television Energy @ 2021-12-08T09:38:26.826989+00:00>>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.radio_energy, old_state=None, new_state=<state sensor.radio_energy=14; unit_of_measurement=kWh, device_class=power, friendly_name=Radio Energy @ 1970-01-02T00:00:00+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.television_energy
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.electricity_price, old_state=None, new_state=<state sensor.electricity_price=0.123; unit_of_measurement=SEK/kWh, friendly_name=Electricity price @ 2021-12-08T09:38:26.828236+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.radio_energy
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.wind_direction, old_state=None, new_state=<state sensor.wind_direction=25; unit_of_measurement=°, friendly_name=Wind Direction @ 2021-12-08T09:38:26.829018+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.electricity_price
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.sps30_pm_1um_weight_concentration, old_state=None, new_state=<state sensor.sps30_pm_1um_weight_concentration=3.7069; unit_of_measurement=µg/m³, friendly_name=SPS30 PM <1µm Weight concentration @ 2021-12-08T09:38:26.829716+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.wind_direction
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.trend_gradient, old_state=None, new_state=<state sensor.trend_gradient=0.002; friendly_name=Trend Gradient @ 2021-12-08T09:38:26.830542+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.sps30_pm_1um_weight_concentration
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.text, old_state=None, new_state=<state sensor.text=should_not_work; friendly_name=Text @ 2021-12-08T09:38:26.831352+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.trend_gradient
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=sensor.text_unit, old_state=None, new_state=<state sensor.text_unit=should_not_work; unit_of_measurement=Text, friendly_name=Text Unit @ 2021-12-08T09:38:26.832041+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.text
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=input_number.threshold, old_state=None, new_state=<state input_number.threshold=5.2; min=0, max=10, step=0.1, mode=auto, friendly_name=Threshold @ 2021-12-08T09:38:26.832761+00:00>>
DEBUG:homeassistant.components.prometheus:Handling state update for sensor.text_unit
DEBUG:homeassistant.components.prometheus:Unsupported sensor: sensor.text
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=input_number.brightness, old_state=None, new_state=<state input_number.brightness=60; min=0, max=100, step=1.0, mode=auto @ 2021-12-08T09:38:26.833494+00:00>>
DEBUG:homeassistant.components.prometheus:Could not convert <state sensor.text_unit=should_not_work; unit_of_measurement=Text, friendly_name=Text Unit @ 2021-12-08T09:38:26.832041+00:00> to float
DEBUG:homeassistant.components.prometheus:Handling state update for input_number.threshold
DEBUG:homeassistant.components.prometheus:Handling state update for input_number.brightness
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=humidifier.humidifier, old_state=None, new_state=<state humidifier.humidifier=on; min_humidity=0, max_humidity=100, humidity=68, device_class=humidifier, friendly_name=Humidifier, supported_features=0 @ 2021-12-08T09:38:26.837691+00:00>>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=humidifier.dehumidifier, old_state=None, new_state=<state humidifier.dehumidifier=on; min_humidity=0, max_humidity=100, humidity=54, device_class=dehumidifier, friendly_name=Dehumidifier, supported_features=0 @ 2021-12-08T09:38:26.838119+00:00>>
DEBUG:homeassistant.core:Bus:Handling <Event state_changed[L]: entity_id=humidifier.hygrostat, old_state=None, new_state=<state humidifier.hygrostat=on; min_humidity=0, max_humidity=100, available_modes=['home', 'eco'], humidity=50, mode=home, friendly_name=Hygrostat, supported_features=1 @ 2021-12-08T09:38:26.838484+00:00>>
DEBUG:homeassistant.components.http.auth:Authenticated 127.0.0.1 for /api/prometheus using bearer token
DEBUG:homeassistant.components.http.view:Serving /api/prometheus to 127.0.0.1 (auth: True)
DEBUG:homeassistant.components.prometheus:Received Prometheus metrics request
DEBUG:homeassistant.components.prometheus:Handling state update for humidifier.humidifier
DEBUG:homeassistant.components.prometheus:Handling state update for humidifier.dehumidifier
DEBUG:homeassistant.components.prometheus:Handling state update for humidifier.hygrostat
INFO:aiohttp.access:127.0.0.1 [08/Dec/2021:09:38:26 +0000] "GET /api/prometheus HTTP/1.1" 200 17081 "-" "Python/3.9 aiohttp/3.8.1"
DEBUG:charset_normalizer:Code page ascii does not fit given bytes sequence at ALL. 'ascii' codec can't decode byte 0xc2 in position 3514: ordinal not in range(128)
INFO:charset_normalizer:Code page utf_8 is a multi byte encoding table and it appear that at least one character was encoded using n-bytes.
INFO:charset_normalizer:utf_8 passed initial chaos probing. Mean measured chaos is 0.000000 %
INFO:charset_normalizer:We detected language [('Dutch', 0.9809), ('Indonesian', 0.9772), ('French', 0.9706), ('English', 0.9691), ('Norwegian', 0.95)] using utf_8
INFO:charset_normalizer:utf_8 is most likely the one. Stopping the process.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
