### PR TITLE
Introduce only_supervisor for @websocket_api.ws_require_user()

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     ATTR_MANUFACTURER,
     ATTR_NAME,
     EVENT_CORE_CONFIG_UPDATE,
+    HASSIO_USER_NAME,
     SERVICE_HOMEASSISTANT_RESTART,
     SERVICE_HOMEASSISTANT_STOP,
     Platform,
@@ -56,7 +57,6 @@ from .const import (
     ATTR_VERSION,
     DATA_KEY_ADDONS,
     DOMAIN,
-    HASSIO_USER_NAME,
     SupervisorEntityModel,
 )
 from .discovery import HassioServiceInfo, async_setup_discovery_view  # noqa: F401

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -56,6 +56,7 @@ from .const import (
     ATTR_VERSION,
     DATA_KEY_ADDONS,
     DOMAIN,
+    HASSIO_USER_NAME,
     SupervisorEntityModel,
 )
 from .discovery import HassioServiceInfo, async_setup_discovery_view  # noqa: F401
@@ -440,11 +441,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
 
             # Migrate old name
             if user.name == "Hass.io":
-                await hass.auth.async_update_user(user, name="Supervisor")
+                await hass.auth.async_update_user(user, name=HASSIO_USER_NAME)
 
     if refresh_token is None:
         user = await hass.auth.async_create_system_user(
-            "Supervisor", group_ids=[GROUP_ID_ADMIN]
+            HASSIO_USER_NAME, group_ids=[GROUP_ID_ADMIN]
         )
         refresh_token = await hass.auth.async_create_refresh_token(user)
         data["hassio_user"] = user.id

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -54,8 +54,6 @@ ATTR_REPOSITORY = "repository"
 DATA_KEY_ADDONS = "addons"
 DATA_KEY_OS = "os"
 
-HASSIO_USER_NAME = "Supervisor"
-
 
 class SupervisorEntityModel(str, Enum):
     """Supervisor entity model."""

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -54,6 +54,8 @@ ATTR_REPOSITORY = "repository"
 DATA_KEY_ADDONS = "addons"
 DATA_KEY_OS = "os"
 
+HASSIO_USER_NAME = "Supervisor"
+
 
 class SupervisorEntityModel(str, Enum):
     """Supervisor entity model."""

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -113,7 +113,7 @@ def ws_info(
     connection.send_result(msg["id"], recorder_info)
 
 
-@websocket_api.require_admin
+@websocket_api.ws_require_user(only_supervisor=True)
 @websocket_api.websocket_command({vol.Required("type"): "backup/start"})
 @websocket_api.async_response
 async def ws_backup_start(
@@ -131,7 +131,7 @@ async def ws_backup_start(
     connection.send_result(msg["id"])
 
 
-@websocket_api.require_admin
+@websocket_api.ws_require_user(only_supervisor=True)
 @websocket_api.websocket_command({vol.Required("type"): "backup/end"})
 @websocket_api.async_response
 async def ws_backup_end(

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.hassio.const import HASSIO_USER_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
 
@@ -70,6 +71,7 @@ def ws_require_user(
     allow_system_user: bool = True,
     only_active_user: bool = True,
     only_inactive_user: bool = False,
+    only_supervisor: bool = False,
 ) -> Callable[[const.WebSocketCommandHandler], const.WebSocketCommandHandler]:
     """Decorate function validating login user exist in current WS connection.
 
@@ -109,6 +111,10 @@ def ws_require_user(
 
             if only_inactive_user and connection.user.is_active:
                 output_error("only_inactive_user", "Not allowed as active user")
+                return
+
+            if only_supervisor and connection.user.name != HASSIO_USER_NAME:
+                output_error("only_supervisor", "Only allowed as Supervisor")
                 return
 
             return func(hass, connection, msg)

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.hassio.const import HASSIO_USER_NAME
+from homeassistant.const import HASSIO_USER_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -756,3 +756,6 @@ ENTITY_CATEGORIES: Final[list[str]] = [
 CAST_APP_ID_HOMEASSISTANT_MEDIA: Final = "B45F4572"
 # The ID of the Home Assistant Lovelace Cast App
 CAST_APP_ID_HOMEASSISTANT_LOVELACE: Final = "A078F6B0"
+
+# User used by Supervisor
+HASSIO_USER_NAME = "Supervisor"

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -360,9 +360,11 @@ async def test_recorder_info_migration_queue_exhausted(hass, hass_ws_client):
     assert response["result"]["thread_running"] is True
 
 
-async def test_backup_start_no_recorder(hass, hass_ws_client):
+async def test_backup_start_no_recorder(
+    hass, hass_ws_client, hass_supervisor_access_token
+):
     """Test getting backup start when recorder is not present."""
-    client = await hass_ws_client()
+    client = await hass_ws_client(hass, hass_supervisor_access_token)
 
     await client.send_json({"id": 1, "type": "backup/start"})
     response = await client.receive_json()
@@ -370,9 +372,9 @@ async def test_backup_start_no_recorder(hass, hass_ws_client):
     assert response["error"]["code"] == "unknown_command"
 
 
-async def test_backup_start_timeout(hass, hass_ws_client):
+async def test_backup_start_timeout(hass, hass_ws_client, hass_supervisor_access_token):
     """Test getting backup start when recorder is not present."""
-    client = await hass_ws_client()
+    client = await hass_ws_client(hass, hass_supervisor_access_token)
     await async_init_recorder_component(hass)
 
     # Ensure there are no queued events
@@ -388,9 +390,9 @@ async def test_backup_start_timeout(hass, hass_ws_client):
             await client.send_json({"id": 2, "type": "backup/end"})
 
 
-async def test_backup_end(hass, hass_ws_client):
+async def test_backup_end(hass, hass_ws_client, hass_supervisor_access_token):
     """Test backup start."""
-    client = await hass_ws_client()
+    client = await hass_ws_client(hass, hass_supervisor_access_token)
     await async_init_recorder_component(hass)
 
     # Ensure there are no queued events
@@ -405,9 +407,11 @@ async def test_backup_end(hass, hass_ws_client):
     assert response["success"]
 
 
-async def test_backup_end_without_start(hass, hass_ws_client):
+async def test_backup_end_without_start(
+    hass, hass_ws_client, hass_supervisor_access_token
+):
     """Test backup start."""
-    client = await hass_ws_client()
+    client = await hass_ws_client(hass, hass_supervisor_access_token)
     await async_init_recorder_component(hass)
 
     # Ensure there are no queued events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH_REQUIRED,
 )
 from homeassistant.components.websocket_api.http import URL
-from homeassistant.const import ATTR_NOW, EVENT_TIME_CHANGED
+from homeassistant.const import ATTR_NOW, EVENT_TIME_CHANGED, HASSIO_USER_NAME
 from homeassistant.helpers import config_entry_oauth2_flow, event
 from homeassistant.setup import async_setup_component
 from homeassistant.util import location
@@ -401,6 +401,26 @@ def hass_read_only_access_token(hass, hass_read_only_user, local_auth):
         hass.auth.async_create_refresh_token(
             hass_read_only_user, CLIENT_ID, credential=credential
         )
+    )
+    return hass.auth.async_create_access_token(refresh_token)
+
+
+@pytest.fixture
+def hass_supervisor_user(hass, local_auth):
+    """Return the Home Assistant Supervisor user."""
+    admin_group = hass.loop.run_until_complete(
+        hass.auth.async_get_group(GROUP_ID_ADMIN)
+    )
+    return MockUser(
+        name=HASSIO_USER_NAME, groups=[admin_group], system_generated=True
+    ).add_to_hass(hass)
+
+
+@pytest.fixture
+def hass_supervisor_access_token(hass, hass_supervisor_user, local_auth):
+    """Return a Home Assistant Supervisor access token."""
+    refresh_token = hass.loop.run_until_complete(
+        hass.auth.async_create_refresh_token(hass_supervisor_user)
     )
     return hass.auth.async_create_access_token(refresh_token)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Introduce `only_supervisor` argument for `@websocket_api.ws_require_user()` decorator and make use of it for the newly introduced `backup/start` and `backup/end` endpoints.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
