### PR TITLE
Reduce cpu requirements for apple_tv mdns and discovery

### DIFF
--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -36,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Apple TV"
 
+BACKOFF_TIME_LOWER_LIMIT = 15  # seconds
 BACKOFF_TIME_UPPER_LIMIT = 300  # Five minutes
 
 SIGNAL_CONNECTED = "apple_tv_connected"
@@ -241,7 +242,11 @@ class AppleTVManager:
             if self.atv is None:
                 self._connection_attempts += 1
                 backoff = min(
-                    randrange(2 ** self._connection_attempts), BACKOFF_TIME_UPPER_LIMIT
+                    max(
+                        BACKOFF_TIME_LOWER_LIMIT,
+                        randrange(2 ** self._connection_attempts),
+                    ),
+                    BACKOFF_TIME_UPPER_LIMIT,
                 )
 
                 _LOGGER.debug("Reconnecting in %d seconds", backoff)

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -282,14 +282,8 @@ class AppleTVManager:
             address,
         )
 
-        atvs = await scan(
-            self.hass.loop, identifier=identifiers, protocol=protocols, aiozc=aiozc
-        )
-        if atvs:
-            return atvs[0]
-
-        _LOGGER.debug("Failed to find device %s, trying later", self.config_entry.title)
-
+        # No need to scan for the device, as soon as async_step_zeroconf runs
+        # it will update the address and reload the config entry when the device is found
         return None
 
     async def _connect(self, conf):

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -271,7 +271,7 @@ class AppleTVManager:
             return atvs[0]
 
         _LOGGER.debug(
-            "Failed to find device %s with address %s, trying to scan",
+            "Failed to find device %s with address %s",
             self.config_entry.title,
             address,
         )

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -265,10 +265,7 @@ class AppleTVManager:
 
         _LOGGER.debug("Discovering device %s", self.config_entry.title)
         atvs = await scan(
-            self.hass.loop,
-            identifier=identifiers,
-            protocol=protocols,
-            hosts=[address],
+            self.hass.loop, identifier=identifiers, protocol=protocols, hosts=[address]
         )
         if atvs:
             return atvs[0]
@@ -278,9 +275,8 @@ class AppleTVManager:
             self.config_entry.title,
             address,
         )
-
-        # No need to scan for the device, as soon as async_step_zeroconf runs
-        # it will update the address and reload the config entry when the device is found
+        # We no longer multicast scan for the device since as soon as async_step_zeroconf runs,
+        # it will update the address and reload the config entry when the device is found.
         return None
 
     async def _connect(self, conf):

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -7,6 +7,7 @@ from pyatv import connect, exceptions, scan
 from pyatv.const import DeviceModel, Protocol
 from pyatv.convert import model_str
 
+from homeassistant.components import zeroconf
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.const import (
@@ -264,8 +265,13 @@ class AppleTVManager:
         }
 
         _LOGGER.debug("Discovering device %s", self.config_entry.title)
+        aiozc = await zeroconf.async_get_async_instance(self.hass)
         atvs = await scan(
-            self.hass.loop, identifier=identifiers, protocol=protocols, hosts=[address]
+            self.hass.loop,
+            identifier=identifiers,
+            protocol=protocols,
+            hosts=[address],
+            aiozc=aiozc,
         )
         if atvs:
             return atvs[0]
@@ -276,7 +282,9 @@ class AppleTVManager:
             address,
         )
 
-        atvs = await scan(self.hass.loop, identifier=identifiers, protocol=protocols)
+        atvs = await scan(
+            self.hass.loop, identifier=identifiers, protocol=protocols, aiozc=aiozc
+        )
         if atvs:
             return atvs[0]
 

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -7,7 +7,6 @@ from pyatv import connect, exceptions, scan
 from pyatv.const import DeviceModel, Protocol
 from pyatv.convert import model_str
 
-from homeassistant.components import zeroconf
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.const import (
@@ -265,13 +264,11 @@ class AppleTVManager:
         }
 
         _LOGGER.debug("Discovering device %s", self.config_entry.title)
-        aiozc = await zeroconf.async_get_async_instance(self.hass)
         atvs = await scan(
             self.hass.loop,
             identifier=identifiers,
             protocol=protocols,
             hosts=[address],
-            aiozc=aiozc,
         )
         if atvs:
             return atvs[0]

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -157,7 +157,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Extract unique identifier from service
         unique_id = get_unique_id(service_type, name, properties)
-        if unique_id:
+        if unique_id is None:
             return self.async_abort(reason="unknown")
         self.scan_filter = discovery_info.host
 

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -165,18 +165,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         unique_id = get_unique_id(service_type, name, properties)
         if unique_id is None:
             return self.async_abort(reason="unknown")
-        self.scan_filter = host
 
-        await self._async_aggregate_discoveries(host, unique_id, service_type)
-        # Scan for the device in order to extract _all_ unique identifiers assigned to
-        # it. Not doing it like this will yield multiple config flows for the same
-        # device, one per protocol, which is undesired.
-        return await self.async_find_device_wrapper(self.async_found_zeroconf_device)
-
-    async def _async_aggregate_discoveries(
-        self, host: str, unique_id: str, service_type: str
-    ) -> None:
-        """Aggregate discoveries for the same host that happen inside of DISCOVERY_AGGREGATION_TIME."""
         #
         # Suppose we have a device with three services: A, B and C. Let's assume
         # service A is discovered by Zeroconf, triggering a device scan that also finds
@@ -207,7 +196,14 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # zeroconf.
         #
         await asyncio.sleep(DISCOVERY_AGGREGATION_TIME)
+
         self._async_check_in_progress_and_set_address(host, unique_id)
+
+        # Scan for the device in order to extract _all_ unique identifiers assigned to
+        # it. Not doing it like this will yield multiple config flows for the same
+        # device, one per protocol, which is undesired.
+        self.scan_filter = host
+        return await self.async_find_device_wrapper(self.async_found_zeroconf_device)
 
     @callback
     def _async_check_in_progress_and_set_address(self, host: str, unique_id: str):

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -251,21 +251,22 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         }
 
-        if not allow_exist:
-            for identifier in self.atv.all_identifiers:
-                for entry in self._async_current_entries():
-                    if identifier in entry.data.get(
-                        CONF_IDENTIFIERS, [entry.unique_id]
-                    ):
-                        if entry.data.get(CONF_ADDRESS) != self.atv.address:
-                            self.hass.config_entries.async_update_entry(
-                                entry,
-                                data={**entry.data, CONF_ADDRESS: self.atv.address},
-                            )
-                            self.hass.async_create_task(
-                                self.hass.config_entries.async_reload(entry.entry_id)
-                            )
-                        raise DeviceAlreadyConfigured()
+        for identifier in self.atv.all_identifiers:
+            for entry in self._async_current_entries():
+                if identifier not in entry.data.get(
+                    CONF_IDENTIFIERS, [entry.unique_id]
+                ):
+                    continue
+                if entry.data.get(CONF_ADDRESS) != self.atv.address:
+                    self.hass.config_entries.async_update_entry(
+                        entry,
+                        data={**entry.data, CONF_ADDRESS: self.atv.address},
+                    )
+                    self.hass.async_create_task(
+                        self.hass.config_entries.async_reload(entry.entry_id)
+                    )
+                if not allow_exist:
+                    raise DeviceAlreadyConfigured()
 
     async def async_step_confirm(self, user_input=None):
         """Handle user-confirmation of discovered node."""

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -219,7 +219,10 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 or context.get(CONF_ADDRESS) != host
             ):
                 continue
-            if unique_id not in context.get("all_identifiers", []):
+            if (
+                "all_identifiers" in context
+                and unique_id not in context["all_identifiers"]
+            ):
                 # Add potentially new identifiers from this device to the existing flow
                 context["all_identifiers"].append(unique_id)
             raise data_entry_flow.AbortFlow("already_in_progress")

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -97,10 +97,12 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         existing config entry. If that's the case, the unique_id from that entry is
         re-used, otherwise the newly discovered identifier is used instead.
         """
+        all_identifiers = set(self.atv.all_identifiers)
         for entry in self._async_current_entries():
-            for identifier in self.atv.all_identifiers:
-                if identifier in entry.data.get(CONF_IDENTIFIERS, [entry.unique_id]):
-                    return entry.unique_id
+            if all_identifiers.intersection(
+                entry.data.get(CONF_IDENTIFIERS, [entry.unique_id])
+            ):
+                return entry.unique_id
         return self.atv.identifier
 
     async def async_step_reauth(self, user_input=None):
@@ -195,7 +197,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # since both flows really represent the same device. They will however end up
         # as two separate flows.
         #
-        # To solve this, all identifiers found during a device scan is stored as
+        # To solve this, all identifiers are stored as
         # "all_identifiers" in the flow context. When a new service is discovered, the
         # code below will check these identifiers for all active flows and abort if a
         # match is found. Before aborting, the original flow is updated with any

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -177,13 +177,6 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, host: str, unique_id: str, service_type: str
     ) -> None:
         """Aggregate discoveries for the same host that happen inside of DISCOVERY_AGGREGATION_TIME."""
-        # Wait DISCOVERY_AGGREGATION_TIME for multiple services to be
-        # discovered via zeroconf.  Once the first service is discovered
-        # this allows other services to be discovered inside the time
-        # window before triggering a scan of the device. This prevents
-        # a multiple scans of the device at the same time since each
-        # apple_tv device has multiple services that are discovered by
-        # zeroconf.
         #
         # Suppose we have a device with three services: A, B and C. Let's assume
         # service A is discovered by Zeroconf, triggering a device scan that also finds
@@ -205,10 +198,18 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # discovered, the identifier of service C will be inserted into
         # "all_identifiers" of the original flow (making the device complete).
         #
+        # Wait DISCOVERY_AGGREGATION_TIME for multiple services to be
+        # discovered via zeroconf. Once the first service is discovered
+        # this allows other services to be discovered inside the time
+        # window before triggering a scan of the device. This prevents
+        # a multiple scans of the device at the same time since each
+        # apple_tv device has multiple services that are discovered by
+        # zeroconf.
+        #
         await asyncio.sleep(DISCOVERY_AGGREGATION_TIME)
         #
         # Must not await until self.context[CONF_ADDRESS] is set or other flows may
-        # see it to soon and all flows will lose the race and nothing moves forward
+        # see it too soon and all flows will lose the race and nothing moves forward
         #
         for flow in self._async_in_progress(include_uninitialized=True):
             context = flow["context"]

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -210,7 +210,12 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         #
         # Must not await until self.context[CONF_ADDRESS] is set or other flows may
         # see it too soon and all flows will lose the race and nothing moves forward
-        #
+        self._async_check_in_progress_and_set_address(host, unique_id)
+        # Safe to await again after self.context[CONF_ADDRESS] is set
+
+    @callback
+    def _async_check_in_progress_and_set_address(self, host: str, unique_id: str):
+        """Check for in-progress flows and update them with identifiers if needed."""
         for flow in self._async_in_progress(include_uninitialized=True):
             context = flow["context"]
             if (
@@ -223,9 +228,6 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 context["all_identifiers"].append(unique_id)
             raise data_entry_flow.AbortFlow("already_in_progress")
         self.context[CONF_ADDRESS] = host
-        #
-        # Safe to await again after self.context[CONF_ADDRESS] is set
-        #
 
     async def async_found_zeroconf_device(self, user_input=None):
         """Handle device found after Zeroconf discovery."""

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -299,9 +299,6 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # If number of services found during device scan mismatch number of
             # identifiers collected during Zeroconf discovery, then trigger a new scan
             # with hopes of finding all services.
-            import pprint
-
-            pprint.pprint([self.context["all_identifiers"], self.atv.all_identifiers])
             if len(self.atv.all_identifiers) != expected_identifier_count:
                 try:
                     await self.async_find_device()

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -191,7 +191,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # discovered via zeroconf. Once the first service is discovered
         # this allows other services to be discovered inside the time
         # window before triggering a scan of the device. This prevents
-        # a multiple scans of the device at the same time since each
+        # multiple scans of the device at the same time since each
         # apple_tv device has multiple services that are discovered by
         # zeroconf.
         #

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -113,7 +113,9 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(self, user_input=None):
         """Inform user that reconfiguration is about to start."""
         if user_input is not None:
-            return await self.async_find_device_wrapper(self.async_pair_next_protocol)
+            return await self.async_find_device_wrapper(
+                self.async_pair_next_protocol, allow_exist=True
+            )
 
         return self.async_show_form(step_id="reconfigure")
 

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -292,20 +292,17 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         for identifier in self.atv.all_identifiers:
             for entry in self._async_current_entries():
-                if identifier not in entry.data.get(
-                    CONF_IDENTIFIERS, [entry.unique_id]
-                ):
-                    continue
-                if entry.data.get(CONF_ADDRESS) != self.atv.address:
-                    self.hass.config_entries.async_update_entry(
-                        entry,
-                        data={**entry.data, CONF_ADDRESS: self.atv.address},
-                    )
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(entry.entry_id)
-                    )
-                if not allow_exist:
-                    raise DeviceAlreadyConfigured()
+                if identifier in entry.data.get(CONF_IDENTIFIERS, [entry.unique_id]):
+                    if entry.data.get(CONF_ADDRESS) != self.atv.address:
+                        self.hass.config_entries.async_update_entry(
+                            entry,
+                            data={**entry.data, CONF_ADDRESS: self.atv.address},
+                        )
+                        self.hass.async_create_task(
+                            self.hass.config_entries.async_reload(entry.entry_id)
+                        )
+                    if not allow_exist:
+                        raise DeviceAlreadyConfigured()
 
     async def async_step_confirm(self, user_input=None):
         """Handle user-confirmation of discovered node."""

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -46,7 +46,7 @@ async def device_scan(identifier, loop):
         except ValueError:
             return None
 
-    # If we have an address only probe that address to avoid
+    # If we have an address, only probe that address to avoid
     # broadcast traffic on the network
     scan_result = await scan(loop, timeout=3, hosts=_host_filter())
     matches = [atv for atv in scan_result if _filter_device(atv)]

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -28,7 +28,7 @@ INPUT_PIN_SCHEMA = vol.Schema({vol.Required(CONF_PIN, default=None): int})
 DEFAULT_START_OFF = False
 
 
-async def device_scan(identifier, loop):
+async def device_scan(hass, identifier, loop):
     """Scan for a specific device using identifier as filter."""
 
     def _filter_device(dev):
@@ -46,8 +46,10 @@ async def device_scan(identifier, loop):
         except ValueError:
             return None
 
+    aiozc = await zeroconf.async_get_async_instance(hass)
+
     for hosts in (_host_filter(), None):
-        scan_result = await scan(loop, timeout=3, hosts=hosts)
+        scan_result = await scan(loop, timeout=3, hosts=hosts, aiozc=aiozc)
         matches = [atv for atv in scan_result if _filter_device(atv)]
 
         if matches:
@@ -226,7 +228,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_find_device(self, allow_exist=False):
         """Scan for the selected device to discover services."""
         self.atv, self.atv_identifiers = await device_scan(
-            self.scan_filter, self.hass.loop
+            self.hass, self.scan_filter, self.hass.loop
         )
         if not self.atv:
             raise DeviceNotFound()

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -165,7 +165,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         unique_id = get_unique_id(service_type, name, properties)
         if unique_id is None:
             return self.async_abort(reason="unknown")
-        self.scan_filter = discovery_info.host
+        self.scan_filter = host
 
         await self._async_aggregate_discoveries(host, unique_id, service_type)
         # Scan for the device in order to extract _all_ unique identifiers assigned to

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -28,7 +28,7 @@ INPUT_PIN_SCHEMA = vol.Schema({vol.Required(CONF_PIN, default=None): int})
 DEFAULT_START_OFF = False
 
 
-async def device_scan(hass, identifier, loop):
+async def device_scan(identifier, loop):
     """Scan for a specific device using identifier as filter."""
 
     def _filter_device(dev):
@@ -46,6 +46,8 @@ async def device_scan(hass, identifier, loop):
         except ValueError:
             return None
 
+    # If we have an address only probe that address to avoid
+    # broadcast traffic on the network
     scan_result = await scan(loop, timeout=3, hosts=_host_filter())
     matches = [atv for atv in scan_result if _filter_device(atv)]
 
@@ -229,7 +231,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_find_device(self, allow_exist=False):
         """Scan for the selected device to discover services."""
         self.atv, self.atv_identifiers = await device_scan(
-            self.hass, self.scan_filter, self.hass.loop
+            self.scan_filter, self.hass.loop
         )
         if not self.atv:
             raise DeviceNotFound()

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -189,10 +189,6 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # potentially new identifiers. In the example above, when service C is
         # discovered, the identifier of service C will be inserted into
         # "all_identifiers" of the original flow (making the device complete).
-        # Also abort if an integration with this identifier already exists
-        await self.async_set_unique_id(self.device_identifier)
-        self._abort_if_unique_id_configured(updates={CONF_ADDRESS: self.atv.address})
-
         for flow in self._async_in_progress():
             for identifier in self.atv.all_identifiers:
                 if identifier not in flow["context"].get("all_identifiers", []):
@@ -206,6 +202,12 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 raise data_entry_flow.AbortFlow("already_in_progress")
 
         self.context["all_identifiers"] = self.atv.all_identifiers
+
+        await self.async_set_unique_id(self.device_identifier)
+        # Also abort if an integration with this identifier already exists
+        # but be sure to update the address if its changed so the scanner
+        # will probe the new address
+        self._abort_if_unique_id_configured(updates={CONF_ADDRESS: self.atv.address})
 
         self.context["identifier"] = self.unique_id
         return await self.async_step_confirm()

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -207,15 +207,15 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # zeroconf.
         #
         await asyncio.sleep(DISCOVERY_AGGREGATION_TIME)
-        #
-        # Must not await until self.context[CONF_ADDRESS] is set or other flows may
-        # see it too soon and all flows will lose the race and nothing moves forward
         self._async_check_in_progress_and_set_address(host, unique_id)
-        # Safe to await again after self.context[CONF_ADDRESS] is set
 
     @callback
     def _async_check_in_progress_and_set_address(self, host: str, unique_id: str):
-        """Check for in-progress flows and update them with identifiers if needed."""
+        """Check for in-progress flows and update them with identifiers if needed.
+
+        This code must not await between checking in progress and setting the host
+        or it will have a race condition where no flows move forward.
+        """
         for flow in self._async_in_progress(include_uninitialized=True):
             context = flow["context"]
             if (

--- a/tests/components/apple_tv/common.py
+++ b/tests/components/apple_tv/common.py
@@ -49,10 +49,10 @@ def create_conf(name, address, *services):
     return atv
 
 
-def mrp_service(enabled=True):
+def mrp_service(enabled=True, unique_id="mrpid"):
     """Create example MRP service."""
     return conf.ManualService(
-        "mrpid",
+        unique_id,
         Protocol.MRP,
         5555,
         {},

--- a/tests/components/apple_tv/common.py
+++ b/tests/components/apple_tv/common.py
@@ -70,3 +70,14 @@ def airplay_service():
         {},
         pairing_requirement=const.PairingRequirement.Mandatory,
     )
+
+
+def raop_service():
+    """Create example RAOP service."""
+    return conf.ManualService(
+        "AABBCCDDEEFF",
+        Protocol.RAOP,
+        7000,
+        {},
+        pairing_requirement=const.PairingRequirement.Mandatory,
+    )

--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -96,12 +96,19 @@ def full_device(mock_scan, dmap_pin):
 @pytest.fixture
 def mrp_device(mock_scan):
     """Mock pyatv.scan."""
-    mock_scan.result.append(
-        create_conf(
-            "127.0.0.1",
-            "MRP Device",
-            mrp_service(),
-        )
+    mock_scan.result.extend(
+        [
+            create_conf(
+                "127.0.0.1",
+                "MRP Device",
+                mrp_service(),
+            ),
+            create_conf(
+                "127.0.0.2",
+                "MRP Device 2",
+                mrp_service(unique_id="unrelated"),
+            ),
+        ]
     )
     yield mock_scan
 

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -15,7 +15,7 @@ from .common import airplay_service, create_conf, mrp_service
 from tests.common import MockConfigEntry
 
 DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
-    host="mock_host",
+    host="127.0.0.1",
     hostname="mock_hostname",
     port=None,
     type="_touch-able._tcp.local.",
@@ -507,7 +507,7 @@ async def test_zeroconf_unsupported_service_aborts(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             name="mock_name",
             port=None,
@@ -525,7 +525,7 @@ async def test_zeroconf_add_mrp_device(hass, mrp_device, pairing):
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             name="Kitchen",
@@ -638,7 +638,7 @@ async def test_zeroconf_abort_if_other_in_progress(hass, mock_scan):
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -658,7 +658,7 @@ async def test_zeroconf_abort_if_other_in_progress(hass, mock_scan):
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -681,7 +681,7 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -700,7 +700,7 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -733,7 +733,7 @@ async def test_zeroconf_additional_protocol_resolve_failure(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -752,7 +752,7 @@ async def test_zeroconf_additional_protocol_resolve_failure(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",
@@ -785,7 +785,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_airplay._tcp.local.",
@@ -804,7 +804,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="mock_host",
+            host="127.0.0.1",
             hostname="mock_hostname",
             port=None,
             type="_mediaremotetv._tcp.local.",

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
-from homeassistant.components.apple_tv import CONF_ADDRESS
+from homeassistant.components.apple_tv import CONF_ADDRESS, config_flow
 from homeassistant.components.apple_tv.const import CONF_START_OFF, DOMAIN
 
 from .common import airplay_service, create_conf, mrp_service
@@ -23,6 +23,13 @@ DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
     name="dmapid._touch-able._tcp.local.",
     properties={"CtlN": "Apple TV"},
 )
+
+
+@pytest.fixture(autouse=True)
+def zero_aggregation_time():
+    """Prevent the aggregation time from delaying the tests."""
+    with patch.object(config_flow, "DISCOVERY_AGGREGATION_TIME", 0):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -820,6 +827,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
             properties={"deviceid": "airplayid"},
         ),
     )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     mock_scan.result = [
         create_conf("127.0.0.1", "Device", mrp_service(), airplay_service())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce cpu requirements for apple_tv

- This effectively offloads the mdns burden to Home Assistant's zeroconf discovery which is already well optimized. 

- Avoid all multicast discovery except during the user flow (since its a firehose)

- We only do unicast discovery to the ip address in the config entry

- We rely on the zeroconf listener to update the ip address if it changes.

- We now wait 15s after discovery via zeroconf to allow other zeroconf discoveries to aggregate to prevent scanning the same device many times and triggering asyncio warnings about the event loop being blocked because the system became cpu bound

- Fixes backoff time randomizing to zero and probing the device right away again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
