### PR TITLE
Fix duplicate metrics in prometheus

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -216,8 +216,6 @@ class PrometheusMetrics:
                 metrics_entity_id = changes["entity_id"]
             elif "disabled_by" in changes:
                 metrics_entity_id = entity_id
-            elif "name" in changes:
-                return
 
         if metrics_entity_id:
             self._remove_labelsets(metrics_entity_id)

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -238,7 +238,6 @@ class PrometheusMetrics:
                         metric.remove(*sample.labels.values())
                     except KeyError:
                         pass
-                    # break
 
     def _handle_attributes(self, state):
         for key, value in state.attributes.items():

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entityfilter, state as state_helper
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
 from homeassistant.helpers.entity_values import EntityValues
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.temperature import fahrenheit_to_celsius
@@ -111,7 +112,10 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         default_metric,
     )
 
-    hass.bus.listen(EVENT_STATE_CHANGED, metrics.handle_event)
+    hass.bus.listen(EVENT_STATE_CHANGED, metrics.handle_state_changed)
+    hass.bus.listen(
+        EVENT_ENTITY_REGISTRY_UPDATED, metrics.handle_entity_registry_updated
+    )
     return True
 
 
@@ -149,7 +153,7 @@ class PrometheusMetrics:
         self._metrics = {}
         self._climate_units = climate_units
 
-    def handle_event(self, event):
+    def handle_state_changed(self, event):
         """Listen for new messages on the bus, and add them to Prometheus."""
         if (state := event.data.get("new_state")) is None:
             return
@@ -187,6 +191,44 @@ class PrometheusMetrics:
             "The last_updated timestamp",
         )
         last_updated_time_seconds.labels(**labels).set(state.last_updated.timestamp())
+
+    def handle_entity_registry_updated(self, event):
+        """Listen for deleted, disabled or renamed entities and remove them from the Prometheus Registry."""
+        if (action := event.data.get("action")) in (None, "create"):
+            return
+
+        entity_id = event.data.get("entity_id")
+        _LOGGER.debug("Handling entity update for %s", entity_id)
+
+        metrics_entity_id = None
+
+        if action == "remove":
+            metrics_entity_id = entity_id
+        elif action == "update":
+            changes = event.data.get("changes")
+            if "entity_id" in changes:
+                metrics_entity_id = changes["entity_id"]
+            elif "disabled_by" in changes or "name" in changes:
+                metrics_entity_id = entity_id
+
+        if metrics_entity_id:
+            self._remove_labelsets(metrics_entity_id)
+
+    def _remove_labelsets(self, entity_id):
+        """Remove labelsets matching the given entity id from all metrics."""
+        for _, metric in self._metrics.items():
+            for sample in metric.collect()[0].samples:
+                if sample.labels["entity"] == entity_id:
+                    _LOGGER.debug(
+                        "Removing labelset from %s for entity_id: %s",
+                        sample.name,
+                        entity_id,
+                    )
+                    try:
+                        metric.remove(*sample.labels.values())
+                    except KeyError:
+                        pass
+                    break
 
     def _handle_attributes(self, state):
         for key, value in state.attributes.items():

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -722,7 +722,7 @@ async def test_renaming_entity_name(hass, hass_client):
     )
     client = await setup_prometheus_client(hass, hass_client, "")
 
-    await async_setup_component(
+    assert await async_setup_component(
         hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
     )
 

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -776,7 +776,7 @@ async def test_renaming_entity_name(hass, hass_client):
     assert "climate.heatpump" in registry.entities
     registry.async_update_entity(
         entity_id="sensor.outside_temperature",
-        name="Inside Temperature",
+        name="Outside Temperature Renamed",
     )
     registry.async_update_entity(
         entity_id="climate.heatpump",
@@ -817,13 +817,13 @@ async def test_renaming_entity_name(hass, hass_client):
     assert (
         'sensor_temperature_celsius{domain="sensor",'
         'entity="sensor.outside_temperature",'
-        'friendly_name="Inside Temperature"} 15.6' in body
+        'friendly_name="Outside Temperature Renamed"} 15.6' in body
     )
 
     assert (
         'entity_available{domain="sensor",'
         'entity="sensor.outside_temperature",'
-        'friendly_name="Inside Temperature"} 1.0' in body
+        'friendly_name="Outside Temperature Renamed"} 1.0' in body
     )
 
     # Keep other sensors

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -780,38 +780,16 @@ async def test_renaming_entity_name(hass, hass_client):
     )
     registry.async_update_entity(
         entity_id="climate.heatpump",
-        name="Renamed",
+        name="HeatPump Renamed",
     )
 
     await hass.async_block_till_done()
     body = await generate_latest_metrics(client)
 
     # Check if old metrics deleted
-    assert (
-        'sensor_temperature_celsius{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 15.6' not in body
-    )
-
-    assert (
-        'entity_available{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 1.0' not in body
-    )
-
-    assert (
-        'climate_action{action="heating",'
-        'domain="climate",'
-        'entity="climate.heatpump",'
-        'friendly_name="HeatPump"} 1.0' not in body
-    )
-
-    assert (
-        'climate_action{action="cooling",'
-        'domain="climate",'
-        'entity="climate.heatpump",'
-        'friendly_name="HeatPump"} 0.0' not in body
-    )
+    body_line = "\n".join(body)
+    assert 'friendly_name="Outside Temperature"' not in body_line
+    assert 'friendly_name="HeatPump"' not in body_line
 
     # Check if new metrics created
     assert (
@@ -824,6 +802,20 @@ async def test_renaming_entity_name(hass, hass_client):
         'entity_available{domain="sensor",'
         'entity="sensor.outside_temperature",'
         'friendly_name="Outside Temperature Renamed"} 1.0' in body
+    )
+
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump Renamed"} 1.0' in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump Renamed"} 0.0' in body
     )
 
     # Keep other sensors
@@ -884,35 +876,26 @@ async def test_renaming_entity_id(hass, hass_client):
     assert "sensor.outside_temperature" in registry.entities
     registry.async_update_entity(
         entity_id="sensor.outside_temperature",
-        new_entity_id="sensor.inside_temperature",
+        new_entity_id="sensor.outside_temperature_renamed",
     )
 
     await hass.async_block_till_done()
     body = await generate_latest_metrics(client)
 
     # Check if old metrics deleted
-    assert (
-        'sensor_temperature_celsius{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 15.6' not in body
-    )
-
-    assert (
-        'entity_available{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 1.0' not in body
-    )
+    body_line = "\n".join(body)
+    assert 'entity="sensor.outside_temperature"' not in body_line
 
     # Check if new metrics created
     assert (
         'sensor_temperature_celsius{domain="sensor",'
-        'entity="sensor.inside_temperature",'
+        'entity="sensor.outside_temperature_renamed",'
         'friendly_name="Outside Temperature"} 15.6' in body
     )
 
     assert (
         'entity_available{domain="sensor",'
-        'entity="sensor.inside_temperature",'
+        'entity="sensor.outside_temperature_renamed",'
         'friendly_name="Outside Temperature"} 1.0' in body
     )
 
@@ -998,31 +981,11 @@ async def test_deleting_entity(hass, hass_client):
     body = await generate_latest_metrics(client)
 
     # Check if old metrics deleted
-    assert (
-        'sensor_temperature_celsius{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 15.6' not in body
-    )
-
-    assert (
-        'entity_available{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 1.0' not in body
-    )
-
-    assert (
-        'climate_action{action="heating",'
-        'domain="climate",'
-        'entity="climate.heatpump",'
-        'friendly_name="HeatPump"} 1.0' not in body
-    )
-
-    assert (
-        'climate_action{action="cooling",'
-        'domain="climate",'
-        'entity="climate.heatpump",'
-        'friendly_name="HeatPump"} 0.0' not in body
-    )
+    body_line = "\n".join(body)
+    assert 'entity="sensor.outside_temperature"' not in body_line
+    assert 'friendly_name="Outside Temperature"' not in body_line
+    assert 'entity="climate.heatpump"' not in body_line
+    assert 'friendly_name="HeatPump"' not in body_line
 
     # Keep other sensors
     assert (
@@ -1116,38 +1079,11 @@ async def test_disabling_entity(hass, hass_client):
     body = await generate_latest_metrics(client)
 
     # Check if old metrics deleted
-    assert (
-        'sensor_temperature_celsius{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 15.6' not in body
-    )
-
-    assert any(
-        'state_change_created{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"}' not in metric
-        for metric in body
-    )
-
-    assert (
-        'state_change_total{domain="sensor",'
-        'entity="sensor.outside_temperature",'
-        'friendly_name="Outside Temperature"} 1.0' not in body
-    )
-
-    assert (
-        'climate_action{action="heating",'
-        'domain="climate",'
-        'entity="climate.heatpump",'
-        'friendly_name="HeatPump"} 1.0' not in body
-    )
-
-    assert (
-        'climate_action{action="cooling",'
-        'domain="climate",'
-        'entity="climate.heatpump",'
-        'friendly_name="HeatPump"} 0.0' not in body
-    )
+    body_line = "\n".join(body)
+    assert 'entity="sensor.outside_temperature"' not in body_line
+    assert 'friendly_name="Outside Temperature"' not in body_line
+    assert 'entity="climate.heatpump"' not in body_line
+    assert 'friendly_name="HeatPump"' not in body_line
 
     # Keep other sensors
     assert (

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -722,6 +722,10 @@ async def test_renaming_entity_name(hass, hass_client):
     )
     client = await setup_prometheus_client(hass, hass_client, "")
 
+    await async_setup_component(
+        hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
+    )
+
     assert await async_setup_component(
         hass, sensor.DOMAIN, {"sensor": [{"platform": "demo"}]}
     )
@@ -753,11 +757,30 @@ async def test_renaming_entity_name(hass, hass_client):
         'friendly_name="Outside Humidity"} 1.0' in body
     )
 
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 1.0' in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 0.0' in body
+    )
+
     registry = entity_registry.async_get(hass)
     assert "sensor.outside_temperature" in registry.entities
+    assert "climate.heatpump" in registry.entities
     registry.async_update_entity(
         entity_id="sensor.outside_temperature",
         name="Inside Temperature",
+    )
+    registry.async_update_entity(
+        entity_id="climate.heatpump",
+        name="Renamed",
     )
 
     await hass.async_block_till_done()
@@ -774,6 +797,20 @@ async def test_renaming_entity_name(hass, hass_client):
         'entity_available{domain="sensor",'
         'entity="sensor.outside_temperature",'
         'friendly_name="Outside Temperature"} 1.0' not in body
+    )
+
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 1.0' not in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 0.0' not in body
     )
 
     # Check if new metrics created
@@ -902,6 +939,10 @@ async def test_deleting_entity(hass, hass_client):
     )
     client = await setup_prometheus_client(hass, hass_client, "")
 
+    await async_setup_component(
+        hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
+    )
+
     assert await async_setup_component(
         hass, sensor.DOMAIN, {"sensor": [{"platform": "demo"}]}
     )
@@ -933,9 +974,25 @@ async def test_deleting_entity(hass, hass_client):
         'friendly_name="Outside Humidity"} 1.0' in body
     )
 
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 1.0' in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 0.0' in body
+    )
+
     registry = entity_registry.async_get(hass)
     assert "sensor.outside_temperature" in registry.entities
+    assert "climate.heatpump" in registry.entities
     registry.async_remove("sensor.outside_temperature")
+    registry.async_remove("climate.heatpump")
 
     await hass.async_block_till_done()
     body = await generate_latest_metrics(client)
@@ -951,6 +1008,20 @@ async def test_deleting_entity(hass, hass_client):
         'entity_available{domain="sensor",'
         'entity="sensor.outside_temperature",'
         'friendly_name="Outside Temperature"} 1.0' not in body
+    )
+
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 1.0' not in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 0.0' not in body
     )
 
     # Keep other sensors
@@ -975,6 +1046,10 @@ async def test_disabling_entity(hass, hass_client):
         {},
     )
     client = await setup_prometheus_client(hass, hass_client, "")
+
+    await async_setup_component(
+        hass, climate.DOMAIN, {"climate": [{"platform": "demo"}]}
+    )
 
     assert await async_setup_component(
         hass, sensor.DOMAIN, {"sensor": [{"platform": "demo"}]}
@@ -1014,12 +1089,28 @@ async def test_disabling_entity(hass, hass_client):
         'friendly_name="Outside Humidity"} 1.0' in body
     )
 
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 1.0' in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 0.0' in body
+    )
+
     registry = entity_registry.async_get(hass)
     assert "sensor.outside_temperature" in registry.entities
+    assert "climate.heatpump" in registry.entities
     registry.async_update_entity(
         entity_id="sensor.outside_temperature",
         disabled_by="user",
     )
+    registry.async_update_entity(entity_id="climate.heatpump", disabled_by="user")
 
     await hass.async_block_till_done()
     body = await generate_latest_metrics(client)
@@ -1042,6 +1133,20 @@ async def test_disabling_entity(hass, hass_client):
         'state_change_total{domain="sensor",'
         'entity="sensor.outside_temperature",'
         'friendly_name="Outside Temperature"} 1.0' not in body
+    )
+
+    assert (
+        'climate_action{action="heating",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 1.0' not in body
+    )
+
+    assert (
+        'climate_action{action="cooling",'
+        'domain="climate",'
+        'entity="climate.heatpump",'
+        'friendly_name="HeatPump"} 0.0' not in body
     )
 
     # Keep other sensors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
Every prometheus metric has at least 3 labels (`entity`, `name`, `domain`).
If a user changes the `friendly_name` a new metric is created, but the old one keeps existing. This was reported in #50382.
This also happens when an entity id is renamed and by deleting or disabling an entity.

In this pull request the `EVENT_ENTITY_REGISTRY_UPDATED` event is used to listen to the changes and to remove the non-existing labelsets.
To remove a labelset the function has to iterate over all labelsets. Since this only happens when an entity is renamed, disabled or deleted this shouldn't make a difference in performance.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50382
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
