### PR TITLE
Fix Tuya cover open/close commands

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -315,7 +315,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             {"code": self.entity_description.key, "value": value}
         ]
 
-        if (self.entity_description.set_position) is not None:
+        if (
+            self.entity_description.set_position is not None
+            and self._set_position_type is not None
+        ):
             commands.append(
                 {
                     "code": self.entity_description.set_position,
@@ -339,7 +342,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             {"code": self.entity_description.key, "value": value}
         ]
 
-        if (self.entity_description.set_position) is not None:
+        if (
+            self.entity_description.set_position is not None
+            and self._set_position_type is not None
+        ):
             commands.append(
                 {
                     "code": self.entity_description.set_position,

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -319,7 +319,11 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             commands.append(
                 {
                     "code": self.entity_description.set_position,
-                    "value": 100,
+                    "value": round(
+                        self._set_position_type.remap_value_from(
+                            100, 0, 100, reverse=True
+                        ),
+                    ),
                 }
             )
 
@@ -339,7 +343,11 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             commands.append(
                 {
                     "code": self.entity_description.set_position,
-                    "value": 0,
+                    "value": round(
+                        self._set_position_type.remap_value_from(
+                            0, 0, 100, reverse=True
+                        ),
+                    ),
                 }
             )
 

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -319,7 +319,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             commands.append(
                 {
                     "code": self.entity_description.set_position,
-                    "value": 0,
+                    "value": 100,
                 }
             )
 
@@ -327,7 +327,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     def close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        value: bool | str = True
+        value: bool | str = False
         if self.device.function[self.entity_description.key].type == "Enum":
             value = "close"
 
@@ -339,7 +339,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             commands.append(
                 {
                     "code": self.entity_description.set_position,
-                    "value": 100,
+                    "value": 0,
                 }
             )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current default boolean command being sent for "open" and "close" is the same `True`.
From testing my garage door opener on Tuya IoT, I believe the "close" command should be `False`.
Also, based on #60995 and the docstring [here](https://github.com/home-assistant/core/blob/2db1013620c0ef756e66652b738cacc7149ce0e1/homeassistant/components/tuya/cover.py#L277), I think the percent values being sent are reversed. Unfortunately, the IoT documentation thoroughly discusses valid values, but doesn't discuss what the values mean...

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR hopefully fixes #60995 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
