### PR TITLE
Consolidate SimpliSafe config flow forms into one

### DIFF
--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -68,7 +68,6 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _async_show_form(self, *, errors: dict[str, Any] | None = None) -> FlowResult:
         """Show the form."""
-        """Handle the start of the config flow."""
         self._oauth_values = async_get_simplisafe_oauth_values()
 
         return self.async_show_form(

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -24,7 +24,7 @@ from .const import CONF_USER_ID, DOMAIN, LOGGER
 
 CONF_AUTH_CODE = "auth_code"
 
-STEP_INPUT_AUTH_CODE_SCHEMA = vol.Schema(
+STEP_USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_AUTH_CODE): cv.string,
     }
@@ -54,8 +54,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self._errors: dict[str, Any] = {}
-        self._oauth_values: SimpliSafeOAuthValues = async_get_simplisafe_oauth_values()
+        self._oauth_values: SimpliSafeOAuthValues | None = None
         self._reauth: bool = False
         self._username: str | None = None
 
@@ -67,19 +66,35 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Define the config flow to handle options."""
         return SimpliSafeOptionsFlowHandler(config_entry)
 
-    async def async_step_input_auth_code(
+    def _async_show_form(self, *, errors: dict[str, Any] | None = None) -> FlowResult:
+        """Show the form."""
+        """Handle the start of the config flow."""
+        self._oauth_values = async_get_simplisafe_oauth_values()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_SCHEMA,
+            errors=errors or {},
+            description_placeholders={CONF_URL: self._oauth_values.auth_url},
+        )
+
+    async def async_step_reauth(self, config: ConfigType) -> FlowResult:
+        """Handle configuration by re-auth."""
+        self._username = config.get(CONF_USERNAME)
+        self._reauth = True
+        return await self.async_step_user()
+
+    async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the input of a SimpliSafe OAuth authorization code."""
+        """Handle the start of the config flow."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="input_auth_code", data_schema=STEP_INPUT_AUTH_CODE_SCHEMA
-            )
+            return self._async_show_form()
 
         if TYPE_CHECKING:
             assert self._oauth_values
 
-        self._errors = {}
+        errors = {}
         session = aiohttp_client.async_get_clientsession(self.hass)
 
         try:
@@ -89,13 +104,13 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 session=session,
             )
         except InvalidCredentialsError:
-            self._errors = {"base": "invalid_auth"}
+            errors = {"base": "invalid_auth"}
         except SimplipyError as err:
             LOGGER.error("Unknown error while logging into SimpliSafe: %s", err)
-            self._errors = {"base": "unknown"}
+            errors = {"base": "unknown"}
 
-        if self._errors:
-            return await self.async_step_user()
+        if errors:
+            return self._async_show_form(errors=errors)
 
         data = {CONF_USER_ID: simplisafe.user_id, CONF_TOKEN: simplisafe.refresh_token}
         unique_id = str(simplisafe.user_id)
@@ -121,25 +136,6 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title=unique_id, data=data)
-
-    async def async_step_reauth(self, config: ConfigType) -> FlowResult:
-        """Handle configuration by re-auth."""
-        self._username = config.get(CONF_USERNAME)
-        self._reauth = True
-        return await self.async_step_user()
-
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the start of the config flow."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user",
-                errors=self._errors,
-                description_placeholders={CONF_URL: self._oauth_values.auth_url},
-            )
-
-        return await self.async_step_input_auth_code()
 
 
 class SimpliSafeOptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -1,15 +1,11 @@
 {
   "config": {
     "step": {
-      "input_auth_code": {
-        "title": "Finish Authorization",
-        "description": "Input the authorization code from the SimpliSafe web app URL:",
+      "user": {
+        "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below.",
         "data": {
           "auth_code": "Authorization Code"
         }
-      },
-      "user": {
-        "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and click Submit."
       }
     },
     "error": {

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -12,32 +12,11 @@
             "unknown": "Unexpected error"
         },
         "step": {
-            "input_auth_code": {
+            "user": {
                 "data": {
                     "auth_code": "Authorization Code"
                 },
-                "description": "Input the authorization code from the SimpliSafe web app URL:",
-                "title": "Finish Authorization"
-            },
-            "mfa": {
-                "description": "Check your email for a link from SimpliSafe. After verifying the link, return here to complete the installation of the integration.",
-                "title": "SimpliSafe Multi-Factor Authentication"
-            },
-            "reauth_confirm": {
-                "data": {
-                    "password": "Password"
-                },
-                "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
-                "title": "Reauthenticate Integration"
-            },
-            "user": {
-                "data": {
-                    "code": "Code (used in Home Assistant UI)",
-                    "password": "Password",
-                    "username": "Email"
-                },
-                "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and click Submit.",
-                "title": "Fill in your information."
+                "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below."
             }
         }
     },

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -54,9 +54,6 @@ async def test_duplicate_error(hass, mock_async_from_auth):
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -73,9 +70,6 @@ async def test_invalid_credentials(hass, mock_async_from_auth):
     assert result["step_id"] == "user"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
     )
@@ -132,9 +126,6 @@ async def test_step_reauth_old_format(hass, mock_async_from_auth):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -166,9 +157,6 @@ async def test_step_reauth_new_format(hass, mock_async_from_auth):
     with patch(
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
         )
@@ -206,9 +194,6 @@ async def test_step_reauth_wrong_account(hass, api, mock_async_from_auth):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -230,9 +215,6 @@ async def test_step_user(hass, mock_async_from_auth):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch("homeassistant.config_entries.ConfigEntries.async_reload"):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -252,9 +234,6 @@ async def test_unknown_error(hass, mock_async_from_auth):
     assert result["step_id"] == "user"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_AUTH_CODE: "code123"}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current two-form config flow for SimpliSafe has a "bug" wherein a user can't access the SimpliSafe login form after the `user` step is completed, which is [causing a lot of confusion](https://github.com/home-assistant/core/issues/59196). This PR consolidates the config flow into one form so that users will always be able to re-initiate the SimpliSafe login process.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/59196
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
