### PR TITLE
[MySensors] Advanced Config Panel + Node FOTA - *Not Yet ready to merge*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -336,7 +336,7 @@ homeassistant/components/mullvad/* @meichthys
 homeassistant/components/mutesync/* @currentoor
 homeassistant/components/my/* @home-assistant/core
 homeassistant/components/myq/* @bdraco @ehendrix23
-homeassistant/components/mysensors/* @MartinHjelmare @functionpointer
+homeassistant/components/mysensors/* @MartinHjelmare @functionpointer @dianlight
 homeassistant/components/mystrom/* @fabaff
 homeassistant/components/nam/* @bieniu
 homeassistant/components/nanoleaf/* @milanmeu

--- a/homeassistant/components/mysensors/const.py
+++ b/homeassistant/components/mysensors/const.py
@@ -34,6 +34,8 @@ MYSENSORS_GATEWAY_START_TASK: str = "mysensors_gateway_start_task_{}"
 MYSENSORS_GATEWAYS: Final = "mysensors_gateways"
 PLATFORM: Final = "platform"
 SCHEMA: Final = "schema"
+NODE_ID: Final = "node_{}"
+NODE_ROOT_CHILD_ID = 0
 CHILD_CALLBACK: str = "mysensors_child_callback_{}_{}_{}_{}"
 NODE_CALLBACK: str = "mysensors_node_callback_{}_{}"
 MYSENSORS_DISCOVERY: str = "mysensors_discovery_{}_{}"
@@ -51,6 +53,8 @@ class DiscoveryInfo(TypedDict):
 
 
 SERVICE_SEND_IR_CODE: Final = "send_ir_code"
+SERVICE_FIRMWARE_LIST: Final = "firmware_list"
+SERVICE_UPDATE_FIRMWARE: Final = "update_firmware"
 
 SensorType = str
 # S_DOOR, S_MOTION, S_SMOKE, ...

--- a/homeassistant/components/mysensors/device.py
+++ b/homeassistant/components/mysensors/device.py
@@ -6,6 +6,9 @@ import logging
 from typing import Any
 
 from mysensors import BaseAsyncGateway, Sensor
+from mysensors.const_14 import MessageType, Stream
+from mysensors.message import Message
+from mysensors.ota import fw_hex_to_int
 from mysensors.sensor import ChildSensor
 
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON
@@ -18,6 +21,7 @@ from .const import (
     CONF_DEVICE,
     DOMAIN,
     NODE_CALLBACK,
+    NODE_ROOT_CHILD_ID,
     PLATFORM_TYPES,
     UPDATE_DELAY,
     DevId,
@@ -31,6 +35,15 @@ ATTR_DESCRIPTION = "description"
 ATTR_DEVICE = "device"
 ATTR_NODE_ID = "node_id"
 ATTR_HEARTBEAT = "heartbeat"
+ATTR_FIRMWARE = "firmware"
+ATTR_FIRMWARE_TYPE = "type"
+ATTR_FIRMWARE_VERSION = "version"
+ATTR_FIRMWARE_BLOCKS = "blocks"
+ATTR_FIRMWARE_CRC = "crc"
+ATTR_FIRMWARE_BOOTLOADER_VERSION = "bl_version"
+ATTR_FIRMWARE_REQ_BLOCK = "req_block"
+ATTR_FIRMWARE_REQ_TOTAL_BLOCKS = "req_total_blocks"
+
 MYSENSORS_PLATFORM_DEVICES = "mysensors_devices_{}"
 
 
@@ -56,6 +69,7 @@ class MySensorsDevice:
         self.child_type = self._child.type
         self._values: dict[int, Any] = {}
         self._update_scheduled = False
+        self._firmware: dict[str, str] = {}
 
     @property
     def dev_id(self) -> DevId:
@@ -87,7 +101,12 @@ class MySensorsDevice:
 
     @property
     def _child(self) -> ChildSensor:
-        return self._node.children[self.child_id]
+        if self.child_id == NODE_ROOT_CHILD_ID:
+            return ChildSensor(
+                child_id=NODE_ROOT_CHILD_ID, child_type=0, description="Node"
+            )
+        else:
+            return self._node.children[self.child_id]
 
     @property
     def sketch_name(self) -> str:
@@ -123,9 +142,12 @@ class MySensorsDevice:
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, f"{self.gateway_id}-{self.node_id}")},
-            manufacturer=DOMAIN,
+            manufacturer="MySensors",
+            model=self.sketch_name,
             name=self.node_name,
             sw_version=self.sketch_version,
+            configuration_url=f"homeassistant://config/mysensors?config_entry={self.gateway_id}&nodeId={self.node_id}",
+            #   via_device={(DOMAIN, self.gateway_id)}, # In future update the Gateway mut be a device itself
         )
 
     @property
@@ -148,6 +170,7 @@ class MySensorsDevice:
             ATTR_CHILD_ID: self.child_id,
             ATTR_DESCRIPTION: child.description,
             ATTR_NODE_ID: self.node_id,
+            ATTR_FIRMWARE: self._firmware,
         }
 
         set_req = self.gateway.const.SetReq
@@ -160,6 +183,8 @@ class MySensorsDevice:
     async def async_update(self) -> None:
         """Update the controller with the latest value from a sensor."""
         node = self.gateway.sensors[self.node_id]
+        if self.child_id == NODE_ROOT_CHILD_ID:
+            return
         child = node.children[self.child_id]
         set_req = self.gateway.const.SetReq
         for value_type, value in child.values.items():
@@ -189,8 +214,43 @@ class MySensorsDevice:
         raise NotImplementedError
 
     @callback
-    def async_update_callback(self) -> None:
+    def async_update_callback(self, msg: Message = None) -> None:
         """Update the device after delay."""
+        if (
+            msg is not None
+            and msg.type == MessageType.stream
+            and msg.sub_type == Stream.ST_FIRMWARE_CONFIG_REQUEST
+        ):
+            (
+                self._firmware[ATTR_FIRMWARE_TYPE],
+                self._firmware[ATTR_FIRMWARE_VERSION],
+                self._firmware[ATTR_FIRMWARE_BLOCKS],
+                self._firmware[ATTR_FIRMWARE_CRC],
+                self._firmware[ATTR_FIRMWARE_BOOTLOADER_VERSION],
+            ) = fw_hex_to_int(msg.payload, 5)
+            _LOGGER.debug("Firmware Request:%s", self._firmware)
+        elif (
+            msg is not None
+            and msg.type == MessageType.stream
+            and msg.sub_type == Stream.ST_FIRMWARE_REQUEST
+        ):
+            (
+                req_fw_type,
+                req_fw_ver,
+                self._firmware[ATTR_FIRMWARE_REQ_BLOCK],
+            ) = fw_hex_to_int(msg.payload, 3)
+            self._firmware[ATTR_FIRMWARE_REQ_TOTAL_BLOCKS] = max(
+                self._firmware[ATTR_FIRMWARE_REQ_BLOCK],
+                self._firmware.get(ATTR_FIRMWARE_REQ_TOTAL_BLOCKS, "0"),
+            )
+            _LOGGER.debug(
+                "Received firmware request with firmware type %s, "
+                "firmware version %s, block index %s / %s",
+                req_fw_type,
+                req_fw_ver,
+                self._firmware[ATTR_FIRMWARE_REQ_BLOCK],
+                self._firmware.get(ATTR_FIRMWARE_REQ_TOTAL_BLOCKS, "0"),
+            )
         if self._update_scheduled:
             return
 
@@ -264,3 +324,98 @@ class MySensorsEntity(MySensorsDevice, Entity):
                 self.async_update_callback,
             )
         )
+
+
+# FIXME: Not yet used
+class MySensorsNodeEntity(MySensorsEntity):
+    """Rappresentation of a MySensor node."""
+
+    def __init__(
+        self,
+        gateway_id: GatewayId,
+        gateway: BaseAsyncGateway,
+        node_id: int,
+        child_id: int,
+        value_type: int,
+    ) -> None:
+        """Set up the MySensors device."""
+        super().__init__(gateway_id, gateway, node_id, child_id, value_type)
+        self._firmware: dict[str, str] = {}
+
+    @property
+    def _extra_attributes(self) -> dict[str, Any]:
+        """Return device specific attributes."""
+        node = self.gateway.sensors[self.node_id]
+        child = node.children[self.child_id]
+        attr = {
+            ATTR_BATTERY_LEVEL: node.battery_level,
+            ATTR_HEARTBEAT: node.heartbeat,
+            ATTR_CHILD_ID: self.child_id,
+            ATTR_DESCRIPTION: child.description,
+            ATTR_NODE_ID: self.node_id,
+            ATTR_FIRMWARE: self._firmware,
+        }
+
+        set_req = self.gateway.const.SetReq
+
+        for value_type, value in self._values.items():
+            attr[set_req(value_type).name] = value
+
+        return attr
+
+    @callback
+    def async_update_callback(self, msg: Message = None) -> None:
+        """Update the device after delay."""
+
+        if (
+            msg is not None
+            and msg.type == MessageType.stream
+            and msg.sub_type == Stream.ST_FIRMWARE_CONFIG_REQUEST
+        ):
+            (
+                self._firmware[ATTR_FIRMWARE_TYPE],
+                self._firmware[ATTR_FIRMWARE_VERSION],
+                self._firmware[ATTR_FIRMWARE_BLOCKS],
+                self._firmware[ATTR_FIRMWARE_CRC],
+                self._firmware[ATTR_FIRMWARE_BOOTLOADER_VERSION],
+            ) = fw_hex_to_int(msg.payload, 5)
+            _LOGGER.debug("Firmware Request: %s", self._firmware)
+        elif (
+            msg is not None
+            and msg.type == MessageType.stream
+            and msg.sub_type == Stream.ST_FIRMWARE_REQUEST
+        ):
+            (
+                req_fw_type,
+                req_fw_ver,
+                self._firmware[ATTR_FIRMWARE_REQ_BLOCK],
+            ) = fw_hex_to_int(msg.payload, 3)
+            self._firmware[ATTR_FIRMWARE_REQ_TOTAL_BLOCKS] = max(
+                self._firmware[ATTR_FIRMWARE_REQ_BLOCK],
+                self._firmware[ATTR_FIRMWARE_REQ_TOTAL_BLOCKS],
+            )
+
+            _LOGGER.info(
+                "Received firmware request with firmware type %s, "
+                "firmware version %s, block index %s / %s",
+                req_fw_type,
+                req_fw_ver,
+                self._firmware[ATTR_FIRMWARE_REQ_BLOCK],
+                self._firmware[ATTR_FIRMWARE_REQ_TOTAL_BLOCKS],
+            )
+
+        if self._update_scheduled:
+            return
+
+        async def update() -> None:
+            """Perform update."""
+            try:
+                await self._async_update_callback()
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Error updating %s", self.name)
+            finally:
+                self._update_scheduled = False
+
+        self._update_scheduled = True
+        delayed_update = partial(self.hass.async_create_task, update())
+        self.hass.loop.call_later(UPDATE_DELAY, delayed_update)

--- a/homeassistant/components/mysensors/manifest.json
+++ b/homeassistant/components/mysensors/manifest.json
@@ -2,9 +2,10 @@
   "domain": "mysensors",
   "name": "MySensors",
   "documentation": "https://www.home-assistant.io/integrations/mysensors",
-  "requirements": ["pymysensors==0.22.1"],
+  "requirements": ["pymysensors==0.23.0"],
+  "dependencies": ["http"],
   "after_dependencies": ["mqtt"],
-  "codeowners": ["@MartinHjelmare", "@functionpointer"],
+  "codeowners": ["@MartinHjelmare", "@functionpointer", "@dianlight"],
   "config_flow": true,
   "iot_class": "local_push"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1661,7 +1661,7 @@ pymsteams==0.1.12
 pymyq==3.1.4
 
 # homeassistant.components.mysensors
-pymysensors==0.22.1
+pymysensors==0.23.0
 
 # homeassistant.components.netgear
 pynetgear==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1016,7 +1016,7 @@ pymonoprice==0.3
 pymyq==3.1.4
 
 # homeassistant.components.mysensors
-pymysensors==0.22.1
+pymysensors==0.23.0
 
 # homeassistant.components.netgear
 pynetgear==0.7.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The use of HA as MySensors controller is quite limited and not complete on the management of individual nodes. 
This patch adds Core services for an advanced node management panel (see [FE PR#10848](https://github.com/home-assistant/frontend/pull/10848)) within the Mysensors integration. And it adds some functionality:
- Node Firmware info
- Firmware Repository ( inside config folder )
- Node remote Reboot
- Node FOTA 
- Orphan node remove and node rediscovery [*Work in progress*]

For visual change please refer to the FE PR: https://github.com/home-assistant/frontend/pull/10848

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
It's a "work-in-progress" PR.  What I'm interested in is getting feedback on whether or not some of the solutions I've chosen are logical or not.

This is just the Core part that exposes the services needed for the FE to work. Here are the new features being managed:
- Adding firmware data to entity state
- Ability to re-configure an MySensors's gateway on UI.
- New folder "mysensors_fw" in config where the .hex files containing the various firmware to be used can be stored.
- New web socket services for the FE:
   - my sensors/device_list -> that returns the list of devices as "seen" by mysensors not in their "has" form. Nodes that do not have associated device/entities also appear.
  - mysensors/firmware_list -> which returns the list of firmware available in the directory "mysernsors_fw".
  - mysensors/fota -> which queues a FOTA request to a node
  - mysensors/reboot -> to request a node to reboot. ( needed in the process of node identification and FOTA ).
  - mysensors/remove -> to remove a node and allow discovery again if the node is not an orphan. ( needed in case of removal of mysensors nodes or change of their functionality ) 
  
- Update Dependencies:  https://github.com/theolind/pymysensors/releases/tag/0.23.0 needed to manage firmware update ad status.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
