### PR TITLE
Add iif (immediate if) template function/filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=hass,alot,datas,dof,dur,ether,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,rime,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,iam,incomfort,ba,haa
+          - --ignore-words-list=hass,alot,datas,dof,dur,ether,farenheit,hist,iff,iif,ines,ist,lightsensor,mut,nd,pres,referer,rime,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,iam,incomfort,ba,haa
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1763,6 +1763,23 @@ def slugify(value, separator="_"):
     return slugify_util(value, separator=separator)
 
 
+def ternary(
+    value: Any, if_true: Any = True, if_false: Any = False, if_none: Any = _SENTINEL
+) -> Any:
+    """Ternary function/filter that allow for common if/else constructs.
+
+    Examples:
+        {{ is_state("device_tracker.frenck", "home") | ternary("yes", "no") }}
+        {{ ternary(1==2, "yes", "no") }}
+        {{ (1 == 1) | ternary("yes", "no") }}
+    """
+    if value is None and if_none is not _SENTINEL:
+        return if_none
+    if bool(value):
+        return if_true
+    return if_false
+
+
 @contextmanager
 def set_template(template_str: str, action: str) -> Generator:
     """Store template being parsed or rendered in a Contextvar to aid error handling."""
@@ -1877,6 +1894,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["int"] = forgiving_int_filter
         self.filters["relative_time"] = relative_time
         self.filters["slugify"] = slugify
+        self.filters["ternary"] = ternary
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -1906,6 +1924,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["pack"] = struct_pack
         self.globals["unpack"] = struct_unpack
         self.globals["slugify"] = slugify
+        self.globals["ternary"] = ternary
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1763,15 +1763,17 @@ def slugify(value, separator="_"):
     return slugify_util(value, separator=separator)
 
 
-def ternary(
+def iif(
     value: Any, if_true: Any = True, if_false: Any = False, if_none: Any = _SENTINEL
 ) -> Any:
-    """Ternary function/filter that allow for common if/else constructs.
+    """Immediate if function/filter that allow for common if/else constructs.
+
+    https://en.wikipedia.org/wiki/IIf
 
     Examples:
-        {{ is_state("device_tracker.frenck", "home") | ternary("yes", "no") }}
-        {{ ternary(1==2, "yes", "no") }}
-        {{ (1 == 1) | ternary("yes", "no") }}
+        {{ is_state("device_tracker.frenck", "home") | iif("yes", "no") }}
+        {{ iif(1==2, "yes", "no") }}
+        {{ (1 == 1) | iif("yes", "no") }}
     """
     if value is None and if_none is not _SENTINEL:
         return if_none
@@ -1894,7 +1896,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["int"] = forgiving_int_filter
         self.filters["relative_time"] = relative_time
         self.filters["slugify"] = slugify
-        self.filters["ternary"] = ternary
+        self.filters["iif"] = iif
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -1924,7 +1926,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["pack"] = struct_pack
         self.globals["unpack"] = struct_unpack
         self.globals["slugify"] = slugify
-        self.globals["ternary"] = ternary
+        self.globals["iif"] = iif
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     VOLUME_LITERS,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import device_registry as dr, entity, template
 from homeassistant.helpers.entity_platform import EntityPlatform
@@ -3099,6 +3100,40 @@ def test_urlencode(hass):
         hass,
     )
     assert tpl.async_render() == "the%20quick%20brown%20fox%20%3D%20true"
+
+
+def test_ternary(hass: HomeAssistant) -> None:
+    """Test the ternary function/filter."""
+    tpl = template.Template("{{ (1 == 1) | ternary }}", hass)
+    assert tpl.async_render() is True
+
+    tpl = template.Template("{{ (1 == 2) | ternary }}", hass)
+    assert tpl.async_render() is False
+
+    tpl = template.Template("{{ (1 == 1) | ternary('yes') }}", hass)
+    assert tpl.async_render() == "yes"
+
+    tpl = template.Template("{{ (1 == 2) | ternary('yes') }}", hass)
+    assert tpl.async_render() is False
+
+    tpl = template.Template("{{ (1 == 2) | ternary('yes', 'no') }}", hass)
+    assert tpl.async_render() == "no"
+
+    tpl = template.Template(
+        "{{ not_exists | default(None) | ternary('yes', 'no') }}", hass
+    )
+    assert tpl.async_render() == "no"
+
+    tpl = template.Template(
+        "{{ not_exists | default(None) | ternary('yes', 'no', 'unknown') }}", hass
+    )
+    assert tpl.async_render() == "unknown"
+
+    tpl = template.Template("{{ ternary(1 == 1) }}", hass)
+    assert tpl.async_render() is True
+
+    tpl = template.Template("{{ ternary(1 == 2, 'yes', 'no') }}", hass)
+    assert tpl.async_render() == "no"
 
 
 async def test_cache_garbage_collection():

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3102,37 +3102,35 @@ def test_urlencode(hass):
     assert tpl.async_render() == "the%20quick%20brown%20fox%20%3D%20true"
 
 
-def test_ternary(hass: HomeAssistant) -> None:
-    """Test the ternary function/filter."""
-    tpl = template.Template("{{ (1 == 1) | ternary }}", hass)
+def test_iif(hass: HomeAssistant) -> None:
+    """Test the immediate if function/filter."""
+    tpl = template.Template("{{ (1 == 1) | iif }}", hass)
     assert tpl.async_render() is True
 
-    tpl = template.Template("{{ (1 == 2) | ternary }}", hass)
+    tpl = template.Template("{{ (1 == 2) | iif }}", hass)
     assert tpl.async_render() is False
 
-    tpl = template.Template("{{ (1 == 1) | ternary('yes') }}", hass)
+    tpl = template.Template("{{ (1 == 1) | iif('yes') }}", hass)
     assert tpl.async_render() == "yes"
 
-    tpl = template.Template("{{ (1 == 2) | ternary('yes') }}", hass)
+    tpl = template.Template("{{ (1 == 2) | iif('yes') }}", hass)
     assert tpl.async_render() is False
 
-    tpl = template.Template("{{ (1 == 2) | ternary('yes', 'no') }}", hass)
+    tpl = template.Template("{{ (1 == 2) | iif('yes', 'no') }}", hass)
+    assert tpl.async_render() == "no"
+
+    tpl = template.Template("{{ not_exists | default(None) | iif('yes', 'no') }}", hass)
     assert tpl.async_render() == "no"
 
     tpl = template.Template(
-        "{{ not_exists | default(None) | ternary('yes', 'no') }}", hass
-    )
-    assert tpl.async_render() == "no"
-
-    tpl = template.Template(
-        "{{ not_exists | default(None) | ternary('yes', 'no', 'unknown') }}", hass
+        "{{ not_exists | default(None) | iif('yes', 'no', 'unknown') }}", hass
     )
     assert tpl.async_render() == "unknown"
 
-    tpl = template.Template("{{ ternary(1 == 1) }}", hass)
+    tpl = template.Template("{{ iif(1 == 1) }}", hass)
     assert tpl.async_render() is True
 
-    tpl = template.Template("{{ ternary(1 == 2, 'yes', 'no') }}", hass)
+    tpl = template.Template("{{ iif(1 == 2, 'yes', 'no') }}", hass)
     assert tpl.async_render() == "no"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a really common pattern in templates:

```yaml
value_template: >-
  {% if something %}
     Yes
  {% else %}
     No
  {% endif %}
```

Tons of variants of this can be found in the forums and our documentation.

This PR suggests adding the iif (immediate if) filter/function to our Jinja2 engine, which helps with these cases.

`iif(value, if_true=True, if_false=False, if_none=<equals if_false by default>)`

The naming matches the definition per Wikipedia:

<https://en.wikipedia.org/wiki/IIf>

Some examples:

```
{{ iif(1==2, "yes", "no") }}
{{ (1 == 1) | iif("yes", "no") }}
{{ is_state("device_tracker.frenck", "home") | iif("yes", "no", "unknown") }}
```

![image](https://user-images.githubusercontent.com/195327/145556250-1f442452-155e-4af7-9622-8b3e00a31085.png)

Inspired by: <https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#defining-different-values-for-true-false-null-ternary>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20769

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
