### PR TITLE
Fix humidifier state error in HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -98,8 +98,8 @@ class HumidifierDehumidifier(HomeAccessory):
             serv_humidifier_dehumidifier.configure_char(
                 CHAR_TARGET_HUMIDIFIER_DEHUMIDIFIER,
                 value=self._hk_device_class,
+                properties={PROP_MIN_VALUE: 1},
                 valid_values={
-                    "HumidifierorDehumidifier": 0,
                     HC_HASS_TO_HOMEKIT_DEVICE_CLASS_NAME[
                         device_class
                     ]: self._hk_device_class

--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -100,7 +100,7 @@ class HumidifierDehumidifier(HomeAccessory):
                 value=self._hk_device_class,
                 properties={
                     PROP_MIN_VALUE: self._hk_device_class,
-                    PROP_MAX_VALUE: self._hk_device_class
+                    PROP_MAX_VALUE: self._hk_device_class,
                 },
                 valid_values={
                     HC_HASS_TO_HOMEKIT_DEVICE_CLASS_NAME[

--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -98,7 +98,10 @@ class HumidifierDehumidifier(HomeAccessory):
             serv_humidifier_dehumidifier.configure_char(
                 CHAR_TARGET_HUMIDIFIER_DEHUMIDIFIER,
                 value=self._hk_device_class,
-                properties={PROP_MIN_VALUE: self._hk_device_class},
+                properties={
+                    PROP_MIN_VALUE: self._hk_device_class,
+                    PROP_MAX_VALUE: self._hk_device_class
+                },
                 valid_values={
                     HC_HASS_TO_HOMEKIT_DEVICE_CLASS_NAME[
                         device_class

--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -99,6 +99,7 @@ class HumidifierDehumidifier(HomeAccessory):
                 CHAR_TARGET_HUMIDIFIER_DEHUMIDIFIER,
                 value=self._hk_device_class,
                 valid_values={
+                    "HumidifierorDehumidifier": 0,
                     HC_HASS_TO_HOMEKIT_DEVICE_CLASS_NAME[
                         device_class
                     ]: self._hk_device_class

--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -98,7 +98,7 @@ class HumidifierDehumidifier(HomeAccessory):
             serv_humidifier_dehumidifier.configure_char(
                 CHAR_TARGET_HUMIDIFIER_DEHUMIDIFIER,
                 value=self._hk_device_class,
-                properties={PROP_MIN_VALUE: 1},
+                properties={PROP_MIN_VALUE: self._hk_device_class},
                 valid_values={
                     HC_HASS_TO_HOMEKIT_DEVICE_CLASS_NAME[
                         device_class


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
The default value of `TargetHumidifierDehumidifierState` in `pyhap` is 0, which stands for "HumidifierorDehumidifier", while the `valid_values` in HomeKit integration only supplies either 1 or 2 for it, leading to the error.

See here:
https://github.com/ikalchev/HAP-python/blob/bc5ecbf6701a3aefba7d9a7abadb28cbf233f451/pyhap/resources/characteristics.json#L1429-L1442

**Edited: This PR is awaiting ikalchev/HAP-python@626c033 being included into HA Core, and then can be merged to actually address the error.**

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61052 fixes #62240
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
