### PR TITLE
Remove external library discovery call in Sonos

### DIFF
--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -2,8 +2,7 @@
 import dataclasses
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
-from homeassistant.components import ssdp
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
@@ -14,7 +13,7 @@ from .helpers import hostname_to_uid
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if Sonos devices have been seen recently with SSDP."""
-    return bool(await ssdp.async_get_discovery_info_by_st(UPNP_ST))
+    return bool(await ssdp.async_get_discovery_info_by_st(hass, UPNP_ST))
 
 
 class SonosDiscoveryFlowHandler(DiscoveryFlowHandler):

--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -3,7 +3,7 @@ import dataclasses
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.components.ssdp import DOMAIN as SSDP_DOMAIN
+from homeassistant.components import ssdp
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
@@ -14,10 +14,7 @@ from .helpers import hostname_to_uid
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if Sonos devices have been seen recently with SSDP."""
-    if ssdp_scanner := hass.data.get(SSDP_DOMAIN):
-        results = await ssdp_scanner.async_get_discovery_info_by_st(UPNP_ST)
-        return bool(results)
-    return False
+    return bool(await ssdp.async_get_discovery_info_by_st(UPNP_ST))
 
 
 class SonosDiscoveryFlowHandler(DiscoveryFlowHandler):

--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -1,22 +1,22 @@
 """Config flow for SONOS."""
 import dataclasses
 
-import soco
-
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
+from homeassistant.components.ssdp import DOMAIN as SSDP_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
 
-from .const import DATA_SONOS_DISCOVERY_MANAGER, DOMAIN
+from .const import DATA_SONOS_DISCOVERY_MANAGER, DOMAIN, UPNP_ST
 from .helpers import hostname_to_uid
 
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
-    """Return if there are devices that can be discovered."""
-    result = await hass.async_add_executor_job(soco.discover)
-    return bool(result)
+    """Return if Sonos devices have been seen recently with SSDP."""
+    ssdp_scanner = hass.data[SSDP_DOMAIN]
+    results = await ssdp_scanner.async_get_discovery_info_by_st(UPNP_ST)
+    return bool(results)
 
 
 class SonosDiscoveryFlowHandler(DiscoveryFlowHandler):

--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -14,9 +14,10 @@ from .helpers import hostname_to_uid
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if Sonos devices have been seen recently with SSDP."""
-    ssdp_scanner = hass.data[SSDP_DOMAIN]
-    results = await ssdp_scanner.async_get_discovery_info_by_st(UPNP_ST)
-    return bool(results)
+    if ssdp_scanner := hass.data.get(SSDP_DOMAIN):
+        results = await ssdp_scanner.async_get_discovery_info_by_st(UPNP_ST)
+        return bool(results)
+    return False
 
 
 class SonosDiscoveryFlowHandler(DiscoveryFlowHandler):

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -4,14 +4,36 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries, core
-from homeassistant.components import zeroconf
+from homeassistant.components import ssdp, zeroconf
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER, DOMAIN
+from homeassistant.const import CONF_HOSTS
+from homeassistant.setup import async_setup_component
 
 
-@patch("homeassistant.components.sonos.config_flow.soco.discover", return_value=True)
-async def test_user_form(discover_mock: MagicMock, hass: core.HomeAssistant):
+async def test_user_form(
+    hass: core.HomeAssistant, zeroconf_payload: zeroconf.ZeroconfServiceInfo
+):
     """Test we get the user initiated form."""
 
+    # Ensure config flow will fail if no devices discovered yet
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == "abort"
+    assert result["reason"] == "no_devices_found"
+
+    # Initiate a discovery to allow config entry creation
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf_payload,
+    )
+
+    # Ensure config flow succeeds after discovery
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -37,7 +59,22 @@ async def test_user_form(discover_mock: MagicMock, hass: core.HomeAssistant):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_form(hass: core.HomeAssistant, zeroconf_payload):
+async def test_user_form_already_created(hass: core.HomeAssistant):
+    """Ensure we abort a flow if the entry is already created from config."""
+    config = {DOMAIN: {MP_DOMAIN: {CONF_HOSTS: "192.168.4.2"}}}
+    await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_zeroconf_form(
+    hass: core.HomeAssistant, zeroconf_payload: zeroconf.ZeroconfServiceInfo
+):
     """Test we pass Zeroconf discoveries to the manager."""
 
     mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()
@@ -69,6 +106,47 @@ async def test_zeroconf_form(hass: core.HomeAssistant, zeroconf_payload):
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_manager.mock_calls) == 2
+
+
+async def test_ssdp_discovery(hass: core.HomeAssistant, soco):
+    """Test that SSDP discoveries create a config flow."""
+
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=ssdp.SsdpServiceInfo(
+            ssdp_location=f"http://{soco.ip_address}/",
+            ssdp_st="urn:schemas-upnp-org:device:ZonePlayer:1",
+            ssdp_usn=f"uuid:{soco.uid}_MR::urn:schemas-upnp-org:service:GroupRenderingControl:1",
+            upnp={
+                ssdp.ATTR_UPNP_UDN: f"uuid:{soco.uid}",
+            },
+        ),
+    )
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    flow = flows[0]
+
+    with patch(
+        "homeassistant.components.sonos.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.sonos.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Sonos"
+    assert result["data"] == {}
+
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_zeroconf_sonos_v1(hass: core.HomeAssistant):
@@ -121,7 +199,9 @@ async def test_zeroconf_sonos_v1(hass: core.HomeAssistant):
     assert len(mock_manager.mock_calls) == 2
 
 
-async def test_zeroconf_form_not_sonos(hass: core.HomeAssistant, zeroconf_payload):
+async def test_zeroconf_form_not_sonos(
+    hass: core.HomeAssistant, zeroconf_payload: zeroconf.ZeroconfServiceInfo
+):
     """Test we abort on non-sonos devices."""
     mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()
 

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -1,16 +1,26 @@
 """Tests for the Sonos config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow
-from homeassistant.components import sonos
+from homeassistant import config_entries, core, data_entry_flow
+from homeassistant.components import sonos, zeroconf
 from homeassistant.setup import async_setup_component
 
 
-async def test_creating_entry_sets_up_media_player(hass):
+async def test_creating_entry_sets_up_media_player(
+    hass: core.HomeAssistant, zeroconf_payload: zeroconf.ZeroconfServiceInfo
+):
     """Test setting up Sonos loads the media player."""
+
+    # Initiate a discovery to allow a user config flow
+    await hass.config_entries.flow.async_init(
+        sonos.DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf_payload,
+    )
+
     with patch(
         "homeassistant.components.sonos.media_player.async_setup_entry",
-    ) as mock_setup, patch("soco.discover", return_value=True):
+    ) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             sonos.DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -26,12 +36,12 @@ async def test_creating_entry_sets_up_media_player(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_configuring_sonos_creates_entry(hass):
+async def test_configuring_sonos_creates_entry(hass: core.HomeAssistant):
     """Test that specifying config will create an entry."""
     with patch(
         "homeassistant.components.sonos.async_setup_entry",
         return_value=True,
-    ) as mock_setup, patch("soco.discover", return_value=True):
+    ) as mock_setup:
         await async_setup_component(
             hass,
             sonos.DOMAIN,
@@ -42,12 +52,12 @@ async def test_configuring_sonos_creates_entry(hass):
     assert len(mock_setup.mock_calls) == 1
 
 
-async def test_not_configuring_sonos_not_creates_entry(hass):
+async def test_not_configuring_sonos_not_creates_entry(hass: core.HomeAssistant):
     """Test that no config will not create an entry."""
     with patch(
         "homeassistant.components.sonos.async_setup_entry",
         return_value=True,
-    ) as mock_setup, patch("soco.discover", return_value=True):
+    ) as mock_setup:
         await async_setup_component(hass, sonos.DOMAIN, {})
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the last use of discovery from `soco` and replaces it with (hopefully) an equivalent `ssdp` discovery check. This was done as the implementations were different, the library would broadcast on all interfaces, etc.

Instead of discovering on-demand using `soco.discovery()`, this will query the known SSDP cache for matching devices. This method works even if Sonos discovery event flows have been ignored.

If SSDP is not working in a user's environment, they can continue to use the YAML config with manual hosts.

Updated tests to reflect the behavior change which relies on the built-in `ssdp` implementation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
