### PR TITLE
Small fix for device triggers and events on Hue integration

### DIFF
--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -40,6 +40,19 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     }
 )
 
+DEFAULT_BUTTON_EVENT_TYPES = (
+    # all except `DOUBLE_SHORT_RELEASE`
+    ButtonEvent.INITIAL_PRESS,
+    ButtonEvent.REPEAT,
+    ButtonEvent.SHORT_RELEASE,
+    ButtonEvent.LONG_RELEASE,
+)
+
+DEVICE_SPECIFIC_EVENT_TYPES = {
+    # device specific overrides of specific supported button events
+    "Hue tap switch": (ButtonEvent.INITIAL_PRESS,),
+}
+
 
 async def async_validate_trigger_config(
     bridge: "HueBridge",
@@ -84,10 +97,13 @@ async def async_get_triggers(bridge: "HueBridge", device_entry: DeviceEntry):
     hue_dev_id = get_hue_device_id(device_entry)
     # extract triggers from all button resources of this Hue device
     triggers = []
+    model_id = api.devices[hue_dev_id].product_data.product_name
     for resource in api.devices.get_sensors(hue_dev_id):
         if resource.type != ResourceTypes.BUTTON:
             continue
-        for event_type in (x.value for x in ButtonEvent if x != ButtonEvent.UNKNOWN):
+        for event_type in DEVICE_SPECIFIC_EVENT_TYPES.get(
+            model_id, DEFAULT_BUTTON_EVENT_TYPES
+        ):
             triggers.append(
                 {
                     CONF_DEVICE_ID: device_entry.id,

--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -111,7 +111,7 @@ async def async_get_triggers(bridge: "HueBridge", device_entry: DeviceEntry):
                     CONF_PLATFORM: "device",
                     CONF_TYPE: event_type,
                     CONF_SUBTYPE: resource.metadata.control_id,
-                    CONF_UNIQUE_ID: device_entry.id,
+                    CONF_UNIQUE_ID: resource.id,
                 }
             )
     return triggers

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -70,12 +70,20 @@ async def test_get_triggers(hass, mock_bridge_v2, v2_resources_test_data, device
                 "platform": "device",
                 "domain": hue.DOMAIN,
                 "device_id": hue_wall_switch_device.id,
-                "unique_id": hue_wall_switch_device.id,
+                "unique_id": resource_id,
                 "type": event_type,
                 "subtype": control_id,
             }
-            for event_type in (x.value for x in ButtonEvent if x != ButtonEvent.UNKNOWN)
-            for control_id in range(1, 3)
+            for event_type in (
+                ButtonEvent.INITIAL_PRESS,
+                ButtonEvent.LONG_RELEASE,
+                ButtonEvent.REPEAT,
+                ButtonEvent.SHORT_RELEASE,
+            )
+            for control_id, resource_id in (
+                (1, "c658d3d8-a013-4b81-8ac6-78b248537e70"),
+                (2, "be1eb834-bdf5-4d26-8fba-7b1feaa83a9d"),
+            )
         ),
     ]
 


### PR DESCRIPTION
## Proposed change
Fixes 2 small glitches for events emitted by Hue remotes and the device triggers:

- Hue tap remote only supports a single event
- Unique id had wrong id


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #61409 fixes #61407
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
