### PR TITLE
Support Lutron Pico remotes

### DIFF
--- a/homeassistant/components/lutron_caseta/binary_sensor.py
+++ b/homeassistant/components/lutron_caseta/binary_sensor.py
@@ -1,5 +1,5 @@
 """Support for Lutron Caseta Occupancy/Vacancy Sensors."""
-from pylutron_caseta import OCCUPANCY_GROUP_OCCUPIED
+from pylutron_caseta import BUTTON_STATUS_PRESSED, OCCUPANCY_GROUP_OCCUPIED
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OCCUPANCY,
@@ -26,6 +26,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entity = LutronOccupancySensor(occupancy_group, bridge, bridge_device)
         entities.append(entity)
 
+    for button in bridge.buttons.values():
+        entity = LutronPicoButton(button, bridge, bridge_device)
+        entities.append(entity)
+
     async_add_entities(entities, True)
 
 
@@ -39,7 +43,7 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
 
     @property
     def is_on(self):
-        """Return the brightness of the light."""
+        """Return True iff the sensor is on."""
         return self._device["status"] == OCCUPANCY_GROUP_OCCUPIED
 
     async def async_added_to_hass(self):
@@ -57,6 +61,52 @@ class LutronOccupancySensor(LutronCasetaDevice, BinarySensorEntity):
     def unique_id(self):
         """Return a unique identifier."""
         return f"occupancygroup_{self.device_id}"
+
+    @property
+    def device_info(self):
+        """Return the device info.
+
+        Sensor entities are aggregated from one or more physical
+        sensors by each room. Therefore, there shouldn't be devices
+        related to any sensor entities.
+        """
+        return None
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {"device_id": self.device_id}
+
+
+class LutronPicoButton(LutronCasetaDevice, BinarySensorEntity):
+    """Representation of a Lutron occupancy group."""
+
+    @property
+    def is_on(self):
+        """Return the brightness of the light."""
+        return self._device["current_state"] == BUTTON_STATUS_PRESSED
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self._smartbridge.add_button_subscriber(self.device_id, self._handle_event)
+
+    def _handle_event(self, event_type):
+        self.async_write_ha_state()
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._device["name"] + str(self._device["button_number"])
+
+    @property
+    def device_id(self):
+        """Return the device ID used for calling pylutron_caseta."""
+        return self._device["device_id"]
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier."""
+        return f"pico_{self.device_id}"
 
     @property
     def device_info(self):

--- a/homeassistant/components/lutron_caseta/manifest.json
+++ b/homeassistant/components/lutron_caseta/manifest.json
@@ -2,7 +2,7 @@
   "domain": "lutron_caseta",
   "name": "Lutron Cas\u00e9ta",
   "documentation": "https://www.home-assistant.io/integrations/lutron_caseta",
-  "requirements": ["pylutron-caseta==0.11.0", "aiolip==1.1.6"],
+  "requirements": ["pylutron-caseta==0.13.0", "aiolip==1.1.6"],
   "config_flow": true,
   "zeroconf": ["_leap._tcp.local."],
   "homekit": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1619,7 +1619,7 @@ pylitejet==0.3.0
 pylitterbot==2021.11.0
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.11.0
+pylutron-caseta==0.13.0
 
 # homeassistant.components.lutron
 pylutron==0.2.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -992,7 +992,7 @@ pylitejet==0.3.0
 pylitterbot==2021.11.0
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.11.0
+pylutron-caseta==0.13.0
 
 # homeassistant.components.mailgun
 pymailgunner==1.4


### PR DESCRIPTION
Support was recently added in [pylutron_caseta] and this change adds the support here as well. Each Pico remote will show as up to five binary sensors (one for each button).

[pylutron_caseta]: https://github.com/gurumitts/pylutron-caseta/blob/dev/CHANGELOG.md#added-1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support sensing the states of each individual Pico remote button. These can then be used in automations. For example, on the remote by my bed, the off switch turns off all the lights in the house, and the on switch turns on just the light in the bedroom.

Note: I wrote this as a binary sensor simply because I had that code in front of me. I later realized that there's a concept of a "device trigger". Please let me know if I should have used that instead and I'll figure it out and update this branch. I also intend to research this on my own a bit this weekend.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
N/A, this is a fairly small and self-contained change. I am happy to do any "paperwork" around this (docs, testing) but would ask for some guidance as I am new to this project.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
