### PR TITLE
Handle None values in weather entity forecast

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -262,7 +262,7 @@ class WeatherEntity(Entity):
                         self.temperature_unit,
                         self.precision,
                     )
-                if ATTR_FORECAST_PRESSURE in forecast_entry:
+                if forecast_entry.get(ATTR_FORECAST_PRESSURE) is not None:
                     if (unit := self.pressure_unit) is not None:
                         pressure = round(
                             self.hass.config.units.pressure(
@@ -271,7 +271,7 @@ class WeatherEntity(Entity):
                             ROUNDING_PRECISION,
                         )
                         forecast_entry[ATTR_FORECAST_PRESSURE] = pressure
-                if ATTR_FORECAST_WIND_SPEED in forecast_entry:
+                if forecast_entry.get(ATTR_FORECAST_WIND_SPEED) is not None:
                     if (unit := self.wind_speed_unit) is not None:
                         wind_speed = round(
                             self.hass.config.units.wind_speed(
@@ -280,7 +280,7 @@ class WeatherEntity(Entity):
                             ROUNDING_PRECISION,
                         )
                         forecast_entry[ATTR_FORECAST_WIND_SPEED] = wind_speed
-                if ATTR_FORECAST_PRECIPITATION in forecast_entry:
+                if forecast_entry.get(ATTR_FORECAST_PRECIPITATION) is not None:
                     if (unit := self.precipitation_unit) is not None:
                         precipitation = round(
                             self.hass.config.units.accumulated_precipitation(

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -262,29 +262,31 @@ class WeatherEntity(Entity):
                         self.temperature_unit,
                         self.precision,
                     )
-                if forecast_entry.get(ATTR_FORECAST_PRESSURE) is not None:
+                if (
+                    native_pressure := forecast_entry.get(ATTR_FORECAST_PRESSURE)
+                ) is not None:
                     if (unit := self.pressure_unit) is not None:
                         pressure = round(
-                            self.hass.config.units.pressure(
-                                forecast_entry[ATTR_FORECAST_PRESSURE], unit
-                            ),
+                            self.hass.config.units.pressure(native_pressure, unit),
                             ROUNDING_PRECISION,
                         )
                         forecast_entry[ATTR_FORECAST_PRESSURE] = pressure
-                if forecast_entry.get(ATTR_FORECAST_WIND_SPEED) is not None:
+                if (
+                    native_wind_speed := forecast_entry.get(ATTR_FORECAST_WIND_SPEED)
+                ) is not None:
                     if (unit := self.wind_speed_unit) is not None:
                         wind_speed = round(
-                            self.hass.config.units.wind_speed(
-                                forecast_entry[ATTR_FORECAST_WIND_SPEED], unit
-                            ),
+                            self.hass.config.units.wind_speed(native_wind_speed, unit),
                             ROUNDING_PRECISION,
                         )
                         forecast_entry[ATTR_FORECAST_WIND_SPEED] = wind_speed
-                if forecast_entry.get(ATTR_FORECAST_PRECIPITATION) is not None:
+                if (
+                    native_precip := forecast_entry.get(ATTR_FORECAST_PRECIPITATION)
+                ) is not None:
                     if (unit := self.precipitation_unit) is not None:
                         precipitation = round(
                             self.hass.config.units.accumulated_precipitation(
-                                forecast_entry[ATTR_FORECAST_PRECIPITATION], unit
+                                native_precip, unit
                             ),
                             ROUNDING_PRECISION,
                         )

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -168,3 +168,26 @@ async def test_precipitation_conversion(
         native_value, native_unit, unit_system.accumulated_precipitation_unit
     )
     assert float(forecast[ATTR_FORECAST_PRECIPITATION]) == approx(expected, rel=1e-2)
+
+
+async def test_none_forecast(
+    hass,
+    enable_custom_integrations,
+):
+    """Test that conversion with None values succeeds."""
+    entity0 = await create_entity(
+        hass,
+        pressure=None,
+        pressure_unit=PRESSURE_INHG,
+        wind_speed=None,
+        wind_speed_unit=SPEED_METERS_PER_SECOND,
+        precipitation=None,
+        precipitation_unit=LENGTH_MILLIMETERS,
+    )
+
+    state = hass.states.get(entity0.entity_id)
+    forecast = state.attributes[ATTR_FORECAST][0]
+
+    assert forecast[ATTR_FORECAST_PRESSURE] is None
+    assert forecast[ATTR_FORECAST_WIND_SPEED] is None
+    assert forecast[ATTR_FORECAST_PRECIPITATION] is None


### PR DESCRIPTION
## Proposed change

I've realized that some of the weather components pass in `None` values to forecast attributes. This currently causes the unit conversions to fail if the units are configured, since the unit conversion methods cannot handle `None`.

*To be clear, nothing is currently failing because of this issue. However, I am running into this problem when fixing my PRs to update the weather unit conversion in components.*

I figure it's easier to handle `None` values inside the weather entity rather than in every component.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
