### PR TITLE
Add buttons and deprecate services for Fritz

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -372,6 +372,7 @@ omit =
     homeassistant/components/freebox/switch.py
     homeassistant/components/fritz/__init__.py
     homeassistant/components/fritz/binary_sensor.py
+    homeassistant/components/fritz/button.py
     homeassistant/components/fritz/common.py
     homeassistant/components/fritz/const.py
     homeassistant/components/fritz/device_tracker.py

--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -1,0 +1,100 @@
+"""Switches for AVM Fritz!Box buttons."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Final
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
+
+from .common import FritzBoxTools
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class FritzButtonDescriptionMixin:
+    """Mixin to describe a Button entity."""
+
+    press_action: Callable
+
+
+@dataclass
+class FritzButtonDescription(ButtonEntityDescription, FritzButtonDescriptionMixin):
+    """Class to describe a Button entity."""
+
+
+BUTTONS: Final = [
+    FritzButtonDescription(
+        key="firmware_update",
+        name="Firmware Update",
+        device_class=ButtonDeviceClass.UPDATE,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        press_action=lambda router: router.async_trigger_firmware_update(),
+    ),
+    FritzButtonDescription(
+        key="reboot",
+        name="Reboot",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        press_action=lambda router: router.async_trigger_reboot(),
+    ),
+    FritzButtonDescription(
+        key="reconnect",
+        name="Reconnect",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        press_action=lambda router: router.async_trigger_reconnect(),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set buttons for device."""
+    _LOGGER.debug("Setting up buttons")
+    router: FritzBoxTools = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities([FritzButton(router, entry.title, button) for button in BUTTONS])
+
+
+class FritzButton(ButtonEntity):
+    """Defines a Fritz!Box base button."""
+
+    entity_description: FritzButtonDescription
+
+    def __init__(
+        self,
+        router: FritzBoxTools,
+        device_friendly_name: str,
+        description: FritzButtonDescription,
+    ) -> None:
+        """Initialize Fritz!Box button."""
+        self.entity_description = description
+        self.router = router
+
+        self._attr_name = f"{device_friendly_name} {description.name}"
+        self._attr_unique_id = slugify(self._attr_name)
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, router.mac)}
+        )
+
+    async def async_press(self) -> None:
+        """Triggers Fritz!Box service."""
+        await self.entity_description.press_action(self.router)

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import logging
 from types import MappingProxyType
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 from fritzconnection import FritzConnection
 from fritzconnection.core.exceptions import (
@@ -301,6 +301,25 @@ class FritzBoxTools:
         _LOGGER.debug("Checking host info for FRITZ!Box router %s", self.host)
         self._update_available, self._latest_firmware = self._update_device_info()
 
+    async def async_trigger_firmware_update(self) -> bool:
+        """Trigger firmware update."""
+        results = await self.hass.async_add_executor_job(
+            self.connection.call_action, "UserInterface:1", "X_AVM-DE_DoUpdate"
+        )
+        return cast(bool, results["NewX_AVM-DE_UpdateState"])
+
+    async def async_trigger_reboot(self) -> None:
+        """Trigger device reboot."""
+        await self.hass.async_add_executor_job(
+            self.connection.call_action, "DeviceConfig1", "Reboot"
+        )
+
+    async def async_trigger_reconnect(self) -> None:
+        """Trigger device reconnect."""
+        await self.hass.async_add_executor_job(
+            self.connection.call_action, "WANIPConn1", "ForceTermination"
+        )
+
     async def service_fritzbox(
         self, service_call: ServiceCall, config_entry: ConfigEntry
     ) -> None:
@@ -312,12 +331,18 @@ class FritzBoxTools:
 
         try:
             if service_call.service == SERVICE_REBOOT:
+                _LOGGER.warning(
+                    'Service "reboot" is deprecated, please use the corresponding button entity instead'
+                )
                 await self.hass.async_add_executor_job(
                     self.connection.call_action, "DeviceConfig1", "Reboot"
                 )
                 return
 
             if service_call.service == SERVICE_RECONNECT:
+                _LOGGER.warning(
+                    'Service "reconnect" is deprecated, please use the corresponding button entity instead'
+                )
                 await self.hass.async_add_executor_job(
                     self.connection.call_action,
                     "WANIPConn1",

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -332,7 +332,7 @@ class FritzBoxTools:
         try:
             if service_call.service == SERVICE_REBOOT:
                 _LOGGER.warning(
-                    'Service "reboot" is deprecated, please use the corresponding button entity instead'
+                    'Service "fritz.reboot" is deprecated, please use the corresponding button entity instead'
                 )
                 await self.hass.async_add_executor_job(
                     self.connection.call_action, "DeviceConfig1", "Reboot"
@@ -341,7 +341,7 @@ class FritzBoxTools:
 
             if service_call.service == SERVICE_RECONNECT:
                 _LOGGER.warning(
-                    'Service "reconnect" is deprecated, please use the corresponding button entity instead'
+                    'Service "fritz.reconnect" is deprecated, please use the corresponding button entity instead'
                 )
                 await self.hass.async_add_executor_job(
                     self.connection.call_action,

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -7,6 +7,7 @@ from homeassistant.const import Platform
 DOMAIN = "fritz"
 
 PLATFORMS = [
+    Platform.BUTTON,
     Platform.BINARY_SENSOR,
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- add "reboot", "reconnect", "firmware update" buttons
- log warning if "reboot" or "reconnect" services are used

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
