### PR TITLE
Add identify buttons to ZHA devices

### DIFF
--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -68,19 +68,9 @@ class ZHAButton(ZhaEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Send out a update command."""
-        if self._command_name:
-            command = getattr(self._channel, self._command_name)
-            if command is not None:
-                arguments = self.get_args()
-                if arguments:
-                    await command(*arguments)
-                else:
-                    await command()
-            else:
-                _LOGGER.warning(
-                    "Attempted to issue command: %s but the command was not found",
-                    self._command_name,
-                )
+        command = getattr(self._channel, self._command_name)
+        arguments = self.get_args()
+        await command(*arguments)
 
 
 @MULTI_MATCH(channel_names=CHANNEL_IDENTIFY)

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -7,8 +7,6 @@ import logging
 from typing import Any
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
-from homeassistant.components.zha.core.registries import ZHA_ENTITIES
-from homeassistant.components.zha.core.typing import ChannelType, ZhaDeviceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC, Platform
 from homeassistant.core import HomeAssistant
@@ -17,6 +15,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .core import discovery
 from .core.const import CHANNEL_IDENTIFY, DATA_ZHA, SIGNAL_ADD_ENTITIES
+from .core.registries import ZHA_ENTITIES
+from .core.typing import ChannelType, ZhaDeviceType
 from .entity import ZhaEntity
 
 MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.BUTTON)

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -87,6 +87,25 @@ class ZHAButton(ZhaEntity, ButtonEntity):
 class ZHAIdentifyButton(ZHAButton):
     """Defines a ZHA identify button."""
 
+    @classmethod
+    def create_entity(
+        cls,
+        unique_id: str,
+        zha_device: ZhaDeviceType,
+        channels: list[ChannelType],
+        **kwargs,
+    ) -> ZhaEntity | None:
+        """Entity Factory.
+
+        Return entity if it is a supported configuration, otherwise return None
+        """
+        platform_restrictions = ZHA_ENTITIES.single_device_matches[Platform.BUTTON]
+        device_restrictions = platform_restrictions[zha_device.ieee]
+        if CHANNEL_IDENTIFY in device_restrictions:
+            return None
+        device_restrictions.append(CHANNEL_IDENTIFY)
+        return cls(unique_id, zha_device, channels, **kwargs)
+
     _attr_device_class: ButtonDeviceClass = ButtonDeviceClass.UPDATE
     _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
     _command_name = "identify"

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -6,11 +6,11 @@ import functools
 import logging
 from typing import Any
 
-from homeassistant.components.button import DOMAIN, ButtonDeviceClass, ButtonEntity
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.components.zha.core.registries import ZHA_ENTITIES
 from homeassistant.components.zha.core.typing import ChannelType, ZhaDeviceType
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,7 +19,7 @@ from .core import discovery
 from .core.const import CHANNEL_IDENTIFY, DATA_ZHA, SIGNAL_ADD_ENTITIES
 from .entity import ZhaEntity
 
-MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, DOMAIN)
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.BUTTON)
 DEFAULT_DURATION = 5  # seconds
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Zigbee Home Automation button from config entry."""
-    entities_to_create = hass.data[DATA_ZHA][DOMAIN]
+    entities_to_create = hass.data[DATA_ZHA][Platform.BUTTON]
 
     unsub = async_dispatcher_connect(
         hass,

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -102,6 +102,7 @@ CLUSTER_TYPE_OUT = "out"
 PLATFORMS = (
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.COVER,
     Platform.DEVICE_TRACKER,

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -67,6 +67,7 @@ class ProbeEndpoint:
         self.discover_by_device_type(channel_pool)
         self.discover_multi_entities(channel_pool)
         self.discover_by_cluster_id(channel_pool)
+        zha_regs.ZHA_ENTITIES.clean_up()
 
     @callback
     def discover_by_device_type(self, channel_pool: zha_typing.ChannelPoolType) -> None:

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -17,6 +17,7 @@ from . import const as zha_const, registries as zha_regs, typing as zha_typing
 from .. import (  # noqa: F401 pylint: disable=unused-import,
     alarm_control_panel,
     binary_sensor,
+    button,
     climate,
     cover,
     device_tracker,

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -9,6 +9,7 @@ import attr
 from zigpy import zcl
 import zigpy.profiles.zha
 import zigpy.profiles.zll
+from zigpy.types.named import EUI64
 
 from homeassistant.const import Platform
 
@@ -228,6 +229,9 @@ class ZHAEntityRegistry:
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
         )
         self._group_registry: dict[str, CALLABLE_T] = {}
+        self.single_device_matches: dict[
+            Platform, dict[EUI64, list[str]]
+        ] = collections.defaultdict(lambda: collections.defaultdict(list))
 
     def get_entity(
         self,
@@ -341,6 +345,12 @@ class ZHAEntityRegistry:
             return zha_ent
 
         return decorator
+
+    def clean_up(self) -> None:
+        """Clean up post discovery."""
+        self.single_device_matches: dict[
+            Platform, dict[EUI64, list[str]]
+        ] = collections.defaultdict(lambda: collections.defaultdict(list))
 
 
 ZHA_ENTITIES = ZHAEntityRegistry()

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -1,0 +1,89 @@
+"""Test ZHA button."""
+from unittest.mock import patch
+
+from freezegun import freeze_time
+import pytest
+from zigpy.const import SIG_EP_PROFILE
+import zigpy.profiles.zha as zha
+import zigpy.zcl.clusters.general as general
+import zigpy.zcl.clusters.security as security
+import zigpy.zcl.foundation as zcl_f
+
+from homeassistant.components.button import DOMAIN, ButtonDeviceClass
+from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_UNKNOWN,
+)
+from homeassistant.helpers import entity_registry as er
+
+from .common import find_entity_id
+from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+
+from tests.common import mock_coro
+
+
+@pytest.fixture
+async def contact_sensor(hass, zigpy_device_mock, zha_device_joined_restored):
+    """Contact sensor fixture."""
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    general.Identify.cluster_id,
+                    security.IasZone.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.IAS_ZONE,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            }
+        },
+    )
+
+    zha_device = await zha_device_joined_restored(zigpy_device)
+    return zha_device, zigpy_device.endpoints[1].identify
+
+
+@freeze_time("2021-11-04 17:37:00", tz_offset=-1)
+async def test_button(hass, contact_sensor):
+    """Test zha button platform."""
+
+    entity_registry = er.async_get(hass)
+    zha_device, cluster = contact_sensor
+    assert cluster is not None
+    entity_id = await find_entity_id(DOMAIN, zha_device, hass)
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.UPDATE
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
+
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=mock_coro([0x00, zcl_f.Status.SUCCESS]),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert len(cluster.request.mock_calls) == 1
+        assert cluster.request.call_args[0][0] is False
+        assert cluster.request.call_args[0][1] == 0
+        assert cluster.request.call_args[0][3] == 5  # duration in seconds
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "2021-11-04T16:37:00+00:00"
+    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.UPDATE

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -260,7 +260,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
             "button.centralite_3315_s_77665544_identify",
-            "button.centralite_3315_s_77665544_identify_2",
             "sensor.centralite_3315_s_77665544_power",
             "sensor.centralite_3315_s_77665544_temperature",
             "binary_sensor.centralite_3315_s_77665544_ias_zone",
@@ -285,11 +284,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["temperature"],
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3315_s_77665544_temperature",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.centralite_3315_s_77665544_identify_2",
             },
         },
     },
@@ -317,7 +311,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
             "button.centralite_3320_l_77665544_identify",
-            "button.centralite_3320_l_77665544_identify_2",
             "sensor.centralite_3320_l_77665544_power",
             "sensor.centralite_3320_l_77665544_temperature",
             "binary_sensor.centralite_3320_l_77665544_ias_zone",
@@ -342,11 +335,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["temperature"],
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3320_l_77665544_temperature",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.centralite_3320_l_77665544_identify_2",
             },
         },
     },
@@ -374,7 +362,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
             "button.centralite_3326_l_77665544_identify",
-            "button.centralite_3326_l_77665544_identify_2",
             "sensor.centralite_3326_l_77665544_power",
             "sensor.centralite_3326_l_77665544_temperature",
             "binary_sensor.centralite_3326_l_77665544_ias_zone",
@@ -399,11 +386,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["temperature"],
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3326_l_77665544_temperature",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.centralite_3326_l_77665544_identify_2",
             },
         },
     },
@@ -433,7 +415,6 @@ DEVICES = [
             "sensor.centralite_motion_sensor_a_77665544_power",
             "sensor.centralite_motion_sensor_a_77665544_temperature",
             "button.centralite_motion_sensor_a_77665544_identify",
-            "button.centralite_motion_sensor_a_77665544_identify_2",
             "binary_sensor.centralite_motion_sensor_a_77665544_ias_zone",
             "binary_sensor.centralite_motion_sensor_a_77665544_occupancy",
         ],
@@ -462,11 +443,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["occupancy"],
                 DEV_SIG_ENT_MAP_CLASS: "Occupancy",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_motion_sensor_a_77665544_occupancy",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.centralite_motion_sensor_a_77665544_identify_2",
             },
         },
     },
@@ -1173,7 +1149,6 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "button.jasco_products_45852_77665544_identify",
             "light.jasco_products_45852_77665544_level_on_off",
-            "button.jasco_products_45852_77665544_identify_2",
             "sensor.jasco_products_45852_77665544_smartenergy_metering",
             "sensor.jasco_products_45852_77665544_smartenergy_metering_summation_delivered",
         ],
@@ -1197,11 +1172,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45852_77665544_smartenergy_metering_summation_delivered",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45852_77665544_identify_2",
             },
         },
     },
@@ -1230,7 +1200,6 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "button.jasco_products_45856_77665544_identify",
             "light.jasco_products_45856_77665544_on_off",
-            "button.jasco_products_45856_77665544_identify_2",
             "sensor.jasco_products_45856_77665544_smartenergy_metering",
             "sensor.jasco_products_45856_77665544_smartenergy_metering_summation_delivered",
         ],
@@ -1254,11 +1223,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45856_77665544_smartenergy_metering_summation_delivered",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45856_77665544_identify_2",
             },
         },
     },
@@ -1287,7 +1251,6 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "button.jasco_products_45857_77665544_identify",
             "light.jasco_products_45857_77665544_level_on_off",
-            "button.jasco_products_45857_77665544_identify_2",
             "sensor.jasco_products_45857_77665544_smartenergy_metering",
             "sensor.jasco_products_45857_77665544_smartenergy_metering_summation_delivered",
         ],
@@ -1311,11 +1274,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45857_77665544_smartenergy_metering_summation_delivered",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45857_77665544_identify_2",
             },
         },
     },
@@ -1862,8 +1820,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_remote_b186acn01_77665544_identify",
-            "button.lumi_lumi_remote_b186acn01_77665544_identify_2",
-            "button.lumi_lumi_remote_b186acn01_77665544_identify_3",
             "sensor.lumi_lumi_remote_b186acn01_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
@@ -1876,16 +1832,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_remote_b186acn01_77665544_power",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b186acn01_77665544_identify_2",
-            },
-            ("button", "00:11:22:33:44:55:66:77-3-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b186acn01_77665544_identify_3",
             },
         },
     },
@@ -1920,8 +1866,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_remote_b286acn01_77665544_identify",
-            "button.lumi_lumi_remote_b286acn01_77665544_identify_2",
-            "button.lumi_lumi_remote_b286acn01_77665544_identify_3",
             "sensor.lumi_lumi_remote_b286acn01_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
@@ -1934,16 +1878,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_remote_b286acn01_77665544_power",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b286acn01_77665544_identify_2",
-            },
-            ("button", "00:11:22:33:44:55:66:77-3-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b286acn01_77665544_identify_3",
             },
         },
     },
@@ -2060,18 +1994,12 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300", "2:0x0006"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_remote_b486opcn01_77665544_identify",
-            "button.lumi_lumi_remote_b486opcn01_77665544_identify_2",
         ],
         DEV_SIG_ENT_MAP: {
             ("button", "00:11:22:33:44:55:66:77-1-3"): {
                 DEV_SIG_CHANNELS: ["identify"],
                 DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
                 DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b486opcn01_77665544_identify",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b486opcn01_77665544_identify_2",
             },
         },
     },
@@ -2153,18 +2081,12 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300", "2:0x0006"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_remote_b686opcn01_77665544_identify",
-            "button.lumi_lumi_remote_b686opcn01_77665544_identify_2",
         ],
         DEV_SIG_ENT_MAP: {
             ("button", "00:11:22:33:44:55:66:77-1-3"): {
                 DEV_SIG_CHANNELS: ["identify"],
                 DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
                 DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b686opcn01_77665544_identify",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b686opcn01_77665544_identify_2",
             },
         },
     },
@@ -2327,8 +2249,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_sensor_86sw1_77665544_identify",
-            "button.lumi_lumi_sensor_86sw1_77665544_identify_2",
-            "button.lumi_lumi_sensor_86sw1_77665544_identify_3",
             "sensor.lumi_lumi_sensor_86sw1_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
@@ -2341,16 +2261,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_86sw1_77665544_power",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_86sw1_77665544_identify_2",
-            },
-            ("button", "00:11:22:33:44:55:66:77-3-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_86sw1_77665544_identify_3",
             },
         },
     },
@@ -2385,8 +2295,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify",
-            "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_2",
-            "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_3",
             "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
@@ -2399,16 +2307,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_2",
-            },
-            ("button", "00:11:22:33:44:55:66:77-3-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_3",
             },
         },
     },
@@ -2443,8 +2341,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_sensor_ht_77665544_identify",
-            "button.lumi_lumi_sensor_ht_77665544_identify_2",
-            "button.lumi_lumi_sensor_ht_77665544_identify_3",
             "sensor.lumi_lumi_sensor_ht_77665544_power",
             "sensor.lumi_lumi_sensor_ht_77665544_temperature",
             "sensor.lumi_lumi_sensor_ht_77665544_humidity",
@@ -2469,16 +2365,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["humidity"],
                 DEV_SIG_ENT_MAP_CLASS: "Humidity",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_ht_77665544_humidity",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_ht_77665544_identify_2",
-            },
-            ("button", "00:11:22:33:44:55:66:77-3-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_ht_77665544_identify_3",
             },
         },
     },
@@ -2792,7 +2678,6 @@ DEVICES = [
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005"],
         DEV_SIG_ENTITIES: [
             "button.lumi_lumi_vibration_aq1_77665544_identify",
-            "button.lumi_lumi_vibration_aq1_77665544_identify_2",
             "sensor.lumi_lumi_vibration_aq1_77665544_power",
             "binary_sensor.lumi_lumi_vibration_aq1_77665544_ias_zone",
             "lock.lumi_lumi_vibration_aq1_77665544_door_lock",
@@ -2817,11 +2702,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["door_lock"],
                 DEV_SIG_ENT_MAP_CLASS: "ZhaDoorLock",
                 DEV_SIG_ENT_MAP_ID: "lock.lumi_lumi_vibration_aq1_77665544_door_lock",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_vibration_aq1_77665544_identify_2",
             },
         },
     },
@@ -3591,7 +3471,6 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "button.sercomm_corp_sz_esw01_77665544_identify",
             "light.sercomm_corp_sz_esw01_77665544_on_off",
-            "button.sercomm_corp_sz_esw01_77665544_identify_2",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_apparent_power",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_current",
@@ -3639,11 +3518,6 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering_summation_delivered",
-            },
-            ("button", "00:11:22:33:44:55:66:77-2-3"): {
-                DEV_SIG_CHANNELS: ["identify"],
-                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.sercomm_corp_sz_esw01_77665544_identify_2",
             },
         },
     },

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -24,6 +24,9 @@ DEV_SIG_ZHA_QUIRK = "zha_quirk"
 DEVICES = [
     {
         DEV_SIG_DEV_NO: 0,
+        SIG_MANUFACTURER: "ADUROLIGHT",
+        SIG_MODEL: "Adurolight_NCC",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00*d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2080,
@@ -31,18 +34,25 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4096, 64716],
                 SIG_EP_OUTPUT: [3, 4, 6, 8, 4096, 64716],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: [],
-        DEV_SIG_ENT_MAP: {},
         DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008"],
-        SIG_MANUFACTURER: "ADUROLIGHT",
-        SIG_MODEL: "Adurolight_NCC",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00*d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "AdurolightNCC",
+        DEV_SIG_ENTITIES: [
+            "button.adurolight_adurolight_ncc_77665544_identify",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.adurolight_adurolight_ncc_77665544_identify",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 1,
+        SIG_MANUFACTURER: "Bosch",
+        SIG_MODEL: "ISW-ZPR1-WP13",
+        SIG_NODE_DESC: b"\x02@\x08\x00\x00l\x00\x00\x00\x00\x00\x00\x00",
         SIG_ENDPOINTS: {
             5: {
                 SIG_EP_TYPE: 1026,
@@ -50,14 +60,26 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 1280, 2821],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["5:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.bosch_isw_zpr1_wp13_77665544_ias_zone",
+            "button.bosch_isw_zpr1_wp13_77665544_identify",
             "sensor.bosch_isw_zpr1_wp13_77665544_power",
             "sensor.bosch_isw_zpr1_wp13_77665544_temperature",
+            "binary_sensor.bosch_isw_zpr1_wp13_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-5-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.bosch_isw_zpr1_wp13_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-5-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.bosch_isw_zpr1_wp13_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-5-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -68,19 +90,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.bosch_isw_zpr1_wp13_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-5-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.bosch_isw_zpr1_wp13_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["5:0x0019"],
-        SIG_MANUFACTURER: "Bosch",
-        SIG_MODEL: "ISW-ZPR1-WP13",
-        SIG_NODE_DESC: b"\x02@\x08\x00\x00l\x00\x00\x00\x00\x00\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 2,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "3130",
+        SIG_NODE_DESC: b"\x02@\x80N\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1,
@@ -88,24 +104,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 2821],
                 SIG_EP_OUTPUT: [3, 6, 8, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.centralite_3130_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.centralite_3130_77665544_identify",
+            "sensor.centralite_3130_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3130_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3130_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "3130",
-        SIG_NODE_DESC: b"\x02@\x80N\x10RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLite3130",
     },
     {
         DEV_SIG_DEV_NO: 3,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "3210-L",
+        SIG_NODE_DESC: b"\x01@\x8eN\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 81,
@@ -113,11 +136,12 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 1794, 2820, 2821, 64515],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.centralite_3210_l_77665544_identify",
             "sensor.centralite_3210_l_77665544_electrical_measurement",
-            "sensor.centralite_3210_l_77665544_electrical_measurement_apparent_power",
             "sensor.centralite_3210_l_77665544_electrical_measurement_apparent_power",
             "sensor.centralite_3210_l_77665544_electrical_measurement_rms_current",
             "sensor.centralite_3210_l_77665544_electrical_measurement_rms_voltage",
@@ -131,15 +155,10 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.centralite_3210_l_77665544_on_off",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
-                DEV_SIG_CHANNELS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergyMetering",
-                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_smartenergy_metering",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_delivered"): {
-                DEV_SIG_CHANNELS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_smartenergy_metering_summation_delivered",
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3210_l_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -161,14 +180,23 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_electrical_measurement_rms_voltage",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
+                DEV_SIG_CHANNELS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergyMetering",
+                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_smartenergy_metering",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_delivered"): {
+                DEV_SIG_CHANNELS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_smartenergy_metering_summation_delivered",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "3210-L",
-        SIG_NODE_DESC: b"\x01@\x8eN\x10RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 4,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "3310-S",
+        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 770,
@@ -176,14 +204,21 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 2821, 64581],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "sensor.centralite_3310_s_77665544_manufacturer_specific",
+            "button.centralite_3310_s_77665544_identify",
             "sensor.centralite_3310_s_77665544_power",
             "sensor.centralite_3310_s_77665544_temperature",
+            "sensor.centralite_3310_s_77665544_manufacturer_specific",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3310_s_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -200,14 +235,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3310_s_77665544_manufacturer_specific",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "3310-S",
-        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLite3310S",
     },
     {
         DEV_SIG_DEV_NO: 5,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "3315-S",
+        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -224,12 +257,25 @@ DEVICES = [
                 SIG_EP_PROFILE: 49887,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.centralite_3315_s_77665544_ias_zone",
+            "button.centralite_3315_s_77665544_identify",
+            "button.centralite_3315_s_77665544_identify_2",
             "sensor.centralite_3315_s_77665544_power",
             "sensor.centralite_3315_s_77665544_temperature",
+            "binary_sensor.centralite_3315_s_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_3315_s_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3315_s_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -240,20 +286,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3315_s_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_3315_s_77665544_ias_zone",
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3315_s_77665544_identify_2",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "3315-S",
-        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLiteIASSensor",
     },
     {
         DEV_SIG_DEV_NO: 6,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "3320-L",
+        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -270,12 +314,25 @@ DEVICES = [
                 SIG_EP_PROFILE: 49887,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.centralite_3320_l_77665544_ias_zone",
+            "button.centralite_3320_l_77665544_identify",
+            "button.centralite_3320_l_77665544_identify_2",
             "sensor.centralite_3320_l_77665544_power",
             "sensor.centralite_3320_l_77665544_temperature",
+            "binary_sensor.centralite_3320_l_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_3320_l_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3320_l_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -286,20 +343,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3320_l_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_3320_l_77665544_ias_zone",
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3320_l_77665544_identify_2",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "3320-L",
-        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLiteIASSensor",
     },
     {
         DEV_SIG_DEV_NO: 7,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "3326-L",
+        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -316,12 +371,25 @@ DEVICES = [
                 SIG_EP_PROFILE: 49887,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.centralite_3326_l_77665544_ias_zone",
+            "button.centralite_3326_l_77665544_identify",
+            "button.centralite_3326_l_77665544_identify_2",
             "sensor.centralite_3326_l_77665544_power",
             "sensor.centralite_3326_l_77665544_temperature",
+            "binary_sensor.centralite_3326_l_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_3326_l_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3326_l_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -332,20 +400,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3326_l_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_3326_l_77665544_ias_zone",
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_3326_l_77665544_identify_2",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "3326-L",
-        SIG_NODE_DESC: b"\x02@\x80\xdf\xc2RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLiteMotionSensor",
     },
     {
         DEV_SIG_DEV_NO: 8,
+        SIG_MANUFACTURER: "CentraLite",
+        SIG_MODEL: "Motion Sensor-A",
+        SIG_NODE_DESC: b"\x02@\x80N\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -362,13 +428,26 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.centralite_motion_sensor_a_77665544_ias_zone",
-            "binary_sensor.centralite_motion_sensor_a_77665544_occupancy",
             "sensor.centralite_motion_sensor_a_77665544_power",
             "sensor.centralite_motion_sensor_a_77665544_temperature",
+            "button.centralite_motion_sensor_a_77665544_identify",
+            "button.centralite_motion_sensor_a_77665544_identify_2",
+            "binary_sensor.centralite_motion_sensor_a_77665544_ias_zone",
+            "binary_sensor.centralite_motion_sensor_a_77665544_occupancy",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_motion_sensor_a_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_motion_sensor_a_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -379,25 +458,23 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_motion_sensor_a_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_motion_sensor_a_77665544_ias_zone",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-2-1030"): {
                 DEV_SIG_CHANNELS: ["occupancy"],
                 DEV_SIG_ENT_MAP_CLASS: "Occupancy",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.centralite_motion_sensor_a_77665544_occupancy",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.centralite_motion_sensor_a_77665544_identify_2",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "CentraLite",
-        SIG_MODEL: "Motion Sensor-A",
-        SIG_NODE_DESC: b"\x02@\x80N\x10RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLite3305S",
     },
     {
         DEV_SIG_DEV_NO: 9,
+        SIG_MANUFACTURER: "ClimaxTechnology",
+        SIG_MODEL: "PSMP5_00.00.02.02TC",
+        SIG_NODE_DESC: b"\x01@\x8e\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 81,
@@ -414,7 +491,9 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["4:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.climaxtechnology_psmp5_00_00_02_02tc_77665544_identify",
             "sensor.climaxtechnology_psmp5_00_00_02_02tc_77665544_smartenergy_metering",
             "sensor.climaxtechnology_psmp5_00_00_02_02tc_77665544_smartenergy_metering_summation_delivered",
             "switch.climaxtechnology_psmp5_00_00_02_02tc_77665544_on_off",
@@ -424,6 +503,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.climaxtechnology_psmp5_00_00_02_02tc_77665544_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.climaxtechnology_psmp5_00_00_02_02tc_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -436,13 +520,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.climaxtechnology_psmp5_00_00_02_02tc_77665544_smartenergy_metering_summation_delivered",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["4:0x0019"],
-        SIG_MANUFACTURER: "ClimaxTechnology",
-        SIG_MODEL: "PSMP5_00.00.02.02TC",
-        SIG_NODE_DESC: b"\x01@\x8e\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 10,
+        SIG_MANUFACTURER: "ClimaxTechnology",
+        SIG_MODEL: "SD8SC_00.00.03.12TC",
+        SIG_NODE_DESC: b"\x02@\x80\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -450,25 +533,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 1280, 1282],
                 SIG_EP_OUTPUT: [0],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.climaxtechnology_sd8sc_00_00_03_12tc_77665544_ias_zone"
+            "button.climaxtechnology_sd8sc_00_00_03_12tc_77665544_identify",
+            "binary_sensor.climaxtechnology_sd8sc_00_00_03_12tc_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.climaxtechnology_sd8sc_00_00_03_12tc_77665544_ias_zone",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.climaxtechnology_sd8sc_00_00_03_12tc_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "ClimaxTechnology",
-        SIG_MODEL: "SD8SC_00.00.03.12TC",
-        SIG_NODE_DESC: b"\x02@\x80\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 11,
+        SIG_MANUFACTURER: "ClimaxTechnology",
+        SIG_MODEL: "WS15_00.00.03.03TC",
+        SIG_NODE_DESC: b"\x02@\x80\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -476,25 +565,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 1280],
                 SIG_EP_OUTPUT: [0],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.climaxtechnology_ws15_00_00_03_03tc_77665544_ias_zone"
+            "button.climaxtechnology_ws15_00_00_03_03tc_77665544_identify",
+            "binary_sensor.climaxtechnology_ws15_00_00_03_03tc_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.climaxtechnology_ws15_00_00_03_03tc_77665544_ias_zone",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.climaxtechnology_ws15_00_00_03_03tc_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "ClimaxTechnology",
-        SIG_MODEL: "WS15_00.00.03.03TC",
-        SIG_NODE_DESC: b"\x02@\x80\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 12,
+        SIG_MANUFACTURER: "Feibit Inc co.",
+        SIG_MODEL: "FB56-ZCW08KU1.1",
+        SIG_NODE_DESC: b"\x01@\x8e\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             11: {
                 SIG_EP_TYPE: 528,
@@ -511,23 +606,29 @@ DEVICES = [
                 SIG_EP_PROFILE: 49246,
             },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "light.feibit_inc_co_fb56_zcw08ku1_1_77665544_level_light_color_on_off"
+            "button.feibit_inc_co_fb56_zcw08ku1_1_77665544_identify",
+            "light.feibit_inc_co_fb56_zcw08ku1_1_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-11"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level", "light_color"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.feibit_inc_co_fb56_zcw08ku1_1_77665544_level_light_color_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-11-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.feibit_inc_co_fb56_zcw08ku1_1_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "Feibit Inc co.",
-        SIG_MODEL: "FB56-ZCW08KU1.1",
-        SIG_NODE_DESC: b"\x01@\x8e\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 13,
+        SIG_MANUFACTURER: "HEIMAN",
+        SIG_MODEL: "SmokeSensor-EM",
+        SIG_NODE_DESC: b"\x02@\x80\x0b\x12RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -535,31 +636,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 1280, 1282],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.heiman_smokesensor_em_77665544_ias_zone",
+            "button.heiman_smokesensor_em_77665544_identify",
             "sensor.heiman_smokesensor_em_77665544_power",
+            "binary_sensor.heiman_smokesensor_em_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.heiman_smokesensor_em_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.heiman_smokesensor_em_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.heiman_smokesensor_em_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.heiman_smokesensor_em_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "HEIMAN",
-        SIG_MODEL: "SmokeSensor-EM",
-        SIG_NODE_DESC: b"\x02@\x80\x0b\x12RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 14,
+        SIG_MANUFACTURER: "Heiman",
+        SIG_MODEL: "CO_V16",
+        SIG_NODE_DESC: b"\x02@\x84\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -567,23 +674,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 9, 1280],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["binary_sensor.heiman_co_v16_77665544_ias_zone"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.heiman_co_v16_77665544_identify",
+            "binary_sensor.heiman_co_v16_77665544_ias_zone",
+        ],
         DEV_SIG_ENT_MAP: {
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.heiman_co_v16_77665544_ias_zone",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.heiman_co_v16_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Heiman",
-        SIG_MODEL: "CO_V16",
-        SIG_NODE_DESC: b"\x02@\x84\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
     },
     {
         DEV_SIG_DEV_NO: 15,
+        SIG_MANUFACTURER: "Heiman",
+        SIG_MODEL: "WarningDevice",
+        SIG_NODE_DESC: b"\x01@\x8e\x0b\x12RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1027,
@@ -591,31 +706,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 4, 9, 1280, 1282],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.heiman_warningdevice_77665544_ias_zone",
+            "button.heiman_warningdevice_77665544_identify",
             "siren.heiman_warningdevice_77665544_ias_wd",
+            "binary_sensor.heiman_warningdevice_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.heiman_warningdevice_77665544_ias_zone",
-            },
             ("siren", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["ias_wd"],
                 DEV_SIG_ENT_MAP_CLASS: "ZHASiren",
                 DEV_SIG_ENT_MAP_ID: "siren.heiman_warningdevice_77665544_ias_wd",
             },
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.heiman_warningdevice_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.heiman_warningdevice_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Heiman",
-        SIG_MODEL: "WarningDevice",
-        SIG_NODE_DESC: b"\x01@\x8e\x0b\x12RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 16,
+        SIG_MANUFACTURER: "HiveHome.com",
+        SIG_MODEL: "MOT003",
+        SIG_NODE_DESC: b"\x02@\x809\x10PP\x00\x00\x00P\x00\x00",
         SIG_ENDPOINTS: {
             6: {
                 SIG_EP_TYPE: 1026,
@@ -623,15 +744,27 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1024, 1026, 1280],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["6:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.hivehome_com_mot003_77665544_ias_zone",
-            "sensor.hivehome_com_mot003_77665544_illuminance",
+            "button.hivehome_com_mot003_77665544_identify",
             "sensor.hivehome_com_mot003_77665544_power",
+            "sensor.hivehome_com_mot003_77665544_illuminance",
             "sensor.hivehome_com_mot003_77665544_temperature",
+            "binary_sensor.hivehome_com_mot003_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-6-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.hivehome_com_mot003_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-6-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.hivehome_com_mot003_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-6-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -647,20 +780,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.hivehome_com_mot003_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-6-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.hivehome_com_mot003_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["6:0x0019"],
-        SIG_MANUFACTURER: "HiveHome.com",
-        SIG_MODEL: "MOT003",
-        SIG_NODE_DESC: b"\x02@\x809\x10PP\x00\x00\x00P\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "MOT003",
     },
     {
         DEV_SIG_DEV_NO: 17,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI bulb E12 WS opal 600lm",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 268,
@@ -677,23 +803,29 @@ DEVICES = [
                 SIG_EP_PROFILE: 41440,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.ikea_of_sweden_tradfri_bulb_e12_ws_opal_600lm_77665544_level_light_color_on_off"
+            "button.ikea_of_sweden_tradfri_bulb_e12_ws_opal_600lm_77665544_identify",
+            "light.ikea_of_sweden_tradfri_bulb_e12_ws_opal_600lm_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.ikea_of_sweden_tradfri_bulb_e12_ws_opal_600lm_77665544_level_light_color_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_bulb_e12_ws_opal_600lm_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI bulb E12 WS opal 600lm",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00,R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 18,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI bulb E26 CWS opal 600lm",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 512,
@@ -701,25 +833,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2821, 4096],
                 SIG_EP_OUTPUT: [5, 25, 32, 4096],
                 SIG_EP_PROFILE: 49246,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.ikea_of_sweden_tradfri_bulb_e26_cws_opal_600lm_77665544_level_light_color_on_off"
+            "button.ikea_of_sweden_tradfri_bulb_e26_cws_opal_600lm_77665544_identify",
+            "light.ikea_of_sweden_tradfri_bulb_e26_cws_opal_600lm_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.ikea_of_sweden_tradfri_bulb_e26_cws_opal_600lm_77665544_level_light_color_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_bulb_e26_cws_opal_600lm_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI bulb E26 CWS opal 600lm",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 19,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI bulb E26 W opal 1000lm",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 256,
@@ -727,25 +865,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 2821, 4096],
                 SIG_EP_OUTPUT: [5, 25, 32, 4096],
                 SIG_EP_PROFILE: 49246,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.ikea_of_sweden_tradfri_bulb_e26_w_opal_1000lm_77665544_level_on_off"
+            "button.ikea_of_sweden_tradfri_bulb_e26_w_opal_1000lm_77665544_identify",
+            "light.ikea_of_sweden_tradfri_bulb_e26_w_opal_1000lm_77665544_level_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.ikea_of_sweden_tradfri_bulb_e26_w_opal_1000lm_77665544_level_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_bulb_e26_w_opal_1000lm_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI bulb E26 W opal 1000lm",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 20,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI bulb E26 WS opal 980lm",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 544,
@@ -753,25 +897,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2821, 4096],
                 SIG_EP_OUTPUT: [5, 25, 32, 4096],
                 SIG_EP_PROFILE: 49246,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.ikea_of_sweden_tradfri_bulb_e26_ws_opal_980lm_77665544_level_light_color_on_off"
+            "button.ikea_of_sweden_tradfri_bulb_e26_ws_opal_980lm_77665544_identify",
+            "light.ikea_of_sweden_tradfri_bulb_e26_ws_opal_980lm_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.ikea_of_sweden_tradfri_bulb_e26_ws_opal_980lm_77665544_level_light_color_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_bulb_e26_ws_opal_980lm_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI bulb E26 WS opal 980lm",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 21,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI bulb E26 opal 1000lm",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 256,
@@ -779,25 +929,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 2821, 4096],
                 SIG_EP_OUTPUT: [5, 25, 32, 4096],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.ikea_of_sweden_tradfri_bulb_e26_opal_1000lm_77665544_level_on_off"
+            "button.ikea_of_sweden_tradfri_bulb_e26_opal_1000lm_77665544_identify",
+            "light.ikea_of_sweden_tradfri_bulb_e26_opal_1000lm_77665544_level_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.ikea_of_sweden_tradfri_bulb_e26_opal_1000lm_77665544_level_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_bulb_e26_opal_1000lm_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI bulb E26 opal 1000lm",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 22,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI control outlet",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 266,
@@ -805,26 +961,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 64636],
                 SIG_EP_OUTPUT: [5, 25, 32],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "switch.ikea_of_sweden_tradfri_control_outlet_77665544_on_off"
+            "button.ikea_of_sweden_tradfri_control_outlet_77665544_identify",
+            "switch.ikea_of_sweden_tradfri_control_outlet_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("switch", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.ikea_of_sweden_tradfri_control_outlet_77665544_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_control_outlet_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI control outlet",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00,R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "TradfriPlug",
     },
     {
         DEV_SIG_DEV_NO: 23,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI motion sensor",
+        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2128,
@@ -832,13 +993,20 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 9, 2821, 4096],
                 SIG_EP_OUTPUT: [3, 4, 6, 25, 4096],
                 SIG_EP_PROFILE: 49246,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.ikea_of_sweden_tradfri_motion_sensor_77665544_on_off",
+            "button.ikea_of_sweden_tradfri_motion_sensor_77665544_identify",
             "sensor.ikea_of_sweden_tradfri_motion_sensor_77665544_power",
+            "binary_sensor.ikea_of_sweden_tradfri_motion_sensor_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_motion_sensor_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -850,14 +1018,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.ikea_of_sweden_tradfri_motion_sensor_77665544_on_off",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI motion sensor",
-        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "IkeaTradfriMotion",
     },
     {
         DEV_SIG_DEV_NO: 24,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI on/off switch",
+        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2080,
@@ -865,26 +1031,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 9, 32, 4096, 64636],
                 SIG_EP_OUTPUT: [3, 4, 6, 8, 25, 258, 4096],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019", "1:0x0102"],
         DEV_SIG_ENTITIES: [
-            "sensor.ikea_of_sweden_tradfri_on_off_switch_77665544_power"
+            "button.ikea_of_sweden_tradfri_on_off_switch_77665544_identify",
+            "sensor.ikea_of_sweden_tradfri_on_off_switch_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_on_off_switch_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.ikea_of_sweden_tradfri_on_off_switch_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019", "1:0x0102"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI on/off switch",
-        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00,R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "IkeaTradfriRemote2Btn",
     },
     {
         DEV_SIG_DEV_NO: 25,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI remote control",
+        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2096,
@@ -892,26 +1063,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 9, 2821, 4096],
                 SIG_EP_OUTPUT: [3, 4, 5, 6, 8, 25, 4096],
                 SIG_EP_PROFILE: 49246,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "sensor.ikea_of_sweden_tradfri_remote_control_77665544_power"
+            "button.ikea_of_sweden_tradfri_remote_control_77665544_identify",
+            "sensor.ikea_of_sweden_tradfri_remote_control_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_remote_control_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.ikea_of_sweden_tradfri_remote_control_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI remote control",
-        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "IkeaTradfriRemote",
     },
     {
         DEV_SIG_DEV_NO: 26,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI signal repeater",
+        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 8,
@@ -928,15 +1104,23 @@ DEVICES = [
                 SIG_EP_PROFILE: 41440,
             },
         },
-        DEV_SIG_ENTITIES: [],
-        DEV_SIG_ENT_MAP: {},
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI signal repeater",
-        SIG_NODE_DESC: b"\x01@\x8e|\x11RR\x00\x00,R\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "button.ikea_of_sweden_tradfri_signal_repeater_77665544_identify",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_signal_repeater_77665544_identify",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 27,
+        SIG_MANUFACTURER: "IKEA of Sweden",
+        SIG_MODEL: "TRADFRI wireless dimmer",
+        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2064,
@@ -944,25 +1128,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 9, 2821, 4096],
                 SIG_EP_OUTPUT: [3, 4, 6, 8, 25, 4096],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "sensor.ikea_of_sweden_tradfri_wireless_dimmer_77665544_power"
+            "button.ikea_of_sweden_tradfri_wireless_dimmer_77665544_identify",
+            "sensor.ikea_of_sweden_tradfri_wireless_dimmer_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ikea_of_sweden_tradfri_wireless_dimmer_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.ikea_of_sweden_tradfri_wireless_dimmer_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019"],
-        SIG_MANUFACTURER: "IKEA of Sweden",
-        SIG_MODEL: "TRADFRI wireless dimmer",
-        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 28,
+        SIG_MANUFACTURER: "Jasco Products",
+        SIG_MODEL: "45852",
+        SIG_NODE_DESC: b"\x01@\x8e$\x11R\xff\x00\x00\x00\xff\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -979,16 +1169,24 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006", "2:0x0008"],
         DEV_SIG_ENTITIES: [
+            "button.jasco_products_45852_77665544_identify",
             "light.jasco_products_45852_77665544_level_on_off",
+            "button.jasco_products_45852_77665544_identify_2",
             "sensor.jasco_products_45852_77665544_smartenergy_metering",
             "sensor.jasco_products_45852_77665544_smartenergy_metering_summation_delivered",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.jasco_products_45852_77665544_level_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45852_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -1000,14 +1198,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45852_77665544_smartenergy_metering_summation_delivered",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45852_77665544_identify_2",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006", "2:0x0008"],
-        SIG_MANUFACTURER: "Jasco Products",
-        SIG_MODEL: "45852",
-        SIG_NODE_DESC: b"\x01@\x8e$\x11R\xff\x00\x00\x00\xff\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 29,
+        SIG_MANUFACTURER: "Jasco Products",
+        SIG_MODEL: "45856",
+        SIG_NODE_DESC: b"\x01@\x8e$\x11R\xff\x00\x00\x00\xff\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 256,
@@ -1024,8 +1226,11 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006"],
         DEV_SIG_ENTITIES: [
+            "button.jasco_products_45856_77665544_identify",
             "light.jasco_products_45856_77665544_on_off",
+            "button.jasco_products_45856_77665544_identify_2",
             "sensor.jasco_products_45856_77665544_smartenergy_metering",
             "sensor.jasco_products_45856_77665544_smartenergy_metering_summation_delivered",
         ],
@@ -1034,6 +1239,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.jasco_products_45856_77665544_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45856_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -1045,14 +1255,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45856_77665544_smartenergy_metering_summation_delivered",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45856_77665544_identify_2",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006"],
-        SIG_MANUFACTURER: "Jasco Products",
-        SIG_MODEL: "45856",
-        SIG_NODE_DESC: b"\x01@\x8e$\x11R\xff\x00\x00\x00\xff\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 30,
+        SIG_MANUFACTURER: "Jasco Products",
+        SIG_MODEL: "45857",
+        SIG_NODE_DESC: b"\x01@\x8e$\x11R\xff\x00\x00\x00\xff\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -1069,16 +1283,24 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006", "2:0x0008"],
         DEV_SIG_ENTITIES: [
+            "button.jasco_products_45857_77665544_identify",
             "light.jasco_products_45857_77665544_level_on_off",
+            "button.jasco_products_45857_77665544_identify_2",
             "sensor.jasco_products_45857_77665544_smartenergy_metering",
             "sensor.jasco_products_45857_77665544_smartenergy_metering_summation_delivered",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.jasco_products_45857_77665544_level_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45857_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -1090,44 +1312,41 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
                 DEV_SIG_ENT_MAP_ID: "sensor.jasco_products_45857_77665544_smartenergy_metering_summation_delivered",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.jasco_products_45857_77665544_identify_2",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006", "2:0x0008"],
-        SIG_MANUFACTURER: "Jasco Products",
-        SIG_MODEL: "45857",
-        SIG_NODE_DESC: b"\x01@\x8e$\x11R\xff\x00\x00\x00\xff\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 31,
+        SIG_MANUFACTURER: "Keen Home Inc",
+        SIG_MODEL: "SV02-610-MP-1.3",
+        SIG_NODE_DESC: b"\x02@\x80[\x11RR\x00\x00*R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 3,
                 DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [
-                    0,
-                    1,
-                    3,
-                    4,
-                    5,
-                    6,
-                    8,
-                    32,
-                    1026,
-                    1027,
-                    2821,
-                    64513,
-                    64514,
-                ],
+                SIG_EP_INPUT: [0, 1, 3, 4, 5, 6, 8, 32, 1026, 1027, 2821, 64513, 64514],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "cover.keen_home_inc_sv02_610_mp_1_3_77665544_level_on_off",
+            "button.keen_home_inc_sv02_610_mp_1_3_77665544_identify",
             "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_power",
             "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_pressure",
             "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_temperature",
+            "cover.keen_home_inc_sv02_610_mp_1_3_77665544_level_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.keen_home_inc_sv02_610_mp_1_3_77665544_identify",
+            },
             ("cover", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["level", "on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "KeenVent",
@@ -1138,54 +1357,46 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_power",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
-                DEV_SIG_CHANNELS: ["temperature"],
-                DEV_SIG_ENT_MAP_CLASS: "Temperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_temperature",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1027"): {
                 DEV_SIG_CHANNELS: ["pressure"],
                 DEV_SIG_ENT_MAP_CLASS: "Pressure",
                 DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_pressure",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
+                DEV_SIG_CHANNELS: ["temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "Temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_610_mp_1_3_77665544_temperature",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Keen Home Inc",
-        SIG_MODEL: "SV02-610-MP-1.3",
-        SIG_NODE_DESC: b"\x02@\x80[\x11RR\x00\x00*R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 32,
+        SIG_MANUFACTURER: "Keen Home Inc",
+        SIG_MODEL: "SV02-612-MP-1.2",
+        SIG_NODE_DESC: b"\x02@\x80[\x11RR\x00\x00*R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 3,
                 DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [
-                    0,
-                    1,
-                    3,
-                    4,
-                    5,
-                    6,
-                    8,
-                    32,
-                    1026,
-                    1027,
-                    2821,
-                    64513,
-                    64514,
-                ],
+                SIG_EP_INPUT: [0, 1, 3, 4, 5, 6, 8, 32, 1026, 1027, 2821, 64513, 64514],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "cover.keen_home_inc_sv02_612_mp_1_2_77665544_level_on_off",
+            "button.keen_home_inc_sv02_612_mp_1_2_77665544_identify",
             "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_power",
             "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_pressure",
             "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_temperature",
+            "cover.keen_home_inc_sv02_612_mp_1_2_77665544_level_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.keen_home_inc_sv02_612_mp_1_2_77665544_identify",
+            },
             ("cover", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["level", "on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "KeenVent",
@@ -1196,54 +1407,46 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_power",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
-                DEV_SIG_CHANNELS: ["temperature"],
-                DEV_SIG_ENT_MAP_CLASS: "Temperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_temperature",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1027"): {
                 DEV_SIG_CHANNELS: ["pressure"],
                 DEV_SIG_ENT_MAP_CLASS: "Pressure",
                 DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_pressure",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
+                DEV_SIG_CHANNELS: ["temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "Temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_2_77665544_temperature",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Keen Home Inc",
-        SIG_MODEL: "SV02-612-MP-1.2",
-        SIG_NODE_DESC: b"\x02@\x80[\x11RR\x00\x00*R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 33,
+        SIG_MANUFACTURER: "Keen Home Inc",
+        SIG_MODEL: "SV02-612-MP-1.3",
+        SIG_NODE_DESC: b"\x02@\x80[\x11RR\x00\x00*R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 3,
                 DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [
-                    0,
-                    1,
-                    3,
-                    4,
-                    5,
-                    6,
-                    8,
-                    32,
-                    1026,
-                    1027,
-                    2821,
-                    64513,
-                    64514,
-                ],
+                SIG_EP_INPUT: [0, 1, 3, 4, 5, 6, 8, 32, 1026, 1027, 2821, 64513, 64514],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "cover.keen_home_inc_sv02_612_mp_1_3_77665544_level_on_off",
+            "button.keen_home_inc_sv02_612_mp_1_3_77665544_identify",
             "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_power",
             "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_pressure",
             "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_temperature",
+            "cover.keen_home_inc_sv02_612_mp_1_3_77665544_level_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.keen_home_inc_sv02_612_mp_1_3_77665544_identify",
+            },
             ("cover", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["level", "on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "KeenVent",
@@ -1254,25 +1457,23 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_power",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
-                DEV_SIG_CHANNELS: ["temperature"],
-                DEV_SIG_ENT_MAP_CLASS: "Temperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_temperature",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1027"): {
                 DEV_SIG_CHANNELS: ["pressure"],
                 DEV_SIG_ENT_MAP_CLASS: "Pressure",
                 DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_pressure",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
+                DEV_SIG_CHANNELS: ["temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "Temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.keen_home_inc_sv02_612_mp_1_3_77665544_temperature",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Keen Home Inc",
-        SIG_MODEL: "SV02-612-MP-1.3",
-        SIG_NODE_DESC: b"\x02@\x80[\x11RR\x00\x00*R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "KeenHomeSmartVent",
     },
     {
         DEV_SIG_DEV_NO: 34,
+        SIG_MANUFACTURER: "King Of Fans,  Inc.",
+        SIG_MODEL: "HBUniversalCFRemote",
+        SIG_NODE_DESC: b"\x02@\x8c\x02\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -1280,17 +1481,24 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 514],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "fan.king_of_fans_inc_hbuniversalcfremote_77665544_fan",
+            "button.king_of_fans_inc_hbuniversalcfremote_77665544_identify",
             "light.king_of_fans_inc_hbuniversalcfremote_77665544_level_on_off",
+            "fan.king_of_fans_inc_hbuniversalcfremote_77665544_fan",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.king_of_fans_inc_hbuniversalcfremote_77665544_level_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.king_of_fans_inc_hbuniversalcfremote_77665544_identify",
             },
             ("fan", "00:11:22:33:44:55:66:77-1-514"): {
                 DEV_SIG_CHANNELS: ["fan"],
@@ -1298,14 +1506,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "fan.king_of_fans_inc_hbuniversalcfremote_77665544_fan",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "King Of Fans,  Inc.",
-        SIG_MODEL: "HBUniversalCFRemote",
-        SIG_NODE_DESC: b"\x02@\x8c\x02\x10RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CeilingFan",
     },
     {
         DEV_SIG_DEV_NO: 35,
+        SIG_MANUFACTURER: "LDS",
+        SIG_MODEL: "ZBT-CCTSwitch-D0001",
+        SIG_NODE_DESC: b"\x02@\x80h\x11RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2048,
@@ -1313,48 +1519,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 4096, 64769],
                 SIG_EP_OUTPUT: [3, 4, 6, 8, 25, 768, 4096],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.lds_zbt_cctswitch_d0001_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019", "1:0x0300"],
+        DEV_SIG_ENTITIES: [
+            "button.lds_zbt_cctswitch_d0001_77665544_identify",
+            "sensor.lds_zbt_cctswitch_d0001_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lds_zbt_cctswitch_d0001_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lds_zbt_cctswitch_d0001_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019", "1:0x0300"],
-        SIG_MANUFACTURER: "LDS",
-        SIG_MODEL: "ZBT-CCTSwitch-D0001",
-        SIG_NODE_DESC: b"\x02@\x80h\x11RR\x00\x00,R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CCTSwitch",
     },
     {
         DEV_SIG_DEV_NO: 36,
-        SIG_ENDPOINTS: {
-            1: {
-                SIG_EP_TYPE: 258,
-                DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2821, 64513],
-                SIG_EP_OUTPUT: [25],
-                SIG_EP_PROFILE: 260,
-            }
-        },
-        DEV_SIG_ENTITIES: ["light.ledvance_a19_rgbw_77665544_level_light_color_on_off"],
-        DEV_SIG_ENT_MAP: {
-            ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.ledvance_a19_rgbw_77665544_level_light_color_on_off",
-            }
-        },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         SIG_MANUFACTURER: "LEDVANCE",
         SIG_MODEL: "A19 RGBW",
         SIG_NODE_DESC: b"\x01@\x8e\x89\x11RR\x00\x00\x00R\x00\x00",
-    },
-    {
-        DEV_SIG_DEV_NO: 37,
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 258,
@@ -1362,25 +1551,63 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2821, 64513],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.ledvance_flex_rgbw_77665544_level_light_color_on_off"
+            "button.ledvance_a19_rgbw_77665544_identify",
+            "light.ledvance_a19_rgbw_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.ledvance_flex_rgbw_77665544_level_light_color_on_off",
-            }
+                DEV_SIG_ENT_MAP_ID: "light.ledvance_a19_rgbw_77665544_level_light_color_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ledvance_a19_rgbw_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
+    },
+    {
+        DEV_SIG_DEV_NO: 37,
         SIG_MANUFACTURER: "LEDVANCE",
         SIG_MODEL: "FLEX RGBW",
         SIG_NODE_DESC: b"\x01@\x8e\x89\x11RR\x00\x00\x00R\x00\x00",
+        SIG_ENDPOINTS: {
+            1: {
+                SIG_EP_TYPE: 258,
+                DEV_SIG_EP_ID: 1,
+                SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2821, 64513],
+                SIG_EP_OUTPUT: [25],
+                SIG_EP_PROFILE: 260,
+            },
+        },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.ledvance_flex_rgbw_77665544_identify",
+            "light.ledvance_flex_rgbw_77665544_level_light_color_on_off",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("light", "00:11:22:33:44:55:66:77-1"): {
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
+                DEV_SIG_ENT_MAP_CLASS: "Light",
+                DEV_SIG_ENT_MAP_ID: "light.ledvance_flex_rgbw_77665544_level_light_color_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ledvance_flex_rgbw_77665544_identify",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 38,
+        SIG_MANUFACTURER: "LEDVANCE",
+        SIG_MODEL: "PLUG",
+        SIG_NODE_DESC: b"\x01@\x8e\x89\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 81,
@@ -1388,23 +1615,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 2821, 64513, 64520],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["switch.ledvance_plug_77665544_on_off"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.ledvance_plug_77665544_identify",
+            "switch.ledvance_plug_77665544_on_off",
+        ],
         DEV_SIG_ENT_MAP: {
             ("switch", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.ledvance_plug_77665544_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ledvance_plug_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LEDVANCE",
-        SIG_MODEL: "PLUG",
-        SIG_NODE_DESC: b"\x01@\x8e\x89\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 39,
+        SIG_MANUFACTURER: "LEDVANCE",
+        SIG_MODEL: "RT RGBW",
+        SIG_NODE_DESC: b"\x01@\x8e\x89\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 258,
@@ -1412,23 +1647,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2821, 64513],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
-        },
-        DEV_SIG_ENTITIES: ["light.ledvance_rt_rgbw_77665544_level_light_color_on_off"],
-        DEV_SIG_ENT_MAP: {
-            ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.ledvance_rt_rgbw_77665544_level_light_color_on_off",
-            }
+            },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LEDVANCE",
-        SIG_MODEL: "RT RGBW",
-        SIG_NODE_DESC: b"\x01@\x8e\x89\x11RR\x00\x00\x00R\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "button.ledvance_rt_rgbw_77665544_identify",
+            "light.ledvance_rt_rgbw_77665544_level_light_color_on_off",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("light", "00:11:22:33:44:55:66:77-1"): {
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
+                DEV_SIG_ENT_MAP_CLASS: "Light",
+                DEV_SIG_ENT_MAP_ID: "light.ledvance_rt_rgbw_77665544_level_light_color_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.ledvance_rt_rgbw_77665544_identify",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 40,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.plug.maus01",
+        SIG_NODE_DESC: b"\x01@\x8e_\x11\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 81,
@@ -1459,30 +1702,28 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
-            "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
+            "button.lumi_lumi_plug_maus01_77665544_identify",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_apparent_power",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_current",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_voltage",
+            "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
+            "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
+            "binary_sensor.lumi_lumi_plug_maus01_77665544_binary_input",
             "switch.lumi_lumi_plug_maus01_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-2-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-3-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
-            },
             ("switch", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.lumi_lumi_plug_maus01_77665544_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_plug_maus01_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -1504,20 +1745,28 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_voltage",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-2-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
+            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-100-15"): {
                 DEV_SIG_CHANNELS: ["binary_input"],
                 DEV_SIG_ENT_MAP_CLASS: "BinaryInput",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_plug_maus01_77665544_binary_input",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.plug.maus01",
-        SIG_NODE_DESC: b"\x01@\x8e_\x11\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Plug",
     },
     {
         DEV_SIG_DEV_NO: 41,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.relay.c2acn01",
+        SIG_NODE_DESC: b"\x01@\x8e7\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -1534,7 +1783,9 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_relay_c2acn01_77665544_identify",
             "light.lumi_lumi_relay_c2acn01_77665544_on_off",
             "light.lumi_lumi_relay_c2acn01_77665544_on_off_2",
             "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement",
@@ -1547,6 +1798,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_relay_c2acn01_77665544_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_relay_c2acn01_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -1574,14 +1830,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_relay_c2acn01_77665544_on_off_2",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.relay.c2acn01",
-        SIG_NODE_DESC: b"\x01@\x8e7\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Relay",
     },
     {
         DEV_SIG_DEV_NO: 42,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.remote.b186acn01",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 24321,
@@ -1605,22 +1859,41 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_remote_b186acn01_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_remote_b186acn01_77665544_identify",
+            "button.lumi_lumi_remote_b186acn01_77665544_identify_2",
+            "button.lumi_lumi_remote_b186acn01_77665544_identify_3",
+            "sensor.lumi_lumi_remote_b186acn01_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b186acn01_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_remote_b186acn01_77665544_power",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b186acn01_77665544_identify_2",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b186acn01_77665544_identify_3",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.remote.b186acn01",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "RemoteB186ACN01",
     },
     {
         DEV_SIG_DEV_NO: 43,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.remote.b286acn01",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 24321,
@@ -1644,128 +1917,102 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_remote_b286acn01_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_remote_b286acn01_77665544_identify",
+            "button.lumi_lumi_remote_b286acn01_77665544_identify_2",
+            "button.lumi_lumi_remote_b286acn01_77665544_identify_3",
+            "sensor.lumi_lumi_remote_b286acn01_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b286acn01_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_remote_b286acn01_77665544_power",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b286acn01_77665544_identify_2",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b286acn01_77665544_identify_3",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.remote.b286acn01",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "RemoteB286ACN01",
     },
     {
         DEV_SIG_DEV_NO: 44,
-        SIG_ENDPOINTS: {
-            1: {
-                SIG_EP_TYPE: 261,
-                DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [0, 1, 3],
-                SIG_EP_OUTPUT: [3, 6, 8, 768],
-                SIG_EP_PROFILE: 260,
-            },
-            2: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 2,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            3: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 3,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            4: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 4,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            5: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 5,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            6: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 6,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-        },
-        DEV_SIG_ENTITIES: [],
-        DEV_SIG_ENT_MAP: {},
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300"],
         SIG_MANUFACTURER: "LUMI",
         SIG_MODEL: "lumi.remote.b286opcn01",
         SIG_NODE_DESC: b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00",
+        SIG_ENDPOINTS: {
+            1: {
+                SIG_EP_TYPE: 261,
+                DEV_SIG_EP_ID: 1,
+                SIG_EP_INPUT: [0, 1, 3],
+                SIG_EP_OUTPUT: [3, 6, 8, 768],
+                SIG_EP_PROFILE: 260,
+            },
+            2: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 2,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            3: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 3,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            4: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 4,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            5: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 5,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            6: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 6,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+        },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_remote_b286opcn01_77665544_identify",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b286opcn01_77665544_identify",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 45,
-        SIG_ENDPOINTS: {
-            1: {
-                SIG_EP_TYPE: 261,
-                DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [0, 1, 3],
-                SIG_EP_OUTPUT: [3, 6, 8, 768],
-                SIG_EP_PROFILE: 260,
-            },
-            2: {
-                SIG_EP_TYPE: 259,
-                DEV_SIG_EP_ID: 2,
-                SIG_EP_INPUT: [3],
-                SIG_EP_OUTPUT: [3, 6],
-                SIG_EP_PROFILE: 260,
-            },
-            3: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 3,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            4: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 4,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            5: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 5,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-            6: {
-                SIG_EP_TYPE: -1,
-                DEV_SIG_EP_ID: 6,
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_PROFILE: -1,
-            },
-        },
-        DEV_SIG_ENTITIES: [],
-        DEV_SIG_ENT_MAP: {},
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300", "2:0x0006"],
         SIG_MANUFACTURER: "LUMI",
         SIG_MODEL: "lumi.remote.b486opcn01",
         SIG_NODE_DESC: b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00",
-    },
-    {
-        DEV_SIG_DEV_NO: 46,
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 261,
@@ -1773,17 +2020,92 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3],
                 SIG_EP_OUTPUT: [3, 6, 8, 768],
                 SIG_EP_PROFILE: 260,
-            }
+            },
+            2: {
+                SIG_EP_TYPE: 259,
+                DEV_SIG_EP_ID: 2,
+                SIG_EP_INPUT: [3],
+                SIG_EP_OUTPUT: [3, 6],
+                SIG_EP_PROFILE: 260,
+            },
+            3: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 3,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            4: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 4,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            5: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 5,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
+            6: {
+                SIG_EP_TYPE: -1,
+                DEV_SIG_EP_ID: 6,
+                SIG_EP_INPUT: [],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: -1,
+            },
         },
-        DEV_SIG_ENTITIES: [],
-        DEV_SIG_ENT_MAP: {},
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300", "2:0x0006"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_remote_b486opcn01_77665544_identify",
+            "button.lumi_lumi_remote_b486opcn01_77665544_identify_2",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b486opcn01_77665544_identify",
+            },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b486opcn01_77665544_identify_2",
+            },
+        },
+    },
+    {
+        DEV_SIG_DEV_NO: 46,
         SIG_MANUFACTURER: "LUMI",
         SIG_MODEL: "lumi.remote.b686opcn01",
         SIG_NODE_DESC: b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00",
+        SIG_ENDPOINTS: {
+            1: {
+                SIG_EP_TYPE: 261,
+                DEV_SIG_EP_ID: 1,
+                SIG_EP_INPUT: [0, 1, 3],
+                SIG_EP_OUTPUT: [3, 6, 8, 768],
+                SIG_EP_PROFILE: 260,
+            },
+        },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_remote_b686opcn01_77665544_identify",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b686opcn01_77665544_identify",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 47,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.remote.b686opcn01",
+        SIG_NODE_DESC: b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 261,
@@ -1828,15 +2150,29 @@ DEVICES = [
                 SIG_EP_PROFILE: None,
             },
         },
-        DEV_SIG_ENTITIES: [],
-        DEV_SIG_ENT_MAP: {},
         DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0300", "2:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.remote.b686opcn01",
-        SIG_NODE_DESC: b"\x02@\x84_\x11\x7fd\x00\x00,d\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_remote_b686opcn01_77665544_identify",
+            "button.lumi_lumi_remote_b686opcn01_77665544_identify_2",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b686opcn01_77665544_identify",
+            },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_remote_b686opcn01_77665544_identify_2",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 48,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.router",
+        SIG_NODE_DESC: b"\x01@\x8e_\x11P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             8: {
                 SIG_EP_TYPE: 256,
@@ -1844,31 +2180,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 6],
                 SIG_EP_OUTPUT: [0, 6],
                 SIG_EP_PROFILE: 260,
-            }
-        },
-        DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_router_77665544_on_off",
-            "light.lumi_lumi_router_77665544_on_off",
-        ],
-        DEV_SIG_ENT_MAP: {
-            ("binary_sensor", "00:11:22:33:44:55:66:77-8-6"): {
-                DEV_SIG_CHANNELS: ["on_off", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Opening",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_router_77665544_on_off",
-            },
-            ("light", "00:11:22:33:44:55:66:77-8"): {
-                DEV_SIG_CHANNELS: ["on_off", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_router_77665544_on_off",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["8:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.router",
-        SIG_NODE_DESC: b"\x01@\x8e_\x11P\xa0\x00\x00\x00\xa0\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "light.lumi_lumi_router_77665544_on_off",
+            "binary_sensor.lumi_lumi_router_77665544_on_off",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("light", "00:11:22:33:44:55:66:77-8"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Light",
+                DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_router_77665544_on_off",
+            },
+            ("binary_sensor", "00:11:22:33:44:55:66:77-8-6"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Opening",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_router_77665544_on_off",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 49,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.router",
+        SIG_NODE_DESC: b"\x01@\x8e_\x11P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             8: {
                 SIG_EP_TYPE: 256,
@@ -1876,31 +2212,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 6, 11, 17],
                 SIG_EP_OUTPUT: [0, 6],
                 SIG_EP_PROFILE: 260,
-            }
-        },
-        DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_router_77665544_on_off",
-            "light.lumi_lumi_router_77665544_on_off",
-        ],
-        DEV_SIG_ENT_MAP: {
-            ("binary_sensor", "00:11:22:33:44:55:66:77-8-6"): {
-                DEV_SIG_CHANNELS: ["on_off", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Opening",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_router_77665544_on_off",
-            },
-            ("light", "00:11:22:33:44:55:66:77-8"): {
-                DEV_SIG_CHANNELS: ["on_off", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_router_77665544_on_off",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["8:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.router",
-        SIG_NODE_DESC: b"\x01@\x8e_\x11P\xa0\x00\x00\x00\xa0\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "light.lumi_lumi_router_77665544_on_off",
+            "binary_sensor.lumi_lumi_router_77665544_on_off",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("light", "00:11:22:33:44:55:66:77-8"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Light",
+                DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_router_77665544_on_off",
+            },
+            ("binary_sensor", "00:11:22:33:44:55:66:77-8-6"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Opening",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_router_77665544_on_off",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 50,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.router",
+        SIG_NODE_DESC: b"\x01@\x8e_\x11P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             8: {
                 SIG_EP_TYPE: 256,
@@ -1908,31 +2244,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 6, 17],
                 SIG_EP_OUTPUT: [0, 6],
                 SIG_EP_PROFILE: 260,
-            }
-        },
-        DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_router_77665544_on_off",
-            "light.lumi_lumi_router_77665544_on_off",
-        ],
-        DEV_SIG_ENT_MAP: {
-            ("binary_sensor", "00:11:22:33:44:55:66:77-8-6"): {
-                DEV_SIG_CHANNELS: ["on_off", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Opening",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_router_77665544_on_off",
-            },
-            ("light", "00:11:22:33:44:55:66:77-8"): {
-                DEV_SIG_CHANNELS: ["on_off", "on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_router_77665544_on_off",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["8:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.router",
-        SIG_NODE_DESC: b"\x01@\x8e_\x11P\xa0\x00\x00\x00\xa0\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "light.lumi_lumi_router_77665544_on_off",
+            "binary_sensor.lumi_lumi_router_77665544_on_off",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("light", "00:11:22:33:44:55:66:77-8"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Light",
+                DEV_SIG_ENT_MAP_ID: "light.lumi_lumi_router_77665544_on_off",
+            },
+            ("binary_sensor", "00:11:22:33:44:55:66:77-8-6"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Opening",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_router_77665544_on_off",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 51,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sen_ill.mgl01",
+        SIG_NODE_DESC: b"\x02@\x84n\x12\x7fd\x00\x00,d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 262,
@@ -1940,23 +2276,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 1024],
                 SIG_EP_OUTPUT: [3],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_sen_ill_mgl01_77665544_illuminance"],
+        DEV_SIG_EVT_CHANNELS: [],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_sen_ill_mgl01_77665544_identify",
+            "sensor.lumi_lumi_sen_ill_mgl01_77665544_illuminance",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sen_ill_mgl01_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1024"): {
                 DEV_SIG_CHANNELS: ["illuminance"],
                 DEV_SIG_ENT_MAP_CLASS: "Illuminance",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sen_ill_mgl01_77665544_illuminance",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sen_ill.mgl01",
-        SIG_NODE_DESC: b"\x02@\x84n\x12\x7fd\x00\x00,d\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 52,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_86sw1",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 24321,
@@ -1980,22 +2324,41 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_sensor_86sw1_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_sensor_86sw1_77665544_identify",
+            "button.lumi_lumi_sensor_86sw1_77665544_identify_2",
+            "button.lumi_lumi_sensor_86sw1_77665544_identify_3",
+            "sensor.lumi_lumi_sensor_86sw1_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_86sw1_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_86sw1_77665544_power",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_86sw1_77665544_identify_2",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_86sw1_77665544_identify_3",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_86sw1",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "RemoteB186ACN01",
     },
     {
         DEV_SIG_DEV_NO: 53,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_cube.aqgl01",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 28417,
@@ -2019,22 +2382,41 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify",
+            "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_2",
+            "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_3",
+            "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_cube_aqgl01_77665544_power",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_2",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_cube_aqgl01_77665544_identify_3",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_cube.aqgl01",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CubeAQGL01",
     },
     {
         DEV_SIG_DEV_NO: 54,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_ht",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 24322,
@@ -2058,12 +2440,21 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
         DEV_SIG_ENTITIES: [
-            "sensor.lumi_lumi_sensor_ht_77665544_humidity",
+            "button.lumi_lumi_sensor_ht_77665544_identify",
+            "button.lumi_lumi_sensor_ht_77665544_identify_2",
+            "button.lumi_lumi_sensor_ht_77665544_identify_3",
             "sensor.lumi_lumi_sensor_ht_77665544_power",
             "sensor.lumi_lumi_sensor_ht_77665544_temperature",
+            "sensor.lumi_lumi_sensor_ht_77665544_humidity",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_ht_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2079,15 +2470,23 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Humidity",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_ht_77665544_humidity",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_ht_77665544_identify_2",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_ht_77665544_identify_3",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005", "3:0x0005"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_ht",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Weather",
     },
     {
         DEV_SIG_DEV_NO: 55,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_magnet",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2128,
@@ -2095,13 +2494,20 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 25, 65535],
                 SIG_EP_OUTPUT: [0, 3, 4, 5, 6, 8, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_sensor_magnet_77665544_on_off",
+            "button.lumi_lumi_sensor_magnet_77665544_identify",
             "sensor.lumi_lumi_sensor_magnet_77665544_power",
+            "binary_sensor.lumi_lumi_sensor_magnet_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_magnet_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2113,14 +2519,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_sensor_magnet_77665544_on_off",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_magnet",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Magnet",
     },
     {
         DEV_SIG_DEV_NO: 56,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_magnet.aq2",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 24321,
@@ -2128,13 +2532,20 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 65535],
                 SIG_EP_OUTPUT: [0, 4, 6, 65535],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_sensor_magnet_aq2_77665544_on_off",
+            "button.lumi_lumi_sensor_magnet_aq2_77665544_identify",
             "sensor.lumi_lumi_sensor_magnet_aq2_77665544_power",
+            "binary_sensor.lumi_lumi_sensor_magnet_aq2_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_magnet_aq2_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2146,14 +2557,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_sensor_magnet_aq2_77665544_on_off",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_magnet.aq2",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "MagnetAQ2",
     },
     {
         DEV_SIG_DEV_NO: 57,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_motion.aq2",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 263,
@@ -2161,25 +2570,17 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 1024, 1030, 1280, 65535],
                 SIG_EP_OUTPUT: [0, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_sensor_motion_aq2_77665544_ias_zone",
-            "binary_sensor.lumi_lumi_sensor_motion_aq2_77665544_occupancy",
-            "sensor.lumi_lumi_sensor_motion_aq2_77665544_illuminance",
+            "button.lumi_lumi_sensor_motion_aq2_77665544_identify",
             "sensor.lumi_lumi_sensor_motion_aq2_77665544_power",
+            "sensor.lumi_lumi_sensor_motion_aq2_77665544_illuminance",
+            "binary_sensor.lumi_lumi_sensor_motion_aq2_77665544_occupancy",
+            "binary_sensor.lumi_lumi_sensor_motion_aq2_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_motion_aq2_77665544_power",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1024"): {
-                DEV_SIG_CHANNELS: ["illuminance"],
-                DEV_SIG_ENT_MAP_CLASS: "Illuminance",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_motion_aq2_77665544_illuminance",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1030"): {
                 DEV_SIG_CHANNELS: ["occupancy"],
                 DEV_SIG_ENT_MAP_CLASS: "Occupancy",
@@ -2190,15 +2591,28 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_sensor_motion_aq2_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_motion_aq2_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_motion_aq2_77665544_power",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1024"): {
+                DEV_SIG_CHANNELS: ["illuminance"],
+                DEV_SIG_ENT_MAP_CLASS: "Illuminance",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_motion_aq2_77665544_illuminance",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_motion.aq2",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "MotionAQ2",
     },
     {
         DEV_SIG_DEV_NO: 58,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_smoke",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2206,32 +2620,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 12, 18, 1280],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_sensor_smoke_77665544_ias_zone",
+            "button.lumi_lumi_sensor_smoke_77665544_identify",
             "sensor.lumi_lumi_sensor_smoke_77665544_power",
+            "binary_sensor.lumi_lumi_sensor_smoke_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_smoke_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_sensor_smoke_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_smoke_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_smoke_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_smoke",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "MijiaHoneywellSmokeDetectorSensor",
     },
     {
         DEV_SIG_DEV_NO: 59,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_switch",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 6,
@@ -2239,24 +2658,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3],
                 SIG_EP_OUTPUT: [0, 4, 5, 6, 8, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_sensor_switch_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_sensor_switch_77665544_identify",
+            "sensor.lumi_lumi_sensor_switch_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_switch_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_switch_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_switch",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "MijaButton",
     },
     {
         DEV_SIG_DEV_NO: 60,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_switch.aq2",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 6,
@@ -2264,24 +2690,25 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 65535],
                 SIG_EP_OUTPUT: [0, 4, 6, 65535],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_sensor_switch_aq2_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006"],
+        DEV_SIG_ENTITIES: [
+            "sensor.lumi_lumi_sensor_switch_aq2_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_switch_aq2_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_switch.aq2",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SwitchAQ2",
     },
     {
         DEV_SIG_DEV_NO: 61,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_switch.aq3",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 6,
@@ -2289,9 +2716,12 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 18],
                 SIG_EP_OUTPUT: [0, 6],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.lumi_lumi_sensor_switch_aq3_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006"],
+        DEV_SIG_ENTITIES: [
+            "sensor.lumi_lumi_sensor_switch_aq3_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
@@ -2299,14 +2729,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_switch_aq3_77665544_power",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_switch.aq3",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SwitchAQ3",
     },
     {
         DEV_SIG_DEV_NO: 62,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.sensor_wleak.aq1",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2314,32 +2742,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 1280],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.lumi_lumi_sensor_wleak_aq1_77665544_ias_zone",
+            "button.lumi_lumi_sensor_wleak_aq1_77665544_identify",
             "sensor.lumi_lumi_sensor_wleak_aq1_77665544_power",
+            "binary_sensor.lumi_lumi_sensor_wleak_aq1_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_wleak_aq1_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_sensor_wleak_aq1_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_sensor_wleak_aq1_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_sensor_wleak_aq1_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.sensor_wleak.aq1",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "LeakAQ1",
     },
     {
         DEV_SIG_DEV_NO: 63,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.vibration.aq1",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 10,
@@ -2356,12 +2789,25 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005"],
         DEV_SIG_ENTITIES: [
+            "button.lumi_lumi_vibration_aq1_77665544_identify",
+            "button.lumi_lumi_vibration_aq1_77665544_identify_2",
+            "sensor.lumi_lumi_vibration_aq1_77665544_power",
             "binary_sensor.lumi_lumi_vibration_aq1_77665544_ias_zone",
             "lock.lumi_lumi_vibration_aq1_77665544_door_lock",
-            "sensor.lumi_lumi_vibration_aq1_77665544_power",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_vibration_aq1_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_vibration_aq1_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2372,20 +2818,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ZhaDoorLock",
                 DEV_SIG_ENT_MAP_ID: "lock.lumi_lumi_vibration_aq1_77665544_door_lock",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.lumi_lumi_vibration_aq1_77665544_ias_zone",
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_vibration_aq1_77665544_identify_2",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0019", "2:0x0005"],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.vibration.aq1",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "VibrationAQ1",
     },
     {
         DEV_SIG_DEV_NO: 64,
+        SIG_MANUFACTURER: "LUMI",
+        SIG_MODEL: "lumi.weather",
+        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 24321,
@@ -2393,29 +2837,36 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 1026, 1027, 1029, 65535],
                 SIG_EP_OUTPUT: [0, 4, 65535],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "sensor.lumi_lumi_weather_77665544_humidity",
+            "button.lumi_lumi_weather_77665544_identify",
             "sensor.lumi_lumi_weather_77665544_power",
             "sensor.lumi_lumi_weather_77665544_pressure",
             "sensor.lumi_lumi_weather_77665544_temperature",
+            "sensor.lumi_lumi_weather_77665544_humidity",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.lumi_lumi_weather_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_weather_77665544_power",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
-                DEV_SIG_CHANNELS: ["temperature"],
-                DEV_SIG_ENT_MAP_CLASS: "Temperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_weather_77665544_temperature",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1027"): {
                 DEV_SIG_CHANNELS: ["pressure"],
                 DEV_SIG_ENT_MAP_CLASS: "Pressure",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_weather_77665544_pressure",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
+                DEV_SIG_CHANNELS: ["temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "Temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_weather_77665544_temperature",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1029"): {
                 DEV_SIG_CHANNELS: ["humidity"],
@@ -2423,14 +2874,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_weather_77665544_humidity",
             },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "LUMI",
-        SIG_MODEL: "lumi.weather",
-        SIG_NODE_DESC: b"\x02@\x807\x10\x7fd\x00\x00\x00d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Weather",
     },
     {
         DEV_SIG_DEV_NO: 65,
+        SIG_MANUFACTURER: "NYCE",
+        SIG_MODEL: "3010",
+        SIG_NODE_DESC: b"\x02@\x80\xb9\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2438,31 +2887,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1280],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.nyce_3010_77665544_ias_zone",
+            "button.nyce_3010_77665544_identify",
             "sensor.nyce_3010_77665544_power",
+            "binary_sensor.nyce_3010_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.nyce_3010_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.nyce_3010_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.nyce_3010_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.nyce_3010_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "NYCE",
-        SIG_MODEL: "3010",
-        SIG_NODE_DESC: b"\x02@\x80\xb9\x10RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 66,
+        SIG_MANUFACTURER: "NYCE",
+        SIG_MODEL: "3014",
+        SIG_NODE_DESC: b"\x02@\x80\xb9\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2470,31 +2925,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1280],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.nyce_3014_77665544_ias_zone",
+            "button.nyce_3014_77665544_identify",
             "sensor.nyce_3014_77665544_power",
+            "binary_sensor.nyce_3014_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.nyce_3014_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.nyce_3014_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.nyce_3014_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.nyce_3014_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "NYCE",
-        SIG_MODEL: "3014",
-        SIG_NODE_DESC: b"\x02@\x80\xb9\x10RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 67,
+        SIG_MANUFACTURER: None,
+        SIG_MODEL: None,
+        SIG_NODE_DESC: b"\x10@\x0f5\x11Y=\x00@\x00=\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 5,
@@ -2511,15 +2972,15 @@ DEVICES = [
                 SIG_EP_PROFILE: 41440,
             },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: ["1:0x0019"],
         DEV_SIG_ENT_MAP: {},
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: None,
-        SIG_MODEL: None,
-        SIG_NODE_DESC: b"\x10@\x0f5\x11Y=\x00@\x00=\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 68,
+        SIG_MANUFACTURER: None,
+        SIG_MODEL: None,
+        SIG_NODE_DESC: b"\x00@\x8f\xcd\xabR\x80\x00\x00\x00\x80\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 48879,
@@ -2527,17 +2988,17 @@ DEVICES = [
                 SIG_EP_INPUT: [],
                 SIG_EP_OUTPUT: [1280],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [],
         DEV_SIG_ENT_MAP: {},
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: None,
-        SIG_MODEL: None,
-        SIG_NODE_DESC: b"\x00@\x8f\xcd\xabR\x80\x00\x00\x00\x80\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 69,
+        SIG_MANUFACTURER: "OSRAM",
+        SIG_MODEL: "LIGHTIFY A19 RGBW",
+        SIG_NODE_DESC: b"\x01@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
         SIG_ENDPOINTS: {
             3: {
                 SIG_EP_TYPE: 258,
@@ -2545,26 +3006,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 64527],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.osram_lightify_a19_rgbw_77665544_level_light_color_on_off"
+            "button.osram_lightify_a19_rgbw_77665544_identify",
+            "light.osram_lightify_a19_rgbw_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-3"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level", "light_color"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.osram_lightify_a19_rgbw_77665544_level_light_color_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.osram_lightify_a19_rgbw_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
-        SIG_MANUFACTURER: "OSRAM",
-        SIG_MODEL: "LIGHTIFY A19 RGBW",
-        SIG_NODE_DESC: b"\x01@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
-        DEV_SIG_ZHA_QUIRK: "LIGHTIFYA19RGBW",
     },
     {
         DEV_SIG_DEV_NO: 70,
+        SIG_MANUFACTURER: "OSRAM",
+        SIG_MODEL: "LIGHTIFY Dimming Switch",
+        SIG_NODE_DESC: b"\x02@\x80\x0c\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1,
@@ -2572,24 +3038,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 2821],
                 SIG_EP_OUTPUT: [3, 6, 8, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["sensor.osram_lightify_dimming_switch_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.osram_lightify_dimming_switch_77665544_identify",
+            "sensor.osram_lightify_dimming_switch_77665544_power",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.osram_lightify_dimming_switch_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_dimming_switch_77665544_power",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0006", "1:0x0008", "1:0x0019"],
-        SIG_MANUFACTURER: "OSRAM",
-        SIG_MODEL: "LIGHTIFY Dimming Switch",
-        SIG_NODE_DESC: b"\x02@\x80\x0c\x11RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "CentraLite3130",
     },
     {
         DEV_SIG_DEV_NO: 71,
+        SIG_MANUFACTURER: "OSRAM",
+        SIG_MODEL: "LIGHTIFY Flex RGBW",
+        SIG_NODE_DESC: b"\x19@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
         SIG_ENDPOINTS: {
             3: {
                 SIG_EP_TYPE: 258,
@@ -2597,26 +3070,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 64527],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
         DEV_SIG_ENTITIES: [
-            "light.osram_lightify_flex_rgbw_77665544_level_light_color_on_off"
+            "button.osram_lightify_flex_rgbw_77665544_identify",
+            "light.osram_lightify_flex_rgbw_77665544_level_light_color_on_off",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-3"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level", "light_color"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.osram_lightify_flex_rgbw_77665544_level_light_color_on_off",
-            }
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.osram_lightify_flex_rgbw_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
-        SIG_MANUFACTURER: "OSRAM",
-        SIG_MODEL: "LIGHTIFY Flex RGBW",
-        SIG_NODE_DESC: b"\x19@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
-        DEV_SIG_ZHA_QUIRK: "FlexRGBW",
     },
     {
         DEV_SIG_DEV_NO: 72,
+        SIG_MANUFACTURER: "OSRAM",
+        SIG_MODEL: "LIGHTIFY RT Tunable White",
+        SIG_NODE_DESC: b"\x01@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
         SIG_ENDPOINTS: {
             3: {
                 SIG_EP_TYPE: 258,
@@ -2624,9 +3102,11 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 2820, 64527],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.osram_lightify_rt_tunable_white_77665544_identify",
             "light.osram_lightify_rt_tunable_white_77665544_level_light_color_on_off",
             "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement",
             "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_apparent_power",
@@ -2635,9 +3115,14 @@ DEVICES = [
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-3"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level", "light_color"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.osram_lightify_rt_tunable_white_77665544_level_light_color_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.osram_lightify_rt_tunable_white_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-3-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -2660,14 +3145,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_voltage",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
-        SIG_MANUFACTURER: "OSRAM",
-        SIG_MODEL: "LIGHTIFY RT Tunable White",
-        SIG_NODE_DESC: b"\x01@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
-        DEV_SIG_ZHA_QUIRK: "A19TunableWhite",
     },
     {
         DEV_SIG_DEV_NO: 73,
+        SIG_MANUFACTURER: "OSRAM",
+        SIG_MODEL: "Plug 01",
+        SIG_NODE_DESC: b"\x01@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
         SIG_ENDPOINTS: {
             3: {
                 SIG_EP_TYPE: 16,
@@ -2675,9 +3158,11 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 2820, 4096, 64527],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 49246,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.osram_plug_01_77665544_identify",
             "sensor.osram_plug_01_77665544_electrical_measurement",
             "sensor.osram_plug_01_77665544_electrical_measurement_apparent_power",
             "sensor.osram_plug_01_77665544_electrical_measurement_rms_current",
@@ -2689,6 +3174,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.osram_plug_01_77665544_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-3-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.osram_plug_01_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-3-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -2711,13 +3201,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_plug_01_77665544_electrical_measurement_rms_voltage",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
-        SIG_MANUFACTURER: "OSRAM",
-        SIG_MODEL: "Plug 01",
-        SIG_NODE_DESC: b"\x01@\x8e\xaa\xbb@\x00\x00\x00\x00\x00\x00\x03",
     },
     {
         DEV_SIG_DEV_NO: 74,
+        SIG_MANUFACTURER: "OSRAM",
+        SIG_MODEL: "Switch 4x-LIGHTIFY",
+        SIG_NODE_DESC: b"\x02@\x80\x0c\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2064,
@@ -2762,14 +3251,6 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
-        DEV_SIG_ENTITIES: ["sensor.osram_switch_4x_lightify_77665544_power"],
-        DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.osram_switch_4x_lightify_77665544_power",
-            }
-        },
         DEV_SIG_EVT_CHANNELS: [
             "1:0x0005",
             "1:0x0006",
@@ -2797,13 +3278,22 @@ DEVICES = [
             "6:0x0008",
             "6:0x0300",
         ],
-        SIG_MANUFACTURER: "OSRAM",
-        SIG_MODEL: "Switch 4x-LIGHTIFY",
-        SIG_NODE_DESC: b"\x02@\x80\x0c\x11RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "LightifyX4",
+        DEV_SIG_ENTITIES: [
+            "sensor.osram_switch_4x_lightify_77665544_power",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_switch_4x_lightify_77665544_power",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 75,
+        SIG_MANUFACTURER: "Philips",
+        SIG_MODEL: "RWL020",
+        SIG_NODE_DESC: b"\x02@\x80\x0b\x10G-\x00\x00\x00-\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2096,
@@ -2820,27 +3310,35 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
-        DEV_SIG_ENTITIES: ["sensor.philips_rwl020_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "2:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.philips_rwl020_77665544_identify",
+            "sensor.philips_rwl020_77665544_power",
+            "binary_sensor.philips_rwl020_77665544_binary_input",
+        ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-2-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.philips_rwl020_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-2-15"): {
                 DEV_SIG_CHANNELS: ["binary_input"],
                 DEV_SIG_ENT_MAP_CLASS: "BinaryInput",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.philips_rwl020_77665544_binary_input",
             },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.philips_rwl020_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-2-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.philips_rwl020_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0008", "2:0x0019"],
-        SIG_MANUFACTURER: "Philips",
-        SIG_MODEL: "RWL020",
-        SIG_NODE_DESC: b"\x02@\x80\x0b\x10G-\x00\x00\x00-\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "PhilipsRWL021",
     },
     {
         DEV_SIG_DEV_NO: 76,
+        SIG_MANUFACTURER: "Samjin",
+        SIG_MODEL: "button",
+        SIG_NODE_DESC: b"\x02@\x80A\x12RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2848,14 +3346,26 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 1280, 2821],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.samjin_button_77665544_ias_zone",
+            "button.samjin_button_77665544_identify",
             "sensor.samjin_button_77665544_power",
             "sensor.samjin_button_77665544_temperature",
+            "binary_sensor.samjin_button_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.samjin_button_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.samjin_button_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2866,20 +3376,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.samjin_button_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.samjin_button_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Samjin",
-        SIG_MODEL: "button",
-        SIG_NODE_DESC: b"\x02@\x80A\x12RR\x00\x00,R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SamjinButton",
     },
     {
         DEV_SIG_DEV_NO: 77,
+        SIG_MANUFACTURER: "Samjin",
+        SIG_MODEL: "multi",
+        SIG_NODE_DESC: b"\x02@\x80A\x12RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2887,15 +3390,26 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 1280, 64514],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.samjin_multi_77665544_ias_zone",
-            "binary_sensor.samjin_multi_77665544_manufacturer_specific",
+            "button.samjin_multi_77665544_identify",
             "sensor.samjin_multi_77665544_power",
             "sensor.samjin_multi_77665544_temperature",
+            "binary_sensor.samjin_multi_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.samjin_multi_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.samjin_multi_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2906,20 +3420,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.samjin_multi_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.samjin_multi_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Samjin",
-        SIG_MODEL: "multi",
-        SIG_NODE_DESC: b"\x02@\x80A\x12RR\x00\x00,R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SmartthingsMultiPurposeSensor",
     },
     {
         DEV_SIG_DEV_NO: 78,
+        SIG_MANUFACTURER: "Samjin",
+        SIG_MODEL: "water",
+        SIG_NODE_DESC: b"\x02@\x80A\x12RR\x00\x00,R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -2927,14 +3434,26 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 1280],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.samjin_water_77665544_ias_zone",
+            "button.samjin_water_77665544_identify",
             "sensor.samjin_water_77665544_power",
             "sensor.samjin_water_77665544_temperature",
+            "binary_sensor.samjin_water_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.samjin_water_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.samjin_water_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -2945,19 +3464,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.samjin_water_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.samjin_water_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Samjin",
-        SIG_MODEL: "water",
-        SIG_NODE_DESC: b"\x02@\x80A\x12RR\x00\x00,R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 79,
+        SIG_MANUFACTURER: "Securifi Ltd.",
+        SIG_MODEL: None,
+        SIG_NODE_DESC: b"\x01@\x8e\x02\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 0,
@@ -2965,9 +3478,11 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 4, 5, 6, 2820, 2821],
                 SIG_EP_OUTPUT: [0, 1, 3, 4, 5, 6, 25, 2820, 2821],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.securifi_ltd_unk_model_77665544_identify",
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement",
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_apparent_power",
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_current",
@@ -2975,10 +3490,10 @@ DEVICES = [
             "switch.securifi_ltd_unk_model_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
-            ("switch", "00:11:22:33:44:55:66:77-1-6"): {
-                DEV_SIG_CHANNELS: ["on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Switch",
-                DEV_SIG_ENT_MAP_ID: "switch.securifi_ltd_unk_model_77665544_on_off",
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.securifi_ltd_unk_model_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3000,14 +3515,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_voltage",
             },
+            ("switch", "00:11:22:33:44:55:66:77-1-6"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Switch",
+                DEV_SIG_ENT_MAP_ID: "switch.securifi_ltd_unk_model_77665544_on_off",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0019"],
-        SIG_MANUFACTURER: "Securifi Ltd.",
-        SIG_MODEL: None,
-        SIG_NODE_DESC: b"\x01@\x8e\x02\x10RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 80,
+        SIG_MANUFACTURER: "Sercomm Corp.",
+        SIG_MODEL: "SZ-DWS04N_SF",
+        SIG_NODE_DESC: b"\x02@\x801\x11R\xff\x00\x00\x00\xff\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -3015,14 +3534,26 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 1280, 2821],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.sercomm_corp_sz_dws04n_sf_77665544_ias_zone",
+            "button.sercomm_corp_sz_dws04n_sf_77665544_identify",
             "sensor.sercomm_corp_sz_dws04n_sf_77665544_power",
             "sensor.sercomm_corp_sz_dws04n_sf_77665544_temperature",
+            "binary_sensor.sercomm_corp_sz_dws04n_sf_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.sercomm_corp_sz_dws04n_sf_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sercomm_corp_sz_dws04n_sf_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -3033,19 +3564,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_dws04n_sf_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.sercomm_corp_sz_dws04n_sf_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Sercomm Corp.",
-        SIG_MODEL: "SZ-DWS04N_SF",
-        SIG_NODE_DESC: b"\x02@\x801\x11R\xff\x00\x00\x00\xff\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 81,
+        SIG_MANUFACTURER: "Sercomm Corp.",
+        SIG_MODEL: "SZ-ESW01",
+        SIG_NODE_DESC: b"\x01@\x8e1\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 256,
@@ -3062,8 +3587,11 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006"],
         DEV_SIG_ENTITIES: [
+            "button.sercomm_corp_sz_esw01_77665544_identify",
             "light.sercomm_corp_sz_esw01_77665544_on_off",
+            "button.sercomm_corp_sz_esw01_77665544_identify_2",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_apparent_power",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_current",
@@ -3077,15 +3605,10 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.sercomm_corp_sz_esw01_77665544_on_off",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
-                DEV_SIG_CHANNELS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergyMetering",
-                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_delivered"): {
-                DEV_SIG_CHANNELS: ["smartenergy_metering"],
-                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering_summation_delivered",
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sercomm_corp_sz_esw01_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3107,14 +3630,28 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_voltage",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
+                DEV_SIG_CHANNELS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergyMetering",
+                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_delivered"): {
+                DEV_SIG_CHANNELS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering_summation_delivered",
+            },
+            ("button", "00:11:22:33:44:55:66:77-2-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sercomm_corp_sz_esw01_77665544_identify_2",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006"],
-        SIG_MANUFACTURER: "Sercomm Corp.",
-        SIG_MODEL: "SZ-ESW01",
-        SIG_NODE_DESC: b"\x01@\x8e1\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 82,
+        SIG_MANUFACTURER: "Sercomm Corp.",
+        SIG_MODEL: "SZ-PIR04",
+        SIG_NODE_DESC: b"\x02@\x801\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -3122,15 +3659,27 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1024, 1026, 1280, 2821],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.sercomm_corp_sz_pir04_77665544_ias_zone",
-            "sensor.sercomm_corp_sz_pir04_77665544_illuminance",
+            "button.sercomm_corp_sz_pir04_77665544_identify",
             "sensor.sercomm_corp_sz_pir04_77665544_power",
+            "sensor.sercomm_corp_sz_pir04_77665544_illuminance",
             "sensor.sercomm_corp_sz_pir04_77665544_temperature",
+            "binary_sensor.sercomm_corp_sz_pir04_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.sercomm_corp_sz_pir04_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sercomm_corp_sz_pir04_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -3146,19 +3695,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_pir04_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.sercomm_corp_sz_pir04_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Sercomm Corp.",
-        SIG_MODEL: "SZ-PIR04",
-        SIG_NODE_DESC: b"\x02@\x801\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 83,
+        SIG_MANUFACTURER: "Sinope Technologies",
+        SIG_MODEL: "RM3250ZB",
+        SIG_NODE_DESC: b"\x11@\x8e\x9c\x11G+\x00\x00*+\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2,
@@ -3166,9 +3709,11 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 2820, 2821, 65281],
                 SIG_EP_OUTPUT: [3, 4, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.sinope_technologies_rm3250zb_77665544_identify",
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement",
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_apparent_power",
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_current",
@@ -3176,10 +3721,10 @@ DEVICES = [
             "switch.sinope_technologies_rm3250zb_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
-            ("switch", "00:11:22:33:44:55:66:77-1-6"): {
-                DEV_SIG_CHANNELS: ["on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Switch",
-                DEV_SIG_ENT_MAP_ID: "switch.sinope_technologies_rm3250zb_77665544_on_off",
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sinope_technologies_rm3250zb_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3201,14 +3746,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_voltage",
             },
+            ("switch", "00:11:22:33:44:55:66:77-1-6"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Switch",
+                DEV_SIG_ENT_MAP_ID: "switch.sinope_technologies_rm3250zb_77665544_on_off",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Sinope Technologies",
-        SIG_MODEL: "RM3250ZB",
-        SIG_NODE_DESC: b"\x11@\x8e\x9c\x11G+\x00\x00*+\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 84,
+        SIG_MANUFACTURER: "Sinope Technologies",
+        SIG_MODEL: "TH1123ZB",
+        SIG_NODE_DESC: b"\x12@\x8c\x9c\x11G+\x00\x00\x00+\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 769,
@@ -3225,25 +3774,27 @@ DEVICES = [
                 SIG_EP_PROFILE: 49757,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "climate.sinope_technologies_th1123zb_77665544_thermostat",
+            "button.sinope_technologies_th1123zb_77665544_identify",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_apparent_power",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_current",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_voltage",
             "sensor.sinope_technologies_th1123zb_77665544_temperature",
             "sensor.sinope_technologies_th1123zb_77665544_thermostat_hvac_action",
+            "climate.sinope_technologies_th1123zb_77665544_thermostat",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sinope_technologies_th1123zb_77665544_identify",
+            },
             ("climate", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["thermostat"],
                 DEV_SIG_ENT_MAP_CLASS: "Thermostat",
                 DEV_SIG_ENT_MAP_ID: "climate.sinope_technologies_th1123zb_77665544_thermostat",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
-                DEV_SIG_CHANNELS: ["temperature"],
-                DEV_SIG_ENT_MAP_CLASS: "Temperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_temperature",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3265,20 +3816,23 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_voltage",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
+                DEV_SIG_CHANNELS: ["temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "Temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_temperature",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-513-hvac_action"): {
                 DEV_SIG_CHANNELS: ["thermostat"],
                 DEV_SIG_ENT_MAP_CLASS: "SinopeHVACAction",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_thermostat_hvac_action",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Sinope Technologies",
-        SIG_MODEL: "TH1123ZB",
-        SIG_NODE_DESC: b"\x12@\x8c\x9c\x11G+\x00\x00\x00+\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SinopeTechnologiesThermostat",
     },
     {
         DEV_SIG_DEV_NO: 85,
+        SIG_MANUFACTURER: "Sinope Technologies",
+        SIG_MODEL: "TH1124ZB",
+        SIG_NODE_DESC: b"\x11@\x8e\x9c\x11G+\x00\x00\x00+\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 769,
@@ -3295,7 +3849,9 @@ DEVICES = [
                 SIG_EP_PROFILE: 49757,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.sinope_technologies_th1124zb_77665544_identify",
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement",
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_apparent_power",
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_current",
@@ -3305,6 +3861,11 @@ DEVICES = [
             "climate.sinope_technologies_th1124zb_77665544_thermostat",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sinope_technologies_th1124zb_77665544_identify",
+            },
             ("climate", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["thermostat"],
                 DEV_SIG_ENT_MAP_CLASS: "Thermostat",
@@ -3341,14 +3902,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_voltage",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Sinope Technologies",
-        SIG_MODEL: "TH1124ZB",
-        SIG_NODE_DESC: b"\x11@\x8e\x9c\x11G+\x00\x00\x00+\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SinopeTechnologiesThermostat",
     },
     {
         DEV_SIG_DEV_NO: 86,
+        SIG_MANUFACTURER: "SmartThings",
+        SIG_MODEL: "outletv4",
+        SIG_NODE_DESC: b"\x01@\x8e\n\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2,
@@ -3356,20 +3915,28 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 9, 15, 2820],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.smartthings_outletv4_77665544_identify",
             "sensor.smartthings_outletv4_77665544_electrical_measurement",
             "sensor.smartthings_outletv4_77665544_electrical_measurement_apparent_power",
             "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_current",
             "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_voltage",
+            "binary_sensor.smartthings_outletv4_77665544_binary_input",
             "switch.smartthings_outletv4_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
-            ("switch", "00:11:22:33:44:55:66:77-1-6"): {
-                DEV_SIG_CHANNELS: ["on_off"],
-                DEV_SIG_ENT_MAP_CLASS: "Switch",
-                DEV_SIG_ENT_MAP_ID: "switch.smartthings_outletv4_77665544_on_off",
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-15"): {
+                DEV_SIG_CHANNELS: ["binary_input"],
+                DEV_SIG_ENT_MAP_CLASS: "BinaryInput",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.smartthings_outletv4_77665544_binary_input",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.smartthings_outletv4_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3391,19 +3958,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
                 DEV_SIG_ENT_MAP_ID: "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_voltage",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-15"): {
-                DEV_SIG_CHANNELS: ["binary_input"],
-                DEV_SIG_ENT_MAP_CLASS: "BinaryInput",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.smartthings_outletv4_77665544_binary_input",
+            ("switch", "00:11:22:33:44:55:66:77-1-6"): {
+                DEV_SIG_CHANNELS: ["on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Switch",
+                DEV_SIG_ENT_MAP_ID: "switch.smartthings_outletv4_77665544_on_off",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "SmartThings",
-        SIG_MODEL: "outletv4",
-        SIG_NODE_DESC: b"\x01@\x8e\n\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 87,
+        SIG_MANUFACTURER: "SmartThings",
+        SIG_MODEL: "tagv4",
+        SIG_NODE_DESC: b"\x02@\x80\n\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 32768,
@@ -3411,9 +3977,14 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 15, 32],
                 SIG_EP_OUTPUT: [3, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["device_tracker.smartthings_tagv4_77665544_power"],
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
+        DEV_SIG_ENTITIES: [
+            "button.smartthings_tagv4_77665544_identify",
+            "device_tracker.smartthings_tagv4_77665544_power",
+            "binary_sensor.smartthings_tagv4_77665544_binary_input",
+        ],
         DEV_SIG_ENT_MAP: {
             ("device_tracker", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["power"],
@@ -3425,15 +3996,18 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "BinaryInput",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.smartthings_tagv4_77665544_binary_input",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.smartthings_tagv4_77665544_identify",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "SmartThings",
-        SIG_MODEL: "tagv4",
-        SIG_NODE_DESC: b"\x02@\x80\n\x11RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "SmartThingsTagV4",
     },
     {
         DEV_SIG_DEV_NO: 88,
+        SIG_MANUFACTURER: "Third Reality, Inc",
+        SIG_MODEL: "3RSS007Z",
+        SIG_NODE_DESC: b"\x02@\x803\x12\x7fd\x00\x00,d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2,
@@ -3441,23 +4015,31 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 25],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
-        DEV_SIG_ENTITIES: ["switch.third_reality_inc_3rss007z_77665544_on_off"],
+        DEV_SIG_EVT_CHANNELS: [],
+        DEV_SIG_ENTITIES: [
+            "button.third_reality_inc_3rss007z_77665544_identify",
+            "switch.third_reality_inc_3rss007z_77665544_on_off",
+        ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.third_reality_inc_3rss007z_77665544_identify",
+            },
             ("switch", "00:11:22:33:44:55:66:77-1-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.third_reality_inc_3rss007z_77665544_on_off",
-            }
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "Third Reality, Inc",
-        SIG_MODEL: "3RSS007Z",
-        SIG_NODE_DESC: b"\x02@\x803\x12\x7fd\x00\x00,d\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 89,
+        SIG_MANUFACTURER: "Third Reality, Inc",
+        SIG_MODEL: "3RSS008Z",
+        SIG_NODE_DESC: b"\x02@\x803\x12\x7fd\x00\x00,d\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 2,
@@ -3465,13 +4047,20 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 4, 5, 6, 25],
                 SIG_EP_OUTPUT: [1],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
+            "button.third_reality_inc_3rss008z_77665544_identify",
             "sensor.third_reality_inc_3rss008z_77665544_power",
             "switch.third_reality_inc_3rss008z_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.third_reality_inc_3rss008z_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -3483,14 +4072,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "switch.third_reality_inc_3rss008z_77665544_on_off",
             },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "Third Reality, Inc",
-        SIG_MODEL: "3RSS008Z",
-        SIG_NODE_DESC: b"\x02@\x803\x12\x7fd\x00\x00,d\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Switch",
     },
     {
         DEV_SIG_DEV_NO: 90,
+        SIG_MANUFACTURER: "Visonic",
+        SIG_MODEL: "MCT-340 E",
+        SIG_NODE_DESC: b"\x02@\x80\x11\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -3498,14 +4085,26 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 32, 1026, 1280, 2821],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.visonic_mct_340_e_77665544_ias_zone",
+            "button.visonic_mct_340_e_77665544_identify",
             "sensor.visonic_mct_340_e_77665544_power",
             "sensor.visonic_mct_340_e_77665544_temperature",
+            "binary_sensor.visonic_mct_340_e_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
+            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
+                DEV_SIG_CHANNELS: ["ias_zone"],
+                DEV_SIG_ENT_MAP_CLASS: "IASZone",
+                DEV_SIG_ENT_MAP_ID: "binary_sensor.visonic_mct_340_e_77665544_ias_zone",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.visonic_mct_340_e_77665544_identify",
+            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
                 DEV_SIG_CHANNELS: ["power"],
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
@@ -3516,20 +4115,13 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Temperature",
                 DEV_SIG_ENT_MAP_ID: "sensor.visonic_mct_340_e_77665544_temperature",
             },
-            ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
-                DEV_SIG_CHANNELS: ["ias_zone"],
-                DEV_SIG_ENT_MAP_CLASS: "IASZone",
-                DEV_SIG_ENT_MAP_ID: "binary_sensor.visonic_mct_340_e_77665544_ias_zone",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Visonic",
-        SIG_MODEL: "MCT-340 E",
-        SIG_NODE_DESC: b"\x02@\x80\x11\x10RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "MCT340E",
     },
     {
         DEV_SIG_DEV_NO: 91,
+        SIG_MANUFACTURER: "Zen Within",
+        SIG_MODEL: "Zen-01",
+        SIG_NODE_DESC: b"\x02@\x80X\x11R\x80\x00\x00\x00\x80\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 769,
@@ -3537,23 +4129,30 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 4, 5, 32, 513, 514, 516, 2821],
                 SIG_EP_OUTPUT: [10, 25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
-            "climate.zen_within_zen_01_77665544_fan_thermostat",
-            "sensor.zen_within_zen_01_77665544_thermostat_hvac_action",
+            "button.zen_within_zen_01_77665544_identify",
             "sensor.zen_within_zen_01_77665544_power",
+            "sensor.zen_within_zen_01_77665544_thermostat_hvac_action",
+            "climate.zen_within_zen_01_77665544_fan_thermostat",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.zen_within_zen_01_77665544_power",
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.zen_within_zen_01_77665544_identify",
             },
             ("climate", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["thermostat", "fan"],
                 DEV_SIG_ENT_MAP_CLASS: "ZenWithinThermostat",
                 DEV_SIG_ENT_MAP_ID: "climate.zen_within_zen_01_77665544_fan_thermostat",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.zen_within_zen_01_77665544_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-513-hvac_action"): {
                 DEV_SIG_CHANNELS: ["thermostat"],
@@ -3561,13 +4160,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.zen_within_zen_01_77665544_thermostat_hvac_action",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "Zen Within",
-        SIG_MODEL: "Zen-01",
-        SIG_NODE_DESC: b"\x02@\x80X\x11R\x80\x00\x00\x00\x80\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 92,
+        SIG_MANUFACTURER: "_TYZB01_ns1ndbww",
+        SIG_MODEL: "TS0004",
+        SIG_NODE_DESC: b"\x01@\x8e\x02\x10R\x00\x02\x00,\x00\x02\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 256,
@@ -3598,6 +4196,7 @@ DEVICES = [
                 SIG_EP_PROFILE: 260,
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
             "light.tyzb01_ns1ndbww_ts0004_77665544_on_off",
             "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_2",
@@ -3608,31 +4207,30 @@ DEVICES = [
             ("light", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_4",
+                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off",
             },
             ("light", "00:11:22:33:44:55:66:77-2"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_3",
+                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_2",
             },
             ("light", "00:11:22:33:44:55:66:77-3"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off",
+                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_3",
             },
             ("light", "00:11:22:33:44:55:66:77-4"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_2",
+                DEV_SIG_ENT_MAP_ID: "light.tyzb01_ns1ndbww_ts0004_77665544_on_off_4",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "_TYZB01_ns1ndbww",
-        SIG_MODEL: "TS0004",
-        SIG_NODE_DESC: b"\x01@\x8e\x02\x10R\x00\x02\x00,\x00\x02\x00",
     },
     {
         DEV_SIG_DEV_NO: 93,
+        SIG_MANUFACTURER: "netvox",
+        SIG_MODEL: "Z308E3ED",
+        SIG_NODE_DESC: b"\x02@\x80\x9f\x10RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 1026,
@@ -3640,32 +4238,37 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 1, 3, 21, 32, 1280, 2821],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
-            "binary_sensor.netvox_z308e3ed_77665544_ias_zone",
+            "button.netvox_z308e3ed_77665544_identify",
             "sensor.netvox_z308e3ed_77665544_power",
+            "binary_sensor.netvox_z308e3ed_77665544_ias_zone",
         ],
         DEV_SIG_ENT_MAP: {
-            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
-                DEV_SIG_CHANNELS: ["power"],
-                DEV_SIG_ENT_MAP_CLASS: "Battery",
-                DEV_SIG_ENT_MAP_ID: "sensor.netvox_z308e3ed_77665544_power",
-            },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-1280"): {
                 DEV_SIG_CHANNELS: ["ias_zone"],
                 DEV_SIG_ENT_MAP_CLASS: "IASZone",
                 DEV_SIG_ENT_MAP_ID: "binary_sensor.netvox_z308e3ed_77665544_ias_zone",
             },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.netvox_z308e3ed_77665544_identify",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
+                DEV_SIG_CHANNELS: ["power"],
+                DEV_SIG_ENT_MAP_CLASS: "Battery",
+                DEV_SIG_ENT_MAP_ID: "sensor.netvox_z308e3ed_77665544_power",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "netvox",
-        SIG_MODEL: "Z308E3ED",
-        SIG_NODE_DESC: b"\x02@\x80\x9f\x10RR\x00\x00\x00R\x00\x00",
-        DEV_SIG_ZHA_QUIRK: "Z308E3ED",
     },
     {
         DEV_SIG_DEV_NO: 94,
+        SIG_MANUFACTURER: "sengled",
+        SIG_MODEL: "E11-G13",
+        SIG_NODE_DESC: b"\x02@\x8c`\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -3673,18 +4276,25 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 1794, 2821],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.sengled_e11_g13_77665544_identify",
             "light.sengled_e11_g13_77665544_level_on_off",
             "sensor.sengled_e11_g13_77665544_smartenergy_metering",
             "sensor.sengled_e11_g13_77665544_smartenergy_metering_summation_delivered",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.sengled_e11_g13_77665544_level_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sengled_e11_g13_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -3697,13 +4307,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_e11_g13_77665544_smartenergy_metering_summation_delivered",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "sengled",
-        SIG_MODEL: "E11-G13",
-        SIG_NODE_DESC: b"\x02@\x8c`\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 95,
+        SIG_MANUFACTURER: "sengled",
+        SIG_MODEL: "E12-N14",
+        SIG_NODE_DESC: b"\x02@\x8c`\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -3711,18 +4320,25 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 1794, 2821],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.sengled_e12_n14_77665544_identify",
             "light.sengled_e12_n14_77665544_level_on_off",
             "sensor.sengled_e12_n14_77665544_smartenergy_metering",
-            "sensor.sengled_e12_n14_77665544_smartenergy_metering_sumaiton_delivered",
+            "sensor.sengled_e12_n14_77665544_smartenergy_metering_summation_delivered",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.sengled_e12_n14_77665544_level_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sengled_e12_n14_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -3735,13 +4351,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_e12_n14_77665544_smartenergy_metering_summation_delivered",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "sengled",
-        SIG_MODEL: "E12-N14",
-        SIG_NODE_DESC: b"\x02@\x8c`\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 96,
+        SIG_MANUFACTURER: "sengled",
+        SIG_MODEL: "Z01-A19NAE26",
+        SIG_NODE_DESC: b"\x02@\x8c`\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,
@@ -3749,18 +4364,25 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 768, 1794, 2821],
                 SIG_EP_OUTPUT: [25],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
         DEV_SIG_ENTITIES: [
+            "button.sengled_z01_a19nae26_77665544_identify",
             "light.sengled_z01_a19nae26_77665544_level_light_color_on_off",
             "sensor.sengled_z01_a19nae26_77665544_smartenergy_metering",
             "sensor.sengled_z01_a19nae26_77665544_smartenergy_metering_summation_delivered",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "light_color", "on_off"],
+                DEV_SIG_CHANNELS: ["on_off", "light_color", "level"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
                 DEV_SIG_ENT_MAP_ID: "light.sengled_z01_a19nae26_77665544_level_light_color_on_off",
+            },
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sengled_z01_a19nae26_77665544_identify",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CHANNELS: ["smartenergy_metering"],
@@ -3773,13 +4395,12 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_ID: "sensor.sengled_z01_a19nae26_77665544_smartenergy_metering_summation_delivered",
             },
         },
-        DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
-        SIG_MANUFACTURER: "sengled",
-        SIG_MODEL: "Z01-A19NAE26",
-        SIG_NODE_DESC: b"\x02@\x8c`\x11RR\x00\x00\x00R\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 97,
+        SIG_MANUFACTURER: "unk_manufacturer",
+        SIG_MODEL: "unk_model",
+        SIG_NODE_DESC: b"\x01@\x8e\x10\x11RR\x00\x00\x00R\x00\x00",
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 512,
@@ -3787,140 +4408,154 @@ DEVICES = [
                 SIG_EP_INPUT: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545],
                 SIG_EP_OUTPUT: [3, 64544],
                 SIG_EP_PROFILE: 260,
-            }
-        },
-        DEV_SIG_ENTITIES: [
-            "cover.unk_manufacturer_unk_model_77665544_level_on_off_shade"
-        ],
-        DEV_SIG_ENT_MAP: {
-            ("cover", "00:11:22:33:44:55:66:77-1"): {
-                DEV_SIG_CHANNELS: ["level", "on_off", "shade"],
-                DEV_SIG_ENT_MAP_CLASS: "Shade",
-                DEV_SIG_ENT_MAP_ID: "cover.unk_manufacturer_unk_model_77665544_level_on_off_shade",
-            }
+            },
         },
         DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "unk_manufacturer",
-        SIG_MODEL: "unk_model",
-        SIG_NODE_DESC: b"\x01@\x8e\x10\x11RR\x00\x00\x00R\x00\x00",
+        DEV_SIG_ENTITIES: [
+            "button.unk_manufacturer_unk_model_77665544_identify",
+            "cover.unk_manufacturer_unk_model_77665544_level_on_off_shade",
+        ],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CHANNELS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "ZHAIdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.unk_manufacturer_unk_model_77665544_identify",
+            },
+            ("cover", "00:11:22:33:44:55:66:77-1"): {
+                DEV_SIG_CHANNELS: ["shade", "level", "on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Shade",
+                DEV_SIG_ENT_MAP_ID: "cover.unk_manufacturer_unk_model_77665544_level_on_off_shade",
+            },
+        },
     },
     {
         DEV_SIG_DEV_NO: 98,
+        SIG_MANUFACTURER: "Digi",
+        SIG_MODEL: "XBee3",
+        SIG_NODE_DESC: b"\x01@\x8e\x1e\x10R\xff\x00\x00,\xff\x00\x00",
         SIG_ENDPOINTS: {
             208: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 208,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000C],
+                SIG_EP_INPUT: [6, 12],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             209: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 209,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000C],
+                SIG_EP_INPUT: [6, 12],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             210: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 210,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000C],
+                SIG_EP_INPUT: [6, 12],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             211: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 211,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000C],
+                SIG_EP_INPUT: [6, 12],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             212: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 212,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             213: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 213,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             214: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 214,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             215: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 215,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000C],
+                SIG_EP_INPUT: [6, 12],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             216: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 216,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             217: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 217,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             218: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 218,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000D],
+                SIG_EP_INPUT: [6, 13],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             219: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 219,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006, 0x000D],
+                SIG_EP_INPUT: [6, 13],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             220: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 220,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             221: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 221,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             222: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 222,
-                SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0006],
+                SIG_EP_INPUT: [6],
                 SIG_EP_OUTPUT: [],
+                SIG_EP_PROFILE: 49413,
             },
             232: {
+                SIG_EP_TYPE: 1,
                 DEV_SIG_EP_ID: 232,
+                SIG_EP_INPUT: [17, 146],
+                SIG_EP_OUTPUT: [8, 17],
                 SIG_EP_PROFILE: 49413,
-                SIG_EP_TYPE: 0x0001,
-                SIG_EP_INPUT: [0x0011, 0x0092],
-                SIG_EP_OUTPUT: [0x0008, 0x0011],
             },
         },
+        DEV_SIG_EVT_CHANNELS: ["232:0x0008"],
         DEV_SIG_ENTITIES: [
+            "number.digi_xbee3_77665544_analog_output",
+            "number.digi_xbee3_77665544_analog_output_2",
+            "sensor.digi_xbee3_77665544_analog_input",
+            "sensor.digi_xbee3_77665544_analog_input_2",
+            "sensor.digi_xbee3_77665544_analog_input_3",
+            "sensor.digi_xbee3_77665544_analog_input_4",
+            "sensor.digi_xbee3_77665544_analog_input_5",
             "switch.digi_xbee3_77665544_on_off",
             "switch.digi_xbee3_77665544_on_off_2",
             "switch.digi_xbee3_77665544_on_off_3",
@@ -3936,28 +4571,42 @@ DEVICES = [
             "switch.digi_xbee3_77665544_on_off_13",
             "switch.digi_xbee3_77665544_on_off_14",
             "switch.digi_xbee3_77665544_on_off_15",
-            "sensor.digi_xbee3_77665544_analog_input",
-            "sensor.digi_xbee3_77665544_analog_input_2",
-            "sensor.digi_xbee3_77665544_analog_input_3",
-            "sensor.digi_xbee3_77665544_analog_input_4",
-            "number.digi_xbee3_77665544_analog_output",
-            "number.digi_xbee3_77665544_analog_output_2",
         ],
         DEV_SIG_ENT_MAP: {
+            ("sensor", "00:11:22:33:44:55:66:77-208-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input",
+            },
             ("switch", "00:11:22:33:44:55:66:77-208-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-209-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_2",
             },
             ("switch", "00:11:22:33:44:55:66:77-209-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off_2",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-210-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_3",
+            },
             ("switch", "00:11:22:33:44:55:66:77-210-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off_3",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-211-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_4",
             },
             ("switch", "00:11:22:33:44:55:66:77-211-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
@@ -3979,6 +4628,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off_7",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-215-12"): {
+                DEV_SIG_CHANNELS: ["analog_input"],
+                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
+                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_5",
+            },
             ("switch", "00:11:22:33:44:55:66:77-215-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
@@ -3994,6 +4648,11 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off_10",
             },
+            ("number", "00:11:22:33:44:55:66:77-218-13"): {
+                DEV_SIG_CHANNELS: ["analog_output"],
+                DEV_SIG_ENT_MAP_CLASS: "ZhaNumber",
+                DEV_SIG_ENT_MAP_ID: "number.digi_xbee3_77665544_analog_output",
+            },
             ("switch", "00:11:22:33:44:55:66:77-218-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
@@ -4003,6 +4662,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off_12",
+            },
+            ("number", "00:11:22:33:44:55:66:77-219-13"): {
+                DEV_SIG_CHANNELS: ["analog_output"],
+                DEV_SIG_ENT_MAP_CLASS: "ZhaNumber",
+                DEV_SIG_ENT_MAP_ID: "number.digi_xbee3_77665544_analog_output_2",
             },
             ("switch", "00:11:22:33:44:55:66:77-220-6"): {
                 DEV_SIG_CHANNELS: ["on_off"],
@@ -4019,62 +4683,27 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Switch",
                 DEV_SIG_ENT_MAP_ID: "switch.digi_xbee3_77665544_on_off_15",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-208-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-209-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_2",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-210-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_3",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-211-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_4",
-            },
-            ("sensor", "00:11:22:33:44:55:66:77-215-12"): {
-                DEV_SIG_CHANNELS: ["analog_input"],
-                DEV_SIG_ENT_MAP_CLASS: "AnalogInput",
-                DEV_SIG_ENT_MAP_ID: "sensor.digi_xbee3_77665544_analog_input_5",
-            },
-            ("number", "00:11:22:33:44:55:66:77-218-13"): {
-                DEV_SIG_CHANNELS: ["analog_output"],
-                DEV_SIG_ENT_MAP_CLASS: "ZhaNumber",
-                DEV_SIG_ENT_MAP_ID: "number.digi_xbee3_77665544_analog_output",
-            },
-            ("number", "00:11:22:33:44:55:66:77-219-13"): {
-                DEV_SIG_CHANNELS: ["analog_output"],
-                DEV_SIG_ENT_MAP_CLASS: "ZhaNumber",
-                DEV_SIG_ENT_MAP_ID: "number.digi_xbee3_77665544_analog_output_2",
-            },
         },
-        DEV_SIG_EVT_CHANNELS: ["232:0x0008"],
-        SIG_MANUFACTURER: "Digi",
-        SIG_MODEL: "XBee3",
-        SIG_NODE_DESC: b"\x01@\x8e\x1e\x10R\xff\x00\x00,\xff\x00\x00",
     },
     {
         DEV_SIG_DEV_NO: 99,
+        SIG_MANUFACTURER: "efektalab.ru",
+        SIG_MODEL: "EFEKTA_PWS",
+        SIG_NODE_DESC: b"\x02@\x80\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
         SIG_ENDPOINTS: {
             1: {
-                SIG_EP_TYPE: 0x000C,
+                SIG_EP_TYPE: 12,
                 DEV_SIG_EP_ID: 1,
-                SIG_EP_INPUT: [0x0000, 0x0001, 0x0402, 0x0408],
+                SIG_EP_INPUT: [0, 1, 1026, 1032],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_PROFILE: 260,
-            }
+            },
         },
+        DEV_SIG_EVT_CHANNELS: [],
         DEV_SIG_ENTITIES: [
             "sensor.efektalab_ru_efekta_pws_77665544_power",
-            "sensor.efektalab_ru_efekta_pws_77665544_temperature",
             "sensor.efektalab_ru_efekta_pws_77665544_soil_moisture",
+            "sensor.efektalab_ru_efekta_pws_77665544_temperature",
         ],
         DEV_SIG_ENT_MAP: {
             ("sensor", "00:11:22:33:44:55:66:77-1-1"): {
@@ -4082,20 +4711,16 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "Battery",
                 DEV_SIG_ENT_MAP_ID: "sensor.efektalab_ru_efekta_pws_77665544_power",
             },
-            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
-                DEV_SIG_CHANNELS: ["temperature"],
-                DEV_SIG_ENT_MAP_CLASS: "Temperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.efektalab_ru_efekta_pws_77665544_temperature",
-            },
             ("sensor", "00:11:22:33:44:55:66:77-1-1032"): {
                 DEV_SIG_CHANNELS: ["soil_moisture"],
                 DEV_SIG_ENT_MAP_CLASS: "SoilMoisture",
                 DEV_SIG_ENT_MAP_ID: "sensor.efektalab_ru_efekta_pws_77665544_soil_moisture",
             },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1026"): {
+                DEV_SIG_CHANNELS: ["temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "Temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.efektalab_ru_efekta_pws_77665544_temperature",
+            },
         },
-        DEV_SIG_EVT_CHANNELS: [],
-        SIG_MANUFACTURER: "efektalab.ru",
-        SIG_MODEL: "EFEKTA_PWS",
-        SIG_NODE_DESC: b"\x02@\x80\x00\x00P\xa0\x00\x00\x00\xa0\x00\x00",
     },
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for the button platform to ZHA and leverages this to add identify buttons to ZHA devices. 

**Things left to be done:**

- [x] update device list for discovery tests
~~- [ ] add stop on match group once this PR is merged: https://github.com/home-assistant/core/pull/60063~~

So the referenced PR was merged and I think we still need to make another change to discovery. With the way things work currently we will get an identify button per device endpoint. We need to add a way to prevent discovery from spanning device endpoints. We may also want to favor a particular ZCL profile ex: ZHA vs the mfg profile on most Centralite devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

https://github.com/home-assistant/home-assistant.io/pull/20845

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
