### PR TITLE
Persist nest media events to disk backed storage

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -89,9 +89,9 @@ INSTALLED_AUTH_DOMAIN = f"{DOMAIN}.installed"
 
 # Fetch media events with a disk backed cache, with a limit for each camera
 # device. The largest media items are mp4 clips at ~120kb each, and we target
-# ~500MB of storage per camera to try to balance a reasonable user experience
+# ~125MB of storage per camera to try to balance a reasonable user experience
 # for event history not not filling the disk.
-EVENT_MEDIA_CACHE_SIZE = 4096
+EVENT_MEDIA_CACHE_SIZE = 1024  # number of events
 
 
 class WebAuth(config_entry_oauth2_flow.LocalOAuth2Implementation):

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -51,7 +51,7 @@ from .const import (
 )
 from .events import EVENT_NAME_MAP, NEST_EVENT
 from .legacy import async_setup_legacy, async_setup_legacy_entry
-from .media_source import get_media_source_devices
+from .media_source import async_get_media_event_store, get_media_source_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,10 +87,11 @@ PLATFORMS = [Platform.SENSOR, Platform.CAMERA, Platform.CLIMATE]
 WEB_AUTH_DOMAIN = DOMAIN
 INSTALLED_AUTH_DOMAIN = f"{DOMAIN}.installed"
 
-# Fetch media for events with an in memory cache. The largest media items
-# are mp4 clips at ~90kb each, so this totals a few MB per camera.
-# Note: Media for events can only be published within 30 seconds of the event
-EVENT_MEDIA_CACHE_SIZE = 64
+# Fetch media events with a disk backed cache, with a limit for each camera
+# device. The largest media items are mp4 clips at ~120kb each, and we target
+# ~500MB of storage per camera to try to balance a reasonable user experience
+# for event history not not filling the disk.
+EVENT_MEDIA_CACHE_SIZE = 4096
 
 
 class WebAuth(config_entry_oauth2_flow.LocalOAuth2Implementation):
@@ -169,6 +170,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ),
     )
 
+    hass.http.register_view(NestEventMediaView(hass))
+
     return True
 
 
@@ -215,6 +218,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Keep media for last N events in memory
     subscriber.cache_policy.event_cache_size = EVENT_MEDIA_CACHE_SIZE
     subscriber.cache_policy.fetch = True
+    # Use disk backed event media store
+    subscriber.cache_policy.store = await async_get_media_event_store(hass, subscriber)
 
     callback = SignalUpdateCallback(hass)
     subscriber.set_update_callback(callback.async_handle_event)
@@ -247,8 +252,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][DATA_SUBSCRIBER] = subscriber
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
-    hass.http.register_view(NestEventMediaView(hass))
 
     return True
 

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -90,7 +90,7 @@ class NestEventMediaStore(EventMediaStore):
 
     This is interface is meant to provide two storage features:
     - media storage of events (jpgs, mp4s)
-    - metadata about events (motion, person, etc)
+    - metadata about events (e.g. motion, person), filename of the media, etc.
 
     The default implementation in nest is in memory, and this allows the data
     to be backed by disk.
@@ -146,7 +146,7 @@ class NestEventMediaStore(EventMediaStore):
         self._store.async_delay_save(provide_data, STORAGE_SAVE_DELAY_SECONDS)
 
     def get_media_key(self, device_id: str, event: ImageEventBase) -> str:
-        """Return the filename to use for the device and event."""
+        """Return the filename to use for a new event."""
         # Convert a nest device id to a home assistant device id
         device_id_str = (
             self._devices.get(device_id, "unknown_device")

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -89,7 +89,7 @@ async def async_get_media_event_store(
 class NestEventMediaStore(EventMediaStore):
     """Storage hook to locally persist nest media for events.
 
-    This is interface is meant to provide two storage features:
+    This interface is meant to provide two storage features:
     - media storage of events (jpgs, mp4s)
     - metadata about events (e.g. motion, person), filename of the media, etc.
 

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -143,10 +143,11 @@ class NestEventMediaStore(EventMediaStore):
 
         self._store.async_delay_save(provide_data, STORAGE_SAVE_DELAY_SECONDS)
 
-    def get_media_key(self, nest_device_id: str, event: ImageEventBase) -> str:
+    def get_media_key(self, device_id: str, event: ImageEventBase) -> str:
         """Return the filename to use for the device and event."""
+        # Convert a nest device id to a home assistant device id
         device_id_str = (
-            self._devices.get(nest_device_id, "unknown_device")
+            self._devices.get(device_id, "unknown_device")
             if self._devices
             else "unknown_device"
         )
@@ -171,8 +172,8 @@ class NestEventMediaStore(EventMediaStore):
             return None
         _LOGGER.debug("Reading event media from disk store: %s", filename)
         try:
-            with open(filename, "rb") as f:
-                return f.read()
+            with open(filename, "rb") as fd:
+                return fd.read()
         except OSError as err:
             _LOGGER.error("Unable to read media file: %s %s", filename, err)
             return None
@@ -184,8 +185,8 @@ class NestEventMediaStore(EventMediaStore):
             return
         _LOGGER.debug("Saving event media to disk store: %s", filename)
         try:
-            with open(filename, "wb") as f:
-                f.write(content)
+            with open(filename, "wb") as fd:
+                fd.write(content)
         except OSError as err:
             _LOGGER.error("Unable to write media file: %s %s", filename, err)
 

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -135,12 +135,12 @@ class NestEventMediaStore(EventMediaStore):
                 )
         return self._data
 
-    async def async_save(self, data: dict | None) -> None:
+    async def async_save(self, data: dict) -> None:  # type: ignore[override]
         """Save data."""
         self._data = data
 
         def provide_data() -> dict:
-            return {} if self._data is None else self._data
+            return data
 
         self._store.async_delay_save(provide_data, STORAGE_SAVE_DELAY_SECONDS)
 

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -161,7 +161,7 @@ class NestEventMediaStore(EventMediaStore):
         time_str = str(int(event.timestamp.timestamp()))
         event_type_str = EVENT_NAME_MAP.get(event.event_type, "event")
         suffix = "jpg" if event.event_image_type == EventImageType.IMAGE else "mp4"
-        return f"{device_id_str}-{time_str}-{event_id_str}-{event_type_str}.{suffix}"
+        return f"{device_id_str}/{time_str}-{event_id_str}-{event_type_str}.{suffix}"
 
     def get_media_filename(self, media_key: str) -> str:
         """Return the filename in storage for a media key."""
@@ -189,7 +189,11 @@ class NestEventMediaStore(EventMediaStore):
         filename = self.get_media_filename(media_key)
 
         def save_media(filename: str, content: bytes) -> None:
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
             if os.path.exists(filename):
+                _LOGGER.debug(
+                    "Event media already exists, not overwriting: %s", filename
+                )
                 return
             _LOGGER.debug("Saving event media to disk store: %s", filename)
             with open(filename, "wb") as media:

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -45,7 +45,7 @@ from homeassistant.components.media_source.models import (
     PlayMedia,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import dt as dt_util, raise_if_invalid_filename
@@ -220,11 +220,13 @@ class NestEventMediaStore(EventMediaStore):
 
     async def _get_devices(self) -> Mapping[str, str]:
         """Return a mapping of nest device id to home assistant device id."""
-        dr = device_registry.async_get(self._hass)
+        device_registry = dr.async_get(self._hass)
         device_manager = await self._subscriber.async_get_device_manager()
         devices = {}
         for device in device_manager.devices.values():
-            if device_entry := dr.async_get_device({(DOMAIN, device.name)}):
+            if device_entry := device_registry.async_get_device(
+                {(DOMAIN, device.name)}
+            ):
                 devices[device.name] = device_entry.id
         return devices
 
@@ -241,7 +243,7 @@ async def get_media_source_devices(hass: HomeAssistant) -> Mapping[str, Device]:
         return {}
     subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
     device_manager = await subscriber.async_get_device_manager()
-    dr = device_registry.async_get(hass)
+    device_registry = dr.async_get(hass)
     devices = {}
     for device in device_manager.devices.values():
         if not (
@@ -249,7 +251,7 @@ async def get_media_source_devices(hass: HomeAssistant) -> Mapping[str, Device]:
             or CameraClipPreviewTrait.NAME in device.traits
         ):
             continue
-        if device_entry := dr.async_get_device({(DOMAIN, device.name)}):
+        if device_entry := device_registry.async_get_device({(DOMAIN, device.name)}):
             devices[device_entry.id] = device
     return devices
 

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -6,6 +6,9 @@ as media in the media source.
 
 import datetime
 from http import HTTPStatus
+import shutil
+from typing import Generator
+from unittest.mock import Mock, patch
 
 import aiohttp
 from google_nest_sdm.device import Device
@@ -16,12 +19,19 @@ from homeassistant.components import media_source
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.components.media_source import const
 from homeassistant.components.media_source.error import Unresolvable
+from homeassistant.components.nest.media_source import MEDIA_PATH
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.template import DATE_STR_FORMAT
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from .common import async_setup_sdm_platform
+from .common import (
+    CONFIG,
+    FakeSubscriber,
+    async_setup_sdm_platform,
+    create_config_entry,
+)
 
 DOMAIN = "nest"
 DEVICE_ID = "example/api/device/id"
@@ -49,6 +59,7 @@ BATTERY_CAMERA_TRAITS = {
     "sdm.devices.traits.CameraPerson": {},
     "sdm.devices.traits.CameraMotion": {},
 }
+
 PERSON_EVENT = "sdm.devices.events.CameraPerson.Person"
 MOTION_EVENT = "sdm.devices.events.CameraMotion.Motion"
 
@@ -61,6 +72,13 @@ GENERATE_IMAGE_URL_RESPONSE = {
 }
 IMAGE_BYTES_FROM_EVENT = b"test url image bytes"
 IMAGE_AUTHORIZATION_HEADERS = {"Authorization": "Basic g.0.eventToken"}
+
+
+@pytest.fixture(autouse=True)
+def cleanup_media_storage(hass):
+    """Test cleanup, remove any media storage persisted during the test."""
+    yield
+    shutil.rmtree(hass.config.path(MEDIA_PATH))
 
 
 async def async_setup_devices(hass, auth, device_type, traits={}, events=[]):
@@ -113,6 +131,22 @@ def create_event_message(event_data, timestamp, device_id=None):
         },
         auth=None,
     )
+
+
+def create_battery_event_data(
+    event_type, event_session_id=EVENT_SESSION_ID, event_id="n:2"
+):
+    """Return event payload data for a battery camera event."""
+    return {
+        event_type: {
+            "eventSessionId": event_session_id,
+            "eventId": event_id,
+        },
+        "sdm.devices.events.CameraClipPreview.ClipPreview": {
+            "eventSessionId": event_session_id,
+            "previewUrl": "https://127.0.0.1/example",
+        },
+    }
 
 
 async def test_no_eligible_devices(hass, auth):
@@ -335,7 +369,7 @@ async def test_event_order(hass, auth):
     event_timestamp_string = event_timestamp2.strftime(DATE_STR_FORMAT)
     assert browse.children[0].title == f"Motion @ {event_timestamp_string}"
     assert not browse.children[0].can_expand
-    assert not browse.can_play
+    assert not browse.children[0].can_play
 
     # Person event is next
     assert browse.children[1].domain == DOMAIN
@@ -344,7 +378,7 @@ async def test_event_order(hass, auth):
     event_timestamp_string = event_timestamp1.strftime(DATE_STR_FORMAT)
     assert browse.children[1].title == f"Person @ {event_timestamp_string}"
     assert not browse.children[1].can_expand
-    assert not browse.can_play
+    assert not browse.children[1].can_play
 
 
 async def test_browse_invalid_device_id(hass, auth):
@@ -436,16 +470,6 @@ async def test_resolve_invalid_event_id(hass, auth):
 async def test_camera_event_clip_preview(hass, auth, hass_client):
     """Test an event for a battery camera video clip."""
     event_timestamp = dt_util.now()
-    event_data = {
-        "sdm.devices.events.CameraMotion.Motion": {
-            "eventSessionId": EVENT_SESSION_ID,
-            "eventId": "n:2",
-        },
-        "sdm.devices.events.CameraClipPreview.ClipPreview": {
-            "eventSessionId": EVENT_SESSION_ID,
-            "previewUrl": "https://127.0.0.1/example",
-        },
-    }
     await async_setup_devices(
         hass,
         auth,
@@ -453,7 +477,7 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
         BATTERY_CAMERA_TRAITS,
         events=[
             create_event_message(
-                event_data,
+                create_battery_event_data(MOTION_EVENT),
                 timestamp=event_timestamp,
             ),
         ],
@@ -498,6 +522,16 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
     ]
 
     client = await hass_client()
+    response = await client.get(media.url)
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    contents = await response.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+    # Fetch again and read from cache. We prove the cache was used by forcing
+    # a server error.
+    auth.responses = [
+        aiohttp.web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR),
+    ]
     response = await client.get(media.url)
     assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
     contents = await response.read()
@@ -692,3 +726,314 @@ async def test_multiple_devices(hass, auth, hass_client):
         hass, f"{const.URI_SCHEME}{DOMAIN}/{device2.id}"
     )
     assert len(browse.children) == 3
+
+
+@pytest.fixture
+def event_store() -> Generator[None, None, None]:
+    """Persist changes to event store immediately."""
+    m = Mock(spec=float)
+    m.return_value = 0
+    with patch(
+        "homeassistant.components.nest.media_source.STORAGE_SAVE_DELAY_SECONDS",
+        new_callable=m,
+    ):
+        yield
+
+
+async def test_media_store_persistence(hass, auth, hass_client, event_store):
+    """Test the disk backed media store persistence."""
+    nest_device = Device.MakeDevice(
+        {
+            "name": DEVICE_ID,
+            "type": CAMERA_DEVICE_TYPE,
+            "traits": BATTERY_CAMERA_TRAITS,
+        },
+        auth=auth,
+    )
+
+    subscriber = FakeSubscriber()
+    device_manager = await subscriber.async_get_device_manager()
+    device_manager.add_device(nest_device)
+    # Fetch media for events when published
+    subscriber.cache_policy.fetch = True
+
+    config_entry = create_config_entry(hass)
+
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
+    ), patch("homeassistant.components.nest.PLATFORMS", [PLATFORM]), patch(
+        "homeassistant.components.nest.api.GoogleNestSubscriber",
+        return_value=subscriber,
+    ):
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
+        await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    assert device
+    assert device.name == DEVICE_NAME
+
+    auth.responses = [
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+    event_timestamp = dt_util.now()
+    await subscriber.async_receive_event(
+        create_event_message(
+            create_battery_event_data(MOTION_EVENT), timestamp=event_timestamp
+        )
+    )
+
+    # Browse to event
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
+    )
+    assert len(browse.children) == 1
+    assert browse.children[0].domain == DOMAIN
+    assert browse.children[0].identifier == f"{device.id}/{EVENT_SESSION_ID}"
+    event_timestamp_string = event_timestamp.strftime(DATE_STR_FORMAT)
+    assert browse.children[0].title == f"Motion @ {event_timestamp_string}"
+    assert not browse.children[0].can_expand
+    assert browse.children[0].can_play
+
+    media = await media_source.async_resolve_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}/{EVENT_SESSION_ID}"
+    )
+    assert media.url == f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}"
+    assert media.mime_type == "video/mp4"
+
+    # Fetch event media
+    client = await hass_client()
+    response = await client.get(media.url)
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    contents = await response.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+    # Ensure event media store persists to disk
+    await hass.async_block_till_done()
+
+    # Unload the integration.
+    assert config_entry.state == ConfigEntryState.LOADED
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+
+    # Now rebuild the entire integration and verify that all persisted storage
+    # can be re-loaded from disk.
+    subscriber = FakeSubscriber()
+    device_manager = await subscriber.async_get_device_manager()
+    device_manager.add_device(nest_device)
+    # Fetch media for events when published
+    subscriber.cache_policy.fetch = True
+
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
+    ), patch("homeassistant.components.nest.PLATFORMS", [PLATFORM]), patch(
+        "homeassistant.components.nest.api.GoogleNestSubscriber",
+        return_value=subscriber,
+    ):
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    assert device
+    assert device.name == DEVICE_NAME
+
+    # Verify event metadata exists
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
+    )
+    assert len(browse.children) == 1
+    assert browse.children[0].domain == DOMAIN
+    assert browse.children[0].identifier == f"{device.id}/{EVENT_SESSION_ID}"
+    event_timestamp_string = event_timestamp.strftime(DATE_STR_FORMAT)
+    assert browse.children[0].title == f"Motion @ {event_timestamp_string}"
+    assert not browse.children[0].can_expand
+    assert browse.children[0].can_play
+
+    media = await media_source.async_resolve_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}/{EVENT_SESSION_ID}"
+    )
+    assert media.url == f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}"
+    assert media.mime_type == "video/mp4"
+
+    # Verify media exists
+    response = await client.get(media.url)
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    contents = await response.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+
+async def test_media_store_filesystem_error(hass, auth, hass_client):
+    """Test a filesystem error read/writing event media."""
+    event_timestamp = dt_util.now()
+    await async_setup_devices(
+        hass,
+        auth,
+        CAMERA_DEVICE_TYPE,
+        BATTERY_CAMERA_TRAITS,
+        events=[
+            create_event_message(
+                create_battery_event_data(MOTION_EVENT),
+                timestamp=event_timestamp,
+            ),
+        ],
+    )
+
+    assert len(hass.states.async_all()) == 1
+    camera = hass.states.get("camera.front")
+    assert camera is not None
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    assert device
+    assert device.name == DEVICE_NAME
+
+    auth.responses = [
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+
+    # The client fetches the media from the server, but has a failure when
+    # persisting the media to disk.
+    client = await hass_client()
+    with patch("homeassistant.components.nest.media_source.open", side_effect=OSError):
+        response = await client.get(
+            f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}"
+        )
+        assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+        contents = await response.read()
+        assert contents == IMAGE_BYTES_FROM_EVENT
+        await hass.async_block_till_done()
+
+    # Fetch the media again, and since the object does not exist in the cache it
+    # needs to be fetched again. The server returns an error to prove that it was
+    # not a cache read. A second attempt succeeds.
+    auth.responses = [
+        aiohttp.web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR),
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+    # First attempt, server fails when fetching
+    response = await client.get(f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}")
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR, (
+        "Response not matched: %s" % response
+    )
+
+    # Second attempt, server responds success
+    response = await client.get(f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}")
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    contents = await response.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+    # Third attempt reads from the disk cache with no server fetch
+    response = await client.get(f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}")
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    contents = await response.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+    auth.responses = [
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+    # Exercise a failure reading from the disk cache. Re-populate from server and write to disk ok
+    with patch("homeassistant.components.nest.media_source.open", side_effect=OSError):
+        response = await client.get(
+            f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}"
+        )
+        assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+        contents = await response.read()
+        assert contents == IMAGE_BYTES_FROM_EVENT
+        await hass.async_block_till_done()
+
+    response = await client.get(f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}")
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    contents = await response.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+
+async def test_camera_event_media_eviction(hass, auth, hass_client):
+    """Test media files getting evicted from the cache."""
+
+    # Set small cache size for testing eviction
+    m = Mock(spec=float)
+    m.return_value = 5
+    with patch("homeassistant.components.nest.EVENT_MEDIA_CACHE_SIZE", new_callable=m):
+        subscriber = await async_setup_devices(
+            hass,
+            auth,
+            CAMERA_DEVICE_TYPE,
+            BATTERY_CAMERA_TRAITS,
+        )
+
+    # Media fetched as soon as it is published
+    subscriber.cache_policy.fetch = True
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    assert device
+    assert device.name == DEVICE_NAME
+
+    # Browse to the device
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
+    )
+    assert browse.domain == DOMAIN
+    assert browse.identifier == device.id
+    assert browse.title == "Front: Recent Events"
+    assert browse.can_expand
+
+    # No events published yet
+    assert len(browse.children) == 0
+
+    event_timestamp = dt_util.now()
+    for i in range(0, 7):
+        auth.responses = [aiohttp.web.Response(body=f"image-bytes-{i}".encode())]
+        ts = event_timestamp + datetime.timedelta(seconds=i)
+        await subscriber.async_receive_event(
+            create_event_message(
+                create_battery_event_data(
+                    MOTION_EVENT, event_session_id=f"event-session-{i}"
+                ),
+                timestamp=ts,
+            )
+        )
+    await hass.async_block_till_done()
+
+    # Cache is limited to 5 events removing media as the cache is filled
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
+    )
+    assert len(browse.children) == 5
+
+    auth.responses = [
+        aiohttp.web.Response(body=b"image-bytes-7"),
+    ]
+    ts = event_timestamp + datetime.timedelta(seconds=8)
+    # Simulate a failure case removing the media on cache eviction
+    with patch(
+        "homeassistant.components.nest.media_source.os.remove", side_effect=OSError
+    ) as mock_remove:
+        await subscriber.async_receive_event(
+            create_event_message(
+                create_battery_event_data(
+                    MOTION_EVENT, event_session_id="event-session-7"
+                ),
+                timestamp=ts,
+            )
+        )
+        await hass.async_block_till_done()
+        assert mock_remove.called
+
+    browse = await media_source.async_browse_media(
+        hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
+    )
+    assert len(browse.children) == 5
+
+    # Verify all other content is still persisted correctly
+    client = await hass_client()
+    for i in range(3, 8):
+        response = await client.get(
+            f"/api/nest/event_media/{device.id}/event-session-{i}"
+        )
+        assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+        contents = await response.read()
+        assert contents == f"image-bytes-{i}".encode()
+        await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Persist nest events in the media player to disk, targeting about ~500mb
per camera device as a cap. Events are stored in config/nest/event_media/.

Add a NestEventMediaStore is used for persistence. It has three main jobs:
- Read/write the key/value data that holds event data (event type, time, device, etc)
- Read/write media contents to disk
- Pick the filename for the media event based on device and event details

The nest event media manager library handles cache management and eviction, and by
default uses an in memory cache. Home Assistant nest integration now provides the
disk backed implementation, which is invoked by the nest library.

The store reads the event metadata key/value dict on startup, and then writes it
back with a short delay of 5 seconds to avoid unnecessary writes.

It is probably safest to manually merge this after the options flow since that adds an opt-out for this feature.

There is one somewhat orthogonal change to move `hass.http.register_view(NestEventMediaView(hass))` caught by adding tests to reload the integration.

Future work planned includes:
- [X] Options flow for disabling media player https://github.com/home-assistant/core/pull/61527
- [ ] Thumbnails in the media player grid
- [ ] Possibly a small memory buffer for media objects themselves (if improves thumbnail performance to avoid unnecessary fetches)
- [ ] Transcoding mp4 clips to animated image previews


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
