### PR TITLE
Cleanup tests for lcn events and device triggers

### DIFF
--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -58,8 +58,11 @@ async def async_get_triggers(
     """List device triggers for LCN devices."""
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(device_id)
+    if device is None:
+        return []
 
-    if device.model.startswith(("LCN host", "LCN group", "LCN resource")):  # type: ignore[union-attr]
+    identifier = next(iter(device.identifiers))
+    if (identifier[1].count("-") != 1) or device.model.startswith("LCN group"):  # type: ignore[union-attr]
         return []
 
     base_trigger = {

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -256,7 +256,7 @@ def register_lcn_host_device(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         identifiers={(DOMAIN, config_entry.entry_id)},
         manufacturer="Issendorff",
         name=config_entry.title,
-        model=f"LCN host ({config_entry.data[CONF_IP_ADDRESS]}:{config_entry.data[CONF_PORT]})",
+        model="LCN host",
     )
 
 

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -256,7 +256,7 @@ def register_lcn_host_device(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         identifiers={(DOMAIN, config_entry.entry_id)},
         manufacturer="Issendorff",
         name=config_entry.title,
-        model="LCN host",
+        model="LCN-PCHK",
     )
 
 

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -8,15 +8,9 @@ import pypck.module
 from pypck.module import GroupConnection, ModuleConnection
 import pytest
 
-from homeassistant.components.lcn.const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, DOMAIN
+from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.components.lcn.helpers import generate_unique_id
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_IP_ADDRESS,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_HOST
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -104,20 +98,18 @@ def create_config_entry_myhome():
 @pytest.fixture(name="lcn_connection")
 async def init_integration(hass, entry):
     """Set up the LCN integration in Home Assistant."""
-    lcn_connection = MockPchkConnectionManager(
-        entry.data[CONF_IP_ADDRESS],
-        entry.data[CONF_PORT],
-        entry.data[CONF_USERNAME],
-        entry.data[CONF_PASSWORD],
-        settings={
-            "SK_NUM_TRIES": entry.data[CONF_SK_NUM_TRIES],
-            "DIM_MODE": pypck.lcn_defs.OutputPortDimMode[entry.data[CONF_DIM_MODE]],
-        },
-        connection_id=entry.entry_id,
-    )
+    lcn_connection = None
+
+    def lcn_connection_factory(*args, **kwargs):
+        nonlocal lcn_connection
+        lcn_connection = MockPchkConnectionManager(*args, **kwargs)
+        return lcn_connection
 
     entry.add_to_hass(hass)
-    with patch("pypck.connection.PchkConnectionManager", return_value=lcn_connection):
+    with patch(
+        "pypck.connection.PchkConnectionManager",
+        side_effect=lcn_connection_factory,
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         yield lcn_connection

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -58,9 +58,9 @@ class MockPchkConnectionManager(PchkConnectionManager):
 
     @patch.object(pypck.connection, "ModuleConnection", MockModuleConnection)
     @patch.object(pypck.connection, "GroupConnection", MockGroupConnection)
-    def get_address_conn(self, addr):
+    def get_address_conn(self, addr, request_serials=False):
         """Get LCN address connection."""
-        return super().get_address_conn(addr, request_serials=False)
+        return super().get_address_conn(addr, request_serials)
 
     send_command = AsyncMock()
 
@@ -101,6 +101,7 @@ def create_config_entry_myhome():
     return create_config_entry("myhome")
 
 
+@pytest.fixture(name="lcn_connection")
 async def init_integration(hass, entry):
     """Set up the LCN integration in Home Assistant."""
     lcn_connection = MockPchkConnectionManager(
@@ -119,7 +120,7 @@ async def init_integration(hass, entry):
     with patch("pypck.connection.PchkConnectionManager", return_value=lcn_connection):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-    return lcn_connection
+        yield lcn_connection
 
 
 async def setup_component(hass):

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -11,14 +11,13 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .conftest import get_device, init_integration
+from .conftest import get_device
 
 from tests.common import assert_lists_same, async_get_device_automations
 
 
-async def test_get_triggers_module_device(hass, entry):
+async def test_get_triggers_module_device(hass, entry, lcn_connection):
     """Test we get the expected triggers from a LCN module device."""
-    await init_integration(hass, entry)
     device = get_device(hass, entry, (0, 7, False))
 
     expected_triggers = [
@@ -52,11 +51,10 @@ async def test_get_triggers_module_device(hass, entry):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_get_triggers_non_module_device(hass, entry):
+async def test_get_triggers_non_module_device(hass, lcn_connection):
     """Test we get the expected triggers from a LCN non-module device."""
     not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
 
-    await init_integration(hass, entry)
     device_registry = dr.async_get(hass)
     for device_id in device_registry.devices:
         device = device_registry.async_get(device_id)
@@ -66,9 +64,8 @@ async def test_get_triggers_non_module_device(hass, entry):
                 assert trigger[CONF_TYPE] not in not_included_types
 
 
-async def test_if_fires_on_transponder_event(hass, calls, entry):
+async def test_if_fires_on_transponder_event(hass, calls, entry, lcn_connection):
     """Test for transponder event triggers firing."""
-    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -112,9 +109,8 @@ async def test_if_fires_on_transponder_event(hass, calls, entry):
     }
 
 
-async def test_if_fires_on_fingerprint_event(hass, calls, entry):
+async def test_if_fires_on_fingerprint_event(hass, calls, entry, lcn_connection):
     """Test for fingerprint event triggers firing."""
-    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -158,9 +154,8 @@ async def test_if_fires_on_fingerprint_event(hass, calls, entry):
     }
 
 
-async def test_if_fires_on_transmitter_event(hass, calls, entry):
+async def test_if_fires_on_transmitter_event(hass, calls, entry, lcn_connection):
     """Test for transmitter event triggers firing."""
-    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -213,9 +208,8 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry):
     }
 
 
-async def test_if_fires_on_send_keys_event(hass, calls, entry):
+async def test_if_fires_on_send_keys_event(hass, calls, entry, lcn_connection):
     """Test for send_keys event triggers firing."""
-    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -261,9 +255,8 @@ async def test_if_fires_on_send_keys_event(hass, calls, entry):
     }
 
 
-async def test_get_transponder_trigger_capabilities(hass, entry):
+async def test_get_transponder_trigger_capabilities(hass, entry, lcn_connection):
     """Test we get the expected capabilities from a transponder device trigger."""
-    await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -283,9 +276,8 @@ async def test_get_transponder_trigger_capabilities(hass, entry):
     ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
 
 
-async def test_get_fingerprint_trigger_capabilities(hass, entry):
+async def test_get_fingerprint_trigger_capabilities(hass, entry, lcn_connection):
     """Test we get the expected capabilities from a fingerprint device trigger."""
-    await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -305,9 +297,8 @@ async def test_get_fingerprint_trigger_capabilities(hass, entry):
     ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
 
 
-async def test_get_transmitter_trigger_capabilities(hass, entry):
+async def test_get_transmitter_trigger_capabilities(hass, entry, lcn_connection):
     """Test we get the expected capabilities from a transmitter device trigger."""
-    await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -337,9 +328,8 @@ async def test_get_transmitter_trigger_capabilities(hass, entry):
     ]
 
 
-async def test_get_send_keys_trigger_capabilities(hass, entry):
+async def test_get_send_keys_trigger_capabilities(hass, entry, lcn_connection):
     """Test we get the expected capabilities from a send_keys device trigger."""
-    await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -374,9 +364,8 @@ async def test_get_send_keys_trigger_capabilities(hass, entry):
     ]
 
 
-async def test_unknown_trigger_capabilities(hass, entry):
+async def test_unknown_trigger_capabilities(hass, entry, lcn_connection):
     """Test we get empty capabilities if trigger is unknown."""
-    await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -1,6 +1,4 @@
 """Tests for LCN device triggers."""
-from unittest.mock import patch
-
 from pypck.inputs import ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
@@ -13,12 +11,11 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .conftest import MockPchkConnectionManager, get_device, init_integration
+from .conftest import get_device, init_integration
 
 from tests.common import assert_lists_same, async_get_device_automations
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_triggers_module_device(hass, entry):
     """Test we get the expected triggers from a LCN module device."""
     await init_integration(hass, entry)
@@ -55,7 +52,6 @@ async def test_get_triggers_module_device(hass, entry):
     assert_lists_same(triggers, expected_triggers)
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_triggers_non_module_device(hass, entry):
     """Test we get the expected triggers from a LCN non-module device."""
     not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
@@ -70,10 +66,9 @@ async def test_get_triggers_non_module_device(hass, entry):
                 assert trigger[CONF_TYPE] not in not_included_types
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_if_fires_on_transponder_event(hass, calls, entry):
     """Test for transponder event triggers firing."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -107,7 +102,6 @@ async def test_if_fires_on_transponder_event(hass, calls, entry):
         code="aabbcc",
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -118,10 +112,9 @@ async def test_if_fires_on_transponder_event(hass, calls, entry):
     }
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_if_fires_on_fingerprint_event(hass, calls, entry):
     """Test for fingerprint event triggers firing."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -155,7 +148,6 @@ async def test_if_fires_on_fingerprint_event(hass, calls, entry):
         code="aabbcc",
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -166,10 +158,9 @@ async def test_if_fires_on_fingerprint_event(hass, calls, entry):
     }
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_if_fires_on_transmitter_event(hass, calls, entry):
     """Test for transmitter event triggers firing."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -209,7 +200,6 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry):
         action=KeyAction.HIT,
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -223,10 +213,9 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry):
     }
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_if_fires_on_send_keys_event(hass, calls, entry):
     """Test for send_keys event triggers firing."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
 
@@ -261,7 +250,6 @@ async def test_if_fires_on_send_keys_event(hass, calls, entry):
         keys=[True, False, False, False, False, False, False, False],
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -273,7 +261,6 @@ async def test_if_fires_on_send_keys_event(hass, calls, entry):
     }
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_transponder_trigger_capabilities(hass, entry):
     """Test we get the expected capabilities from a transponder device trigger."""
     await init_integration(hass, entry)
@@ -296,7 +283,6 @@ async def test_get_transponder_trigger_capabilities(hass, entry):
     ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_fingerprint_trigger_capabilities(hass, entry):
     """Test we get the expected capabilities from a fingerprint device trigger."""
     await init_integration(hass, entry)
@@ -319,7 +305,6 @@ async def test_get_fingerprint_trigger_capabilities(hass, entry):
     ) == [{"name": "code", "optional": True, "type": "string", "lower": True}]
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_transmitter_trigger_capabilities(hass, entry):
     """Test we get the expected capabilities from a transmitter device trigger."""
     await init_integration(hass, entry)
@@ -352,7 +337,6 @@ async def test_get_transmitter_trigger_capabilities(hass, entry):
     ]
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_send_keys_trigger_capabilities(hass, entry):
     """Test we get the expected capabilities from a send_keys device trigger."""
     await init_integration(hass, entry)
@@ -390,7 +374,6 @@ async def test_get_send_keys_trigger_capabilities(hass, entry):
     ]
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_unknown_trigger_capabilities(hass, entry):
     """Test we get empty capabilities if trigger is unknown."""
     await init_integration(hass, entry)

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -58,7 +58,8 @@ async def test_get_triggers_non_module_device(hass, lcn_connection):
     device_registry = dr.async_get(hass)
     for device_id in device_registry.devices:
         device = device_registry.async_get(device_id)
-        if device.model.startswith(("LCN host", "LCN group", "LCN resource")):
+        identifier = next(iter(device.identifiers))
+        if (identifier[1].count("-") != 1) or device.model.startswith("LCN group"):
             triggers = await async_get_device_automations(hass, "trigger", device_id)
             for trigger in triggers:
                 assert trigger[CONF_TYPE] not in not_included_types

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -3,15 +3,11 @@ from pypck.inputs import Input, ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
 
-from .conftest import init_integration
-
 from tests.common import async_capture_events
 
 
-async def test_fire_transponder_event(hass, entry):
+async def test_fire_transponder_event(hass, lcn_connection):
     """Test the transponder event is fired."""
-    lcn_connection = await init_integration(hass, entry)
-
     events = async_capture_events(hass, "lcn_transponder")
 
     inp = ModStatusAccessControl(
@@ -28,10 +24,8 @@ async def test_fire_transponder_event(hass, entry):
     assert events[0].data["code"] == "aabbcc"
 
 
-async def test_fire_fingerprint_event(hass, entry):
+async def test_fire_fingerprint_event(hass, lcn_connection):
     """Test the fingerprint event is fired."""
-    lcn_connection = await init_integration(hass, entry)
-
     events = async_capture_events(hass, "lcn_fingerprint")
 
     inp = ModStatusAccessControl(
@@ -48,10 +42,8 @@ async def test_fire_fingerprint_event(hass, entry):
     assert events[0].data["code"] == "aabbcc"
 
 
-async def test_fire_transmitter_event(hass, entry):
+async def test_fire_transmitter_event(hass, lcn_connection):
     """Test the transmitter event is fired."""
-    lcn_connection = await init_integration(hass, entry)
-
     events = async_capture_events(hass, "lcn_transmitter")
 
     inp = ModStatusAccessControl(
@@ -74,10 +66,8 @@ async def test_fire_transmitter_event(hass, entry):
     assert events[0].data["action"] == "hit"
 
 
-async def test_fire_sendkeys_event(hass, entry):
+async def test_fire_sendkeys_event(hass, lcn_connection):
     """Test the send_keys event is fired."""
-    lcn_connection = await init_integration(hass, entry)
-
     events = async_capture_events(hass, "lcn_send_keys")
 
     inp = ModSendKeysHost(
@@ -104,10 +94,8 @@ async def test_fire_sendkeys_event(hass, entry):
     assert events[3].data["action"] == "make"
 
 
-async def test_dont_fire_on_non_module_input(hass, entry):
+async def test_dont_fire_on_non_module_input(hass, lcn_connection):
     """Test for no event is fired if a non-module input is received."""
-    lcn_connection = await init_integration(hass, entry)
-
     inp = Input()
 
     for event_name in (
@@ -122,17 +110,15 @@ async def test_dont_fire_on_non_module_input(hass, entry):
         assert len(events) == 0
 
 
-async def test_dont_fire_on_unknown_module(hass, entry):
+async def test_dont_fire_on_unknown_module(hass, lcn_connection):
     """Test for no event is fired if an input from an unknown module is received."""
-    lcn_connection = await init_integration(hass, entry)
-
     inp = ModStatusAccessControl(
         LcnAddr(0, 10, False),  # unknown module
         periphery=AccessControlPeriphery.FINGERPRINT,
         code="aabbcc",
     )
 
-    events = async_capture_events(hass, "lcn_transmitter")
+    events = async_capture_events(hass, "lcn_fingerprint")
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
     assert len(events) == 0

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -1,19 +1,16 @@
 """Tests for LCN events."""
-from unittest.mock import patch
-
 from pypck.inputs import Input, ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
 
-from .conftest import MockPchkConnectionManager, init_integration
+from .conftest import init_integration
 
 from tests.common import async_capture_events
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_fire_transponder_event(hass, entry):
     """Test the transponder event is fired."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
 
     events = async_capture_events(hass, "lcn_transponder")
 
@@ -23,7 +20,6 @@ async def test_fire_transponder_event(hass, entry):
         code="aabbcc",
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -32,10 +28,9 @@ async def test_fire_transponder_event(hass, entry):
     assert events[0].data["code"] == "aabbcc"
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_fire_fingerprint_event(hass, entry):
     """Test the fingerprint event is fired."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
 
     events = async_capture_events(hass, "lcn_fingerprint")
 
@@ -45,7 +40,6 @@ async def test_fire_fingerprint_event(hass, entry):
         code="aabbcc",
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -54,10 +48,9 @@ async def test_fire_fingerprint_event(hass, entry):
     assert events[0].data["code"] == "aabbcc"
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_fire_transmitter_event(hass, entry):
     """Test the transmitter event is fired."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
 
     events = async_capture_events(hass, "lcn_transmitter")
 
@@ -70,7 +63,6 @@ async def test_fire_transmitter_event(hass, entry):
         action=KeyAction.HIT,
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -82,10 +74,9 @@ async def test_fire_transmitter_event(hass, entry):
     assert events[0].data["action"] == "hit"
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_fire_sendkeys_event(hass, entry):
     """Test the send_keys event is fired."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
 
     events = async_capture_events(hass, "lcn_send_keys")
 
@@ -95,7 +86,6 @@ async def test_fire_sendkeys_event(hass, entry):
         keys=[True, True, False, False, False, False, False, False],
     )
 
-    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -114,13 +104,11 @@ async def test_fire_sendkeys_event(hass, entry):
     assert events[3].data["action"] == "make"
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_dont_fire_on_non_module_input(hass, entry):
     """Test for no event is fired if a non-module input is received."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
 
     inp = Input()
-    lcn_connection = MockPchkConnectionManager.return_value
 
     for event_name in (
         "lcn_transponder",
@@ -134,18 +122,15 @@ async def test_dont_fire_on_non_module_input(hass, entry):
         assert len(events) == 0
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_dont_fire_on_unknown_module(hass, entry):
     """Test for no event is fired if an input from an unknown module is received."""
-    await init_integration(hass, entry)
+    lcn_connection = await init_integration(hass, entry)
 
     inp = ModStatusAccessControl(
         LcnAddr(0, 10, False),  # unknown module
         periphery=AccessControlPeriphery.FINGERPRINT,
         code="aabbcc",
     )
-
-    lcn_connection = MockPchkConnectionManager.return_value
 
     events = async_capture_events(hass, "lcn_transmitter")
     await lcn_connection.async_process_input(inp)

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -15,7 +15,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from .conftest import MockPchkConnectionManager, init_integration, setup_component
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_async_setup_entry(hass, entry):
     """Test a successful setup entry and unload of entry."""
     await init_integration(hass, entry)
@@ -30,7 +29,6 @@ async def test_async_setup_entry(hass, entry):
     assert not hass.data.get(DOMAIN)
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_async_setup_multiple_entries(hass, entry, entry2):
     """Test a successful setup and unload of multiple entries."""
     for config_entry in (entry, entry2):
@@ -49,7 +47,6 @@ async def test_async_setup_multiple_entries(hass, entry, entry2):
     assert not hass.data.get(DOMAIN)
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_async_setup_entry_update(hass, entry):
     """Test a successful setup entry if entry with same id already exists."""
     # setup first entry
@@ -74,9 +71,10 @@ async def test_async_setup_entry_update(hass, entry):
     assert dummy_device in device_registry.devices.values()
 
     # setup new entry with same data via import step (should cleanup dummy device)
-    await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=entry.data
-    )
+    with patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager):
+        await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=entry.data
+        )
 
     assert dummy_device not in device_registry.devices.values()
     assert dummy_entity not in entity_registry.entities.values()
@@ -87,7 +85,10 @@ async def test_async_setup_entry_raises_authentication_error(hass, entry):
     with patch.object(
         PchkConnectionManager, "async_connect", side_effect=PchkAuthenticationError
     ):
-        await init_integration(hass, entry)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
@@ -96,22 +97,29 @@ async def test_async_setup_entry_raises_license_error(hass, entry):
     with patch.object(
         PchkConnectionManager, "async_connect", side_effect=PchkLicenseError
     ):
-        await init_integration(hass, entry)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
 async def test_async_setup_entry_raises_timeout_error(hass, entry):
     """Test that an authentication error is handled properly."""
     with patch.object(PchkConnectionManager, "async_connect", side_effect=TimeoutError):
-        await init_integration(hass, entry)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
-@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_async_setup_from_configuration_yaml(hass):
     """Test a successful setup using data from configuration.yaml."""
-
-    with patch("homeassistant.components.lcn.async_setup_entry") as async_setup_entry:
+    with (
+        patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager),
+        patch("homeassistant.components.lcn.async_setup_entry") as async_setup_entry,
+    ):
         await setup_component(hass)
 
         assert async_setup_entry.await_count == 2

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -116,10 +116,9 @@ async def test_async_setup_entry_raises_timeout_error(hass, entry):
 
 async def test_async_setup_from_configuration_yaml(hass):
     """Test a successful setup using data from configuration.yaml."""
-    with (
-        patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager),
-        patch("homeassistant.components.lcn.async_setup_entry") as async_setup_entry,
-    ):
+    with patch(
+        "pypck.connection.PchkConnectionManager", MockPchkConnectionManager
+    ), patch("homeassistant.components.lcn.async_setup_entry") as async_setup_entry:
         await setup_component(hass)
 
         assert async_setup_entry.await_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
After merging there were some additional suggestion to PR #58745.
Acces to the underlying LCN connection object is implemented by patching the class and return a previously created instance on instantiation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
