### PR TITLE
Fix Flash effect for Hue lights

### DIFF
--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -6,16 +6,19 @@ from typing import Any
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.groups import GroupedLight, Room, Zone
+from aiohue.v2.models.feature import AlertEffectType
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
+    ATTR_FLASH,
     ATTR_TRANSITION,
     ATTR_XY_COLOR,
     COLOR_MODE_BRIGHTNESS,
     COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_ONOFF,
     COLOR_MODE_XY,
+    SUPPORT_FLASH,
     SUPPORT_TRANSITION,
     LightEntity,
 )
@@ -32,6 +35,7 @@ ALLOWED_ERRORS = [
     'device (groupedLight) is "soft off", command (on) may not have effect',
     "device (light) has communication issues, command (on) may not have effect",
     'device (light) is "soft off", command (on) may not have effect',
+    "attribute (supportedAlertActions) cannot be written",
 ]
 
 
@@ -88,6 +92,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         self.group = group
         self.controller = controller
         self.api: HueBridgeV2 = bridge.api
+        self._attr_supported_features |= SUPPORT_FLASH
         self._attr_supported_features |= SUPPORT_TRANSITION
 
         # Entities for Hue groups are disabled by default
@@ -146,6 +151,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         xy_color = kwargs.get(ATTR_XY_COLOR)
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
+        flash = kwargs.get(ATTR_FLASH)
         if brightness is not None:
             # Hue uses a range of [0, 100] to control brightness.
             brightness = float((brightness / 255) * 100)
@@ -160,6 +166,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             and xy_color is None
             and color_temp is None
             and transition is None
+            and flash is None
         ):
             await self.bridge.async_request_call(
                 self.controller.set_state,
@@ -180,6 +187,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                 color_xy=xy_color if light.supports_color else None,
                 color_temp=color_temp if light.supports_color_temperature else None,
                 transition_time=transition,
+                alert=AlertEffectType.BREATHE if flash is not None else None,
                 allowed_errors=ALLOWED_ERRORS,
             )
 

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -121,6 +121,17 @@ async def test_light_turn_on_service(hass, mock_bridge_v2, v2_resources_test_dat
     assert mock_bridge_v2.mock_requests[1]["json"]["on"]["on"] is True
     assert mock_bridge_v2.mock_requests[1]["json"]["dynamics"]["duration"] == 6000
 
+    # test again with sending flash/alert
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": test_light_id, "flash": "long"},
+        blocking=True,
+    )
+    assert len(mock_bridge_v2.mock_requests) == 3
+    assert mock_bridge_v2.mock_requests[2]["json"]["on"]["on"] is True
+    assert mock_bridge_v2.mock_requests[2]["json"]["alert"]["action"] == "breathe"
+
 
 async def test_light_turn_off_service(hass, mock_bridge_v2, v2_resources_test_data):
     """Test calling the turn off service on a light."""


### PR DESCRIPTION
## Proposed change
With the transition to the V2 API/implementation of Hue, the Flash effect/action was abandoned, mostly because it no longer exists that way in the API. This effect is however missed by users that depend on it. The new API provides an alternative, the "breathe" alert, which is comparable to the previous "long" flash.

https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light__id__put

This fix will bring back the flash effect with a few notes:

- On turn on command, the breathe effect will flash the light for about 15 seconds
- On turn off command , the breathe effect will flash the light shortly (once) and turn off.
- You can not turn on the light with a short flash only
- You can not turn off the light with a long flash effect

Users can work around these limitations in their own scrips/automations. At least there's now a way to trigger the flash effect again on the Hue lights.

For maximum compatibility the flash attribute on the service call is forgiving. If the value is not None, it will execute the breathe action on the bridge for the light. 


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61560
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
