### PR TITLE
Require RPi.GPIO and bump adafruit-circuitpython-dht to 3.7.0 in dht

### DIFF
--- a/homeassistant/components/dht/manifest.json
+++ b/homeassistant/components/dht/manifest.json
@@ -2,7 +2,12 @@
   "domain": "dht",
   "name": "DHT Sensor",
   "documentation": "https://www.home-assistant.io/integrations/dht",
-  "requirements": ["adafruit-circuitpython-dht==3.6.0"],
-  "codeowners": ["@thegardenmonkey"],
+  "requirements": [
+    "adafruit-circuitpython-dht==3.7.0",
+    "RPi.GPIO==0.7.1a4"
+  ],
+  "codeowners": [
+    "@thegardenmonkey"
+  ],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -97,7 +97,7 @@ accuweather==0.3.0
 adafruit-circuitpython-bmp280==3.1.1
 
 # homeassistant.components.dht
-adafruit-circuitpython-dht==3.6.0
+adafruit-circuitpython-dht==3.7.0
 
 # homeassistant.components.mcp23017
 adafruit-circuitpython-mcp230xx==2.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,6 +64,7 @@ PyViCare==2.13.1
 PyXiaomiGateway==0.13.4
 
 # homeassistant.components.bmp280
+# homeassistant.components.dht
 # homeassistant.components.mcp23017
 # homeassistant.components.rpi_gpio
 # homeassistant.components.rpi_rf


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds RPi.GPIO dependency for DHT integration which appears to be broken on an RPI docker installation after the migration to single docker image.

This PR should resolve the following bug:

2021-12-13 21:23:38 ERROR (MainThread) [homeassistant.config] Platform error: sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config.py", line 887, in async_process_component_config
    platform = p_integration.get_platform(domain)
  File "/usr/src/homeassistant/homeassistant/loader.py", line 530, in get_platform
    cache[full_name] = self._import_platform(platform_name)
  File "/usr/src/homeassistant/homeassistant/loader.py", line 535, in _import_platform
    return importlib.import_module(f"{self.pkg_path}.{platform_name}")
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/config/custom_components/dht/sensor.py", line 7, in <module>
    import adafruit_dht
  File "/usr/local/lib/python3.9/site-packages/adafruit_dht.py", line 32, in <module>
    from digitalio import DigitalInOut, Pull, Direction
  File "/usr/local/lib/python3.9/site-packages/digitalio.py", line 15, in <module>
    from adafruit_blinka.microcontroller.bcm283x.pin import Pin
  File "/usr/local/lib/python3.9/site-packages/adafruit_blinka/microcontroller/bcm283x/pin.py", line 2, in <module>
    import RPi.GPIO as GPIO
ModuleNotFoundError: No module named 'RPi'

Link the github release notes for adafruit: https://github.com/adafruit/Adafruit_CircuitPython_DHT/releases/tag/3.7.0
Link to the compare for 3.6 to 3.7 - https://github.com/adafruit/Adafruit_CircuitPython_DHT/compare/3.6.0...3.7.0
The Blinka module has the requirement for the RPi.GPIO module - https://github.com/adafruit/Adafruit_Blinka.

The real fix is the inclusion of RPi.GPIO if you running HA on a PI and I included the adafruit dht bump since that is what I tested on and it seemed to provide a number of updates since 3.6.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
