### PR TITLE
Create config flow in aten_pe

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -86,7 +86,9 @@ omit =
     homeassistant/components/asuswrt/__init__.py
     homeassistant/components/asuswrt/diagnostics.py
     homeassistant/components/asuswrt/router.py
-    homeassistant/components/aten_pe/*
+    homeassistant/components/aten_pe/__init__.py
+    homeassistant/components/aten_pe/const.py
+    homeassistant/components/aten_pe/switch.py
     homeassistant/components/atome/*
     homeassistant/components/aurora/__init__.py
     homeassistant/components/aurora/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -91,6 +91,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/atag/ @MatsNL
 /tests/components/atag/ @MatsNL
 /homeassistant/components/aten_pe/ @mtdcr
+/tests/components/aten_pe/ @mtdcr
 /homeassistant/components/atome/ @baqs
 /homeassistant/components/august/ @bdraco
 /tests/components/august/ @bdraco

--- a/homeassistant/components/aten_pe/__init__.py
+++ b/homeassistant/components/aten_pe/__init__.py
@@ -1,1 +1,22 @@
 """The ATEN PE component."""
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Component setup, do nothing."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, SWITCH_DOMAIN)
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_forward_entry_unload(entry, SWITCH_DOMAIN)

--- a/homeassistant/components/aten_pe/__init__.py
+++ b/homeassistant/components/aten_pe/__init__.py
@@ -1,22 +1,17 @@
 """The ATEN PE component."""
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = [Platform.SWITCH]
 
 
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
-    """Component setup, do nothing."""
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, SWITCH_DOMAIN)
-    )
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, SWITCH_DOMAIN)
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/aten_pe/config_flow.py
+++ b/homeassistant/components/aten_pe/config_flow.py
@@ -1,0 +1,116 @@
+"""Config flow for aten_pe integration."""
+from __future__ import annotations
+
+import logging
+
+from atenpdu import AtenPE, AtenPEError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_USERNAME
+
+from .const import (
+    CONF_AUTH_KEY,
+    CONF_COMMUNITY,
+    CONF_PRIV_KEY,
+    DEFAULT_COMMUNITY,
+    DEFAULT_PORT,
+    DEFAULT_USERNAME,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AtenPEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for aten_pe."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._errors: dict[str, str] = {}
+
+    def _host_in_configuration_exists(self, host, port) -> bool:
+        """Return True if host exists in configuration."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_HOST) == host and entry.data.get(CONF_PORT) == port:
+                return True
+        return False
+
+    async def _test_connection(self, host, port, config):
+        """Check if we can connect to the device."""
+        dev = AtenPE(
+            node=host,
+            serv=port,
+            community=config.get(CONF_COMMUNITY, DEFAULT_COMMUNITY),
+            username=config.get(CONF_USERNAME, DEFAULT_USERNAME),
+            authkey=config.get(CONF_AUTH_KEY),
+            privkey=config.get(CONF_PRIV_KEY),
+        )
+
+        try:
+            await self.hass.async_add_executor_job(dev.initialize)
+            await dev.deviceMAC()
+            return True
+        except AtenPEError:
+            self._errors[CONF_HOST] = "cannot_connect"
+            _LOGGER.error("Could not connect to device at %s:%s", host, port)
+        return False
+
+    async def async_step_user(self, user_input=None):
+        """Step when user initializes a integration."""
+        self._errors = {}
+        if user_input is not None:
+            host = user_input.get(CONF_HOST)
+            port = user_input.get(CONF_PORT, DEFAULT_PORT)
+            if self._host_in_configuration_exists(host, port):
+                self._errors[CONF_HOST] = "already_configured"
+            else:
+                if await self._test_connection(host, port, user_input):
+                    if port == DEFAULT_PORT:
+                        title = host
+                    else:
+                        title = f"{host}:{port}"
+                    return self.async_create_entry(title=title, data=user_input)
+        else:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=user_input.get(CONF_HOST)): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=user_input.get(CONF_PORT, DEFAULT_PORT),
+                    ): str,
+                    vol.Optional(
+                        CONF_COMMUNITY,
+                        default=user_input.get(CONF_COMMUNITY, DEFAULT_COMMUNITY),
+                    ): str,
+                    vol.Optional(
+                        CONF_USERNAME,
+                        default=user_input.get(CONF_USERNAME, DEFAULT_USERNAME),
+                    ): str,
+                    vol.Optional(
+                        CONF_AUTH_KEY,
+                        default=user_input.get(CONF_AUTH_KEY, ""),
+                    ): str,
+                    vol.Optional(
+                        CONF_PRIV_KEY,
+                        default=user_input.get(CONF_PRIV_KEY, ""),
+                    ): str,
+                }
+            ),
+            errors=self._errors,
+        )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        host = user_input.get(CONF_HOST)
+        port = user_input.get(CONF_PORT)
+        if self._host_in_configuration_exists(host, port):
+            return self.async_abort(reason="already_configured")
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/aten_pe/config_flow.py
+++ b/homeassistant/components/aten_pe/config_flow.py
@@ -65,15 +65,14 @@ class AtenPEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input.get(CONF_HOST)
             port = user_input.get(CONF_PORT, DEFAULT_PORT)
-            if self._host_in_configuration_exists(host, port):
-                self._errors[CONF_HOST] = "already_configured"
-            else:
-                if await self._test_connection(host, port, user_input):
-                    if port == DEFAULT_PORT:
-                        title = host
-                    else:
-                        title = f"{host}:{port}"
-                    return self.async_create_entry(title=title, data=user_input)
+            await self.async_set_unique_id(f"{host}:{port}")
+            self._abort_if_unique_id_configured()
+            if await self._test_connection(host, port, user_input):
+                if port == DEFAULT_PORT:
+                    title = host
+                else:
+                    title = f"{host}:{port}"
+                return self.async_create_entry(title=title, data=user_input)
         else:
             user_input = {}
 

--- a/homeassistant/components/aten_pe/config_flow.py
+++ b/homeassistant/components/aten_pe/config_flow.py
@@ -26,11 +26,6 @@ class AtenPEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for aten_pe."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-
-    def __init__(self) -> None:
-        """Initialize the config flow."""
-        self._errors: dict[str, str] = {}
 
     def _host_in_configuration_exists(self, host, port) -> bool:
         """Return True if host exists in configuration."""
@@ -55,13 +50,12 @@ class AtenPEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await dev.deviceMAC()
             return True
         except AtenPEError:
-            self._errors[CONF_HOST] = "cannot_connect"
             _LOGGER.error("Could not connect to device at %s:%s", host, port)
         return False
 
     async def async_step_user(self, user_input=None):
         """Step when user initializes a integration."""
-        self._errors = {}
+        errors = {}
         if user_input is not None:
             host = user_input.get(CONF_HOST)
             port = user_input.get(CONF_PORT, DEFAULT_PORT)
@@ -73,6 +67,8 @@ class AtenPEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     title = f"{host}:{port}"
                 return self.async_create_entry(title=title, data=user_input)
+            else:
+                errors[CONF_HOST] = "cannot_connect"
         else:
             user_input = {}
 
@@ -103,7 +99,7 @@ class AtenPEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ): str,
                 }
             ),
-            errors=self._errors,
+            errors=errors,
         )
 
     async def async_step_import(self, user_input=None):

--- a/homeassistant/components/aten_pe/const.py
+++ b/homeassistant/components/aten_pe/const.py
@@ -1,0 +1,8 @@
+"""Constants for aten_pe."""
+CONF_AUTH_KEY = "auth_key"
+CONF_COMMUNITY = "community"
+CONF_PRIV_KEY = "priv_key"
+DEFAULT_COMMUNITY = "private"
+DEFAULT_PORT = "161"
+DEFAULT_USERNAME = "administrator"
+DOMAIN = "aten_pe"

--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "aten_pe",
   "name": "ATEN Rack PDU",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aten_pe",
   "requirements": ["atenpdu==0.3.2"],
   "codeowners": ["@mtdcr"],

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -99,7 +99,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         switches.append(AtenSwitch(dev, info, mac, outlet.id, outlet.name))
 
     async_add_entities(switches, True)
-    return True
 
 
 class AtenSwitch(SwitchEntity):

--- a/homeassistant/components/aten_pe/translations/de.json
+++ b/homeassistant/components/aten_pe/translations/de.json
@@ -1,0 +1,24 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Ger\u00e4t ist bereits konfiguriert"
+        },
+        "error": {
+            "cannot_connect": "Verbindung fehlgeschlagen, versuchen Sie es erneut",
+            "unknown": "Unerwarteter Fehler"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "community": "SNMPv1 Community",
+                    "username": "SNMPv3 Benutzername",
+                    "auth_key": "SNMPv3 Auth Key",
+                    "priv_key": "SNMPv3 Priv Key"
+                },
+                "title": "Zugangsdaten"
+            }
+        }
+    }
+}

--- a/homeassistant/components/aten_pe/translations/de.json
+++ b/homeassistant/components/aten_pe/translations/de.json
@@ -4,8 +4,7 @@
             "already_configured": "Ger\u00e4t ist bereits konfiguriert"
         },
         "error": {
-            "cannot_connect": "Verbindung fehlgeschlagen, versuchen Sie es erneut",
-            "unknown": "Unerwarteter Fehler"
+            "cannot_connect": "Verbindung fehlgeschlagen, versuchen Sie es erneut"
         },
         "step": {
             "user": {

--- a/homeassistant/components/aten_pe/translations/en.json
+++ b/homeassistant/components/aten_pe/translations/en.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect, please try again",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "community": "SNMPv1 Community",
+                    "username": "SNMPv3 Username",
+                    "auth_key": "SNMPv3 Auth Key",
+                    "priv_key": "SNMPv3 Priv Key"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/aten_pe/translations/en.json
+++ b/homeassistant/components/aten_pe/translations/en.json
@@ -4,8 +4,7 @@
             "already_configured": "Device is already configured"
         },
         "error": {
-            "cannot_connect": "Failed to connect, please try again",
-            "unknown": "Unexpected error"
+            "cannot_connect": "Failed to connect, please try again"
         },
         "step": {
             "user": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -33,6 +33,7 @@ FLOWS = {
         "aseko_pool_live",
         "asuswrt",
         "atag",
+        "aten_pe",
         "august",
         "aurora",
         "aurora_abb_powerone",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -271,6 +271,9 @@ async-upnp-client==0.27.0
 # homeassistant.components.sleepiq
 asyncsleepiq==1.2.3
 
+# homeassistant.components.aten_pe
+atenpdu==0.3.2
+
 # homeassistant.components.aurora
 auroranoaa==0.0.2
 

--- a/tests/components/aten_pe/__init__.py
+++ b/tests/components/aten_pe/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ATEN PE component."""

--- a/tests/components/aten_pe/test_config_flow.py
+++ b/tests/components/aten_pe/test_config_flow.py
@@ -1,0 +1,15 @@
+"""Define tests for the ATEN PE config flow."""
+
+from homeassistant import data_entry_flow
+from homeassistant.components.aten_pe.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+
+
+async def test_show_form(hass):
+    """Test that the form is served with no input."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == SOURCE_USER


### PR DESCRIPTION
## Proposed change

This implements config flow for the aten_pe component.

I had this laying around for a year. Maybe someone else wants to take over from here.

Depends on https://github.com/home-assistant/core/pull/61906.

What's missing?
- Tests (config flow and yaml import)

## Type of change

- [ ] Dependency upgrade https://github.com/mtdcr/pductl/compare/0.3.0...0.3.2
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
