### PR TITLE
Silently retry Fronius inverter endpoint 2 times

### DIFF
--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, TypeVar
 
-from pyfronius import FroniusError
+from pyfronius import BadStatusError, FroniusError
 
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.core import callback
@@ -118,7 +118,6 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(minutes=10)
     valid_descriptions = INVERTER_ENTITY_DESCRIPTIONS
 
-    MAX_FAILED_UPDATES = 2
     SILENT_RETRIES = 3
 
     def __init__(
@@ -138,7 +137,7 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
                 data = await self.solar_net.fronius.current_inverter_data(
                     self.inverter_info.solar_net_id
                 )
-            except FroniusError as err:
+            except BadStatusError as err:
                 if silent_retry == (self.SILENT_RETRIES - 1):
                     raise err
                 continue

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -43,6 +43,8 @@ class FroniusCoordinatorBase(
     error_interval: timedelta
     valid_descriptions: list[SensorEntityDescription]
 
+    MAX_FAILED_UPDATES = 3
+
     def __init__(self, *args: Any, solar_net: FroniusSolarNet, **kwargs: Any) -> None:
         """Set up the FroniusCoordinatorBase class."""
         self._failed_update_count = 0
@@ -62,7 +64,7 @@ class FroniusCoordinatorBase(
                 data = await self._update_method()
             except FroniusError as err:
                 self._failed_update_count += 1
-                if self._failed_update_count == 3:
+                if self._failed_update_count == self.MAX_FAILED_UPDATES:
                     self.update_interval = self.error_interval
                 raise UpdateFailed(err) from err
 
@@ -116,6 +118,9 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
     error_interval = timedelta(minutes=10)
     valid_descriptions = INVERTER_ENTITY_DESCRIPTIONS
 
+    MAX_FAILED_UPDATES = 2
+    SILENT_RETRIES = 3
+
     def __init__(
         self, *args: Any, inverter_info: FroniusDeviceInfo, **kwargs: Any
     ) -> None:
@@ -125,9 +130,19 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
 
     async def _update_method(self) -> dict[SolarNetId, Any]:
         """Return data per solar net id from pyfronius."""
-        data = await self.solar_net.fronius.current_inverter_data(
-            self.inverter_info.solar_net_id
-        )
+        # almost 1% of `current_inverter_data` requests on Symo devices result in
+        # `BadStatusError Code: 8 - LNRequestTimeout` due to flaky internal
+        # communication between the logger and the inverter.
+        for silent_retry in range(self.SILENT_RETRIES):
+            try:
+                data = await self.solar_net.fronius.current_inverter_data(
+                    self.inverter_info.solar_net_id
+                )
+            except FroniusError as err:
+                if silent_retry == (self.SILENT_RETRIES - 1):
+                    raise err
+                continue
+            break
         # wrap a single devices data in a dict with solar_net_id key for
         # FroniusCoordinatorBase _async_update_data and add_entities_for_seen_keys
         return {self.inverter_info.solar_net_id: data}

--- a/tests/components/fronius/test_coordinator.py
+++ b/tests/components/fronius/test_coordinator.py
@@ -1,7 +1,7 @@
 """Test the Fronius update coordinators."""
 from unittest.mock import patch
 
-from pyfronius import FroniusError
+from pyfronius import BadStatusError, FroniusError
 
 from homeassistant.components.fronius.coordinator import (
     FroniusInverterUpdateCoordinator,
@@ -28,21 +28,21 @@ async def test_adaptive_update_interval(hass, aioclient_mock):
         mock_inverter_data.assert_called_once()
         mock_inverter_data.reset_mock()
 
-        mock_inverter_data.side_effect = FroniusError
-        # first 2 requests at default interval - 4th has different interval
+        mock_inverter_data.side_effect = FroniusError()
+        # first 3 bad requests at default interval - 4th has different interval
         for _ in range(3):
             async_fire_time_changed(
                 hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
             )
             await hass.async_block_till_done()
-        # 3 silent retries for inverter endpoint * 2 request intervals = 9
-        assert mock_inverter_data.call_count == 6
+        assert mock_inverter_data.call_count == 3
         mock_inverter_data.reset_mock()
+
         async_fire_time_changed(
             hass, dt.utcnow() + FroniusInverterUpdateCoordinator.error_interval
         )
         await hass.async_block_till_done()
-        assert mock_inverter_data.call_count == 3
+        assert mock_inverter_data.call_count == 1
         mock_inverter_data.reset_mock()
 
         mock_inverter_data.side_effect = None
@@ -59,3 +59,15 @@ async def test_adaptive_update_interval(hass, aioclient_mock):
         )
         await hass.async_block_till_done()
         mock_inverter_data.assert_called_once()
+        mock_inverter_data.reset_mock()
+
+        # BadStatusError on inverter endpoints have special handling
+        mock_inverter_data.side_effect = BadStatusError("mock_endpoint", 8)
+        # first 3 requests at default interval - 4th has different interval
+        for _ in range(3):
+            async_fire_time_changed(
+                hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+            )
+            await hass.async_block_till_done()
+        # BadStatusError does 3 silent retries for inverter endpoint * 3 request intervals = 9
+        assert mock_inverter_data.call_count == 9


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Almost 1% of `current_inverter_data()` (GetInverterRealtimeData.cgi with device scope) requests on Symo devices result in `BadStatusError Code: 8 - LNRequestTimeout` due to flaky internal communication between Datalogger (our bridge device) and inverter.
Subsequent calls always succeeded in my ~5000 tests - so we retry 2 times silently before raising an error (and writing to the log).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61783
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
