### PR TITLE
Remove deprecated yaml config from flux_led

### DIFF
--- a/homeassistant/components/flux_led/button.py
+++ b/homeassistant/components/flux_led/button.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import FluxLedUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import FluxLedUpdateCoordinator
 from .entity import FluxBaseEntity
 
 

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Flux LED/MagicLight."""
 from __future__ import annotations
 
-import logging
 from typing import Any, Final, cast
 
 from flux_led.const import ATTR_ID, ATTR_IPADDR, ATTR_MODEL, ATTR_MODEL_DESCRIPTION
@@ -40,9 +39,6 @@ from .discovery import (
 CONF_DEVICE: Final = "device"
 
 
-_LOGGER = logging.getLogger(__name__)
-
-
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Magic Home Integration."""
 
@@ -58,30 +54,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> OptionsFlow:
         """Get the options flow for the Flux LED component."""
         return OptionsFlow(config_entry)
-
-    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
-        """Handle configuration via YAML import."""
-        _LOGGER.debug("Importing configuration from YAML for flux_led")
-        host = user_input[CONF_HOST]
-        self._async_abort_entries_match({CONF_HOST: host})
-        if mac := user_input[CONF_MAC]:
-            await self.async_set_unique_id(dr.format_mac(mac), raise_on_progress=False)
-            self._abort_if_unique_id_configured(updates={CONF_HOST: host})
-        return self.async_create_entry(
-            title=user_input[CONF_NAME],
-            data={
-                CONF_HOST: host,
-                CONF_NAME: user_input[CONF_NAME],
-                CONF_PROTOCOL: user_input.get(CONF_PROTOCOL),
-            },
-            options={
-                CONF_CUSTOM_EFFECT_COLORS: user_input[CONF_CUSTOM_EFFECT_COLORS],
-                CONF_CUSTOM_EFFECT_SPEED_PCT: user_input[CONF_CUSTOM_EFFECT_SPEED_PCT],
-                CONF_CUSTOM_EFFECT_TRANSITION: user_input[
-                    CONF_CUSTOM_EFFECT_TRANSITION
-                ],
-            },
-        )
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle discovery via dhcp."""

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PROTOCOL
+from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import device_registry as dr

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -33,7 +33,6 @@ API: Final = "flux_api"
 
 SIGNAL_STATE_UPDATED = "flux_led_{}_state_updated"
 
-CONF_AUTOMATIC_ADD: Final = "automatic_add"
 DEFAULT_NETWORK_SCAN_INTERVAL: Final = 120
 DEFAULT_SCAN_INTERVAL: Final = 5
 DEFAULT_EFFECT_SPEED: Final = 50
@@ -50,21 +49,11 @@ FLUX_LED_EXCEPTIONS: Final = (
 STARTUP_SCAN_TIMEOUT: Final = 5
 DISCOVER_SCAN_TIMEOUT: Final = 10
 
-CONF_DEVICES: Final = "devices"
-CONF_CUSTOM_EFFECT: Final = "custom_effect"
 CONF_MODEL: Final = "model"
 CONF_MINOR_VERSION: Final = "minor_version"
 CONF_REMOTE_ACCESS_ENABLED: Final = "remote_access_enabled"
 CONF_REMOTE_ACCESS_HOST: Final = "remote_access_host"
 CONF_REMOTE_ACCESS_PORT: Final = "remote_access_port"
-
-MODE_AUTO: Final = "auto"
-MODE_RGB: Final = "rgb"
-MODE_RGBW: Final = "rgbw"
-
-# This mode enables white value to be controlled by brightness.
-# RGB value is ignored when this mode is specified.
-MODE_WHITE: Final = "w"
 
 TRANSITION_GRADUAL: Final = "gradual"
 TRANSITION_JUMP: Final = "jump"

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -17,7 +17,6 @@ from homeassistant.components.flux_led.const import (
     CONF_REMOTE_ACCESS_HOST,
     CONF_REMOTE_ACCESS_PORT,
     DOMAIN,
-    MODE_RGB,
     TRANSITION_JUMP,
     TRANSITION_STROBE,
 )
@@ -25,6 +24,7 @@ from homeassistant.const import (
     CONF_DEVICE,
     CONF_HOST,
     CONF_MAC,
+    CONF_MODE,
     CONF_NAME,
     CONF_PROTOCOL,
 )
@@ -215,56 +215,6 @@ async def test_discovery_no_device(hass: HomeAssistant):
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "no_devices_found"
-
-
-async def test_import(hass: HomeAssistant):
-    """Test import from yaml."""
-    config = {
-        CONF_HOST: IP_ADDRESS,
-        CONF_MAC: MAC_ADDRESS,
-        CONF_NAME: "floor lamp",
-        CONF_PROTOCOL: "ledenet",
-        CONF_MODEL: MODE_RGB,
-        CONF_CUSTOM_EFFECT_COLORS: "[255,0,0], [0,0,255]",
-        CONF_CUSTOM_EFFECT_SPEED_PCT: 30,
-        CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_STROBE,
-    }
-
-    # Success
-    with _patch_discovery(), _patch_wifibulb(), patch(
-        f"{MODULE}.async_setup", return_value=True
-    ) as mock_setup, patch(
-        f"{MODULE}.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "floor lamp"
-    assert result["data"] == {
-        CONF_HOST: IP_ADDRESS,
-        CONF_NAME: "floor lamp",
-        CONF_PROTOCOL: "ledenet",
-    }
-    assert result["options"] == {
-        CONF_CUSTOM_EFFECT_COLORS: "[255,0,0], [0,0,255]",
-        CONF_CUSTOM_EFFECT_SPEED_PCT: 30,
-        CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_STROBE,
-    }
-    mock_setup.assert_called_once()
-    mock_setup_entry.assert_called_once()
-
-    # Duplicate
-    with _patch_discovery(), _patch_wifibulb():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
 
 
 async def test_manual_working_discovery(hass: HomeAssistant):
@@ -584,7 +534,6 @@ async def test_options(hass: HomeAssistant):
         domain=DOMAIN,
         data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
         options={
-            CONF_MODEL: MODE_RGB,
             CONF_CUSTOM_EFFECT_COLORS: "[255,0,0], [0,0,255]",
             CONF_CUSTOM_EFFECT_SPEED_PCT: 30,
             CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_STROBE,

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -20,14 +20,7 @@ from homeassistant.components.flux_led.const import (
     TRANSITION_JUMP,
     TRANSITION_STROBE,
 )
-from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_HOST,
-    CONF_MAC,
-    CONF_MODE,
-    CONF_NAME,
-    CONF_PROTOCOL,
-)
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
 

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -1,6 +1,6 @@
 """Tests for light platform."""
 from datetime import timedelta
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 from flux_led.const import (
     COLOR_MODE_ADDRESSABLE as FLUX_COLOR_MODE_ADDRESSABLE,
@@ -54,10 +54,8 @@ from homeassistant.util.dt import utcnow
 
 from . import (
     DEFAULT_ENTRY_TITLE,
-    FLUX_DISCOVERY,
     IP_ADDRESS,
     MAC_ADDRESS,
-    MODEL,
     _mocked_bulb,
     _patch_discovery,
     _patch_wifibulb,

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -16,20 +16,12 @@ import pytest
 from homeassistant.components import flux_led
 from homeassistant.components.flux_led.const import (
     CONF_COLORS,
-    CONF_CUSTOM_EFFECT,
     CONF_CUSTOM_EFFECT_COLORS,
     CONF_CUSTOM_EFFECT_SPEED_PCT,
     CONF_CUSTOM_EFFECT_TRANSITION,
-    CONF_DEVICES,
-    CONF_MINOR_VERSION,
-    CONF_MODEL,
-    CONF_REMOTE_ACCESS_ENABLED,
-    CONF_REMOTE_ACCESS_HOST,
-    CONF_REMOTE_ACCESS_PORT,
     CONF_SPEED_PCT,
     CONF_TRANSITION,
     DOMAIN,
-    MODE_AUTO,
     TRANSITION_JUMP,
 )
 from homeassistant.components.light import (
@@ -51,8 +43,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_MODE,
     CONF_NAME,
-    CONF_PLATFORM,
-    CONF_PROTOCOL,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -971,7 +961,7 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
         data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
         unique_id=MAC_ADDRESS,
         options={
-            CONF_MODE: MODE_AUTO,
+            CONF_MODE: "auto",
             CONF_CUSTOM_EFFECT_COLORS: "[0,0,255], [255,0,0]",
             CONF_CUSTOM_EFFECT_SPEED_PCT: 88,
             CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_JUMP,
@@ -1047,7 +1037,7 @@ async def test_rgb_light_custom_effects_invalid_colors(
 ) -> None:
     """Test an rgb light with a invalid effect."""
     options = {
-        CONF_MODE: MODE_AUTO,
+        CONF_MODE: "auto",
         CONF_CUSTOM_EFFECT_SPEED_PCT: 88,
         CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_JUMP,
     }
@@ -1130,145 +1120,6 @@ async def test_rgb_light_custom_effect_via_service(
         [(0, 0, 255), (255, 0, 0)], 30, "jump"
     )
     bulb.async_set_custom_pattern.reset_mock()
-
-
-async def test_migrate_from_yaml_with_custom_effect(hass: HomeAssistant) -> None:
-    """Test migrate from yaml."""
-    config = {
-        LIGHT_DOMAIN: [
-            {
-                CONF_PLATFORM: DOMAIN,
-                CONF_DEVICES: {
-                    IP_ADDRESS: {
-                        CONF_NAME: "flux_lamppost",
-                        CONF_PROTOCOL: "ledenet",
-                        CONF_CUSTOM_EFFECT: {
-                            CONF_SPEED_PCT: 30,
-                            CONF_TRANSITION: "strobe",
-                            CONF_COLORS: [[255, 0, 0], [255, 255, 0], [0, 255, 0]],
-                        },
-                    }
-                },
-            }
-        ],
-    }
-
-    last_address = None
-
-    async def _discovery(self, *args, address=None, **kwargs):
-        # Only return discovery results when doing directed discovery
-        nonlocal last_address
-        last_address = address
-        return [FLUX_DISCOVERY] if address == IP_ADDRESS else []
-
-    def _mock_getBulbInfo(*args, **kwargs):
-        nonlocal last_address
-        return [FLUX_DISCOVERY] if last_address == IP_ADDRESS else []
-
-    with patch(
-        "homeassistant.components.flux_led.discovery.AIOBulbScanner.async_scan",
-        new=_discovery,
-    ), patch(
-        "homeassistant.components.flux_led.discovery.AIOBulbScanner.getBulbInfo",
-        new=_mock_getBulbInfo,
-    ), _patch_wifibulb():
-        await async_setup_component(hass, LIGHT_DOMAIN, config)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert entries
-
-    migrated_entry = None
-    for entry in entries:
-        if entry.unique_id == MAC_ADDRESS:
-            migrated_entry = entry
-            break
-
-    assert migrated_entry is not None
-    assert migrated_entry.data == {
-        CONF_HOST: IP_ADDRESS,
-        CONF_NAME: "flux_lamppost",
-        CONF_PROTOCOL: "ledenet",
-        CONF_MODEL: MODEL,
-        CONF_REMOTE_ACCESS_ENABLED: True,
-        CONF_REMOTE_ACCESS_HOST: "the.cloud",
-        CONF_REMOTE_ACCESS_PORT: 8816,
-        CONF_MINOR_VERSION: 0x04,
-    }
-    assert migrated_entry.options == {
-        CONF_CUSTOM_EFFECT_COLORS: "[(255, 0, 0), (255, 255, 0), (0, 255, 0)]",
-        CONF_CUSTOM_EFFECT_SPEED_PCT: 30,
-        CONF_CUSTOM_EFFECT_TRANSITION: "strobe",
-    }
-
-
-async def test_migrate_from_yaml_no_custom_effect(hass: HomeAssistant) -> None:
-    """Test migrate from yaml."""
-    config = {
-        LIGHT_DOMAIN: [
-            {
-                CONF_PLATFORM: DOMAIN,
-                CONF_DEVICES: {
-                    IP_ADDRESS: {
-                        CONF_NAME: "flux_lamppost",
-                        CONF_PROTOCOL: "ledenet",
-                    }
-                },
-            }
-        ],
-    }
-
-    last_address = None
-
-    async def _discovery(self, *args, address=None, **kwargs):
-        # Only return discovery results when doing directed discovery
-        nonlocal last_address
-        last_address = address
-        return [FLUX_DISCOVERY] if address == IP_ADDRESS else []
-
-    def _mock_getBulbInfo(*args, **kwargs):
-        nonlocal last_address
-        return [FLUX_DISCOVERY] if last_address == IP_ADDRESS else []
-
-    with patch(
-        "homeassistant.components.flux_led.discovery.AIOBulbScanner.async_scan",
-        new=_discovery,
-    ), patch(
-        "homeassistant.components.flux_led.discovery.AIOBulbScanner.getBulbInfo",
-        new=_mock_getBulbInfo,
-    ), _patch_wifibulb():
-        await async_setup_component(hass, LIGHT_DOMAIN, config)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert entries
-
-    migrated_entry = None
-    for entry in entries:
-        if entry.unique_id == MAC_ADDRESS:
-            migrated_entry = entry
-            break
-
-    assert migrated_entry is not None
-    assert migrated_entry.data == {
-        CONF_HOST: IP_ADDRESS,
-        CONF_NAME: "flux_lamppost",
-        CONF_PROTOCOL: "ledenet",
-        CONF_MODEL: MODEL,
-        CONF_REMOTE_ACCESS_ENABLED: True,
-        CONF_REMOTE_ACCESS_HOST: "the.cloud",
-        CONF_REMOTE_ACCESS_PORT: 8816,
-        CONF_MINOR_VERSION: 0x04,
-    }
-    assert migrated_entry.options == {
-        CONF_CUSTOM_EFFECT_COLORS: None,
-        CONF_CUSTOM_EFFECT_SPEED_PCT: 50,
-        CONF_CUSTOM_EFFECT_TRANSITION: "gradual",
-    }
 
 
 async def test_addressable_light(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the Flux Led integration has been removed.

Flux Led is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated yaml config from flux_led

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
