### PR TITLE
Use device registry in aten_pe

### DIFF
--- a/homeassistant/components/aten_pe/manifest.json
+++ b/homeassistant/components/aten_pe/manifest.json
@@ -2,7 +2,7 @@
   "domain": "aten_pe",
   "name": "ATEN Rack PDU",
   "documentation": "https://www.home-assistant.io/integrations/aten_pe",
-  "requirements": ["atenpdu==0.3.0"],
+  "requirements": ["atenpdu==0.3.2"],
   "codeowners": ["@mtdcr"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -91,7 +91,9 @@ class AtenSwitch(SwitchEntity):
 
     _attr_device_class = SwitchDeviceClass.OUTLET
 
-    def __init__(self, device, info, mac, outlet, name):
+    def __init__(
+        self, device: AtenPE, info: DeviceInfo, mac: str, outlet: str, name: str
+    ) -> None:
         """Initialize an ATEN PE switch."""
         self._device = device
         self._outlet = outlet

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -70,13 +71,13 @@ async def async_setup_platform(
         _LOGGER.error("Failed to initialize %s:%s: %s", node, serv, str(exc))
         raise PlatformNotReady from exc
 
-    info = {
-        "connections": {(CONNECTION_NETWORK_MAC, mac)},
-        "name": name,
-        "manufacturer": "ATEN",
-        "model": model,
-        "sw_version": sw_version,
-    }
+    info = DeviceInfo(
+        connections={(CONNECTION_NETWORK_MAC, mac)},
+        manufacturer="ATEN",
+        model=model,
+        name=name,
+        sw_version=sw_version,
+    )
 
     switches = []
     async for outlet in outlets:

--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -15,6 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -62,13 +63,24 @@ async def async_setup_platform(
         await hass.async_add_executor_job(dev.initialize)
         mac = await dev.deviceMAC()
         outlets = dev.outlets()
+        name = await dev.deviceName()
+        model = await dev.modelName()
+        sw_version = await dev.deviceFWversion()
     except AtenPEError as exc:
         _LOGGER.error("Failed to initialize %s:%s: %s", node, serv, str(exc))
         raise PlatformNotReady from exc
 
+    info = {
+        "connections": {(CONNECTION_NETWORK_MAC, mac)},
+        "name": name,
+        "manufacturer": "ATEN",
+        "model": model,
+        "sw_version": sw_version,
+    }
+
     switches = []
     async for outlet in outlets:
-        switches.append(AtenSwitch(dev, mac, outlet.id, outlet.name))
+        switches.append(AtenSwitch(dev, info, mac, outlet.id, outlet.name))
 
     async_add_entities(switches, True)
 
@@ -78,10 +90,11 @@ class AtenSwitch(SwitchEntity):
 
     _attr_device_class = SwitchDeviceClass.OUTLET
 
-    def __init__(self, device, mac, outlet, name):
+    def __init__(self, device, info, mac, outlet, name):
         """Initialize an ATEN PE switch."""
         self._device = device
         self._outlet = outlet
+        self._attr_device_info = info
         self._attr_unique_id = f"{mac}-{outlet}"
         self._attr_name = name or f"Outlet {outlet}"
 
@@ -101,6 +114,6 @@ class AtenSwitch(SwitchEntity):
         if status == "on":
             self._attr_is_on = True
             self._attr_current_power_w = await self._device.outletPower(self._outlet)
-        else:
+        elif status == "off":
             self._attr_is_on = False
             self._attr_current_power_w = 0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ async-upnp-client==0.23.3
 asyncpysupla==0.0.5
 
 # homeassistant.components.aten_pe
-atenpdu==0.3.0
+atenpdu==0.3.2
 
 # homeassistant.components.aurora
 auroranoaa==0.0.2


### PR DESCRIPTION
## Proposed change

This PR was factored out from https://github.com/home-assistant/core/pull/61806 and adds `device_info` to aten_pe.

## Type of change

- [x] Dependency upgrade https://github.com/mtdcr/pductl/compare/0.3.0...0.3.2
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
