### PR TITLE
Add get_image method to Stream

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -216,7 +216,7 @@ class Stream:
         self._thread_quit = threading.Event()
         self._outputs: dict[str, StreamOutput] = {}
         self._fast_restart_once = False
-        self._keyframe_converter = KeyFrameConverter()
+        self._keyframe_converter = KeyFrameConverter(hass)
         self._available: bool = True
         self._update_callback: Callable[[], None] | None = None
         self._logger = (
@@ -429,14 +429,6 @@ class Stream:
         width: int | None = None,
         height: int | None = None,
     ) -> bytes | None:
-        """
-        Fetch an image from the Stream and return it as a jpeg in bytes.
+        """Wrap get_image from KeyFrameConverter."""
 
-        This should only be called from the main thread.
-        """
-        # Use a lock to ensure only one thread is working on the keyframe at a time
-        async with self._keyframe_converter.lock:
-            self._keyframe_converter.image = await self.hass.async_add_executor_job(
-                self._keyframe_converter.generate_image, width, height
-            )
-        return self._keyframe_converter.image
+        return await self._keyframe_converter.get_image(width=width, height=height)

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -50,7 +50,7 @@ from .const import (
     STREAM_RESTART_RESET_TIME,
     TARGET_SEGMENT_DURATION_NON_LL_HLS,
 )
-from .core import PROVIDERS, IdleTimer, StreamOutput, StreamSettings
+from .core import PROVIDERS, IdleTimer, KeyFrame, StreamOutput, StreamSettings
 from .hls import HlsStreamOutput, async_setup_hls
 
 _LOGGER = logging.getLogger(__name__)
@@ -137,6 +137,8 @@ def filter_libav_logging() -> None:
 
     # Set log level to error for libav.mp4
     logging.getLogger("libav.mp4").setLevel(logging.ERROR)
+    # Suppress "deprecated pixel format" WARNING
+    logging.getLogger("libav.swscaler").setLevel(logging.ERROR)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -214,6 +216,7 @@ class Stream:
         self._thread_quit = threading.Event()
         self._outputs: dict[str, StreamOutput] = {}
         self._fast_restart_once = False
+        self.last_keyframe = KeyFrame()
         self._available: bool = True
         self._update_callback: Callable[[], None] | None = None
         self._logger = (
@@ -327,6 +330,7 @@ class Stream:
                     self.source,
                     self.options,
                     stream_state,
+                    self.last_keyframe,
                     self._thread_quit,
                 )
             except StreamWorkerError as err:
@@ -419,3 +423,8 @@ class Stream:
             # Wait for latest segment, then add the lookback
             await hls.recv()
             recorder.prepend(list(hls.get_segments())[-num_segments:])
+
+    async def get_image(self) -> bytes | None:
+        """Fetch an image from the Stream and return it as a jpeg in bytes."""
+
+        return await self.hass.async_add_executor_job(self.last_keyframe.get_bytes)

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -435,9 +435,8 @@ class Stream:
         This should only be called from the main thread.
         """
         # Use a lock to ensure only one thread is working on the keyframe at a time
-        await self._keyframe_converter.lock.acquire()
-        self._keyframe_converter.image = await self.hass.async_add_executor_job(
-            self._keyframe_converter.generate_image, width, height
-        )
-        self._keyframe_converter.lock.release()
+        async with self._keyframe_converter.lock:
+            self._keyframe_converter.image = await self.hass.async_add_executor_job(
+                self._keyframe_converter.generate_image, width, height
+            )
         return self._keyframe_converter.image

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -424,7 +424,11 @@ class Stream:
             await hls.recv()
             recorder.prepend(list(hls.get_segments())[-num_segments:])
 
-    async def get_image(self) -> bytes | None:
+    async def get_image(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+    ) -> bytes | None:
         """
         Fetch an image from the Stream and return it as a jpeg in bytes.
 
@@ -433,7 +437,7 @@ class Stream:
         # Use a lock to ensure only one thread is working on the keyframe at a time
         await self._keyframe_converter.lock.acquire()
         self._keyframe_converter.image = await self.hass.async_add_executor_job(
-            self._keyframe_converter.generate_image
+            self._keyframe_converter.generate_image, width, height
         )
         self._keyframe_converter.lock.release()
         return self._keyframe_converter.image

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -424,6 +424,6 @@ class Stream:
             await hls.recv()
             recorder.prepend(list(hls.get_segments())[-num_segments:])
 
-    async def get_image(self) -> bytes:
+    async def get_image(self) -> bytes | None:
         """Fetch an image from the Stream and return it as a jpeg in bytes."""
         return await self._keyframe_converter.get_image()

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -216,7 +216,7 @@ class Stream:
         self._thread_quit = threading.Event()
         self._outputs: dict[str, StreamOutput] = {}
         self._fast_restart_once = False
-        self.keyframe_converter = KeyFrameConverter()
+        self._keyframe_converter = KeyFrameConverter()
         self._available: bool = True
         self._update_callback: Callable[[], None] | None = None
         self._logger = (
@@ -330,7 +330,7 @@ class Stream:
                     self.source,
                     self.options,
                     stream_state,
-                    self.keyframe_converter,
+                    self._keyframe_converter,
                     self._thread_quit,
                 )
             except StreamWorkerError as err:
@@ -426,5 +426,4 @@ class Stream:
 
     async def get_image(self) -> bytes:
         """Fetch an image from the Stream and return it as a jpeg in bytes."""
-
-        return await self.keyframe_converter.get_keyframe_image()
+        return await self._keyframe_converter.get_image()

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -42,3 +42,5 @@ STREAM_RESTART_RESET_TIME = 300  # Reset wait_timeout after this many seconds
 CONF_LL_HLS = "ll_hls"
 CONF_PART_DURATION = "part_duration"
 CONF_SEGMENT_DURATION = "segment_duration"
+
+KEYFRAME_TIMEOUT = 60  # Number of seconds to wait for the next keyframe in get_image

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -42,5 +42,3 @@ STREAM_RESTART_RESET_TIME = 300  # Reset wait_timeout after this many seconds
 CONF_LL_HLS = "ll_hls"
 CONF_PART_DURATION = "part_duration"
 CONF_SEGMENT_DURATION = "segment_duration"
-
-KEYFRAME_TIMEOUT = 10  # Number of seconds to wait for the worker to get the keyframe

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -43,4 +43,4 @@ CONF_LL_HLS = "ll_hls"
 CONF_PART_DURATION = "part_duration"
 CONF_SEGMENT_DURATION = "segment_duration"
 
-KEYFRAME_TIMEOUT = 60  # Number of seconds to wait for the next keyframe in get_image
+KEYFRAME_TIMEOUT = 10  # Number of seconds to wait for the worker to get the keyframe

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -392,7 +392,7 @@ class KeyFrameConverter:
         """
         Create a codec context to be used for decoding the keyframes.
 
-        This is run by the worker thread and will only be called once.
+        This is run by the worker thread and will only be called once per worker.
         """
 
         # Keep import here so that we can import stream integration without installing reqs

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -390,7 +390,7 @@ class KeyFrameConverter:
         self._hass = hass
         self._image: bytes | None = None
         self._turbojpeg = TurboJPEGSingleton.instance()
-        self.lock = asyncio.Lock()
+        self._lock = asyncio.Lock()
         self._codec_context: CodecContext | None = None
 
     def create_codec_context(self, codec_context: CodecContext) -> None:
@@ -431,6 +431,6 @@ class KeyFrameConverter:
     ) -> bytes | None:
         """Fetch an image from the Stream and return it as a jpeg in bytes."""
         # Use a lock to ensure only one thread is working on the keyframe at a time
-        async with self.lock:
+        async with self._lock:
             await self._hass.async_add_executor_job(self._generate_image, width, height)
         return self._image

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -375,7 +375,7 @@ class KeyFrameConverter:
         self._turbojpeg = TurboJPEGSingleton.instance()
         self.lock = asyncio.Lock()
 
-    def generate_image(self) -> bytes | None:
+    def generate_image(self, width: int | None, height: int | None) -> bytes | None:
         """Generate the keyframe image. This is called in an executor thread."""
         if not (self._turbojpeg and self.packet):
             return self.image
@@ -387,6 +387,9 @@ class KeyFrameConverter:
             if frames := packet.decode():
                 break
         if frames:
-            bgr_array = frames[0].to_ndarray(format="bgr24")
+            frame = frames[0]
+            if width and height:
+                frame = frame.reformat(width=width, height=height)
+            bgr_array = frame.to_ndarray(format="bgr24")
             image = bytes(self._turbojpeg.encode(bgr_array))
         return image

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -381,9 +381,11 @@ class KeyFrameConverter:
         if not (self._turbojpeg and self.packet):
             return self.image
         image = None
+        packet = self.packet
+        self.packet = None
         # decode packet (try up to 3 times)
         for _i in range(3):
-            if frames := self.packet.decode():
+            if frames := packet.decode():
                 break
         if frames:
             image_file = BytesIO()

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -382,10 +382,12 @@ class KeyFrameConverter:
         image = None
         packet = self.packet
         self.packet = None
-        # decode packet (try up to 3 times)
-        for _i in range(3):
-            if frames := packet.decode():
+        # decode packet (flush afterwards)
+        frames = packet.decode()
+        for _i in range(2):
+            if frames:
                 break
+            frames = packet.stream.codec_context.decode(None)
         if frames:
             frame = frames[0]
             if width and height:

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -5,7 +5,6 @@ import asyncio
 from collections import deque
 from collections.abc import Iterable
 import datetime
-from io import BytesIO
 from typing import TYPE_CHECKING
 
 from aiohttp import web
@@ -388,9 +387,6 @@ class KeyFrameConverter:
             if frames := packet.decode():
                 break
         if frames:
-            image_file = BytesIO()
             bgr_array = frames[0].to_ndarray(format="bgr24")
-            image_file.write(self._turbojpeg.encode(bgr_array))
-            image = image_file.getvalue()
-            image_file.close()
+            image = bytes(self._turbojpeg.encode(bgr_array))
         return image

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -376,8 +376,8 @@ class KeyFrame:
         from homeassistant.components.camera.img_util import TurboJPEGSingleton
 
         self.keyframe: Packet | bytes | None = None
-        self.turbojpeg = TurboJPEGSingleton.instance()
         self.get_bytes = self._get_bytes
+        self.turbojpeg = TurboJPEGSingleton.instance()
         if not self.turbojpeg:
             self.get_bytes = lambda: None
 

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -2,7 +2,7 @@
   "domain": "stream",
   "name": "Stream",
   "documentation": "https://www.home-assistant.io/integrations/stream",
-  "requirements": ["ha-av==8.0.4-rc.1"],
+  "requirements": ["ha-av==8.0.4-rc.1", "PyTurboJPEG==1.6.3"],
   "dependencies": ["http"],
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
   "quality_scale": "internal",

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -476,7 +476,7 @@ def stream_worker(
 
     def is_video(packet: av.Packet) -> Any:
         """Return true if the packet is for the video stream."""
-        return packet.stream == video_stream
+        return packet.stream.type == "video"
 
     # Have to work around two problems with RTSP feeds in ffmpeg
     # 1 - first frame has bad pts/dts https://trac.ffmpeg.org/ticket/5018
@@ -538,5 +538,5 @@ def stream_worker(
 
             muxer.mux_packet(packet)
 
-            if packet.is_keyframe and packet.stream.type == "video":
+            if packet.is_keyframe and is_video(packet):
                 keyframe_converter.packet = packet

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -454,8 +454,7 @@ def stream_worker(
         video_stream = container.streams.video[0]
     except (KeyError, IndexError) as ex:
         raise StreamWorkerError("Stream has no video") from ex
-    # Since we are only decoding one frame at a time we don't need threading
-    video_stream.codec_context.thread_type = "NONE"
+    keyframe_converter.create_codec_context(codec_context=video_stream.codec_context)
     try:
         audio_stream = container.streams.audio[0]
     except (KeyError, IndexError):

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -14,7 +14,7 @@ import av
 
 from homeassistant.core import HomeAssistant
 
-from . import redact_credentials
+from . import KeyFrame, redact_credentials
 from .const import (
     ATTR_SETTINGS,
     AUDIO_CODECS,
@@ -439,6 +439,7 @@ def stream_worker(
     source: str,
     options: dict[str, str],
     stream_state: StreamState,
+    last_keyframe: KeyFrame,
     quit_event: Event,
 ) -> None:
     """Handle consuming streams."""
@@ -535,3 +536,5 @@ def stream_worker(
                 raise StreamWorkerError("Error demuxing stream: %s" % str(ex)) from ex
 
             muxer.mux_packet(packet)
+            if packet.is_keyframe and packet.stream.type == "video":
+                last_keyframe.keyframe = packet

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -14,7 +14,7 @@ import av
 
 from homeassistant.core import HomeAssistant
 
-from . import KeyFrame, redact_credentials
+from . import KeyFrameConverter, redact_credentials
 from .const import (
     ATTR_SETTINGS,
     AUDIO_CODECS,
@@ -439,7 +439,7 @@ def stream_worker(
     source: str,
     options: dict[str, str],
     stream_state: StreamState,
-    last_keyframe: KeyFrame,
+    keyframe_converter: KeyFrameConverter,
     quit_event: Event,
 ) -> None:
     """Handle consuming streams."""
@@ -539,5 +539,9 @@ def stream_worker(
 
             muxer.mux_packet(packet)
 
-            if packet.is_keyframe and packet.stream.type == "video":
-                last_keyframe.keyframe = packet
+            if (
+                keyframe_converter.image_requested
+                and packet.is_keyframe
+                and packet.stream.type == "video"
+            ):
+                keyframe_converter.generate_keyframe_image(packet)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -539,9 +539,8 @@ def stream_worker(
 
             muxer.mux_packet(packet)
 
-            if (
-                keyframe_converter.image_requested
-                and packet.is_keyframe
-                and packet.stream.type == "video"
-            ):
-                keyframe_converter.generate_keyframe_image(packet)
+            if packet.is_keyframe and packet.stream.type == "video":
+                keyframe_converter.packet = packet
+
+            if keyframe_converter.image_requested:
+                keyframe_converter.check_generate_image()

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -454,6 +454,8 @@ def stream_worker(
         video_stream = container.streams.video[0]
     except (KeyError, IndexError) as ex:
         raise StreamWorkerError("Stream has no video") from ex
+    # Since we are only decoding one frame at a time we don't need threading
+    video_stream.codec_context.thread_type = "NONE"
     try:
         audio_stream = container.streams.audio[0]
     except (KeyError, IndexError):

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -541,6 +541,3 @@ def stream_worker(
 
             if packet.is_keyframe and packet.stream.type == "video":
                 keyframe_converter.packet = packet
-
-            if keyframe_converter.image_requested:
-                keyframe_converter.check_generate_image()

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -538,5 +538,6 @@ def stream_worker(
                 raise StreamWorkerError("Error demuxing stream: %s" % str(ex)) from ex
 
             muxer.mux_packet(packet)
+
             if packet.is_keyframe and packet.stream.type == "video":
                 last_keyframe.keyframe = packet

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -55,6 +55,7 @@ PySocks==1.7.1
 PyTransportNSW==0.1.1
 
 # homeassistant.components.camera
+# homeassistant.components.stream
 PyTurboJPEG==1.6.3
 
 # homeassistant.components.vicare

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -33,6 +33,7 @@ PyRMVtransport==0.3.3
 PyTransportNSW==0.1.1
 
 # homeassistant.components.camera
+# homeassistant.components.stream
 PyTurboJPEG==1.6.3
 
 # homeassistant.components.vicare

--- a/tests/components/camera/common.py
+++ b/tests/components/camera/common.py
@@ -29,4 +29,5 @@ def mock_turbo_jpeg(
         (second_width, second_height, 0, 0),
     ]
     mocked_turbo_jpeg.scale_with_quality.return_value = EMPTY_8_6_JPEG
+    mocked_turbo_jpeg.encode.return_value = EMPTY_8_6_JPEG
     return mocked_turbo_jpeg

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -104,6 +104,11 @@ class FakeAvInputStream:
 
         self.codec_context = FakeCodecContext()
 
+    @property
+    def type(self):
+        """Return packet type."""
+        return "video" if self.name == VIDEO_STREAM_FORMAT else "audio"
+
     def __str__(self) -> str:
         """Return a stream name for debugging."""
         return f"FakePyAvStream<{self.name}, {self.time_base}>"

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -272,7 +272,7 @@ def run_worker(hass, stream, stream_source):
     """Run the stream worker under test."""
     stream_state = StreamState(hass, stream.outputs)
     stream_worker(
-        stream_source, {}, stream_state, KeyFrameConverter(), threading.Event()
+        stream_source, {}, stream_state, KeyFrameConverter(hass), threading.Event()
     )
 
 
@@ -888,7 +888,7 @@ async def test_get_image(hass, record_worker_sync):
     with patch.object(hass.config, "is_allowed_path", return_value=True):
         await stream.async_record("/example/path")
 
-    assert stream._keyframe_converter.image is None
+    assert stream._keyframe_converter._image is None
 
     await record_worker_sync.join()
 

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -98,6 +98,12 @@ class FakeAvInputStream:
 
         self.codec = FakeCodec()
 
+        class FakeCodecContext:
+            name = "h264"
+            extradata = None
+
+        self.codec_context = FakeCodecContext()
+
     def __str__(self) -> str:
         """Return a stream name for debugging."""
         return f"FakePyAvStream<{self.name}, {self.time_base}>"

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -883,7 +883,7 @@ async def test_get_image(hass, record_worker_sync):
     with patch.object(hass.config, "is_allowed_path", return_value=True):
         await stream.async_record("/example/path")
 
-    assert stream.keyframe_converter._image == b""
+    assert stream._keyframe_converter._image == b""
     image_future = asyncio.create_task(stream.get_image())
 
     await record_worker_sync.join()

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -13,7 +13,6 @@ pushed to the output streams. The packet sequence can be used to exercise
 failure modes or corner cases like how out of order packets are handled.
 """
 
-import asyncio
 import fractions
 import io
 import logging
@@ -883,12 +882,10 @@ async def test_get_image(hass, record_worker_sync):
     with patch.object(hass.config, "is_allowed_path", return_value=True):
         await stream.async_record("/example/path")
 
-    assert stream._keyframe_converter._image is None
-    image_future = asyncio.create_task(stream.get_image())
+    assert stream._keyframe_converter.image is None
 
     await record_worker_sync.join()
 
-    image = await image_future
-    assert image == EMPTY_8_6_JPEG
+    assert await stream.get_image() == EMPTY_8_6_JPEG
 
     stream.stop()

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -883,7 +883,7 @@ async def test_get_image(hass, record_worker_sync):
     with patch.object(hass.config, "is_allowed_path", return_value=True):
         await stream.async_record("/example/path")
 
-    assert stream._keyframe_converter._image == b""
+    assert stream._keyframe_converter._image is None
     image_future = asyncio.create_task(stream.get_image())
 
     await record_worker_sync.join()

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -98,11 +98,6 @@ class FakeAvInputStream:
 
         self.codec = FakeCodec()
 
-        class FakeCodecContext:
-            thread_type = "SLICE"
-
-        self.codec_context = FakeCodecContext()
-
     def __str__(self) -> str:
         """Return a stream name for debugging."""
         return f"FakePyAvStream<{self.name}, {self.time_base}>"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a `get_image` method to `Stream` which generates a still image from the most recent keyframe in the RTSP feed. This can be used by camera platforms that support Stream but have no still snapshot url. This can be used as an alternative to using haffmpeg to establish a new connection to the camera whenever an image is requested, but for this to work properly the stream must be active (ie "preload stream" needs to be on).
The jpeg creation step requires turbojpeg to be installed (alternatively we could use pillow).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
