### PR TITLE
Add input_button

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -65,6 +65,7 @@ components: &components
   - homeassistant/components/homeassistant/**
   - homeassistant/components/image/*
   - homeassistant/components/input_boolean/*
+  - homeassistant/components/input_button/*
   - homeassistant/components/input_datetime/*
   - homeassistant/components/input_number/*
   - homeassistant/components/input_select/*

--- a/.strict-typing
+++ b/.strict-typing
@@ -65,6 +65,7 @@ homeassistant.components.http.*
 homeassistant.components.huawei_lte.*
 homeassistant.components.hyperion.*
 homeassistant.components.image_processing.*
+homeassistant.components.input_button.*
 homeassistant.components.input_select.*
 homeassistant.components.integration.*
 homeassistant.components.iqvia.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -425,6 +425,8 @@ homeassistant/components/influxdb/* @fabaff @mdegat01
 tests/components/influxdb/* @fabaff @mdegat01
 homeassistant/components/input_boolean/* @home-assistant/core
 tests/components/input_boolean/* @home-assistant/core
+homeassistant/components/input_button/* @home-assistant/core
+tests/components/input_button/* @home-assistant/core
 homeassistant/components/input_datetime/* @home-assistant/core
 tests/components/input_datetime/* @home-assistant/core
 homeassistant/components/input_number/* @home-assistant/core

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -11,6 +11,7 @@
     "frontend",
     "history",
     "input_boolean",
+    "input_button",
     "input_datetime",
     "input_number",
     "input_select",

--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -119,6 +119,22 @@ async def async_setup(hass, config):
         )
     )
 
+    # Set up input button
+    tasks.append(
+        bootstrap.async_setup_component(
+            hass,
+            "input_button",
+            {
+                "input_button": {
+                    "bell": {
+                        "icon": "mdi:bell-ring-outline",
+                        "name": "Ring bell",
+                    }
+                }
+            },
+        )
+    )
+
     # Set up input number
     tasks.append(
         bootstrap.async_setup_component(

--- a/homeassistant/components/input_button/__init__.py
+++ b/homeassistant/components/input_button/__init__.py
@@ -1,0 +1,171 @@
+"""Support to keep track of user controlled buttons for within automations."""
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+import voluptuous as vol
+
+from homeassistant.components.button import SERVICE_PRESS, ButtonEntity
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    CONF_ICON,
+    CONF_ID,
+    CONF_NAME,
+    SERVICE_RELOAD,
+)
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import collection
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import RestoreEntity
+import homeassistant.helpers.service
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import ConfigType
+
+DOMAIN = "input_button"
+
+_LOGGER = logging.getLogger(__name__)
+
+CREATE_FIELDS = {
+    vol.Required(CONF_NAME): vol.All(str, vol.Length(min=1)),
+    vol.Optional(CONF_ICON): cv.icon,
+}
+
+UPDATE_FIELDS = {
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_ICON): cv.icon,
+}
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: cv.schema_with_slug_keys(vol.Any(UPDATE_FIELDS, None))},
+    extra=vol.ALLOW_EXTRA,
+)
+
+RELOAD_SERVICE_SCHEMA = vol.Schema({})
+STORAGE_KEY = DOMAIN
+STORAGE_VERSION = 1
+
+
+class InputButtonStorageCollection(collection.StorageCollection):
+    """Input button collection stored in storage."""
+
+    CREATE_SCHEMA = vol.Schema(CREATE_FIELDS)
+    UPDATE_SCHEMA = vol.Schema(UPDATE_FIELDS)
+
+    async def _process_create_data(self, data: dict) -> vol.Schema:
+        """Validate the config is valid."""
+        return self.CREATE_SCHEMA(data)
+
+    @callback
+    def _get_suggested_id(self, info: dict) -> str:
+        """Suggest an ID based on the config."""
+        return cast(str, info[CONF_NAME])
+
+    async def _update_data(self, data: dict, update_data: dict) -> dict:
+        """Return a new updated data object."""
+        update_data = self.UPDATE_SCHEMA(update_data)
+        return {**data, **update_data}
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up an input button."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    id_manager = collection.IDManager()
+
+    yaml_collection = collection.YamlCollection(
+        logging.getLogger(f"{__name__}.yaml_collection"), id_manager
+    )
+    collection.sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, yaml_collection, InputButton.from_yaml
+    )
+
+    storage_collection = InputButtonStorageCollection(
+        Store(hass, STORAGE_VERSION, STORAGE_KEY),
+        logging.getLogger(f"{__name__}.storage_collection"),
+        id_manager,
+    )
+    collection.sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, storage_collection, InputButton
+    )
+
+    await yaml_collection.async_load(
+        [{CONF_ID: id_, **(conf or {})} for id_, conf in config.get(DOMAIN, {}).items()]
+    )
+    await storage_collection.async_load()
+
+    collection.StorageCollectionWebsocket(
+        storage_collection, DOMAIN, DOMAIN, CREATE_FIELDS, UPDATE_FIELDS
+    ).async_setup(hass)
+
+    async def reload_service_handler(service_call: ServiceCall) -> None:
+        """Remove all input buttons and load new ones from config."""
+        conf = await component.async_prepare_reload(skip_reset=True)
+        if conf is None:
+            return
+        await yaml_collection.async_load(
+            [
+                {CONF_ID: id_, **(conf or {})}
+                for id_, conf in conf.get(DOMAIN, {}).items()
+            ]
+        )
+
+    homeassistant.helpers.service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        reload_service_handler,
+        schema=RELOAD_SERVICE_SCHEMA,
+    )
+
+    component.async_register_entity_service(SERVICE_PRESS, {}, "_async_press_action")
+
+    return True
+
+
+class InputButton(ButtonEntity, RestoreEntity):
+    """Representation of a button."""
+
+    _attr_should_poll = False
+
+    def __init__(self, config: ConfigType) -> None:
+        """Initialize a button."""
+        self._config = config
+        self.editable = True
+        self._attr_unique_id = config[CONF_ID]
+
+    @classmethod
+    def from_yaml(cls, config: ConfigType) -> ButtonEntity:
+        """Return entity instance initialized from yaml storage."""
+        button = cls(config)
+        button.entity_id = f"{DOMAIN}.{config[CONF_ID]}"
+        button.editable = False
+        return button
+
+    @property
+    def name(self) -> str | None:
+        """Return name of the button."""
+        return self._config.get(CONF_NAME)
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon to be used for this entity."""
+        return self._config.get(CONF_ICON)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, bool]:
+        """Return the state attributes of the entity."""
+        return {ATTR_EDITABLE: self.editable}
+
+    async def async_press(self) -> None:
+        """Press the button.
+
+        Left emtpty intentionally.
+        The input button itself doesn't trigger anything.
+        """
+        return None
+
+    async def async_update_config(self, config: ConfigType) -> None:
+        """Handle when the config is updated."""
+        self._config = config
+        self.async_write_ha_state()

--- a/homeassistant/components/input_button/__init__.py
+++ b/homeassistant/components/input_button/__init__.py
@@ -1,4 +1,4 @@
-"""Support to keep track of user controlled buttons for within automations."""
+"""Support to keep track of user controlled buttons which can be used in automations."""
 from __future__ import annotations
 
 import logging

--- a/homeassistant/components/input_button/manifest.json
+++ b/homeassistant/components/input_button/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "input_button",
+  "name": "Input Button",
+  "documentation": "https://www.home-assistant.io/integrations/input_button",
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/input_button/services.yaml
+++ b/homeassistant/components/input_button/services.yaml
@@ -1,0 +1,6 @@
+press:
+  name: Press
+  description: Press the input button entity.
+  target:
+    entity:
+      domain: input_button

--- a/mypy.ini
+++ b/mypy.ini
@@ -726,6 +726,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.input_button.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.input_select.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -102,6 +102,7 @@ ALLOWED_USED_COMPONENTS = {
     "hassio",
     "homeassistant",
     "input_boolean",
+    "input_button",
     "input_datetime",
     "input_number",
     "input_select",

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -64,6 +64,7 @@ NO_IOT_CLASS = [
     "image_processing",
     "image",
     "input_boolean",
+    "input_button",
     "input_datetime",
     "input_number",
     "input_select",

--- a/tests/components/input_button/__init__.py
+++ b/tests/components/input_button/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the input_test component."""

--- a/tests/components/input_button/test_init.py
+++ b/tests/components/input_button/test_init.py
@@ -241,6 +241,38 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     assert result[storage_ent][ATTR_NAME] == "from storage"
 
 
+async def test_ws_create_update(hass, hass_ws_client, storage_setup):
+    """Test creating and updating via WS."""
+    assert await storage_setup(config={DOMAIN: {}})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 7, "type": f"{DOMAIN}/create", "name": "new"})
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(f"{DOMAIN}.new")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "new"
+
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
+
+    await client.send_json(
+        {"id": 8, "type": f"{DOMAIN}/update", f"{DOMAIN}_id": "new", "name": "newer"}
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(f"{DOMAIN}.new")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "newer"
+
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "new") is not None
+
+
 async def test_ws_delete(hass, hass_ws_client, storage_setup):
     """Test WS delete cleans up entity registry."""
     assert await storage_setup()

--- a/tests/components/input_button/test_init.py
+++ b/tests/components/input_button/test_init.py
@@ -1,0 +1,284 @@
+"""The tests for the input_test component."""
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.input_button import DOMAIN, SERVICE_PRESS
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    ATTR_NAME,
+    SERVICE_RELOAD,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import Context, CoreState, State
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import mock_component, mock_restore_cache
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def storage_setup(hass, hass_storage):
+    """Storage setup."""
+
+    async def _storage(items=None, config=None):
+        if items is None:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {"items": [{"id": "from_storage", "name": "from storage"}]},
+            }
+        else:
+            hass_storage[DOMAIN] = items
+        if config is None:
+            config = {DOMAIN: {}}
+        return await async_setup_component(hass, DOMAIN, config)
+
+    return _storage
+
+
+async def test_config(hass):
+    """Test config."""
+    invalid_configs = [None, 1, {}, {"name with space": None}]
+
+    for cfg in invalid_configs:
+        assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
+
+
+async def test_config_options(hass):
+    """Test configuration options."""
+    count_start = len(hass.states.async_entity_ids())
+
+    _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test_1": None,
+                "test_2": {"name": "Hello World", "icon": "mdi:work"},
+            }
+        },
+    )
+
+    _LOGGER.debug("ENTITIES: %s", hass.states.async_entity_ids())
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_button.test_1")
+    state_2 = hass.states.get("input_button.test_2")
+
+    assert state_1 is not None
+    assert state_2 is not None
+
+    assert state_1.state == STATE_UNKNOWN
+    assert ATTR_ICON not in state_1.attributes
+    assert ATTR_FRIENDLY_NAME not in state_1.attributes
+
+    assert state_2.state == STATE_UNKNOWN
+    assert state_2.attributes.get(ATTR_FRIENDLY_NAME) == "Hello World"
+    assert state_2.attributes.get(ATTR_ICON) == "mdi:work"
+
+
+async def test_restore_state(hass):
+    """Ensure states are restored on startup."""
+    mock_restore_cache(
+        hass,
+        (State("input_button.b1", "2021-01-01T23:59:59+00:00"),),
+    )
+
+    hass.state = CoreState.starting
+    mock_component(hass, "recorder")
+
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": None, "b2": None}})
+
+    state = hass.states.get("input_button.b1")
+    assert state
+    assert state.state == "2021-01-01T23:59:59+00:00"
+
+    state = hass.states.get("input_button.b2")
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_input_button_context(hass, hass_admin_user):
+    """Test that input_button context works."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"update": {}}})
+
+    state = hass.states.get("input_button.update")
+    assert state is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: state.entity_id},
+        True,
+        Context(user_id=hass_admin_user.id),
+    )
+
+    state2 = hass.states.get("input_button.update")
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == hass_admin_user.id
+
+
+async def test_reload(hass, hass_admin_user):
+    """Test reload service."""
+    count_start = len(hass.states.async_entity_ids())
+    ent_reg = er.async_get(hass)
+
+    _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
+
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test_1": None,
+                "test_2": {"name": "Hello World", "icon": "mdi:work"},
+            }
+        },
+    )
+
+    _LOGGER.debug("ENTITIES: %s", hass.states.async_entity_ids())
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_button.test_1")
+    state_2 = hass.states.get("input_button.test_2")
+    state_3 = hass.states.get("input_button.test_3")
+
+    assert state_1 is not None
+    assert state_2 is not None
+    assert state_3 is None
+
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is None
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value={
+            DOMAIN: {
+                "test_2": {
+                    "name": "Hello World reloaded",
+                    "icon": "mdi:work_reloaded",
+                },
+                "test_3": None,
+            }
+        },
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+
+    assert count_start + 2 == len(hass.states.async_entity_ids())
+
+    state_1 = hass.states.get("input_button.test_1")
+    state_2 = hass.states.get("input_button.test_2")
+    state_3 = hass.states.get("input_button.test_3")
+
+    assert state_1 is None
+    assert state_2 is not None
+    assert state_3 is not None
+
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_2") is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, "test_3") is not None
+
+
+async def test_load_from_storage(hass, storage_setup):
+    """Test set up from storage."""
+    assert await storage_setup()
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "from storage"
+    assert state.attributes.get(ATTR_EDITABLE)
+
+
+async def test_editable_state_attribute(hass, storage_setup):
+    """Test editable attribute."""
+    assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
+
+    state = hass.states.get(f"{DOMAIN}.from_storage")
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "from storage"
+    assert state.attributes.get(ATTR_EDITABLE)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state.state == STATE_UNKNOWN
+    assert not state.attributes.get(ATTR_EDITABLE)
+
+
+async def test_ws_list(hass, hass_ws_client, storage_setup):
+    """Test listing via WS."""
+    assert await storage_setup(config={DOMAIN: {"from_yaml": None}})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 6, "type": f"{DOMAIN}/list"})
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    storage_ent = "from_storage"
+    yaml_ent = "from_yaml"
+    result = {item["id"]: item for item in resp["result"]}
+
+    assert len(result) == 1
+    assert storage_ent in result
+    assert yaml_ent not in result
+    assert result[storage_ent][ATTR_NAME] == "from storage"
+
+
+async def test_ws_delete(hass, hass_ws_client, storage_setup):
+    """Test WS delete cleans up entity registry."""
+    assert await storage_setup()
+
+    input_id = "from_storage"
+    input_entity_id = f"{DOMAIN}.{input_id}"
+    ent_reg = er.async_get(hass)
+
+    state = hass.states.get(input_entity_id)
+    assert state is not None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is not None
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 6, "type": f"{DOMAIN}/delete", f"{DOMAIN}_id": f"{input_id}"}
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(input_entity_id)
+    assert state is None
+    assert ent_reg.async_get_entity_id(DOMAIN, DOMAIN, input_id) is None
+
+
+async def test_setup_no_config(hass, hass_admin_user):
+    """Test component setup with no config."""
+    count_start = len(hass.states.async_entity_ids())
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file", autospec=True, return_value={}
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+
+    assert count_start == len(hass.states.async_entity_ids())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the first steps for `input_button`.
It has been requested quite a bit, the main use case seems to be: Kicking off an existing automations as a button.

```yaml
input_button:
  bell:
    name: Ring it!
```

Storage support has been added, so it can support the frontend helpers in a followup PR as well. Additionally for follow up is Alexa, Google Assistant & HomeKit support.

Frontend PR: <https://github.com/home-assistant/frontend/pull/10974>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20764
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/10974
- Link to brands pull request: https://github.com/home-assistant/brands/pull/3014

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
