### PR TITLE
Mqtt rework on value templates

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -317,6 +317,36 @@ class MqttCommandTemplate:
         )
 
 
+class MqttValueTemplate:
+    """Class for rendering MQTT value template with possible json values."""
+
+    def __init__(
+        self,
+        value_template: template.Template | None,
+        hass: HomeAssistant,
+    ) -> None:
+        """Instantiate a value template."""
+        self._attr_value_template = value_template
+        if value_template is None:
+            return
+
+        value_template.hass = hass
+
+    @callback
+    def async_render_with_possible_json_value(
+        self,
+        payload: ReceivePayloadType,
+        variables: template.TemplateVarsType = None,
+    ) -> ReceivePayloadType:
+        """Render with possible json value or pass-though a received MQTT value."""
+        if self._attr_value_template is None:
+            return payload
+
+        return self._attr_value_template.async_render_with_possible_json_value(
+            payload, variables=variables
+        )
+
+
 @dataclass
 class MqttServiceInfo(BaseServiceInfo):
     """Prepared info from mqtt entries."""

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -367,17 +367,12 @@ class MqttValueTemplate:
 
         if default == _SENTINEL:
             return self._attr_value_template.async_render_with_possible_json_value(
-                payload, variables=values or None
+                payload, variables=values
             )
 
         return self._attr_value_template.async_render_with_possible_json_value(
             payload, default, variables=values
         )
-
-    @property
-    def value_template(self) -> template.Template | None:
-        """Return the active value template or None."""
-        return self._attr_value_template
 
 
 @dataclass

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -324,6 +324,7 @@ class MqttValueTemplate:
         self,
         value_template: template.Template | None,
         hass: HomeAssistant,
+        variables: template.TemplateVarsType = None,
     ) -> None:
         """Instantiate a value template."""
         self._attr_value_template = value_template
@@ -331,6 +332,9 @@ class MqttValueTemplate:
             return
 
         value_template.hass = hass
+
+        if variables is not None:
+            self._variables = variables
 
     @callback
     def async_render_with_possible_json_value(
@@ -342,8 +346,15 @@ class MqttValueTemplate:
         if self._attr_value_template is None:
             return payload
 
+        values: dict[str, Any] = {}
+        if self._variables is not None:
+            values.update(self._variables)
+
+        if variables is not None:
+            values.update(variables)
+
         return self._attr_value_template.async_render_with_possible_json_value(
-            payload, variables=variables
+            payload, variables=values
         )
 
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -331,7 +331,7 @@ class MqttValueTemplate:
         config_attributes: template.TemplateVarsType = None,
     ) -> None:
         """Instantiate a value template."""
-        self._attr_value_template = value_template
+        self._value_template = value_template
         self._config_attributes = config_attributes
         if value_template is None:
             return
@@ -350,7 +350,7 @@ class MqttValueTemplate:
         variables: template.TemplateVarsType = None,
     ) -> ReceivePayloadType:
         """Render with possible json value or pass-though a received MQTT value."""
-        if self._attr_value_template is None:
+        if self._value_template is None:
             return payload
 
         values: dict[str, Any] = {}
@@ -366,11 +366,11 @@ class MqttValueTemplate:
             values[ATTR_NAME] = self._entity.name
 
         if default == _SENTINEL:
-            return self._attr_value_template.async_render_with_possible_json_value(
+            return self._value_template.async_render_with_possible_json_value(
                 payload, variables=values
             )
 
-        return self._attr_value_template.async_render_with_possible_json_value(
+        return self._value_template.async_render_with_possible_json_value(
             payload, default, variables=values
         )
 

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, MqttCommandTemplate, subscription
+from . import PLATFORMS, MqttCommandTemplate, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -165,9 +165,9 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
         return DISCOVERY_SCHEMA
 
     def _setup_from_config(self, config):
-        value_template = self._config.get(CONF_VALUE_TEMPLATE)
-        if value_template is not None:
-            value_template.hass = self.hass
+        self._value_template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
         self._command_template = MqttCommandTemplate(
             self._config[CONF_COMMAND_TEMPLATE], entity=self
         ).async_render
@@ -179,12 +179,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg):
             """Run when new MQTT message has been received."""
-            payload = msg.payload
-            value_template = self._config.get(CONF_VALUE_TEMPLATE)
-            if value_template is not None:
-                payload = value_template.async_render_with_possible_json_value(
-                    msg.payload, self._state
-                )
+            payload = self._value_template(msg.payload)
             if payload not in (
                 STATE_ALARM_DISARMED,
                 STATE_ALARM_ARMED_HOME,

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -166,7 +166,8 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
 
     def _setup_from_config(self, config):
         self._value_template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE),
+            entity=self,
         ).async_render_with_possible_json_value
         self._command_template = MqttCommandTemplate(
             self._config[CONF_COMMAND_TEMPLATE], entity=self

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -120,7 +120,8 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
 
     def _setup_from_config(self, config):
         self._value_template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE),
+            entity=self,
         ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import CONF_ENCODING, CONF_QOS, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -119,9 +119,9 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
         return DISCOVERY_SCHEMA
 
     def _setup_from_config(self, config):
-        value_template = self._config.get(CONF_VALUE_TEMPLATE)
-        if value_template is not None:
-            value_template.hass = self.hass
+        self._value_template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -137,7 +137,6 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
         @log_messages(self.hass, self.entity_id)
         def state_message_received(msg):
             """Handle a new received MQTT state message."""
-            payload = msg.payload
             # auto-expire enabled?
             expire_after = self._config.get(CONF_EXPIRE_AFTER)
 
@@ -159,20 +158,16 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
                     self.hass, self._value_is_expired, expiration_at
                 )
 
-            value_template = self._config.get(CONF_VALUE_TEMPLATE)
-            if value_template is not None:
-                payload = value_template.async_render_with_possible_json_value(
-                    payload, variables={"entity_id": self.entity_id}
+            payload = self._value_template(msg.payload)
+            if not payload.strip():  # No output from template, ignore
+                _LOGGER.debug(
+                    "Empty template output for entity: %s with state topic: %s. Payload: '%s', with value template '%s'",
+                    self._config[CONF_NAME],
+                    self._config[CONF_STATE_TOPIC],
+                    msg.payload,
+                    self._config.get(CONF_VALUE_TEMPLATE),
                 )
-                if not payload.strip():  # No output from template, ignore
-                    _LOGGER.debug(
-                        "Empty template output for entity: %s with state topic: %s. Payload: '%s', with value template '%s'",
-                        self._config[CONF_NAME],
-                        self._config[CONF_STATE_TOPIC],
-                        msg.payload,
-                        value_template,
-                    )
-                    return
+                return
 
             if payload == self._config[CONF_PAYLOAD_ON]:
                 self._state = True
@@ -180,8 +175,8 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
                 self._state = False
             else:  # Payload is not for this entity
                 template_info = ""
-                if value_template is not None:
-                    template_info = f", template output: '{payload}', with value template '{str(value_template)}'"
+                if self._config.get(CONF_VALUE_TEMPLATE) is not None:
+                    template_info = f", template output: '{payload}', with value template '{str(self._config.get(CONF_VALUE_TEMPLATE))}'"
                 _LOGGER.info(
                     "No matching payload found for entity: %s with state topic: %s. Payload: '%s'%s",
                     self._config[CONF_NAME],

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -386,7 +386,10 @@ class MqttClimate(MqttEntity, ClimateEntity):
         for key in VALUE_TEMPLATE_KEYS & config.keys():
             value_templates[key] = config[key]
         self._value_templates = {
-            key: MqttValueTemplate(template, self).async_render_with_possible_json_value
+            key: MqttValueTemplate(
+                template,
+                entity=self,
+            ).async_render_with_possible_json_value
             for key, template in value_templates.items()
         }
 

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -56,7 +56,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import MQTT_BASE_PLATFORM_SCHEMA, PLATFORMS, MqttCommandTemplate, subscription
+from . import (
+    MQTT_BASE_PLATFORM_SCHEMA,
+    PLATFORMS,
+    MqttCommandTemplate,
+    MqttValueTemplate,
+    subscription,
+)
 from .. import mqtt
 from .const import CONF_ENCODING, CONF_QOS, CONF_RETAIN, DOMAIN
 from .debug_info import log_messages
@@ -372,19 +378,17 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         value_templates = {}
         for key in VALUE_TEMPLATE_KEYS:
-            value_templates[key] = lambda value: value
+            value_templates[key] = None
         if CONF_VALUE_TEMPLATE in config:
-            value_template = config.get(CONF_VALUE_TEMPLATE)
-            value_template.hass = self.hass
             value_templates = {
-                key: value_template.async_render_with_possible_json_value
-                for key in VALUE_TEMPLATE_KEYS
+                key: config.get(CONF_VALUE_TEMPLATE) for key in VALUE_TEMPLATE_KEYS
             }
         for key in VALUE_TEMPLATE_KEYS & config.keys():
-            tpl = config[key]
-            value_templates[key] = tpl.async_render_with_possible_json_value
-            tpl.hass = self.hass
-        self._value_templates = value_templates
+            value_templates[key] = config[key]
+        self._value_templates = {
+            key: MqttValueTemplate(template, self).async_render_with_possible_json_value
+            for key, template in value_templates.items()
+        }
 
         command_templates = {}
         for key in COMMAND_TEMPLATE_KEYS:

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -40,7 +40,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, MqttCommandTemplate, subscription
+from . import PLATFORMS, MqttCommandTemplate, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -303,27 +303,38 @@ class MqttCover(MqttEntity, CoverEntity):
             # Force into optimistic tilt mode.
             self._tilt_optimistic = True
 
-        value_template = self._config.get(CONF_VALUE_TEMPLATE)
-        if value_template is not None:
-            value_template.hass = self.hass
+        template_config_attributes = {
+            "position_open": self._config[CONF_POSITION_OPEN],
+            "position_closed": self._config[CONF_POSITION_CLOSED],
+            "tilt_min": self._config[CONF_TILT_MIN],
+            "tilt_max": self._config[CONF_TILT_MAX],
+        }
+
+        self._value_template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
         self._set_position_template = MqttCommandTemplate(
             self._config.get(CONF_SET_POSITION_TEMPLATE), entity=self
         ).async_render
 
-        get_position_template = self._config.get(CONF_GET_POSITION_TEMPLATE)
-        if get_position_template is not None:
-            get_position_template.hass = self.hass
+        self._get_position_template = MqttValueTemplate(
+            self._config.get(CONF_GET_POSITION_TEMPLATE),
+            self,
+            config_attributes=template_config_attributes,
+        ).async_render_with_possible_json_value
 
         self._set_tilt_template = MqttCommandTemplate(
             self._config.get(CONF_TILT_COMMAND_TEMPLATE), entity=self
         ).async_render
 
-        tilt_status_template = self._config.get(CONF_TILT_STATUS_TEMPLATE)
-        if tilt_status_template is not None:
-            tilt_status_template.hass = self.hass
+        self._tilt_status_template = MqttValueTemplate(
+            self._config.get(CONF_TILT_STATUS_TEMPLATE),
+            self,
+            config_attributes=template_config_attributes,
+        ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):  # noqa: C901
+    async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -331,19 +342,7 @@ class MqttCover(MqttEntity, CoverEntity):
         @log_messages(self.hass, self.entity_id)
         def tilt_message_received(msg):
             """Handle tilt updates."""
-            payload = msg.payload
-            template = self._config.get(CONF_TILT_STATUS_TEMPLATE)
-            if template is not None:
-                variables = {
-                    "entity_id": self.entity_id,
-                    "position_open": self._config[CONF_POSITION_OPEN],
-                    "position_closed": self._config[CONF_POSITION_CLOSED],
-                    "tilt_min": self._config[CONF_TILT_MIN],
-                    "tilt_max": self._config[CONF_TILT_MAX],
-                }
-                payload = template.async_render_with_possible_json_value(
-                    payload, variables=variables
-                )
+            payload = self._tilt_status_template(msg.payload)
 
             if not payload:
                 _LOGGER.debug("Ignoring empty tilt message from '%s'", msg.topic)
@@ -355,13 +354,7 @@ class MqttCover(MqttEntity, CoverEntity):
         @log_messages(self.hass, self.entity_id)
         def state_message_received(msg):
             """Handle new MQTT state messages."""
-            payload = msg.payload
-            template = self._config.get(CONF_VALUE_TEMPLATE)
-            if template is not None:
-                variables = {"entity_id": self.entity_id}
-                payload = template.async_render_with_possible_json_value(
-                    payload, variables=variables
-                )
+            payload = self._value_template(msg.payload)
 
             if not payload:
                 _LOGGER.debug("Ignoring empty state message from '%s'", msg.topic)
@@ -399,44 +392,29 @@ class MqttCover(MqttEntity, CoverEntity):
         @log_messages(self.hass, self.entity_id)
         def position_message_received(msg):
             """Handle new MQTT position messages."""
-            payload = msg.payload
+            payload = self._get_position_template(msg.payload)
 
-            template = self._config.get(CONF_GET_POSITION_TEMPLATE)
-            if template is not None:
-                variables = {
-                    "entity_id": self.entity_id,
-                    "position_open": self._config[CONF_POSITION_OPEN],
-                    "position_closed": self._config[CONF_POSITION_CLOSED],
-                    "tilt_min": self._config[CONF_TILT_MIN],
-                    "tilt_max": self._config[CONF_TILT_MAX],
-                }
-                payload = template.async_render_with_possible_json_value(
-                    payload, variables=variables
-                )
+            if not payload:
+                _LOGGER.debug("Ignoring empty position message from '%s'", msg.topic)
+                return
 
-                if not payload:
-                    _LOGGER.debug(
-                        "Ignoring empty position message from '%s'", msg.topic
+            try:
+                payload = json_loads(payload)
+            except JSONDecodeError:
+                pass
+
+            if isinstance(payload, dict):
+                if "position" not in payload:
+                    _LOGGER.warning(
+                        "Template (position_template) returned JSON without position attribute"
                     )
                     return
-
-                try:
-                    payload = json_loads(payload)
-                except JSONDecodeError:
-                    pass
-
-                if isinstance(payload, dict):
-                    if "position" not in payload:
-                        _LOGGER.warning(
-                            "Template (position_template) returned JSON without position attribute"
-                        )
-                        return
-                    if "tilt_position" in payload:
-                        if not self._config.get(CONF_TILT_STATE_OPTIMISTIC):
-                            # reset forced set tilt optimistic
-                            self._tilt_optimistic = False
-                        self.tilt_payload_received(payload["tilt_position"])
-                    payload = payload["position"]
+                if "tilt_position" in payload:
+                    if not self._config.get(CONF_TILT_STATE_OPTIMISTIC):
+                        # reset forced set tilt optimistic
+                        self._tilt_optimistic = False
+                    self.tilt_payload_received(payload["tilt_position"])
+                payload = payload["position"]
 
             try:
                 percentage_payload = self.find_percentage_in_range(

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -311,7 +311,8 @@ class MqttCover(MqttEntity, CoverEntity):
         }
 
         self._value_template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE),
+            entity=self,
         ).async_render_with_possible_json_value
 
         self._set_position_template = MqttCommandTemplate(
@@ -320,7 +321,7 @@ class MqttCover(MqttEntity, CoverEntity):
 
         self._get_position_template = MqttValueTemplate(
             self._config.get(CONF_GET_POSITION_TEMPLATE),
-            self,
+            entity=self,
             config_attributes=template_config_attributes,
         ).async_render_with_possible_json_value
 
@@ -330,7 +331,7 @@ class MqttCover(MqttEntity, CoverEntity):
 
         self._tilt_status_template = MqttValueTemplate(
             self._config.get(CONF_TILT_STATUS_TEMPLATE),
-            self,
+            entity=self,
             config_attributes=template_config_attributes,
         ).async_render_with_possible_json_value
 

--- a/homeassistant/components/mqtt/device_tracker/schema_discovery.py
+++ b/homeassistant/components/mqtt/device_tracker/schema_discovery.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
-from .. import subscription
+from .. import MqttValueTemplate, subscription
 from ... import mqtt
 from ..const import CONF_QOS, CONF_STATE_TOPIC
 from ..debug_info import log_messages
@@ -73,9 +73,9 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
-        value_template = self._config.get(CONF_VALUE_TEMPLATE)
-        if value_template is not None:
-            value_template.hass = self.hass
+        self._value_template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -84,10 +84,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg):
             """Handle new MQTT messages."""
-            payload = msg.payload
-            value_template = self._config.get(CONF_VALUE_TEMPLATE)
-            if value_template is not None:
-                payload = value_template.async_render_with_possible_json_value(payload)
+            payload = self._value_template(msg.payload)
             if payload == self._config[CONF_PAYLOAD_HOME]:
                 self._location_name = STATE_HOME
             elif payload == self._config[CONF_PAYLOAD_NOT_HOME]:

--- a/homeassistant/components/mqtt/device_tracker/schema_discovery.py
+++ b/homeassistant/components/mqtt/device_tracker/schema_discovery.py
@@ -74,7 +74,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
         self._value_template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -357,7 +357,8 @@ class MqttFan(MqttEntity, FanEntity):
 
         for key, tpl in self._value_templates.items():
             self._value_templates[key] = MqttValueTemplate(
-                tpl, self
+                tpl,
+                entity=self,
             ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -40,7 +40,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from . import PLATFORMS, MqttCommandTemplate, subscription
+from . import PLATFORMS, MqttCommandTemplate, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -356,11 +356,9 @@ class MqttFan(MqttEntity, FanEntity):
             ).async_render
 
         for key, tpl in self._value_templates.items():
-            if tpl is None:
-                self._value_templates[key] = lambda value: value
-            else:
-                tpl.hass = self.hass
-                self._value_templates[key] = tpl.async_render_with_possible_json_value
+            self._value_templates[key] = MqttValueTemplate(
+                tpl, self
+            ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, MqttCommandTemplate, subscription
+from . import PLATFORMS, MqttCommandTemplate, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -262,11 +262,9 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
             ).async_render
 
         for key, tpl in self._value_templates.items():
-            if tpl is None:
-                self._value_templates[key] = lambda value: value
-            else:
-                tpl.hass = self.hass
-                self._value_templates[key] = tpl.async_render_with_possible_json_value
+            self._value_templates[key] = MqttValueTemplate(
+                tpl, self
+            ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -263,7 +263,8 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
 
         for key, tpl in self._value_templates.items():
             self._value_templates[key] = MqttValueTemplate(
-                tpl, self
+                tpl,
+                entity=self,
             ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -51,7 +51,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.util.color as color_util
 
-from .. import MqttCommandTemplate, subscription
+from .. import MqttCommandTemplate, MqttValueTemplate, subscription
 from ... import mqtt
 from ..const import (
     CONF_COMMAND_TOPIC,
@@ -325,12 +325,17 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
 
         value_templates = {}
         for key in VALUE_TEMPLATE_KEYS:
-            value_templates[key] = lambda value, _: value
+            value_templates[key] = None
+        if CONF_VALUE_TEMPLATE in config:
+            value_templates = {
+                key: config.get(CONF_VALUE_TEMPLATE) for key in VALUE_TEMPLATE_KEYS
+            }
         for key in VALUE_TEMPLATE_KEYS & config.keys():
-            tpl = config[key]
-            value_templates[key] = tpl.async_render_with_possible_json_value
-            tpl.hass = self.hass
-        self._value_templates = value_templates
+            value_templates[key] = config[key]
+        self._value_templates = {
+            key: MqttValueTemplate(template, self).async_render_with_possible_json_value
+            for key, template in value_templates.items()
+        }
 
         command_templates = {}
         for key in COMMAND_TEMPLATE_KEYS:

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -333,7 +333,9 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         for key in VALUE_TEMPLATE_KEYS & config.keys():
             value_templates[key] = config[key]
         self._value_templates = {
-            key: MqttValueTemplate(template, self).async_render_with_possible_json_value
+            key: MqttValueTemplate(
+                template, entity=self
+            ).async_render_with_possible_json_value
             for key, template in value_templates.items()
         }
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -33,7 +33,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.util.color as color_util
 
-from .. import subscription
+from .. import MqttValueTemplate, subscription
 from ... import mqtt
 from ..const import (
     CONF_COMMAND_TOPIC,
@@ -160,7 +160,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
         """(Re)Subscribe to topics."""
         for tpl in self._templates.values():
             if tpl is not None:
-                tpl.hass = self.hass
+                tpl = MqttValueTemplate(tpl, self)
 
         last_state = await self.async_get_last_state()
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -160,7 +160,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
         """(Re)Subscribe to topics."""
         for tpl in self._templates.values():
             if tpl is not None:
-                tpl = MqttValueTemplate(tpl, self)
+                tpl = MqttValueTemplate(tpl, entity=self)
 
         last_state = await self.async_get_last_state()
 

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -119,7 +119,8 @@ class MqttLock(MqttEntity, LockEntity):
         self._optimistic = config[CONF_OPTIMISTIC]
 
         self._value_template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE),
+            entity=self,
         ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -118,9 +118,9 @@ class MqttLock(MqttEntity, LockEntity):
         """(Re)Setup the entity."""
         self._optimistic = config[CONF_OPTIMISTIC]
 
-        value_template = self._config.get(CONF_VALUE_TEMPLATE)
-        if value_template is not None:
-            value_template.hass = self.hass
+        self._value_template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -129,10 +129,7 @@ class MqttLock(MqttEntity, LockEntity):
         @log_messages(self.hass, self.entity_id)
         def message_received(msg):
             """Handle new MQTT messages."""
-            payload = msg.payload
-            value_template = self._config.get(CONF_VALUE_TEMPLATE)
-            if value_template is not None:
-                payload = value_template.async_render_with_possible_json_value(payload)
+            payload = self._value_template(msg.payload)
             if payload == self._config[CONF_STATE_LOCKED]:
                 self._state = True
             elif payload == self._config[CONF_STATE_UNLOCKED]:

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.entity import (
 )
 from homeassistant.helpers.typing import ConfigType
 
-from . import DATA_MQTT, debug_info, publish, subscription
+from . import DATA_MQTT, MqttValueTemplate, debug_info, publish, subscription
 from .const import (
     ATTR_DISCOVERY_HASH,
     ATTR_DISCOVERY_PAYLOAD,
@@ -254,17 +254,15 @@ class MqttAttributes(Entity):
 
     async def _attributes_subscribe_topics(self):
         """(Re)Subscribe to topics."""
-        attr_tpl = self._attributes_config.get(CONF_JSON_ATTRS_TEMPLATE)
-        if attr_tpl is not None:
-            attr_tpl.hass = self.hass
+        attr_tpl = MqttValueTemplate(
+            self._attributes_config.get(CONF_JSON_ATTRS_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
         @callback
         @log_messages(self.hass, self.entity_id)
         def attributes_message_received(msg: ReceiveMessage) -> None:
             try:
-                payload = msg.payload
-                if attr_tpl is not None:
-                    payload = attr_tpl.async_render_with_possible_json_value(payload)
+                payload = attr_tpl(msg.payload)
                 json_dict = json.loads(payload) if isinstance(payload, str) else None
                 if isinstance(json_dict, dict):
                     filtered_dict = {
@@ -356,14 +354,9 @@ class MqttAvailability(Entity):
             topic,  # pylint: disable=unused-variable
             avail_topic_conf,
         ) in self._avail_topics.items():
-            tpl = avail_topic_conf[CONF_AVAILABILITY_TEMPLATE]
-            if tpl is None:
-                avail_topic_conf[CONF_AVAILABILITY_TEMPLATE] = lambda value: value
-            else:
-                tpl.hass = self.hass
-                avail_topic_conf[
-                    CONF_AVAILABILITY_TEMPLATE
-                ] = tpl.async_render_with_possible_json_value
+            avail_topic_conf[CONF_AVAILABILITY_TEMPLATE] = MqttValueTemplate(
+                avail_topic_conf[CONF_AVAILABILITY_TEMPLATE], self
+            ).async_render_with_possible_json_value
 
         self._avail_config = config
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -255,7 +255,7 @@ class MqttAttributes(Entity):
     async def _attributes_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         attr_tpl = MqttValueTemplate(
-            self._attributes_config.get(CONF_JSON_ATTRS_TEMPLATE), self
+            self._attributes_config.get(CONF_JSON_ATTRS_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
         @callback
@@ -355,7 +355,8 @@ class MqttAvailability(Entity):
             avail_topic_conf,
         ) in self._avail_topics.items():
             avail_topic_conf[CONF_AVAILABILITY_TEMPLATE] = MqttValueTemplate(
-                avail_topic_conf[CONF_AVAILABILITY_TEMPLATE], self
+                avail_topic_conf[CONF_AVAILABILITY_TEMPLATE],
+                entity=self,
             ).async_render_with_possible_json_value
 
         self._avail_config = config

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -158,7 +158,8 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
                 config.get(CONF_COMMAND_TEMPLATE), entity=self
             ).async_render,
             CONF_VALUE_TEMPLATE: MqttValueTemplate(
-                config.get(CONF_VALUE_TEMPLATE), self
+                config.get(CONF_VALUE_TEMPLATE),
+                entity=self,
             ).async_render_with_possible_json_value,
         }
 

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, MqttCommandTemplate, subscription
+from . import PLATFORMS, MqttCommandTemplate, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -157,17 +157,10 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
             CONF_COMMAND_TEMPLATE: MqttCommandTemplate(
                 config.get(CONF_COMMAND_TEMPLATE), entity=self
             ).async_render,
-            CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
+            CONF_VALUE_TEMPLATE: MqttValueTemplate(
+                config.get(CONF_VALUE_TEMPLATE), self
+            ).async_render_with_possible_json_value,
         }
-
-        value_template = self._templates[CONF_VALUE_TEMPLATE]
-        if value_template is None:
-            self._templates[CONF_VALUE_TEMPLATE] = lambda value: value
-        else:
-            value_template.hass = self.hass
-            self._templates[
-                CONF_VALUE_TEMPLATE
-            ] = value_template.async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -124,7 +124,8 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
                 config.get(CONF_COMMAND_TEMPLATE), entity=self
             ).async_render,
             CONF_VALUE_TEMPLATE: MqttValueTemplate(
-                config.get(CONF_VALUE_TEMPLATE), self
+                config.get(CONF_VALUE_TEMPLATE),
+                entity=self,
             ).async_render_with_possible_json_value,
         }
 

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, MqttCommandTemplate, subscription
+from . import PLATFORMS, MqttCommandTemplate, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -123,17 +123,10 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
             CONF_COMMAND_TEMPLATE: MqttCommandTemplate(
                 config.get(CONF_COMMAND_TEMPLATE), entity=self
             ).async_render,
-            CONF_VALUE_TEMPLATE: config.get(CONF_VALUE_TEMPLATE),
+            CONF_VALUE_TEMPLATE: MqttValueTemplate(
+                config.get(CONF_VALUE_TEMPLATE), self
+            ).async_render_with_possible_json_value,
         }
-
-        value_template = self._templates[CONF_VALUE_TEMPLATE]
-        if value_template is None:
-            self._templates[CONF_VALUE_TEMPLATE] = lambda value: value
-        else:
-            value_template.hass = self.hass
-            self._templates[
-                CONF_VALUE_TEMPLATE
-            ] = value_template.async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -168,10 +168,10 @@ class MqttSensor(MqttEntity, SensorEntity):
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
         self._template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
         self._last_reset_template = MqttValueTemplate(
-            self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE), self
+            self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import CONF_ENCODING, CONF_QOS, CONF_STATE_TOPIC, DOMAIN
 from .debug_info import log_messages
@@ -167,19 +167,18 @@ class MqttSensor(MqttEntity, SensorEntity):
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
-        template = self._config.get(CONF_VALUE_TEMPLATE)
-        if template is not None:
-            template.hass = self.hass
-        last_reset_template = self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE)
-        if last_reset_template is not None:
-            last_reset_template.hass = self.hass
+        self._template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
+        self._last_reset_template = MqttValueTemplate(
+            self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
         def _update_state(msg):
-            payload = msg.payload
             # auto-expire enabled?
             expire_after = self._config.get(CONF_EXPIRE_AFTER)
             if expire_after is not None and expire_after > 0:
@@ -198,14 +197,7 @@ class MqttSensor(MqttEntity, SensorEntity):
                     self.hass, self._value_is_expired, expiration_at
                 )
 
-            template = self._config.get(CONF_VALUE_TEMPLATE)
-            if template is not None:
-                variables = {"entity_id": self.entity_id}
-                payload = template.async_render_with_possible_json_value(
-                    payload,
-                    self._state,
-                    variables=variables,
-                )
+            payload = self._template(msg.payload)
 
             if payload is not None and self.device_class in (
                 SensorDeviceClass.DATE,
@@ -221,16 +213,8 @@ class MqttSensor(MqttEntity, SensorEntity):
             self._state = payload
 
         def _update_last_reset(msg):
-            payload = msg.payload
+            payload = self._last_reset_template(msg.payload)
 
-            template = self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE)
-            if template is not None:
-                variables = {"entity_id": self.entity_id}
-                payload = template.async_render_with_possible_json_value(
-                    payload,
-                    self._state,
-                    variables=variables,
-                )
             if not payload:
                 _LOGGER.debug("Ignoring empty last_reset message from '%s'", msg.topic)
                 return

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -129,7 +129,7 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
         self._optimistic = config[CONF_OPTIMISTIC]
 
         self._value_template = MqttValueTemplate(
-            self._config.get(CONF_VALUE_TEMPLATE), self
+            self._config.get(CONF_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import PLATFORMS, subscription
+from . import PLATFORMS, MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     CONF_COMMAND_TOPIC,
@@ -128,9 +128,9 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
 
         self._optimistic = config[CONF_OPTIMISTIC]
 
-        template = self._config.get(CONF_VALUE_TEMPLATE)
-        if template is not None:
-            template.hass = self.hass
+        self._value_template = MqttValueTemplate(
+            self._config.get(CONF_VALUE_TEMPLATE), self
+        ).async_render_with_possible_json_value
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -139,10 +139,7 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
         @log_messages(self.hass, self.entity_id)
         def state_message_received(msg):
             """Handle new MQTT state messages."""
-            payload = msg.payload
-            template = self._config.get(CONF_VALUE_TEMPLATE)
-            if template is not None:
-                payload = template.async_render_with_possible_json_value(payload)
+            payload = self._value_template(msg.payload)
             if payload == self._state_on:
                 self._state = True
             elif payload == self._state_off:

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 
-from . import subscription
+from . import MqttValueTemplate, subscription
 from .. import mqtt
 from .const import (
     ATTR_DISCOVERY_HASH,
@@ -143,12 +143,9 @@ class MQTTTagScanner:
         )
 
     def _setup_from_config(self, config):
-        self._value_template = lambda value, error_value: value
-        if CONF_VALUE_TEMPLATE in config:
-            value_template = config.get(CONF_VALUE_TEMPLATE)
-            value_template.hass = self.hass
-
-            self._value_template = value_template.async_render_with_possible_json_value
+        self._value_template = MqttValueTemplate(
+            config.get(CONF_VALUE_TEMPLATE), self.hass
+        ).async_render_with_possible_json_value
 
     async def setup(self):
         """Set up the MQTT tag scanner."""
@@ -171,7 +168,7 @@ class MQTTTagScanner:
         """Subscribe to MQTT topics."""
 
         async def tag_scanned(msg):
-            tag_id = self._value_template(msg.payload, error_value="").strip()
+            tag_id = self._value_template(msg.payload, "").strip()
             if not tag_id:  # No output from template, ignore
                 return
 

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -144,7 +144,8 @@ class MQTTTagScanner:
 
     def _setup_from_config(self, config):
         self._value_template = MqttValueTemplate(
-            config.get(CONF_VALUE_TEMPLATE), self.hass
+            config.get(CONF_VALUE_TEMPLATE),
+            hass=self.hass,
         ).async_render_with_possible_json_value
 
     async def setup(self):

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -244,7 +244,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         """(Re)Subscribe to topics."""
         for tpl in self._templates.values():
             if tpl is not None:
-                tpl = MqttValueTemplate(tpl, self)
+                tpl = MqttValueTemplate(tpl, entity=self)
 
         @callback
         @log_messages(self.hass, self.entity_id)

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.icon import icon_for_battery_level
 
-from .. import subscription
+from .. import MqttValueTemplate, subscription
 from ... import mqtt
 from ..const import CONF_COMMAND_TOPIC, CONF_ENCODING, CONF_QOS, CONF_RETAIN
 from ..debug_info import log_messages
@@ -244,7 +244,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         """(Re)Subscribe to topics."""
         for tpl in self._templates.values():
             if tpl is not None:
-                tpl.hass = self.hass
+                tpl = MqttValueTemplate(tpl, self)
 
         @callback
         @log_messages(self.hass, self.entity_id)
@@ -256,7 +256,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             ):
                 battery_level = self._templates[
                     CONF_BATTERY_LEVEL_TEMPLATE
-                ].async_render_with_possible_json_value(msg.payload, error_value=None)
+                ].async_render_with_possible_json_value(msg.payload, None)
                 if battery_level:
                     self._battery_level = int(battery_level)
 
@@ -266,7 +266,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             ):
                 charging = self._templates[
                     CONF_CHARGING_TEMPLATE
-                ].async_render_with_possible_json_value(msg.payload, error_value=None)
+                ].async_render_with_possible_json_value(msg.payload, None)
                 if charging:
                     self._charging = cv.boolean(charging)
 
@@ -276,7 +276,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             ):
                 cleaning = self._templates[
                     CONF_CLEANING_TEMPLATE
-                ].async_render_with_possible_json_value(msg.payload, error_value=None)
+                ].async_render_with_possible_json_value(msg.payload, None)
                 if cleaning:
                     self._cleaning = cv.boolean(cleaning)
 
@@ -286,7 +286,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             ):
                 docked = self._templates[
                     CONF_DOCKED_TEMPLATE
-                ].async_render_with_possible_json_value(msg.payload, error_value=None)
+                ].async_render_with_possible_json_value(msg.payload, None)
                 if docked:
                     self._docked = cv.boolean(docked)
 
@@ -296,7 +296,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             ):
                 error = self._templates[
                     CONF_ERROR_TEMPLATE
-                ].async_render_with_possible_json_value(msg.payload, error_value=None)
+                ].async_render_with_possible_json_value(msg.payload, None)
                 if error is not None:
                     self._error = cv.string(error)
 
@@ -318,7 +318,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             ):
                 fan_speed = self._templates[
                     CONF_FAN_SPEED_TEMPLATE
-                ].async_render_with_possible_json_value(msg.payload, error_value=None)
+                ].async_render_with_possible_json_value(msg.payload, None)
                 if fan_speed:
                     self._fan_speed = fan_speed
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -245,12 +245,12 @@ async def test_value_template_value(hass):
 
     # test rendering value
     tpl = template.Template("{{ value_json.id }}", hass)
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass)
     assert val_tpl.async_render_with_possible_json_value('{"id": 4321}') == "4321"
 
     # test variables at rendering
     tpl = template.Template("{{ value_json.id }} {{ some_var }}", hass)
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass)
     assert (
         val_tpl.async_render_with_possible_json_value(
             '{"id": 4321}', variables=variables
@@ -260,7 +260,7 @@ async def test_value_template_value(hass):
 
     # test with default value if an error occurs due to an invalid template
     tpl = template.Template("{{ value_json.id | as_datetime }}")
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass)
     assert (
         val_tpl.async_render_with_possible_json_value('{"otherid": 4321}', "my default")
         == "my default"

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -238,6 +238,35 @@ async def test_command_template_variables(hass, mqtt_mock):
     assert state.state == "beer"
 
 
+async def test_value_template_value(hass):
+    """Test the rendering of MQTT value template."""
+
+    variables = {"id": 1234, "some_var": "beer"}
+
+    # test rendering value
+    tpl = template.Template("{{ value_json.id }}", hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass)
+    assert val_tpl.async_render_with_possible_json_value('{"id": 4321}') == "4321"
+
+    # test variables at rendering
+    tpl = template.Template("{{ value_json.id }} {{ some_var }}", hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass)
+    assert (
+        val_tpl.async_render_with_possible_json_value(
+            '{"id": 4321}', variables=variables
+        )
+        == "4321 beer"
+    )
+
+    # test with default value if an error occurs due to an invalid template
+    tpl = template.Template("{{ value_json.id | as_datetime }}")
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass)
+    assert (
+        val_tpl.async_render_with_possible_json_value('{"otherid": 4321}', "my default")
+        == "my default"
+    )
+
+
 async def test_service_call_without_topic_does_not_publish(hass, mqtt_mock):
     """Test the service call if topic is missing."""
     with pytest.raises(vol.Invalid):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Value templates have been reworked. A new helper class `MqttValueTemplate` is introduced to avoid code duplication.
This is a follow up on the rework om command templates.

Entity attributes `entity_id` and `name` are now available for all value_templates on all Mqtt platforms. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20735

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
