### PR TITLE
Align zeroconf matching with ZeroconfServiceInfo

### DIFF
--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -7,7 +7,7 @@
   "zeroconf": [
     "_mediaremotetv._tcp.local.",
     "_touch-able._tcp.local.",
-    {"type":"_airplay._tcp.local.","model":"appletv*"}
+    {"type":"_airplay._tcp.local.","properties":{"model":"appletv*"}}
   ],
   "codeowners": ["@postlund"],
   "iot_class": "local_push"

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -26,15 +26,15 @@
   "zeroconf": [
     {
       "type": "_axis-video._tcp.local.",
-      "macaddress": "00408C*"
+      "properties": {"macaddress": "00408c*"}
     },
     {
       "type": "_axis-video._tcp.local.",
-      "macaddress": "ACCC8E*"
+      "properties": {"macaddress": "accc8e*"}
     },
     {
       "type": "_axis-video._tcp.local.",
-      "macaddress": "B8A44F*"
+      "properties": {"macaddress": "b8a44f*"}
     }
   ],
   "after_dependencies": ["mqtt"],

--- a/homeassistant/components/doorbird/manifest.json
+++ b/homeassistant/components/doorbird/manifest.json
@@ -7,7 +7,7 @@
   "zeroconf": [
     {
       "type": "_axis-video._tcp.local.",
-      "macaddress": "1CCAE3*"
+      "properties": {"macaddress": "1ccae3*"}
     }
   ],
   "codeowners": ["@oblogic7", "@bdraco"],

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -11,7 +11,7 @@
     },
     {
       "type": "_http._tcp.local.",
-      "manufacturer": "nettigo"
+      "properties": {"manufacturer": "nettigo"}
     }
   ],
   "config_flow": true,

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -14,7 +14,7 @@
     }
   ],
   "zeroconf": [
-    {"type":"_airplay._tcp.local.","manufacturer":"samsung*"}
+    {"type":"_airplay._tcp.local.","properties":{"manufacturer":"samsung*"}}
   ],
   "dhcp": [
     {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -14,11 +14,15 @@ ZEROCONF = {
     "_airplay._tcp.local.": [
         {
             "domain": "apple_tv",
-            "model": "appletv*"
+            "properties": {
+                "model": "appletv*"
+            }
         },
         {
             "domain": "samsungtv",
-            "manufacturer": "samsung*"
+            "properties": {
+                "manufacturer": "samsung*"
+            }
         }
     ],
     "_api._udp.local.": [
@@ -29,19 +33,27 @@ ZEROCONF = {
     "_axis-video._tcp.local.": [
         {
             "domain": "axis",
-            "macaddress": "00408C*"
+            "properties": {
+                "macaddress": "00408c*"
+            }
         },
         {
             "domain": "axis",
-            "macaddress": "ACCC8E*"
+            "properties": {
+                "macaddress": "accc8e*"
+            }
         },
         {
             "domain": "axis",
-            "macaddress": "B8A44F*"
+            "properties": {
+                "macaddress": "b8a44f*"
+            }
         },
         {
             "domain": "doorbird",
-            "macaddress": "1CCAE3*"
+            "properties": {
+                "macaddress": "1ccae3*"
+            }
         }
     ],
     "_bond._tcp.local.": [
@@ -123,7 +135,9 @@ ZEROCONF = {
         },
         {
             "domain": "nam",
-            "manufacturer": "nettigo"
+            "properties": {
+                "manufacturer": "nettigo"
+            }
         },
         {
             "domain": "rachio",

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -58,6 +58,8 @@ _UNDEF = object()  # Internal; not helpers.typing.UNDEFINED due to circular depe
 
 MAX_LOAD_CONCURRENTLY = 4
 
+MOVED_ZEROCONF_PROPS = ("macaddress", "model", "manufacturer")
+
 
 class Manifest(TypedDict, total=False):
     """
@@ -182,21 +184,38 @@ async def async_get_config_flows(hass: HomeAssistant) -> set[str]:
     return flows
 
 
-async def async_get_zeroconf(hass: HomeAssistant) -> dict[str, list[dict[str, str]]]:
+def async_process_zeroconf_match_dict(entry: dict[str, Any]) -> dict[str, Any]:
+    """Handle backwards compat with zeroconf matchers."""
+    entry_without_type: dict[str, Any] = entry.copy()
+    del entry_without_type["type"]
+    # These properties keys used to be at the top level, we relocate
+    # them for backwards compat
+    for moved_prop in MOVED_ZEROCONF_PROPS:
+        if value := entry_without_type.pop(moved_prop, None):
+            if "properties" not in entry_without_type:
+                prop_dict: dict[str, str] = {}
+                entry_without_type["properties"] = prop_dict
+            else:
+                prop_dict = entry_without_type["properties"]
+            prop_dict[moved_prop] = value.lower()
+    return entry_without_type
+
+
+async def async_get_zeroconf(
+    hass: HomeAssistant,
+) -> dict[str, list[dict[str, str | dict[str, str]]]]:
     """Return cached list of zeroconf types."""
-    zeroconf: dict[str, list[dict[str, str]]] = ZEROCONF.copy()
+    zeroconf: dict[str, list[dict[str, str | dict[str, str]]]] = ZEROCONF.copy()  # type: ignore[assignment]
 
     integrations = await async_get_custom_components(hass)
     for integration in integrations.values():
         if not integration.zeroconf:
             continue
         for entry in integration.zeroconf:
-            data = {"domain": integration.domain}
+            data: dict[str, str | dict[str, str]] = {"domain": integration.domain}
             if isinstance(entry, dict):
                 typ = entry["type"]
-                entry_without_type = entry.copy()
-                del entry_without_type["type"]
-                data.update(entry_without_type)
+                data.update(async_process_zeroconf_match_dict(entry))
             else:
                 typ = entry
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -192,6 +192,10 @@ def async_process_zeroconf_match_dict(entry: dict[str, Any]) -> dict[str, Any]:
     # them for backwards compat
     for moved_prop in MOVED_ZEROCONF_PROPS:
         if value := entry_without_type.pop(moved_prop, None):
+            _LOGGER.warning(
+                'Matching the zeroconf property "%s" at top-level is depercated and should be moved into a properties dict; Check the developer documentation',
+                moved_prop,
+            )
             if "properties" not in entry_without_type:
                 prop_dict: dict[str, str] = {}
                 entry_without_type["properties"] = prop_dict

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -193,7 +193,7 @@ def async_process_zeroconf_match_dict(entry: dict[str, Any]) -> dict[str, Any]:
     for moved_prop in MOVED_ZEROCONF_PROPS:
         if value := entry_without_type.pop(moved_prop, None):
             _LOGGER.warning(
-                'Matching the zeroconf property "%s" at top-level is depercated and should be moved into a properties dict; Check the developer documentation',
+                'Matching the zeroconf property "%s" at top-level is deprecated and should be moved into a properties dict; Check the developer documentation',
                 moved_prop,
             )
             if "properties" not in entry_without_type:

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -175,7 +175,7 @@ def verify_wildcard(value: str):
 
 
 def verify_lower_case_dict(*keys: Any) -> Callable[[dict], dict]:
-    """Validate that at least one key exists."""
+    """Verify all values are lowercase."""
 
     def validate(obj: dict) -> dict:
         """Test values in dict are lowercase."""

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable
 from urllib.parse import urlparse
 
 from awesomeversion import (
@@ -174,20 +173,6 @@ def verify_wildcard(value: str):
     return value
 
 
-def verify_lower_case_dict(*keys: Any) -> Callable[[dict], dict]:
-    """Verify all values are lowercase."""
-
-    def validate(obj: dict) -> dict:
-        """Test values in dict are lowercase."""
-        if not isinstance(obj, dict):
-            raise vol.Invalid("expected dictionary")
-
-        for v in obj.values():
-            verify_lowercase(v)
-
-    return validate
-
-
 MANIFEST_SCHEMA = vol.Schema(
     {
         vol.Required("domain"): str,
@@ -212,7 +197,9 @@ MANIFEST_SCHEMA = vol.Schema(
                             ),
                             vol.Optional("model"): vol.All(str, verify_lowercase),
                             vol.Optional("name"): vol.All(str, verify_lowercase),
-                            vol.Optional("properties"): verify_lower_case_dict,
+                            vol.Optional("properties"): vol.Schema(
+                                {str: verify_lowercase}
+                            ),
                         }
                     ),
                 ),

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 from awesomeversion import (
@@ -11,6 +12,8 @@ from awesomeversion import (
 )
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
+
+from homeassistant.helpers import config_validation as cv
 
 from .model import Config, Integration
 
@@ -171,6 +174,20 @@ def verify_wildcard(value: str):
     return value
 
 
+def verify_lower_case_dict(*keys: Any) -> Callable[[dict], dict]:
+    """Validate that at least one key exists."""
+
+    def validate(obj: dict) -> dict:
+        """Test values in dict are lowercase."""
+        if not isinstance(obj, dict):
+            raise vol.Invalid("expected dictionary")
+
+        for v in obj.values():
+            verify_lowercase(v)
+
+    return validate
+
+
 MANIFEST_SCHEMA = vol.Schema(
     {
         vol.Required("domain"): str,
@@ -180,16 +197,24 @@ MANIFEST_SCHEMA = vol.Schema(
         vol.Optional("zeroconf"): [
             vol.Any(
                 str,
-                vol.Schema(
-                    {
-                        vol.Required("type"): str,
-                        vol.Optional("macaddress"): vol.All(
-                            str, verify_uppercase, verify_wildcard
-                        ),
-                        vol.Optional("manufacturer"): vol.All(str, verify_lowercase),
-                        vol.Optional("model"): vol.All(str, verify_lowercase),
-                        vol.Optional("name"): vol.All(str, verify_lowercase),
-                    }
+                vol.All(
+                    cv.deprecated("macaddress"),
+                    cv.deprecated("model"),
+                    cv.deprecated("manufacturer"),
+                    vol.Schema(
+                        {
+                            vol.Required("type"): str,
+                            vol.Optional("macaddress"): vol.All(
+                                str, verify_uppercase, verify_wildcard
+                            ),
+                            vol.Optional("manufacturer"): vol.All(
+                                str, verify_lowercase
+                            ),
+                            vol.Optional("model"): vol.All(str, verify_lowercase),
+                            vol.Optional("name"): vol.All(str, verify_lowercase),
+                            vol.Optional("properties"): verify_lower_case_dict,
+                        }
+                    ),
                 ),
             )
         ],

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections import OrderedDict, defaultdict
 import json
 
+from homeassistant.loader import async_process_zeroconf_match_dict
+
 from .model import Config, Integration
 
 BASE = """
@@ -42,9 +44,7 @@ def generate_and_validate(integrations: dict[str, Integration]):
             data = {"domain": domain}
             if isinstance(entry, dict):
                 typ = entry["type"]
-                entry_without_type = entry.copy()
-                del entry_without_type["type"]
-                data.update(entry_without_type)
+                data.update(async_process_zeroconf_match_dict(entry))
             else:
                 typ = entry
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -295,7 +295,11 @@ async def test_zeroconf_match_macaddress(hass, mock_async_zeroconf):
         zc_gen.ZEROCONF,
         {
             "_http._tcp.local.": [
-                {"domain": "shelly", "name": "shelly*", "macaddress": "FFAADD*"}
+                {
+                    "domain": "shelly",
+                    "name": "shelly*",
+                    "properties": {"macaddress": "ffaadd*"},
+                }
             ]
         },
         clear=True,
@@ -330,7 +334,11 @@ async def test_zeroconf_match_manufacturer(hass, mock_async_zeroconf):
 
     with patch.dict(
         zc_gen.ZEROCONF,
-        {"_airplay._tcp.local.": [{"domain": "samsungtv", "manufacturer": "samsung*"}]},
+        {
+            "_airplay._tcp.local.": [
+                {"domain": "samsungtv", "properties": {"manufacturer": "samsung*"}}
+            ]
+        },
         clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
@@ -363,7 +371,11 @@ async def test_zeroconf_match_model(hass, mock_async_zeroconf):
 
     with patch.dict(
         zc_gen.ZEROCONF,
-        {"_airplay._tcp.local.": [{"domain": "appletv", "model": "appletv*"}]},
+        {
+            "_airplay._tcp.local.": [
+                {"domain": "appletv", "properties": {"model": "appletv*"}}
+            ]
+        },
         clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
@@ -396,7 +408,11 @@ async def test_zeroconf_match_manufacturer_not_present(hass, mock_async_zeroconf
 
     with patch.dict(
         zc_gen.ZEROCONF,
-        {"_airplay._tcp.local.": [{"domain": "samsungtv", "manufacturer": "samsung*"}]},
+        {
+            "_airplay._tcp.local.": [
+                {"domain": "samsungtv", "properties": {"manufacturer": "samsung*"}}
+            ]
+        },
         clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"
@@ -460,7 +476,11 @@ async def test_zeroconf_no_match_manufacturer(hass, mock_async_zeroconf):
 
     with patch.dict(
         zc_gen.ZEROCONF,
-        {"_airplay._tcp.local.": [{"domain": "samsungtv", "manufacturer": "samsung*"}]},
+        {
+            "_airplay._tcp.local.": [
+                {"domain": "samsungtv", "properties": {"manufacturer": "samsung*"}}
+            ]
+        },
         clear=True,
     ), patch.object(
         hass.config_entries.flow, "async_init"


### PR DESCRIPTION
## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently zeroconf matching only allows matching the `macaddress`
`model`, and `manufacturer` properties along with the `name` from
the ZeroconfServiceInfo. Since properties are arbitrarily
defined by the zeroconf service, the list of named properties
has grown over time.

Matching now allows for any arbitrarily defined property

All property matches must be lowercase, wildcards are supported

Replaces https://github.com/home-assistant/core/pull/62001

The top level keys `model`, `manufacturer`, and `macaddress`
are now deprecated from the `manifest.json` file and should
be moved into a `properties` dict.

Example:
```
-    {"type":"_airplay._tcp.local.","model":"appletv*"}
+    {"type":"_airplay._tcp.local.","properties":{"model":"appletv*"}}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1159

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
