### PR TITLE
Use enums in tasmota tests

### DIFF
--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -11,13 +11,13 @@ from hatasmota.utils import (
     get_topic_tele_will,
 )
 
-from homeassistant.components import binary_sensor
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     EVENT_STATE_CHANGED,
     STATE_OFF,
     STATE_ON,
+    Platform,
 )
 import homeassistant.core as ha
 import homeassistant.util.dt as dt_util
@@ -292,7 +292,7 @@ async def test_availability_when_connection_lost(
     config["swc"][0] = 1
     config["swn"][0] = "Test"
     await help_test_availability_when_connection_lost(
-        hass, mqtt_client_mock, mqtt_mock, binary_sensor.DOMAIN, config
+        hass, mqtt_client_mock, mqtt_mock, Platform.BINARY_SENSOR, config
     )
 
 
@@ -301,7 +301,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["swc"][0] = 1
     config["swn"][0] = "Test"
-    await help_test_availability(hass, mqtt_mock, binary_sensor.DOMAIN, config)
+    await help_test_availability(hass, mqtt_mock, Platform.BINARY_SENSOR, config)
 
 
 async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
@@ -310,7 +310,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     config["swc"][0] = 1
     config["swn"][0] = "Test"
     await help_test_availability_discovery_update(
-        hass, mqtt_mock, binary_sensor.DOMAIN, config
+        hass, mqtt_mock, Platform.BINARY_SENSOR, config
     )
 
 
@@ -326,7 +326,7 @@ async def test_availability_poll_state(
         hass,
         mqtt_client_mock,
         mqtt_mock,
-        binary_sensor.DOMAIN,
+        Platform.BINARY_SENSOR,
         config,
         poll_topic,
         "10",
@@ -343,7 +343,7 @@ async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog, setup_ta
     config2["swn"][0] = "Test"
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, binary_sensor.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.BINARY_SENSOR, config1, config2
     )
 
 
@@ -358,7 +358,7 @@ async def test_discovery_update_unchanged_binary_sensor(
         "homeassistant.components.tasmota.binary_sensor.TasmotaBinarySensor.discovery_update"
     ) as discovery_update:
         await help_test_discovery_update_unchanged(
-            hass, mqtt_mock, caplog, binary_sensor.DOMAIN, config, discovery_update
+            hass, mqtt_mock, caplog, Platform.BINARY_SENSOR, config, discovery_update
         )
 
 
@@ -368,7 +368,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     config["swc"][0] = 1
     unique_id = f"{DEFAULT_CONFIG['mac']}_binary_sensor_switch_0"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, binary_sensor.DOMAIN, unique_id, config
+        hass, mqtt_mock, Platform.BINARY_SENSOR, unique_id, config
     )
 
 
@@ -384,7 +384,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
         get_topic_tele_will(config),
     ]
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock, binary_sensor.DOMAIN, config, topics
+        hass, mqtt_mock, Platform.BINARY_SENSOR, config, topics
     )
 
 
@@ -394,5 +394,5 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     config["swc"][0] = 1
     config["swn"][0] = "Test"
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock, binary_sensor.DOMAIN, config
+        hass, mqtt_mock, Platform.BINARY_SENSOR, config
     )

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -13,7 +13,7 @@ import pytest
 
 from homeassistant.components import cover
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
-from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN, Platform
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -392,7 +392,7 @@ async def test_controlling_state_via_mqtt_inverted(hass, mqtt_mock, setup_tasmot
 async def call_service(hass, entity_id, service, **kwargs):
     """Call a fan service."""
     await hass.services.async_call(
-        cover.DOMAIN,
+        Platform.COVER,
         service,
         {"entity_id": entity_id, **kwargs},
         blocking=True,
@@ -538,7 +538,7 @@ async def test_availability_when_connection_lost(
         hass,
         mqtt_client_mock,
         mqtt_mock,
-        cover.DOMAIN,
+        Platform.COVER,
         config,
         entity_id="test_cover_1",
     )
@@ -551,7 +551,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     config["rl"][0] = 3
     config["rl"][1] = 3
     await help_test_availability(
-        hass, mqtt_mock, cover.DOMAIN, config, entity_id="test_cover_1"
+        hass, mqtt_mock, Platform.COVER, config, entity_id="test_cover_1"
     )
 
 
@@ -562,7 +562,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     config["rl"][0] = 3
     config["rl"][1] = 3
     await help_test_availability_discovery_update(
-        hass, mqtt_mock, cover.DOMAIN, config, entity_id="test_cover_1"
+        hass, mqtt_mock, Platform.COVER, config, entity_id="test_cover_1"
     )
 
 
@@ -575,7 +575,7 @@ async def test_availability_poll_state(
     config["rl"][1] = 3
     poll_topic = "tasmota_49A3BC/cmnd/STATUS"
     await help_test_availability_poll_state(
-        hass, mqtt_client_mock, mqtt_mock, cover.DOMAIN, config, poll_topic, "10"
+        hass, mqtt_client_mock, mqtt_mock, Platform.COVER, config, poll_topic, "10"
     )
 
 
@@ -594,7 +594,7 @@ async def test_discovery_removal_cover(hass, mqtt_mock, caplog, setup_tasmota):
         hass,
         mqtt_mock,
         caplog,
-        cover.DOMAIN,
+        Platform.COVER,
         config1,
         config2,
         entity_id="test_cover_1",
@@ -615,7 +615,7 @@ async def test_discovery_update_unchanged_cover(hass, mqtt_mock, caplog, setup_t
             hass,
             mqtt_mock,
             caplog,
-            cover.DOMAIN,
+            Platform.COVER,
             config,
             discovery_update,
             entity_id="test_cover_1",
@@ -631,7 +631,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     config["rl"][1] = 3
     unique_id = f"{DEFAULT_CONFIG['mac']}_cover_shutter_0"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, cover.DOMAIN, unique_id, config
+        hass, mqtt_mock, Platform.COVER, unique_id, config
     )
 
 
@@ -648,7 +648,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
         get_topic_tele_will(config),
     ]
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock, cover.DOMAIN, config, topics, entity_id="test_cover_1"
+        hass, mqtt_mock, Platform.COVER, config, topics, entity_id="test_cover_1"
     )
 
 
@@ -659,5 +659,5 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     config["rl"][0] = 3
     config["rl"][1] = 3
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock, cover.DOMAIN, config, entity_id="test_cover_1"
+        hass, mqtt_mock, Platform.COVER, config, entity_id="test_cover_1"
     )

--- a/tests/components/tasmota/test_fan.py
+++ b/tests/components/tasmota/test_fan.py
@@ -13,7 +13,7 @@ from voluptuous import MultipleInvalid
 
 from homeassistant.components import fan
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
-from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON, Platform
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -191,7 +191,7 @@ async def test_availability_when_connection_lost(
     config["dn"] = "Test"
     config["if"] = 1
     await help_test_availability_when_connection_lost(
-        hass, mqtt_client_mock, mqtt_mock, fan.DOMAIN, config
+        hass, mqtt_client_mock, mqtt_mock, Platform.FAN, config
     )
 
 
@@ -200,7 +200,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
     config["if"] = 1
-    await help_test_availability(hass, mqtt_mock, fan.DOMAIN, config)
+    await help_test_availability(hass, mqtt_mock, Platform.FAN, config)
 
 
 async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
@@ -208,7 +208,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["dn"] = "Test"
     config["if"] = 1
-    await help_test_availability_discovery_update(hass, mqtt_mock, fan.DOMAIN, config)
+    await help_test_availability_discovery_update(hass, mqtt_mock, Platform.FAN, config)
 
 
 async def test_availability_poll_state(
@@ -219,7 +219,7 @@ async def test_availability_poll_state(
     config["if"] = 1
     poll_topic = "tasmota_49A3BC/cmnd/STATE"
     await help_test_availability_poll_state(
-        hass, mqtt_client_mock, mqtt_mock, fan.DOMAIN, config, poll_topic, ""
+        hass, mqtt_client_mock, mqtt_mock, Platform.FAN, config, poll_topic, ""
     )
 
 
@@ -233,7 +233,7 @@ async def test_discovery_removal_fan(hass, mqtt_mock, caplog, setup_tasmota):
     config2["if"] = 0
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, fan.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.FAN, config1, config2
     )
 
 
@@ -246,7 +246,7 @@ async def test_discovery_update_unchanged_fan(hass, mqtt_mock, caplog, setup_tas
         "homeassistant.components.tasmota.fan.TasmotaFan.discovery_update"
     ) as discovery_update:
         await help_test_discovery_update_unchanged(
-            hass, mqtt_mock, caplog, fan.DOMAIN, config, discovery_update
+            hass, mqtt_mock, caplog, Platform.FAN, config, discovery_update
         )
 
 
@@ -257,7 +257,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     config["if"] = 1
     unique_id = f"{DEFAULT_CONFIG['mac']}_fan_fan_ifan"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, fan.DOMAIN, unique_id, config
+        hass, mqtt_mock, Platform.FAN, unique_id, config
     )
 
 
@@ -272,7 +272,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
         get_topic_tele_will(config),
     ]
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock, fan.DOMAIN, config, topics
+        hass, mqtt_mock, Platform.FAN, config, topics
     )
 
 
@@ -282,5 +282,5 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     config["dn"] = "Test"
     config["if"] = 1
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock, fan.DOMAIN, config
+        hass, mqtt_mock, Platform.FAN, config
     )

--- a/tests/components/tasmota/test_light.py
+++ b/tests/components/tasmota/test_light.py
@@ -10,10 +10,9 @@ from hatasmota.utils import (
     get_topic_tele_will,
 )
 
-from homeassistant.components import light
 from homeassistant.components.light import SUPPORT_EFFECT, SUPPORT_TRANSITION
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
-from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON, Platform
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -1620,7 +1619,7 @@ async def test_availability_when_connection_lost(
     config["rl"][0] = 2
     config["lt_st"] = 1  # 1 channel light (Dimmer)
     await help_test_availability_when_connection_lost(
-        hass, mqtt_client_mock, mqtt_mock, light.DOMAIN, config
+        hass, mqtt_client_mock, mqtt_mock, Platform.LIGHT, config
     )
 
 
@@ -1629,7 +1628,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
     config["lt_st"] = 1  # 1 channel light (Dimmer)
-    await help_test_availability(hass, mqtt_mock, light.DOMAIN, config)
+    await help_test_availability(hass, mqtt_mock, Platform.LIGHT, config)
 
 
 async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
@@ -1637,7 +1636,9 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 2
     config["lt_st"] = 1  # 1 channel light (Dimmer)
-    await help_test_availability_discovery_update(hass, mqtt_mock, light.DOMAIN, config)
+    await help_test_availability_discovery_update(
+        hass, mqtt_mock, Platform.LIGHT, config
+    )
 
 
 async def test_availability_poll_state(
@@ -1649,7 +1650,7 @@ async def test_availability_poll_state(
     config["lt_st"] = 1  # 1 channel light (Dimmer)
     poll_topic = "tasmota_49A3BC/cmnd/STATE"
     await help_test_availability_poll_state(
-        hass, mqtt_client_mock, mqtt_mock, light.DOMAIN, config, poll_topic, ""
+        hass, mqtt_client_mock, mqtt_mock, Platform.LIGHT, config, poll_topic, ""
     )
 
 
@@ -1663,7 +1664,7 @@ async def test_discovery_removal_light(hass, mqtt_mock, caplog, setup_tasmota):
     config2["lt_st"] = 0
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, light.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.LIGHT, config1, config2
     )
 
 
@@ -1677,7 +1678,7 @@ async def test_discovery_removal_relay_as_light(hass, mqtt_mock, caplog, setup_t
     config2["so"]["30"] = 0  # Disable Home Assistant auto-discovery as light
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, light.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.LIGHT, config1, config2
     )
 
 
@@ -1693,7 +1694,7 @@ async def test_discovery_removal_relay_as_light2(
     config2["so"]["30"] = 0  # Disable Home Assistant auto-discovery as light
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, light.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.LIGHT, config1, config2
     )
 
 
@@ -1706,7 +1707,7 @@ async def test_discovery_update_unchanged_light(hass, mqtt_mock, caplog, setup_t
         "homeassistant.components.tasmota.light.TasmotaLight.discovery_update"
     ) as discovery_update:
         await help_test_discovery_update_unchanged(
-            hass, mqtt_mock, caplog, light.DOMAIN, config, discovery_update
+            hass, mqtt_mock, caplog, Platform.LIGHT, config, discovery_update
         )
 
 
@@ -1717,7 +1718,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     config["lt_st"] = 1  # 1 channel light (Dimmer)
     unique_id = f"{DEFAULT_CONFIG['mac']}_light_light_0"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, light.DOMAIN, unique_id, config
+        hass, mqtt_mock, Platform.LIGHT, unique_id, config
     )
 
 
@@ -1728,7 +1729,7 @@ async def test_discovery_device_remove_relay_as_light(hass, mqtt_mock, setup_tas
     config["so"]["30"] = 1  # Enforce Home Assistant auto-discovery as light
     unique_id = f"{DEFAULT_CONFIG['mac']}_light_relay_0"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, light.DOMAIN, unique_id, config
+        hass, mqtt_mock, Platform.LIGHT, unique_id, config
     )
 
 
@@ -1743,7 +1744,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
         get_topic_tele_will(config),
     ]
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock, light.DOMAIN, config, topics
+        hass, mqtt_mock, Platform.LIGHT, config, topics
     )
 
 
@@ -1753,5 +1754,5 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     config["rl"][0] = 2
     config["lt_st"] = 1  # 1 channel light (Dimmer)
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock, light.DOMAIN, config
+        hass, mqtt_mock, Platform.LIGHT, config
     )

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -14,7 +14,7 @@ from hatasmota.utils import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import sensor
+from homeassistant.components.sensor import ATTR_STATE_CLASS, DOMAIN, SensorStateClass
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
@@ -291,9 +291,7 @@ async def test_indexed_sensor_state_via_mqtt2(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("sensor.tasmota_energy_total")
     assert state.state == "unavailable"
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
-    assert (
-        state.attributes[sensor.ATTR_STATE_CLASS] == sensor.STATE_CLASS_TOTAL_INCREASING
-    )
+    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL_INCREASING
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
     await hass.async_block_till_done()
@@ -342,9 +340,7 @@ async def test_indexed_sensor_state_via_mqtt3(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("sensor.tasmota_energy_total_1")
     assert state.state == "unavailable"
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
-    assert (
-        state.attributes[sensor.ATTR_STATE_CLASS] == sensor.STATE_CLASS_TOTAL_INCREASING
-    )
+    assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL_INCREASING
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
     await hass.async_block_till_done()
@@ -490,7 +486,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
-        sensor.DOMAIN,
+        DOMAIN,
         "tasmota",
         "00000049A3BC_status_sensor_status_sensor_status_signal",
         suggested_object_id="tasmota_status",
@@ -550,7 +546,7 @@ async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_t
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
-        sensor.DOMAIN,
+        DOMAIN,
         "tasmota",
         "00000049A3BC_status_sensor_status_sensor_status_restart_reason",
         suggested_object_id="tasmota_status",
@@ -635,7 +631,7 @@ async def test_restart_time_status_sensor_state_via_mqtt(
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
-        sensor.DOMAIN,
+        DOMAIN,
         "tasmota",
         "00000049A3BC_status_sensor_status_sensor_last_restart_time",
         suggested_object_id="tasmota_status",
@@ -888,7 +884,7 @@ async def test_availability_when_connection_lost(
         hass,
         mqtt_client_mock,
         mqtt_mock,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         sensor_config,
         "tasmota_dht11_temperature",
@@ -902,7 +898,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     await help_test_availability(
         hass,
         mqtt_mock,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         sensor_config,
         "tasmota_dht11_temperature",
@@ -916,7 +912,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     await help_test_availability_discovery_update(
         hass,
         mqtt_mock,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         sensor_config,
         "tasmota_dht11_temperature",
@@ -934,7 +930,7 @@ async def test_availability_poll_state(
         hass,
         mqtt_client_mock,
         mqtt_mock,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         poll_topic,
         "10",
@@ -951,7 +947,7 @@ async def test_discovery_removal_sensor(hass, mqtt_mock, caplog, setup_tasmota):
         hass,
         mqtt_mock,
         caplog,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         config,
         sensor_config1,
@@ -974,7 +970,7 @@ async def test_discovery_update_unchanged_sensor(
             hass,
             mqtt_mock,
             caplog,
-            sensor.DOMAIN,
+            DOMAIN,
             config,
             discovery_update,
             sensor_config,
@@ -989,7 +985,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
     unique_id = f"{DEFAULT_CONFIG['mac']}_sensor_sensor_DHT11_Temperature"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, sensor.DOMAIN, unique_id, config, sensor_config
+        hass, mqtt_mock, DOMAIN, unique_id, config, sensor_config
     )
 
 
@@ -1005,7 +1001,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     await help_test_entity_id_update_subscriptions(
         hass,
         mqtt_mock,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         topics,
         sensor_config,
@@ -1020,7 +1016,7 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     await help_test_entity_id_update_discovery_update(
         hass,
         mqtt_mock,
-        sensor.DOMAIN,
+        DOMAIN,
         config,
         sensor_config,
         "tasmota_dht11_temperature",

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -14,9 +14,9 @@ from hatasmota.utils import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.sensor import ATTR_STATE_CLASS, DOMAIN, SensorStateClass
+from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
-from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN, Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
@@ -486,7 +486,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
-        DOMAIN,
+        Platform.SENSOR,
         "tasmota",
         "00000049A3BC_status_sensor_status_sensor_status_signal",
         suggested_object_id="tasmota_status",
@@ -546,7 +546,7 @@ async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_t
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
-        DOMAIN,
+        Platform.SENSOR,
         "tasmota",
         "00000049A3BC_status_sensor_status_sensor_status_restart_reason",
         suggested_object_id="tasmota_status",
@@ -631,7 +631,7 @@ async def test_restart_time_status_sensor_state_via_mqtt(
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
-        DOMAIN,
+        Platform.SENSOR,
         "tasmota",
         "00000049A3BC_status_sensor_status_sensor_last_restart_time",
         suggested_object_id="tasmota_status",
@@ -884,7 +884,7 @@ async def test_availability_when_connection_lost(
         hass,
         mqtt_client_mock,
         mqtt_mock,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         sensor_config,
         "tasmota_dht11_temperature",
@@ -898,7 +898,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     await help_test_availability(
         hass,
         mqtt_mock,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         sensor_config,
         "tasmota_dht11_temperature",
@@ -912,7 +912,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     await help_test_availability_discovery_update(
         hass,
         mqtt_mock,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         sensor_config,
         "tasmota_dht11_temperature",
@@ -930,7 +930,7 @@ async def test_availability_poll_state(
         hass,
         mqtt_client_mock,
         mqtt_mock,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         poll_topic,
         "10",
@@ -947,7 +947,7 @@ async def test_discovery_removal_sensor(hass, mqtt_mock, caplog, setup_tasmota):
         hass,
         mqtt_mock,
         caplog,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         config,
         sensor_config1,
@@ -970,7 +970,7 @@ async def test_discovery_update_unchanged_sensor(
             hass,
             mqtt_mock,
             caplog,
-            DOMAIN,
+            Platform.SENSOR,
             config,
             discovery_update,
             sensor_config,
@@ -985,7 +985,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     sensor_config = copy.deepcopy(DEFAULT_SENSOR_CONFIG)
     unique_id = f"{DEFAULT_CONFIG['mac']}_sensor_sensor_DHT11_Temperature"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, DOMAIN, unique_id, config, sensor_config
+        hass, mqtt_mock, Platform.SENSOR, unique_id, config, sensor_config
     )
 
 
@@ -1001,7 +1001,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
     await help_test_entity_id_update_subscriptions(
         hass,
         mqtt_mock,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         topics,
         sensor_config,
@@ -1016,7 +1016,7 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     await help_test_entity_id_update_discovery_update(
         hass,
         mqtt_mock,
-        DOMAIN,
+        Platform.SENSOR,
         config,
         sensor_config,
         "tasmota_dht11_temperature",

--- a/tests/components/tasmota/test_switch.py
+++ b/tests/components/tasmota/test_switch.py
@@ -9,9 +9,8 @@ from hatasmota.utils import (
     get_topic_tele_will,
 )
 
-from homeassistant.components import switch
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
-from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_OFF, STATE_ON, Platform
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -143,7 +142,7 @@ async def test_availability_when_connection_lost(
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
     await help_test_availability_when_connection_lost(
-        hass, mqtt_client_mock, mqtt_mock, switch.DOMAIN, config
+        hass, mqtt_client_mock, mqtt_mock, Platform.SWITCH, config
     )
 
 
@@ -151,7 +150,7 @@ async def test_availability(hass, mqtt_mock, setup_tasmota):
     """Test availability."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
-    await help_test_availability(hass, mqtt_mock, switch.DOMAIN, config)
+    await help_test_availability(hass, mqtt_mock, Platform.SWITCH, config)
 
 
 async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
@@ -159,7 +158,7 @@ async def test_availability_discovery_update(hass, mqtt_mock, setup_tasmota):
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
     await help_test_availability_discovery_update(
-        hass, mqtt_mock, switch.DOMAIN, config
+        hass, mqtt_mock, Platform.SWITCH, config
     )
 
 
@@ -171,7 +170,7 @@ async def test_availability_poll_state(
     config["rl"][0] = 1
     poll_topic = "tasmota_49A3BC/cmnd/STATE"
     await help_test_availability_poll_state(
-        hass, mqtt_client_mock, mqtt_mock, switch.DOMAIN, config, poll_topic, ""
+        hass, mqtt_client_mock, mqtt_mock, Platform.SWITCH, config, poll_topic, ""
     )
 
 
@@ -183,7 +182,7 @@ async def test_discovery_removal_switch(hass, mqtt_mock, caplog, setup_tasmota):
     config2["rl"][0] = 0
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, switch.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.SWITCH, config1, config2
     )
 
 
@@ -197,7 +196,7 @@ async def test_discovery_removal_relay_as_light(hass, mqtt_mock, caplog, setup_t
     config2["so"]["30"] = 1  # Enforce Home Assistant auto-discovery as light
 
     await help_test_discovery_removal(
-        hass, mqtt_mock, caplog, switch.DOMAIN, config1, config2
+        hass, mqtt_mock, caplog, Platform.SWITCH, config1, config2
     )
 
 
@@ -211,7 +210,7 @@ async def test_discovery_update_unchanged_switch(
         "homeassistant.components.tasmota.switch.TasmotaSwitch.discovery_update"
     ) as discovery_update:
         await help_test_discovery_update_unchanged(
-            hass, mqtt_mock, caplog, switch.DOMAIN, config, discovery_update
+            hass, mqtt_mock, caplog, Platform.SWITCH, config, discovery_update
         )
 
 
@@ -221,7 +220,7 @@ async def test_discovery_device_remove(hass, mqtt_mock, setup_tasmota):
     config["rl"][0] = 1
     unique_id = f"{DEFAULT_CONFIG['mac']}_switch_relay_0"
     await help_test_discovery_device_remove(
-        hass, mqtt_mock, switch.DOMAIN, unique_id, config
+        hass, mqtt_mock, Platform.SWITCH, unique_id, config
     )
 
 
@@ -235,7 +234,7 @@ async def test_entity_id_update_subscriptions(hass, mqtt_mock, setup_tasmota):
         get_topic_tele_will(config),
     ]
     await help_test_entity_id_update_subscriptions(
-        hass, mqtt_mock, switch.DOMAIN, config, topics
+        hass, mqtt_mock, Platform.SWITCH, config, topics
     )
 
 
@@ -244,5 +243,5 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock, setup_tasmota)
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["rl"][0] = 1
     await help_test_entity_id_update_discovery_update(
-        hass, mqtt_mock, switch.DOMAIN, config
+        hass, mqtt_mock, Platform.SWITCH, config
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use enums in tasmota tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
