### PR TITLE
Use enums in sensor tests

### DIFF
--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -2,14 +2,9 @@
 import pytest
 
 import homeassistant.components.automation as automation
-from homeassistant.components.sensor import DOMAIN
+from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN, SensorDeviceClass
 from homeassistant.components.sensor.device_condition import ENTITY_CONDITIONS
-from homeassistant.const import (
-    CONF_PLATFORM,
-    DEVICE_CLASS_BATTERY,
-    PERCENTAGE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import CONF_PLATFORM, PERCENTAGE, STATE_UNKNOWN
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 
@@ -22,10 +17,7 @@ from tests.common import (
     mock_registry,
 )
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
-from tests.testing_config.custom_components.test.sensor import (
-    DEVICE_CLASSES,
-    UNITS_OF_MEASUREMENT,
-)
+from tests.testing_config.custom_components.test.sensor import UNITS_OF_MEASUREMENT
 
 
 @pytest.fixture
@@ -126,8 +118,8 @@ async def test_get_conditions_no_state(hass, device_reg, entity_reg):
 @pytest.mark.parametrize(
     "set_state,device_class_reg,device_class_state,unit_reg,unit_state",
     [
-        (False, DEVICE_CLASS_BATTERY, None, PERCENTAGE, None),
-        (True, None, DEVICE_CLASS_BATTERY, None, PERCENTAGE),
+        (False, SensorDeviceClass.BATTERY, None, PERCENTAGE, None),
+        (True, None, SensorDeviceClass.BATTERY, None, PERCENTAGE),
     ],
 )
 async def test_get_condition_capabilities(

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -4,14 +4,9 @@ from datetime import timedelta
 import pytest
 
 import homeassistant.components.automation as automation
-from homeassistant.components.sensor import DOMAIN
+from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN, SensorDeviceClass
 from homeassistant.components.sensor.device_trigger import ENTITY_TRIGGERS
-from homeassistant.const import (
-    CONF_PLATFORM,
-    DEVICE_CLASS_BATTERY,
-    PERCENTAGE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import CONF_PLATFORM, PERCENTAGE, STATE_UNKNOWN
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -26,10 +21,7 @@ from tests.common import (
     mock_registry,
 )
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
-from tests.testing_config.custom_components.test.sensor import (
-    DEVICE_CLASSES,
-    UNITS_OF_MEASUREMENT,
-)
+from tests.testing_config.custom_components.test.sensor import UNITS_OF_MEASUREMENT
 
 
 @pytest.fixture
@@ -93,8 +85,8 @@ async def test_get_triggers(hass, device_reg, entity_reg, enable_custom_integrat
 @pytest.mark.parametrize(
     "set_state,device_class_reg,device_class_state,unit_reg,unit_state",
     [
-        (False, DEVICE_CLASS_BATTERY, None, PERCENTAGE, None),
-        (True, None, DEVICE_CLASS_BATTERY, None, PERCENTAGE),
+        (False, SensorDeviceClass.BATTERY, None, PERCENTAGE, None),
+        (True, None, SensorDeviceClass.BATTERY, None, PERCENTAGE),
     ],
 )
 async def test_get_trigger_capabilities(

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -4,12 +4,9 @@ from datetime import date, datetime, timezone
 import pytest
 from pytest import approx
 
-from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
-    DEVICE_CLASS_DATE,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_TIMESTAMP,
     STATE_UNKNOWN,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
@@ -45,7 +42,7 @@ async def test_temperature_conversion(
         name="Test",
         native_value=str(native_value),
         native_unit_of_measurement=native_unit,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
     )
 
     entity0 = platform.ENTITIES["0"]
@@ -124,21 +121,23 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
     platform.ENTITIES["0"] = platform.MockSensor(
-        name="Test", native_value=test_timestamp, device_class=DEVICE_CLASS_TIMESTAMP
+        name="Test",
+        native_value=test_timestamp,
+        device_class=SensorDeviceClass.TIMESTAMP,
     )
     platform.ENTITIES["1"] = platform.MockSensor(
-        name="Test", native_value=test_date, device_class=DEVICE_CLASS_DATE
+        name="Test", native_value=test_date, device_class=SensorDeviceClass.DATE
     )
     platform.ENTITIES["2"] = platform.MockSensor(
-        name="Test", native_value=None, device_class=DEVICE_CLASS_TIMESTAMP
+        name="Test", native_value=None, device_class=SensorDeviceClass.TIMESTAMP
     )
     platform.ENTITIES["3"] = platform.MockSensor(
-        name="Test", native_value=None, device_class=DEVICE_CLASS_DATE
+        name="Test", native_value=None, device_class=SensorDeviceClass.DATE
     )
     platform.ENTITIES["4"] = platform.MockSensor(
         name="Test",
         native_value=test_local_timestamp,
-        device_class=DEVICE_CLASS_TIMESTAMP,
+        device_class=SensorDeviceClass.TIMESTAMP,
     )
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
@@ -163,44 +162,44 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
 @pytest.mark.parametrize(
     "device_class,native_value,state_value",
     [
-        (DEVICE_CLASS_DATE, "2021-11-09", "2021-11-09"),
+        (SensorDeviceClass.DATE, "2021-11-09", "2021-11-09"),
         (
-            DEVICE_CLASS_DATE,
+            SensorDeviceClass.DATE,
             "2021-01-09T12:00:00+00:00",
             "2021-01-09",
         ),
         (
-            DEVICE_CLASS_DATE,
+            SensorDeviceClass.DATE,
             "2021-01-09T00:00:00+01:00",
             "2021-01-08",
         ),
         (
-            DEVICE_CLASS_TIMESTAMP,
+            SensorDeviceClass.TIMESTAMP,
             "2021-01-09T12:00:00+00:00",
             "2021-01-09T12:00:00+00:00",
         ),
         (
-            DEVICE_CLASS_TIMESTAMP,
+            SensorDeviceClass.TIMESTAMP,
             "2021-01-09 12:00:00+00:00",
             "2021-01-09T12:00:00+00:00",
         ),
         (
-            DEVICE_CLASS_TIMESTAMP,
+            SensorDeviceClass.TIMESTAMP,
             "2021-01-09T12:00:00+04:00",
             "2021-01-09T08:00:00+00:00",
         ),
         (
-            DEVICE_CLASS_TIMESTAMP,
+            SensorDeviceClass.TIMESTAMP,
             "2021-01-09 12:00:00+01:00",
             "2021-01-09T11:00:00+00:00",
         ),
         (
-            DEVICE_CLASS_TIMESTAMP,
+            SensorDeviceClass.TIMESTAMP,
             "2021-01-09 12:00:00",
             "2021-01-09T12:00:00",
         ),
         (
-            DEVICE_CLASS_TIMESTAMP,
+            SensorDeviceClass.TIMESTAMP,
             "2021-01-09T12:00:00",
             "2021-01-09T12:00:00",
         ),
@@ -237,7 +236,9 @@ async def test_reject_timezoneless_datetime_str(
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
     platform.ENTITIES["0"] = platform.MockSensor(
-        name="Test", native_value=test_timestamp, device_class=DEVICE_CLASS_TIMESTAMP
+        name="Test",
+        native_value=test_timestamp,
+        device_class=SensorDeviceClass.TIMESTAMP,
     )
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})

--- a/tests/components/sensor/test_significant_change.py
+++ b/tests/components/sensor/test_significant_change.py
@@ -1,13 +1,7 @@
 """Test the sensor significant change platform."""
 import pytest
 
-from homeassistant.components.sensor.significant_change import (
-    DEVICE_CLASS_AQI,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_TEMPERATURE,
-    async_check_significant_change,
-)
+from homeassistant.components.sensor import SensorDeviceClass, significant_change
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -16,24 +10,24 @@ from homeassistant.const import (
 )
 
 AQI_ATTRS = {
-    ATTR_DEVICE_CLASS: DEVICE_CLASS_AQI,
+    ATTR_DEVICE_CLASS: SensorDeviceClass.AQI,
 }
 
 BATTERY_ATTRS = {
-    ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
+    ATTR_DEVICE_CLASS: SensorDeviceClass.BATTERY,
 }
 
 HUMIDITY_ATTRS = {
-    ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
+    ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
 }
 
 TEMP_CELSIUS_ATTRS = {
-    ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+    ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
 }
 
 TEMP_FREEDOM_ATTRS = {
-    ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+    ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT,
 }
 
@@ -63,6 +57,8 @@ TEMP_FREEDOM_ATTRS = {
 async def test_significant_change_temperature(old_state, new_state, attrs, result):
     """Detect temperature significant changes."""
     assert (
-        async_check_significant_change(None, old_state, attrs, new_state, attrs)
+        significant_change.async_check_significant_change(
+            None, old_state, attrs, new_state, attrs
+        )
         is result
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use enums in sensor tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
