### PR TITLE
Add wemo config_flow test to get 100% coverage

### DIFF
--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Wemo."""
 
-from pywemo import discover_devices
+import pywemo
 
 from homeassistant.helpers import config_entry_flow
 
@@ -9,7 +9,7 @@ from . import DOMAIN
 
 async def _async_has_devices(hass):
     """Return if there are devices that can be discovered."""
-    return bool(await hass.async_add_executor_job(discover_devices))
+    return bool(await hass.async_add_executor_job(pywemo.discover_devices))
 
 
 config_entry_flow.register_discovery_flow(DOMAIN, "Wemo", _async_has_devices)

--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Wemo."""
 
-import pywemo
+from pywemo import discover_devices
 
 from homeassistant.helpers import config_entry_flow
 
@@ -9,7 +9,7 @@ from . import DOMAIN
 
 async def _async_has_devices(hass):
     """Return if there are devices that can be discovered."""
-    return bool(await hass.async_add_executor_job(pywemo.discover_devices))
+    return bool(await hass.async_add_executor_job(discover_devices))
 
 
 config_entry_flow.register_discovery_flow(DOMAIN, "Wemo", _async_has_devices)

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -15,8 +15,8 @@ async def test_not_discovered(hass: HomeAssistant) -> None:
         context={"source": SOURCE_USER},
     )
 
-    with patch("homeassistant.components.wemo.config_flow.pywemo") as pywemo:
-        pywemo.discover_devices.return_value = []
+    with patch("homeassistant.components.wemo.config_flow.pywemo") as mock_pywemo:
+        mock_pywemo.discover_devices.return_value = []
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -1,0 +1,21 @@
+"""Tests for Wemo config flow."""
+
+from homeassistant import data_entry_flow
+from homeassistant.components.wemo.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.core import HomeAssistant
+
+from tests.common import patch
+
+
+async def test_not_discovered(hass: HomeAssistant) -> None:
+    """Test setting up with no devices discovered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    with patch("pywemo.discover_devices", return_value=[]):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "no_devices_found"

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -15,7 +15,9 @@ async def test_not_discovered(hass: HomeAssistant) -> None:
         context={"source": SOURCE_USER},
     )
 
-    with patch("pywemo.discover_devices", return_value=[]):
+    with patch(
+        "homeassistant.components.wemo.config_flow.discover_devices", return_value=[]
+    ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -15,9 +15,8 @@ async def test_not_discovered(hass: HomeAssistant) -> None:
         context={"source": SOURCE_USER},
     )
 
-    with patch(
-        "homeassistant.components.wemo.config_flow.discover_devices", return_value=[]
-    ):
+    with patch("homeassistant.components.wemo.config_flow.pywemo") as pywemo:
+        pywemo.discover_devices.return_value = []
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improving test coverage of wemo/config_flow.py.

Doing this prior to making a config_flow change in #62157.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
