### PR TITLE
Add unique ID to config entry in Luftdaten

### DIFF
--- a/homeassistant/components/luftdaten/config_flow.py
+++ b/homeassistant/components/luftdaten/config_flow.py
@@ -18,25 +18,6 @@ import homeassistant.helpers.config_validation as cv
 from .const import CONF_SENSOR_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 
-@callback
-def configured_sensors(hass):
-    """Return a set of configured Luftdaten sensors."""
-    return {
-        entry.data[CONF_SENSOR_ID]
-        for entry in hass.config_entries.async_entries(DOMAIN)
-    }
-
-
-@callback
-def duplicate_stations(hass):
-    """Return a set of duplicate configured Luftdaten stations."""
-    stations = [
-        int(entry.data[CONF_SENSOR_ID])
-        for entry in hass.config_entries.async_entries(DOMAIN)
-    ]
-    return {x for x in stations if stations.count(x) > 1}
-
-
 class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Luftdaten config flow."""
 
@@ -59,10 +40,8 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             return self._show_form()
 
-        sensor_id = user_input[CONF_SENSOR_ID]
-
-        if sensor_id in configured_sensors(self.hass):
-            return self._show_form({CONF_SENSOR_ID: "already_configured"})
+        await self.async_set_unique_id(str(user_input[CONF_SENSOR_ID]))
+        self._abort_if_unique_id_configured()
 
         luftdaten = Luftdaten(user_input[CONF_SENSOR_ID])
         try:
@@ -86,4 +65,6 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         scan_interval = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         user_input.update({CONF_SCAN_INTERVAL: scan_interval.total_seconds()})
 
-        return self.async_create_entry(title=str(sensor_id), data=user_input)
+        return self.async_create_entry(
+            title=str(user_input[CONF_SENSOR_ID]), data=user_input
+        )

--- a/tests/components/luftdaten/conftest.py
+++ b/tests/components/luftdaten/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures for Luftdaten tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.luftdaten import DOMAIN
+from homeassistant.components.luftdaten.const import CONF_SENSOR_ID
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="12345",
+        domain=DOMAIN,
+        data={CONF_SENSOR_ID: 123456},
+        unique_id="12345",
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[None, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.luftdaten.async_setup_entry", return_value=True
+    ):
+        yield

--- a/tests/components/luftdaten/test_config_flow.py
+++ b/tests/components/luftdaten/test_config_flow.py
@@ -1,84 +1,114 @@
 """Define tests for the Luftdaten config flow."""
-from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from homeassistant import data_entry_flow
-from homeassistant.components.luftdaten import DOMAIN, config_flow
+from luftdaten.exceptions import LuftdatenConnectionError
+
+from homeassistant.components.luftdaten import DOMAIN
 from homeassistant.components.luftdaten.const import CONF_SENSOR_ID
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_SCAN_INTERVAL, CONF_SHOW_ON_MAP
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
 
 from tests.common import MockConfigEntry
 
 
-async def test_duplicate_error(hass):
+async def test_duplicate_error(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Test that errors are shown when duplicates are added."""
-    conf = {CONF_SENSOR_ID: "12345abcde"}
+    mock_config_entry.add_to_hass(hass)
 
-    MockConfigEntry(domain=DOMAIN, data=conf).add_to_hass(hass)
-    flow = config_flow.LuftDatenFlowHandler()
-    flow.hass = hass
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    result = await flow.async_step_user(user_input=conf)
-    assert result["errors"] == {CONF_SENSOR_ID: "already_configured"}
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_SENSOR_ID: 12345},
+    )
+
+    assert result2.get("type") == RESULT_TYPE_ABORT
+    assert result2.get("reason") == "already_configured"
 
 
-async def test_communication_error(hass):
+async def test_communication_error(hass: HomeAssistant) -> None:
     """Test that no sensor is added while unable to communicate with API."""
-    conf = {CONF_SENSOR_ID: "12345abcde"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    flow = config_flow.LuftDatenFlowHandler()
-    flow.hass = hass
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
 
-    with patch("luftdaten.Luftdaten.get_data", return_value=None):
-        result = await flow.async_step_user(user_input=conf)
-        assert result["errors"] == {CONF_SENSOR_ID: "invalid_sensor"}
+    with patch("luftdaten.Luftdaten.get_data", side_effect=LuftdatenConnectionError):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_SENSOR_ID: 12345},
+        )
+
+    assert result2.get("type") == RESULT_TYPE_FORM
+    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("errors") == {CONF_SENSOR_ID: "cannot_connect"}
 
 
-async def test_invalid_sensor(hass):
+async def test_invalid_sensor(hass: HomeAssistant) -> None:
     """Test that an invalid sensor throws an error."""
-    conf = {CONF_SENSOR_ID: "12345abcde"}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    flow = config_flow.LuftDatenFlowHandler()
-    flow.hass = hass
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
 
     with patch("luftdaten.Luftdaten.get_data", return_value=False), patch(
         "luftdaten.Luftdaten.validate_sensor", return_value=False
     ):
-        result = await flow.async_step_user(user_input=conf)
-        assert result["errors"] == {CONF_SENSOR_ID: "invalid_sensor"}
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_SENSOR_ID: 12345},
+        )
+
+    assert result2.get("type") == RESULT_TYPE_FORM
+    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("errors") == {CONF_SENSOR_ID: "invalid_sensor"}
 
 
-async def test_show_form(hass):
-    """Test that the form is served with no input."""
-    flow = config_flow.LuftDatenFlowHandler()
-    flow.hass = hass
-
-    result = await flow.async_step_user(user_input=None)
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-
-async def test_step_user(hass):
+async def test_step_user(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Test that the user step works."""
-    conf = {
-        CONF_SENSOR_ID: "12345abcde",
-        CONF_SHOW_ON_MAP: False,
-        CONF_SCAN_INTERVAL: timedelta(minutes=5),
-    }
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    flow = config_flow.LuftDatenFlowHandler()
-    flow.hass = hass
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
 
     with patch("luftdaten.Luftdaten.get_data", return_value=True), patch(
         "luftdaten.Luftdaten.validate_sensor", return_value=True
     ):
-        result = await flow.async_step_user(user_input=conf)
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_SENSOR_ID: 12345,
+                CONF_SHOW_ON_MAP: False,
+            },
+        )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "12345abcde"
-        assert result["data"] == {
-            CONF_SENSOR_ID: "12345abcde",
-            CONF_SHOW_ON_MAP: False,
-            CONF_SCAN_INTERVAL: 300,
-        }
+    assert result2.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result2.get("title") == "12345"
+    assert result2.get("data") == {
+        CONF_SENSOR_ID: 12345,
+        CONF_SHOW_ON_MAP: False,
+        CONF_SCAN_INTERVAL: 600.0,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Luftdaten used an old method to determine a duplicate entry.

This PR:

- Adds a unique ID to config entry in the config flow
- Abort is already configured
- Existing entries are migrated on setup.
- Removes existing logic for duplicate sensor ID detection
- Removes logic that de-duplicated sensors (from the YAML import days)
- Rewrites config flow tests, these are (unfortunately) closely related; As the existing tests would not work with the unique ID capabilities.

Notes:
- Test coverage of the config flow is not 100% yet (it wasn't 100% either), which wasn't a goal of this PR.
- More cleanups/changes are pending, however, this PR is already reasonable in size.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
