### PR TITLE
2021.12.3

### DIFF
--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brunt Blind Engine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/brunt",
-  "requirements": ["brunt==1.0.1"],
+  "requirements": ["brunt==1.0.2"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/ebusd/manifest.json
+++ b/homeassistant/components/ebusd/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ebusd",
   "name": "ebusd",
   "documentation": "https://www.home-assistant.io/integrations/ebusd",
-  "requirements": ["ebusdpy==0.0.16"],
+  "requirements": ["ebusdpy==0.0.17"],
   "codeowners": [],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -94,6 +94,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             firmware_date=None,
             model_info=None,
             model_description=None,
+            remote_access_enabled=None,
+            remote_access_host=None,
+            remote_access_port=None,
         )
         return await self._async_handle_discovery()
 
@@ -261,6 +264,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             firmware_date=None,
             model_info=None,
             model_description=bulb.model_data.description,
+            remote_access_enabled=None,
+            remote_access_host=None,
+            remote_access_port=None,
         )
 
 

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flux LED/MagicHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.26.7"],
+  "requirements": ["flux_led==0.26.15"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch"],
   "iot_class": "local_push",

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -120,10 +120,11 @@ class Light(HomeAccessory):
         if self._event_timer:
             self._event_timer()
         self._event_timer = async_call_later(
-            self.hass, CHANGE_COALESCE_TIME_WINDOW, self._send_events
+            self.hass, CHANGE_COALESCE_TIME_WINDOW, self._async_send_events
         )
 
-    def _send_events(self, *_):
+    @callback
+    def _async_send_events(self, *_):
         """Process all changes at once."""
         _LOGGER.debug("Coalesced _set_chars: %s", self._pending_events)
         char_values = self._pending_events

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -3,7 +3,7 @@
   "name": "Philips Hue",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/hue",
-  "requirements": ["aiohue==3.0.5"],
+  "requirements": ["aiohue==3.0.6"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/homeassistant/components/hue/services.py
+++ b/homeassistant/components/hue/services.py
@@ -146,8 +146,10 @@ async def hue_activate_scene_v2(
             continue
         # found match!
         if transition:
-            transition = transition * 100  # in steps of 100ms
-        await api.scenes.recall(scene.id, dynamic=dynamic, duration=transition)
+            transition = transition * 1000  # transition is in ms
+        await bridge.async_request_call(
+            api.scenes.recall, scene.id, dynamic=dynamic, duration=transition
+        )
         return True
     LOGGER.debug(
         "Unable to find scene %s for group %s on bridge %s",

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -42,7 +42,10 @@ CONF_STATE_ADDRESS: Final = "state_address"
 CONF_SYNC_STATE: Final = "sync_state"
 CONF_KNX_INITIAL_CONNECTION_TYPES: Final = [CONF_KNX_TUNNELING, CONF_KNX_ROUTING]
 
+# yaml config merged with config entry data
 DATA_KNX_CONFIG: Final = "knx_config"
+# original hass yaml config
+DATA_HASS_CONFIG: Final = "knx_hass_config"
 
 ATTR_COUNTER: Final = "counter"
 ATTR_SOURCE: Final = "source"

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -112,6 +112,7 @@ def log_entry(hass, name, message, domain=None, entity_id=None, context=None):
     hass.add_job(async_log_entry, hass, name, message, domain, entity_id, context)
 
 
+@callback
 @bind_hass
 def async_log_entry(hass, name, message, domain=None, entity_id=None, context=None):
     """Add an entry to the logbook."""

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["ffmpeg", "http", "media_source"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
-  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.4.8"],
+  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.4.9"],
   "codeowners": ["@allenporter"],
   "quality_scale": "platinum",
   "dhcp": [

--- a/homeassistant/components/nextbus/sensor.py
+++ b/homeassistant/components/nextbus/sensor.py
@@ -214,7 +214,7 @@ class NextBusDepartureSensor(SensorEntity):
 
         # Generate list of upcoming times
         self._attributes["upcoming"] = ", ".join(
-            sorted(p["minutes"] for p in predictions)
+            sorted((p["minutes"] for p in predictions), key=int)
         )
 
         latest_prediction = maybe_first(predictions)

--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -1,6 +1,8 @@
 """The 1-Wire component."""
 import logging
 
+from pyownet import protocol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -18,7 +20,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     onewirehub = OneWireHub(hass)
     try:
         await onewirehub.initialize(entry)
-    except CannotConnect as exc:
+    except (
+        CannotConnect,  # Failed to connect to the server
+        protocol.OwnetError,  # Connected to server, but failed to list the devices
+    ) as exc:
         raise ConfigEntryNotReady() from exc
 
     hass.data[DOMAIN][entry.entry_id] = onewirehub

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -68,13 +68,12 @@ from .utils import (
 BLOCK_PLATFORMS: Final = [
     "binary_sensor",
     "button",
-    "climate",
     "cover",
     "light",
     "sensor",
     "switch",
 ]
-BLOCK_SLEEPING_PLATFORMS: Final = ["binary_sensor", "sensor"]
+BLOCK_SLEEPING_PLATFORMS: Final = ["binary_sensor", "climate", "sensor"]
 RPC_PLATFORMS: Final = ["binary_sensor", "button", "light", "sensor", "switch"]
 _LOGGER: Final = logging.getLogger(__name__)
 

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -187,7 +187,7 @@ class BlockSleepingClimate(
         """Device availability."""
         if self.device_block is not None:
             return not cast(bool, self.device_block.valveError)
-        return True
+        return self.wrapper.last_update_success
 
     @property
     def hvac_mode(self) -> str:

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -641,9 +641,13 @@ class LightTemplate(TemplateEntity, LightEntity):
     @callback
     def _update_color(self, render):
         """Update the hs_color from the template."""
+        if render is None:
+            self._color = None
+            return
+
         h_str = s_str = None
         if isinstance(render, str):
-            if render in (None, "None", ""):
+            if render in ("None", ""):
                 self._color = None
                 return
             h_str, s_str = map(

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from . import ValloxDataUpdateCoordinator
 from .const import (
@@ -107,7 +108,7 @@ class ValloxFilterRemainingSensor(ValloxSensor):
         days_remaining_delta = timedelta(days=days_remaining)
         now = datetime.utcnow().replace(hour=13, minute=0, second=0, microsecond=0)
 
-        return now + days_remaining_delta
+        return (now + days_remaining_delta).astimezone(dt_util.UTC)
 
 
 class ValloxCellStateSensor(ValloxSensor):

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -234,6 +234,7 @@ class GroupProbe:
             unsub()
             self._unsubs.remove(unsub)
 
+    @callback
     def _reprobe_group(self, group_id: int) -> None:
         """Reprobe a group for entities after its members change."""
         zha_gateway = self._hass.data[zha_const.DATA_ZHA][zha_const.DATA_ZHA_GATEWAY]

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from homeassistant.backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1052,6 +1052,7 @@ class Script:
         if self._change_listener_job:
             self._hass.async_run_hass_job(self._change_listener_job)
 
+    @callback
     def _chain_change_listener(self, sub_script: Script) -> None:
         if sub_script.is_running:
             self.last_action = sub_script.last_action

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -573,7 +573,7 @@ dweepy==0.3.0
 dynalite_devices==0.1.46
 
 # homeassistant.components.ebusd
-ebusdpy==0.0.16
+ebusdpy==0.0.17
 
 # homeassistant.components.ecoal_boiler
 ecoaliface==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -440,7 +440,7 @@ brother==1.1.0
 brottsplatskartan==0.0.1
 
 # homeassistant.components.brunt
-brunt==1.0.1
+brunt==1.0.2
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ google-cloud-pubsub==2.1.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.4.8
+google-nest-sdm==0.4.9
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -186,7 +186,7 @@ aiohomekit==0.6.4
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==3.0.5
+aiohue==3.0.6
 
 # homeassistant.components.imap
 aioimaplib==0.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -658,7 +658,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.26.7
+flux_led==0.26.15
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ broadlink==0.18.0
 brother==1.1.0
 
 # homeassistant.components.brunt
-brunt==1.0.1
+brunt==1.0.2
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,7 +131,7 @@ aiohomekit==0.6.4
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==3.0.5
+aiohue==3.0.6
 
 # homeassistant.components.apache_kafka
 aiokafka==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -461,7 +461,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
-google-nest-sdm==0.4.8
+google-nest-sdm==0.4.9
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,7 +399,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.26.7
+flux_led==0.26.15
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -40,6 +40,7 @@ BASIC_RESULTS = {
                 {"minutes": "1", "epochTime": "1553807371000"},
                 {"minutes": "2", "epochTime": "1553807372000"},
                 {"minutes": "3", "epochTime": "1553807373000"},
+                {"minutes": "10", "epochTime": "1553807380000"},
             ],
         },
     }
@@ -128,7 +129,7 @@ async def test_verify_valid_state(
     assert state.attributes["route"] == VALID_ROUTE_TITLE
     assert state.attributes["stop"] == VALID_STOP_TITLE
     assert state.attributes["direction"] == "Outbound"
-    assert state.attributes["upcoming"] == "1, 2, 3"
+    assert state.attributes["upcoming"] == "1, 2, 3, 10"
 
 
 async def test_message_dict(

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,6 +1,8 @@
 """Tests for 1-Wire config flow."""
 import logging
+from unittest.mock import MagicMock
 
+from pyownet import protocol
 import pytest
 
 from homeassistant.components.onewire.const import DOMAIN
@@ -11,6 +13,20 @@ from homeassistant.core import HomeAssistant
 @pytest.mark.usefixtures("owproxy_with_connerror")
 async def test_owserver_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry):
     """Test connection failure raises ConfigEntryNotReady."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not hass.data.get(DOMAIN)
+
+
+async def test_owserver_listing_failure(
+    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock
+):
+    """Test listing failure raises ConfigEntryNotReady."""
+    owproxy.return_value.dir.side_effect = protocol.OwnetError()
+
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
- Update ebusdpy version (@sindudas - #59899)
- Nextbus upcoming sort as integer (@ViViDboarder - #61416)
- Add restore logic to Shelly climate platform (@chemelli74 - #61632)
- Fix OwnetError preventing onewire initialisation (@epenet - #61696)
- Fix notify platform setup for KNX (@marvin-w - #61842)
- Bump aiohue to 3.0.6 (@marcelveldt - #61974)
- Brunt dependency bump to 1.0.2 (@eavanvalkenburg - #62014)
- Bump flux_led to 0.26.15 (@bdraco - #62017)
- Fix none-check in template light (@emontnemery - #62089)
- Add missing timezone information (@DeerMaximum - #62106)
- Improve availability for Shelly Valve (@chemelli74 - #62129)
- Fix Non-thread-safe operation in homekit light events (@bdraco - #62147)
- Fix Non-thread-safe operation in logbook (@bdraco - #62148)
- Bump google-nest-sdm to 0.4.9 (@allenporter - #62160)
- Add guard in call to activate_scene in Hue (@marcelveldt - #62177)
- Fix threading error in scripts with repeat or choose actions (@emontnemery - #62168)
- Fix threading error in zha (@emontnemery - #62170)