### PR TITLE
Remove myself from yeelight codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1055,8 +1055,8 @@ homeassistant/components/yamaha_musiccast/* @vigonotion @micha91
 tests/components/yamaha_musiccast/* @vigonotion @micha91
 homeassistant/components/yandex_transport/* @rishatik92 @devbis
 tests/components/yandex_transport/* @rishatik92 @devbis
-homeassistant/components/yeelight/* @rytilahti @zewelor @shenxn @starkillerOG
-tests/components/yeelight/* @rytilahti @zewelor @shenxn @starkillerOG
+homeassistant/components/yeelight/* @zewelor @shenxn @starkillerOG
+tests/components/yeelight/* @zewelor @shenxn @starkillerOG
 homeassistant/components/yeelightsunflower/* @lindsaymarkward
 homeassistant/components/yi/* @bachya
 homeassistant/components/youless/* @gjong

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
   "requirements": ["yeelight==0.7.8", "async-upnp-client==0.23.0"],
-  "codeowners": ["@rytilahti", "@zewelor", "@shenxn", "@starkillerOG"],
+  "codeowners": ["@zewelor", "@shenxn", "@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],
   "quality_scale": "platinum",


### PR DESCRIPTION
Since I haven't been done much besides performing the initial port to use python-yeelight what feels like ages ago, it doesn't make sense to be listed as a codeowner for this integration.

Yeelight bulbs still hold a special place in my mind, being my first iot devices that led me to homeassistant and other adventures. I'm thankful for all contributors and maintainers who have made it a breeze to use these devices in homeassistant. As I still have some devices around, I will continue to be a happy user also in the future, so thanks & farewell!