### PR TITLE
Fix bug in which SimpliSafe websocket won't reconnect on error

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -527,6 +527,8 @@ class SimpliSafe:
         try:
             await self._api.websocket.async_connect()
             await self._api.websocket.async_listen()
+        except asyncio.CancelledError:
+            raise
         except WebsocketError as err:
             LOGGER.error("Failed to connect to websocket: %s", err)
         except Exception as err:  # pylint: disable=broad-except

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -524,23 +524,20 @@ class SimpliSafe:
         if TYPE_CHECKING:
             assert self._api.websocket
 
-        should_reconnect = True
-
         try:
             await self._api.websocket.async_connect()
             await self._api.websocket.async_listen()
         except asyncio.CancelledError:
-            should_reconnect = False
+            raise
         except WebsocketError as err:
             LOGGER.error("Failed to connect to websocket: %s", err)
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.error("Unknown exception while connecting to websocket: %s", err)
 
-        if should_reconnect:
-            LOGGER.info("Disconnected from websocket; reconnecting")
-            self._websocket_reconnect_task = self._hass.async_create_task(
-                self._async_websocket_connect()
-            )
+        LOGGER.info("Disconnected from websocket; reconnecting")
+        self._websocket_reconnect_task = self._hass.async_create_task(
+            self._async_websocket_connect()
+        )
 
     @callback
     def _async_websocket_on_event(self, event: WebsocketEvent) -> None:

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -592,6 +592,10 @@ class SimpliSafe:
 
             if self._websocket_reconnect_task:
                 self._websocket_reconnect_task.cancel()
+                try:
+                    await self._websocket_reconnect_task
+                except asyncio.CancelledError:
+                    LOGGER.debug("Websocket reconnection task successfully canceled")
 
             await self._api.websocket.async_disconnect()
 
@@ -647,7 +651,7 @@ class SimpliSafe:
                 # If a websocket connection is open, reconnect it to use the
                 # new access token:
                 self._websocket_reconnect_task = self._hass.async_create_task(
-                    self._api.websocket.async_reconnect()
+                    self._async_websocket_connect()
                 )
 
         self.entry.async_on_unload(

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, cast
 from simplipy import API
 from simplipy.device import Device, DeviceTypes
 from simplipy.errors import (
-    ConnectionClosedError,
     EndpointUnavailableError,
     InvalidCredentialsError,
     SimplipyError,
@@ -532,8 +531,6 @@ class SimpliSafe:
             await self._api.websocket.async_listen()
         except asyncio.CancelledError:
             should_reconnect = False
-        except ConnectionClosedError:
-            LOGGER.info("Connection to websocket was closed")
         except WebsocketError as err:
             LOGGER.error("Failed to connect to websocket: %s", err)
         except Exception as err:  # pylint: disable=broad-except

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -527,8 +527,6 @@ class SimpliSafe:
         try:
             await self._api.websocket.async_connect()
             await self._api.websocket.async_listen()
-        except asyncio.CancelledError:
-            raise
         except WebsocketError as err:
             LOGGER.error("Failed to connect to websocket: %s", err)
         except Exception as err:  # pylint: disable=broad-except


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds appropriate logic to catch SimpliSafe websocket errors and, when appropriate, reconnect to the websocket.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/62238
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
