### PR TITLE
Allow name-only location updates for mobile_app device_tracker

### DIFF
--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -312,8 +312,8 @@ async def webhook_render_template(hass, config_entry, data):
 @validate_schema(
     {
         vol.Optional(ATTR_LOCATION_NAME): cv.string,
-        vol.Required(ATTR_GPS): cv.gps,
-        vol.Required(ATTR_GPS_ACCURACY): cv.positive_int,
+        vol.Optional(ATTR_GPS): cv.gps,
+        vol.Optional(ATTR_GPS_ACCURACY): cv.positive_int,
         vol.Optional(ATTR_BATTERY): cv.positive_int,
         vol.Optional(ATTR_SPEED): cv.positive_int,
         vol.Optional(ATTR_ALTITUDE): vol.Coerce(float),

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -310,16 +310,19 @@ async def webhook_render_template(hass, config_entry, data):
 
 @WEBHOOK_COMMANDS.register("update_location")
 @validate_schema(
-    {
-        vol.Optional(ATTR_LOCATION_NAME): cv.string,
-        vol.Optional(ATTR_GPS): cv.gps,
-        vol.Optional(ATTR_GPS_ACCURACY): cv.positive_int,
-        vol.Optional(ATTR_BATTERY): cv.positive_int,
-        vol.Optional(ATTR_SPEED): cv.positive_int,
-        vol.Optional(ATTR_ALTITUDE): vol.Coerce(float),
-        vol.Optional(ATTR_COURSE): cv.positive_int,
-        vol.Optional(ATTR_VERTICAL_ACCURACY): cv.positive_int,
-    }
+    vol.Schema(
+        cv.key_dependency(ATTR_GPS, ATTR_GPS_ACCURACY),
+        {
+            vol.Optional(ATTR_LOCATION_NAME): cv.string,
+            vol.Optional(ATTR_GPS): cv.gps,
+            vol.Optional(ATTR_GPS_ACCURACY): cv.positive_int,
+            vol.Optional(ATTR_BATTERY): cv.positive_int,
+            vol.Optional(ATTR_SPEED): cv.positive_int,
+            vol.Optional(ATTR_ALTITUDE): vol.Coerce(float),
+            vol.Optional(ATTR_COURSE): cv.positive_int,
+            vol.Optional(ATTR_VERTICAL_ACCURACY): cv.positive_int,
+        },
+    )
 )
 async def webhook_update_location(hass, config_entry, data):
     """Handle an update location webhook."""

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -7,7 +7,12 @@ import pytest
 from homeassistant.components.camera import SUPPORT_STREAM as CAMERA_SUPPORT_STREAM
 from homeassistant.components.mobile_app.const import CONF_SECRET
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
-from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.const import (
+    CONF_WEBHOOK_ID,
+    STATE_HOME,
+    STATE_NOT_HOME,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -283,7 +288,46 @@ async def test_webhook_requires_encryption(webhook_client, create_registrations)
     assert webhook_json["error"]["code"] == "encryption_required"
 
 
-async def test_webhook_update_location(hass, webhook_client, create_registrations):
+async def test_webhook_update_location_without_locations(
+    hass, webhook_client, create_registrations
+):
+    """Test that location can be updated."""
+
+    # start off with a location set by name
+    resp = await webhook_client.post(
+        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+        json={
+            "type": "update_location",
+            "data": {"location_name": STATE_HOME},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.state == STATE_HOME
+
+    # set location to an 'unknown' state
+    resp = await webhook_client.post(
+        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+        json={
+            "type": "update_location",
+            "data": {"altitude": 123},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes["altitude"] == 123
+
+
+async def test_webhook_update_location_with_gps(
+    hass, webhook_client, create_registrations
+):
     """Test that location can be updated."""
     resp = await webhook_client.post(
         "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
@@ -301,6 +345,68 @@ async def test_webhook_update_location(hass, webhook_client, create_registration
     assert state.attributes["longitude"] == 2.0
     assert state.attributes["gps_accuracy"] == 10
     assert state.attributes["altitude"] == -10
+
+
+async def test_webhook_update_location_with_location_name(
+    hass, webhook_client, create_registrations
+):
+    """Test that location can be updated."""
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value={
+            ZONE_DOMAIN: [
+                {
+                    "name": "zone_name",
+                    "latitude": 1.23,
+                    "longitude": -4.56,
+                    "radius": 200,
+                    "icon": "mdi:test-tube",
+                },
+            ]
+        },
+    ):
+        await hass.services.async_call(ZONE_DOMAIN, "reload", blocking=True)
+
+    resp = await webhook_client.post(
+        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+        json={
+            "type": "update_location",
+            "data": {"location_name": "zone_name"},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state.state == "zone_name"
+
+    resp = await webhook_client.post(
+        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+        json={
+            "type": "update_location",
+            "data": {"location_name": STATE_HOME},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state.state == STATE_HOME
+
+    resp = await webhook_client.post(
+        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+        json={
+            "type": "update_location",
+            "data": {"location_name": STATE_NOT_HOME},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state.state == STATE_NOT_HOME
 
 
 async def test_webhook_enable_encryption(hass, webhook_client, create_registrations):

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -347,6 +347,24 @@ async def test_webhook_update_location_with_gps(
     assert state.attributes["altitude"] == -10
 
 
+async def test_webhook_update_location_with_gps_without_accuracy(
+    hass, webhook_client, create_registrations
+):
+    """Test that location can be updated."""
+    resp = await webhook_client.post(
+        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+        json={
+            "type": "update_location",
+            "data": {"gps": [1, 2]},
+        },
+    )
+
+    assert resp.status == HTTPStatus.OK
+
+    state = hass.states.get("device_tracker.test_1_2")
+    assert state.state == STATE_UNKNOWN
+
+
 async def test_webhook_update_location_with_location_name(
     hass, webhook_client, create_registrations
 ):


### PR DESCRIPTION
## Proposed change
Allows sending name-only updates to the device_trackers, for example to do `home` vs. `not_home` without exposing accurate location values.

Motivation here originates in multi-server support in the iOS app. We want to limit location exposure to some not-their-primary-server instances like a parent's or friend's instance.

I'm somewhat intentionally (rather than requiring one of the `location_name`/`gps` keys) including the ability to redact the device_tracker (no gps/location name) and get it into the 'unknown' state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
