### PR TITLE
Add external Tibber statistics

### DIFF
--- a/homeassistant/components/tibber/manifest.json
+++ b/homeassistant/components/tibber/manifest.json
@@ -1,8 +1,9 @@
 {
+  "after_dependencies": ["recorder"],
   "domain": "tibber",
   "name": "Tibber",
   "documentation": "https://www.home-assistant.io/integrations/tibber",
-  "requirements": ["pyTibber==0.21.4"],
+  "requirements": ["pyTibber==0.21.6"],
   "codeowners": ["@danielhiversen"],
   "quality_scale": "silver",
   "config_flow": true,

--- a/homeassistant/components/tibber/manifest.json
+++ b/homeassistant/components/tibber/manifest.json
@@ -1,5 +1,5 @@
 {
-  "after_dependencies": ["recorder"],
+  "dependencies": ["recorder"],
   "domain": "tibber",
   "name": "Tibber",
   "documentation": "https://www.home-assistant.io/integrations/tibber",

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -257,7 +257,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         if home.has_active_subscription and not home.has_real_time_consumption:
             if coordinator is None:
-                coordinator = TibberDataCoordinator(tibber_connection, hass)
+                coordinator = TibberDataCoordinator(hass, tibber_connection)
             for entity_description in SENSORS:
                 entities.append(TibberDataSensor(home, coordinator, entity_description))
 
@@ -519,7 +519,7 @@ class TibberRtDataCoordinator(update_coordinator.DataUpdateCoordinator):
 class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
     """Handle Tibber data and insert statistics."""
 
-    def __init__(self, tibber_connection, hass):
+    def __init__(self, hass, tibber_connection):
         """Initialize the data handler."""
         super().__init__(
             hass,

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -8,6 +8,12 @@ from random import randrange
 
 import aiohttp
 
+from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    get_last_statistics,
+    statistics_during_period,
+)
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -235,6 +241,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         try:
             await home.update_info()
         except asyncio.TimeoutError as err:
+            print(err)
             _LOGGER.error("Timeout connecting to Tibber home: %s ", err)
             raise PlatformNotReady() from err
         except aiohttp.ClientError as err:
@@ -251,13 +258,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         if home.has_active_subscription and not home.has_real_time_consumption:
             if coordinator is None:
-                coordinator = update_coordinator.DataUpdateCoordinator(
-                    hass,
-                    _LOGGER,
-                    name=f"Tibber {tibber_connection.name}",
-                    update_method=tibber_connection.fetch_consumption_data_active_homes,
-                    update_interval=timedelta(hours=1),
-                )
+                coordinator = TibberDataCoordinator(tibber_connection, hass)
             for entity_description in SENSORS:
                 entities.append(TibberDataSensor(home, coordinator, entity_description))
 
@@ -514,3 +515,89 @@ class TibberRtDataCoordinator(update_coordinator.DataUpdateCoordinator):
             _LOGGER.error(errors[0])
             return None
         return self.data.get("data", {}).get("liveMeasurement")
+
+
+class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
+    """Handle Tibber data and insert statistics."""
+
+    def __init__(self, tibber_connection, hass):
+        """Initialize the data handler."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"Tibber {tibber_connection.name}",
+            update_interval=timedelta(hours=1),
+        )
+        self._tibber_connection = tibber_connection
+
+    async def _async_update_data(self):
+        """Update data via API."""
+        await self._tibber_connection.fetch_consumption_data_active_homes()
+        await self._insert_statistics()
+
+    async def _insert_statistics(self):
+        """Insert Tibber statistics."""
+        for home in self._tibber_connection.get_homes():
+            if not home.hourly_consumption_data:
+                continue
+
+            statistic_id = (
+                f"{TIBBER_DOMAIN}:{home.home_id.replace('-', '')}_energy_consumption"
+            )
+
+            last_stats = await self.hass.async_add_executor_job(
+                get_last_statistics, self.hass, 1, statistic_id, True
+            )
+
+            if not last_stats:
+                hourly_consumption_data = await home.get_historic_data(5 * 365 * 24)
+
+                _sum = 0
+                last_stats_time = None
+            else:
+                hourly_consumption_data = home.hourly_consumption_data
+
+                start = dt_util.parse_datetime(
+                    hourly_consumption_data[0]["from"]
+                ) - timedelta(hours=1)
+                stat = await self.hass.async_add_executor_job(
+                    statistics_during_period,
+                    self.hass,
+                    start,
+                    None,
+                    [statistic_id],
+                    "hour",
+                    True,
+                )
+                _sum = stat[statistic_id][0]["sum"]
+                last_stats_time = stat[statistic_id][0]["start"]
+
+            statistics = []
+
+            for data in hourly_consumption_data:
+                if data.get("consumption") is None:
+                    continue
+
+                start = dt_util.parse_datetime(data["from"])
+                if last_stats_time is not None and start <= last_stats_time:
+                    continue
+
+                _sum += data["consumption"]
+
+                statistics.append(
+                    StatisticData(
+                        start=start,
+                        state=data["consumption"],
+                        sum=_sum,
+                    )
+                )
+
+            metadata = StatisticMetaData(
+                has_mean=False,
+                has_sum=True,
+                name=f"{home.name} consumption",
+                source=TIBBER_DOMAIN,
+                statistic_id=statistic_id,
+                unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+            )
+            async_add_external_statistics(self.hass, metadata, statistics)

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -241,7 +241,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         try:
             await home.update_info()
         except asyncio.TimeoutError as err:
-            print(err)
             _LOGGER.error("Timeout connecting to Tibber home: %s ", err)
             raise PlatformNotReady() from err
         except aiohttp.ClientError as err:

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -549,11 +549,14 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
             )
 
             if not last_stats:
+                # First time we insert 5 years of data (if available)
                 hourly_consumption_data = await home.get_historic_data(5 * 365 * 24)
 
                 _sum = 0
                 last_stats_time = None
             else:
+                # hourly_consumption_data contains the last 30 days of consumption data.
+                # We update the statistics with the last 30 days of data to handle corrections in the data.
                 hourly_consumption_data = home.hourly_consumption_data
 
                 start = dt_util.parse_datetime(

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -541,7 +541,7 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
                 continue
 
             statistic_id = (
-                f"{TIBBER_DOMAIN}:{home.home_id.replace('-', '')}_energy_consumption"
+                f"{TIBBER_DOMAIN}:energy_consumption_{home.home_id.replace('-', '')}"
             )
 
             last_stats = await self.hass.async_add_executor_job(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1339,7 +1339,7 @@ pyRFXtrx==0.27.0
 # pySwitchmate==0.4.6
 
 # homeassistant.components.tibber
-pyTibber==0.21.4
+pyTibber==0.21.6
 
 # homeassistant.components.dlink
 pyW215==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -820,7 +820,7 @@ pyMetno==0.9.0
 pyRFXtrx==0.27.0
 
 # homeassistant.components.tibber
-pyTibber==0.21.4
+pyTibber==0.21.6
 
 # homeassistant.components.nextbus
 py_nextbusnext==0.1.5

--- a/tests/components/tibber/test_config_flow.py
+++ b/tests/components/tibber/test_config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components.tibber.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_init_recorder_component
 
 
 @pytest.fixture(name="tibber_setup", autouse=True)
@@ -19,6 +19,8 @@ def tibber_setup_fixture():
 
 async def test_show_config_form(hass):
     """Test show configuration form."""
+    await async_init_recorder_component(hass)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -29,6 +31,8 @@ async def test_show_config_form(hass):
 
 async def test_create_entry(hass):
     """Test create entry from user input."""
+    await async_init_recorder_component(hass)
+
     test_data = {
         CONF_ACCESS_TOKEN: "valid",
     }
@@ -53,6 +57,8 @@ async def test_create_entry(hass):
 
 async def test_flow_entry_already_exists(hass):
     """Test user input for config_entry that already exists."""
+    await async_init_recorder_component(hass)
+
     first_entry = MockConfigEntry(
         domain="tibber",
         data={CONF_ACCESS_TOKEN: "valid"},

--- a/tests/components/tibber/test_statistics.py
+++ b/tests/components/tibber/test_statistics.py
@@ -1,0 +1,73 @@
+"""Test adding external statistics from Tibber."""
+from unittest.mock import AsyncMock
+
+from homeassistant.components.recorder.statistics import statistics_during_period
+from homeassistant.components.tibber.sensor import TibberDataCoordinator
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_init_recorder_component
+from tests.components.recorder.common import async_wait_recording_done_without_instance
+
+_CONSUMPTION_DATA_1 = [
+    {
+        "from": "2022-01-03T00:00:00.000+01:00",
+        "totalCost": 1.1,
+        "consumption": 2.1,
+    },
+    {
+        "from": "2022-01-03T01:00:00.000+01:00",
+        "totalCost": 1.2,
+        "consumption": 2.2,
+    },
+    {
+        "from": "2022-01-03T02:00:00.000+01:00",
+        "totalCost": 1.3,
+        "consumption": 2.3,
+    },
+]
+
+
+async def test_async_setup_entry(hass):
+    """Test setup Tibber."""
+    await async_init_recorder_component(hass)
+
+    def _get_homes():
+        tibber_home = AsyncMock()
+        tibber_home.home_id = "home_id"
+        tibber_home.get_historic_data.return_value = _CONSUMPTION_DATA_1
+        return [tibber_home]
+
+    tibber_connection = AsyncMock()
+    tibber_connection.name = "tibber"
+    tibber_connection.fetch_consumption_data_active_homes.return_value = None
+    tibber_connection.get_homes = _get_homes
+
+    coordinator = TibberDataCoordinator(hass, tibber_connection)
+    await coordinator._async_update_data()
+    await async_wait_recording_done_without_instance(hass)
+
+    statistic_id = "tibber:home_id_energy_consumption"
+
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.parse_datetime(_CONSUMPTION_DATA_1[0]["from"]),
+        None,
+        [statistic_id],
+        "hour",
+        True,
+    )
+
+    assert len(stats) == 1
+    assert len(stats[statistic_id]) == 3
+    _sum = 0
+    for k, stat in enumerate(stats[statistic_id]):
+        assert stat["start"] == dt_util.parse_datetime(_CONSUMPTION_DATA_1[k]["from"])
+        assert stat["state"] == _CONSUMPTION_DATA_1[k]["consumption"]
+        assert stat["mean"] is None
+        assert stat["min"] is None
+        assert stat["max"] is None
+        assert stat["last_reset"] is None
+
+        _sum += _CONSUMPTION_DATA_1[k]["consumption"]
+        assert stat["sum"] == _sum

--- a/tests/components/tibber/test_statistics.py
+++ b/tests/components/tibber/test_statistics.py
@@ -46,7 +46,7 @@ async def test_async_setup_entry(hass):
     await coordinator._async_update_data()
     await async_wait_recording_done_without_instance(hass)
 
-    statistic_id = "tibber:home_id_energy_consumption"
+    statistic_id = "tibber:energy_consumption_home_id"
 
     stats = await hass.async_add_executor_job(
         statistics_during_period,


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tibber, add external statistics
Tibber customers without a real-time meter get the hourly consumption for the previous day once a day.
Sometimes these values are temporary and will then be updated later.
The first time we fetch 5 years of day.
The next time we update the last 30 days of data.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21026

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
