### PR TITLE
Add MQTT encoding parameter for all subscribed topics

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -210,6 +210,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
                     "topic": self._config[CONF_STATE_TOPIC],
                     "msg_callback": message_received,
                     "qos": self._config[CONF_QOS],
+                    "encoding": self._config[CONF_ENCODING] or None,
                 }
             },
         )

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -405,6 +405,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
                     "topic": self._topic[topic],
                     "msg_callback": msg_callback,
                     "qos": qos,
+                    "encoding": self._config[CONF_ENCODING] or None,
                 }
 
         def render_template(msg, template_name):

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -461,6 +461,7 @@ class MqttCover(MqttEntity, CoverEntity):
                 "topic": self._config.get(CONF_GET_POSITION_TOPIC),
                 "msg_callback": position_message_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
 
         if self._config.get(CONF_STATE_TOPIC):
@@ -468,6 +469,7 @@ class MqttCover(MqttEntity, CoverEntity):
                 "topic": self._config.get(CONF_STATE_TOPIC),
                 "msg_callback": state_message_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
 
         if self._config.get(CONF_TILT_STATUS_TOPIC) is not None:
@@ -476,6 +478,7 @@ class MqttCover(MqttEntity, CoverEntity):
                 "topic": self._config.get(CONF_TILT_STATUS_TOPIC),
                 "msg_callback": tilt_message_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
 
         self._sub_state = await subscription.async_subscribe_topics(

--- a/homeassistant/components/mqtt/device_tracker/schema_discovery.py
+++ b/homeassistant/components/mqtt/device_tracker/schema_discovery.py
@@ -20,7 +20,7 @@ import homeassistant.helpers.config_validation as cv
 
 from .. import subscription
 from ... import mqtt
-from ..const import CONF_ENCODING, CONF_QOS, CONF_STATE_TOPIC
+from ..const import CONF_QOS, CONF_STATE_TOPIC
 from ..debug_info import log_messages
 from ..mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
 
@@ -105,7 +105,6 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                     "topic": self._config[CONF_STATE_TOPIC],
                     "msg_callback": message_received,
                     "qos": self._config[CONF_QOS],
-                    "encoding": self._config[CONF_ENCODING] or None,
                 }
             },
         )

--- a/homeassistant/components/mqtt/device_tracker/schema_discovery.py
+++ b/homeassistant/components/mqtt/device_tracker/schema_discovery.py
@@ -20,7 +20,7 @@ import homeassistant.helpers.config_validation as cv
 
 from .. import subscription
 from ... import mqtt
-from ..const import CONF_QOS, CONF_STATE_TOPIC
+from ..const import CONF_ENCODING, CONF_QOS, CONF_STATE_TOPIC
 from ..debug_info import log_messages
 from ..mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
 
@@ -105,6 +105,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                     "topic": self._config[CONF_STATE_TOPIC],
                     "msg_callback": message_received,
                     "qos": self._config[CONF_QOS],
+                    "encoding": self._config[CONF_ENCODING] or None,
                 }
             },
         )

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -385,6 +385,7 @@ class MqttFan(MqttEntity, FanEntity):
                 "topic": self._topic[CONF_STATE_TOPIC],
                 "msg_callback": state_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
 
         @callback
@@ -429,6 +430,7 @@ class MqttFan(MqttEntity, FanEntity):
                 "topic": self._topic[CONF_PERCENTAGE_STATE_TOPIC],
                 "msg_callback": percentage_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
             self._percentage = None
 
@@ -461,6 +463,7 @@ class MqttFan(MqttEntity, FanEntity):
                 "topic": self._topic[CONF_PRESET_MODE_STATE_TOPIC],
                 "msg_callback": preset_mode_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
             self._preset_mode = None
 
@@ -483,6 +486,7 @@ class MqttFan(MqttEntity, FanEntity):
                 "topic": self._topic[CONF_OSCILLATION_STATE_TOPIC],
                 "msg_callback": oscillation_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
             self._oscillation = False
 

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -291,6 +291,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 "topic": self._topic[CONF_STATE_TOPIC],
                 "msg_callback": state_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
 
         @callback
@@ -336,6 +337,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 "topic": self._topic[CONF_TARGET_HUMIDITY_STATE_TOPIC],
                 "msg_callback": target_humidity_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
             self._target_humidity = None
 
@@ -368,6 +370,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 "topic": self._topic[CONF_MODE_STATE_TOPIC],
                 "msg_callback": mode_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
             self._mode = None
 

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -426,6 +426,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                     "topic": self._topic[topic],
                     "msg_callback": msg_callback,
                     "qos": self._config[CONF_QOS],
+                    "encoding": self._config[CONF_ENCODING] or None,
                 }
 
         def restore_state(attribute, condition_attribute=None):
@@ -458,6 +459,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 "topic": self._topic[CONF_STATE_TOPIC],
                 "msg_callback": state_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
         elif self._optimistic and last_state:
             self._state = last_state.state == STATE_ON

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -378,6 +378,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                         "topic": self._topic[CONF_STATE_TOPIC],
                         "msg_callback": state_received,
                         "qos": self._config[CONF_QOS],
+                        "encoding": self._config[CONF_ENCODING] or None,
                     }
                 },
             )

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -254,6 +254,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
                         "topic": self._topics[CONF_STATE_TOPIC],
                         "msg_callback": state_received,
                         "qos": self._config[CONF_QOS],
+                        "encoding": self._config[CONF_ENCODING] or None,
                     }
                 },
             )

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -152,6 +152,7 @@ class MqttLock(MqttEntity, LockEntity):
                         "topic": self._config.get(CONF_STATE_TOPIC),
                         "msg_callback": message_received,
                         "qos": self._config[CONF_QOS],
+                        "encoding": self._config[CONF_ENCODING] or None,
                     }
                 },
             )

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -290,6 +290,7 @@ class MqttAttributes(Entity):
                     "topic": self._attributes_config.get(CONF_JSON_ATTRS_TOPIC),
                     "msg_callback": attributes_message_received,
                     "qos": self._attributes_config.get(CONF_QOS),
+                    "encoding": self._attributes_config[CONF_ENCODING] or None,
                 }
             },
         )

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -215,6 +215,7 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
                         "topic": self._config.get(CONF_STATE_TOPIC),
                         "msg_callback": message_received,
                         "qos": self._config[CONF_QOS],
+                        "encoding": self._config[CONF_ENCODING] or None,
                     }
                 },
             )

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -171,6 +171,7 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
                         "topic": self._config.get(CONF_STATE_TOPIC),
                         "msg_callback": message_received,
                         "qos": self._config[CONF_QOS],
+                        "encoding": self._config[CONF_ENCODING] or None,
                     }
                 },
             )

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -278,6 +278,7 @@ class MqttSensor(MqttEntity, SensorEntity):
                 "topic": self._config[CONF_LAST_RESET_TOPIC],
                 "msg_callback": last_reset_message_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
 
         self._sub_state = await subscription.async_subscribe_topics(

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -162,6 +162,7 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
                         "topic": self._config.get(CONF_STATE_TOPIC),
                         "msg_callback": state_message_received,
                         "qos": self._config[CONF_QOS],
+                        "encoding": self._config[CONF_ENCODING] or None,
                     }
                 },
             )

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -17,7 +17,6 @@ from .. import mqtt
 from .const import (
     ATTR_DISCOVERY_HASH,
     ATTR_DISCOVERY_TOPIC,
-    CONF_ENCODING,
     CONF_QOS,
     CONF_TOPIC,
     DOMAIN,
@@ -186,7 +185,6 @@ class MQTTTagScanner:
                     "topic": self._config[CONF_TOPIC],
                     "msg_callback": tag_scanned,
                     "qos": self._config[CONF_QOS],
-                    "encoding": self._config[CONF_ENCODING] or None,
                 }
             },
         )

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -17,6 +17,7 @@ from .. import mqtt
 from .const import (
     ATTR_DISCOVERY_HASH,
     ATTR_DISCOVERY_TOPIC,
+    CONF_ENCODING,
     CONF_QOS,
     CONF_TOPIC,
     DOMAIN,
@@ -185,6 +186,7 @@ class MQTTTagScanner:
                     "topic": self._config[CONF_TOPIC],
                     "msg_callback": tag_scanned,
                     "qos": self._config[CONF_QOS],
+                    "encoding": self._config[CONF_ENCODING] or None,
                 }
             },
         )

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -199,7 +199,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
         self._fan_speed_list = config[CONF_FAN_SPEED_LIST]
         self._qos = config[CONF_QOS]
         self._retain = config[CONF_RETAIN]
-        self._encoding = config[CONF_ENCODING]
+        self._encoding = config[CONF_ENCODING] or None
 
         self._command_topic = config.get(CONF_COMMAND_TOPIC)
         self._set_fan_speed_topic = config.get(CONF_SET_FAN_SPEED_TOPIC)
@@ -333,6 +333,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
                     "topic": topic,
                     "msg_callback": message_received,
                     "qos": self._qos,
+                    "encoding": self._encoding,
                 }
                 for i, topic in enumerate(topics_list)
             },

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -214,6 +214,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                 "topic": self._config.get(CONF_STATE_TOPIC),
                 "msg_callback": state_message_received,
                 "qos": self._config[CONF_QOS],
+                "encoding": self._config[CONF_ENCODING] or None,
             }
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state, topics

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -707,26 +707,22 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
 
 
 @pytest.mark.parametrize(
-    "topic,value,attribute",
+    "topic,value",
     [
-        ("state_topic", "armed_home", None),
-        ("state_topic", "disarmed", None),
+        ("state_topic", "armed_home"),
+        ("state_topic", "disarmed"),
     ],
 )
-async def test_encoding_subscribable_topics(
-    hass, mqtt_mock, caplog, topic, value, attribute
-):
+async def test_encoding_subscribable_topics(hass, mqtt_mock, caplog, topic, value):
     """Test handling of incoming encoded payload."""
-    config = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
     await help_test_encoding_subscribable_topics(
         hass,
         mqtt_mock,
         caplog,
         alarm_control_panel.DOMAIN,
-        config,
+        DEFAULT_CONFIG[alarm_control_panel.DOMAIN],
         topic,
         value,
-        attribute,
     )
 
 

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -43,6 +43,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -702,6 +703,30 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
     )
     await help_test_discovery_broken(
         hass, mqtt_mock, caplog, alarm_control_panel.DOMAIN, data1, data2
+    )
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute",
+    [
+        ("state_topic", "armed_home", None),
+        ("state_topic", "disarmed", None),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute
+):
+    """Test handling of incoming encoded payload."""
+    config = copy.deepcopy(DEFAULT_CONFIG[alarm_control_panel.DOMAIN])
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        alarm_control_panel.DOMAIN,
+        config,
+        topic,
+        value,
+        attribute,
     )
 
 

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -28,6 +28,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -756,6 +757,36 @@ async def test_discovery_update_binary_sensor_template(hass, mqtt_mock, caplog):
         config2,
         state_data1=state_data1,
         state_data2=state_data2,
+    )
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("json_attributes_topic", '{ "id": 123 }', "id", 123),
+        (
+            "json_attributes_topic",
+            '{ "id": 123, "temperature": 34.0 }',
+            "temperature",
+            34.0,
+        ),
+        ("state_topic", "ON", None, "on"),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG[binary_sensor.DOMAIN],
+        topic,
+        value,
+        attribute,
+        attribute_value,
     )
 
 

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -766,11 +766,36 @@ async def help_test_discovery_broken(hass, mqtt_mock, caplog, domain, data1, dat
 
 
 async def help_test_encoding_subscribable_topics(
-    hass, mqtt_mock, caplog, domain, config, topic, value, attribute=None
+    hass,
+    mqtt_mock,
+    caplog,
+    domain,
+    config,
+    topic,
+    value,
+    attribute=None,
+    attribute_value=None,
+    init_payload=None,
+    skip_raw_test=False,
 ):
     """Test handling of incoming encoded payload."""
 
-    async def _test_encoding(hass, domain, entity_id, topic, attribute, encoded_value):
+    async def _test_encoding(
+        hass,
+        entity_id,
+        topic,
+        encoded_value,
+        attribute,
+        init_payload_topic,
+        init_payload_value,
+    ):
+        state = hass.states.get(entity_id)
+
+        if init_payload_value:
+            # Sometimes a device needs to have an initialization pay load, e.g. to switch the device on.
+            async_fire_mqtt_message(hass, init_payload_topic, init_payload_value)
+            await hass.async_block_till_done()
+
         state = hass.states.get(entity_id)
 
         async_fire_mqtt_message(hass, topic, encoded_value)
@@ -783,20 +808,38 @@ async def help_test_encoding_subscribable_topics(
 
         return state.state if state else None
 
+    init_payload_value_utf8 = None
+    init_payload_value_utf16 = None
     # setup test1 default encoding
     config1 = copy.deepcopy(config)
-    config1["name"] = "test1"
+    if domain == "device_tracker":
+        config1["unique_id"] = "test1"
+    else:
+        config1["name"] = "test1"
     config1[topic] = "topic/test1"
     # setup test2 alternate encoding
     config2 = copy.deepcopy(config)
-    config2["name"] = "test2"
+    if domain == "device_tracker":
+        config2["unique_id"] = "test2"
+    else:
+        config2["name"] = "test2"
     config2["encoding"] = "utf-16"
     config2[topic] = "topic/test2"
     # setup test3 raw encoding
     config3 = copy.deepcopy(config)
-    config3["name"] = "test3"
+    if domain == "device_tracker":
+        config3["unique_id"] = "test3"
+    else:
+        config3["name"] = "test3"
     config3["encoding"] = ""
     config3[topic] = "topic/test3"
+
+    if init_payload:
+        config1[init_payload[0]] = "topic/init_payload1"
+        config2[init_payload[0]] = "topic/init_payload2"
+        config3[init_payload[0]] = "topic/init_payload3"
+        init_payload_value_utf8 = init_payload[1].encode("utf-8")
+        init_payload_value_utf16 = init_payload[1].encode("utf-16")
 
     await hass.async_block_till_done()
 
@@ -805,43 +848,53 @@ async def help_test_encoding_subscribable_topics(
     )
     await hass.async_block_till_done()
 
+    expected_result = attribute_value or value
+
     # test1 default encoding
     assert (
         await _test_encoding(
             hass,
-            domain,
             f"{domain}.test1",
             "topic/test1",
-            attribute,
             value.encode("utf-8"),
+            attribute,
+            "topic/init_payload1",
+            init_payload_value_utf8,
         )
-        == value
+        == expected_result
     )
 
     # test2 alternate encoding
     assert (
         await _test_encoding(
             hass,
-            domain,
             f"{domain}.test2",
             "topic/test2",
-            attribute,
             value.encode("utf-16"),
+            attribute,
+            "topic/init_payload2",
+            init_payload_value_utf16,
         )
-        == value
+        == expected_result
     )
 
-    # test3 raw encoding
+    # test3 raw encoded input
+    if skip_raw_test:
+        return
 
-    await _test_encoding(
-        hass,
-        domain,
-        f"{domain}.test3",
-        "topic/test3",
-        attribute,
-        value.encode("utf-16"),
-    )
-    assert f"Received unexpected payload: {value.encode('utf-16')}" in caplog.text
+    try:
+        result = await _test_encoding(
+            hass,
+            f"{domain}.test3",
+            "topic/test3",
+            value.encode("utf-16"),
+            attribute,
+            "topic/init_payload3",
+            init_payload_value_utf16,
+        )
+        assert result != expected_result
+    except (AttributeError, TypeError, ValueError):
+        pass
 
 
 async def help_test_entity_device_info_with_identifier(hass, mqtt_mock, domain, config):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -54,6 +54,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -3165,3 +3166,29 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = cover.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "open", None, None),
+        ("state_topic", "closing", None, None),
+        ("position_topic", "40.0", "current_position", 40.0),
+        ("tilt_status_topic", "60.0", "current_tilt_position", 60.0),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        cover.DOMAIN,
+        DEFAULT_CONFIG[cover.DOMAIN],
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -6,8 +6,22 @@ import pytest
 from voluptuous.error import MultipleInvalid
 
 from homeassistant.components import fan
-from homeassistant.components.fan import NotValidPresetModeError
-from homeassistant.components.mqtt.fan import MQTT_FAN_ATTRIBUTES_BLOCKED
+from homeassistant.components.fan import (
+    ATTR_OSCILLATING,
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    ATTR_PRESET_MODES,
+    NotValidPresetModeError,
+)
+from homeassistant.components.mqtt.fan import (
+    CONF_OSCILLATION_COMMAND_TOPIC,
+    CONF_OSCILLATION_STATE_TOPIC,
+    CONF_PERCENTAGE_COMMAND_TOPIC,
+    CONF_PERCENTAGE_STATE_TOPIC,
+    CONF_PRESET_MODE_COMMAND_TOPIC,
+    CONF_PRESET_MODE_STATE_TOPIC,
+    MQTT_FAN_ATTRIBUTES_BLOCKED,
+)
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_SUPPORTED_FEATURES,
@@ -26,6 +40,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -1268,6 +1283,42 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "ON", None, "on"),
+        (CONF_PRESET_MODE_STATE_TOPIC, "auto", ATTR_PRESET_MODE, "auto"),
+        (CONF_PERCENTAGE_STATE_TOPIC, "60", ATTR_PERCENTAGE, 60),
+        (
+            CONF_OSCILLATION_STATE_TOPIC,
+            "oscillate_on",
+            ATTR_OSCILLATING,
+            True,
+        ),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    config = copy.deepcopy(DEFAULT_CONFIG[fan.DOMAIN])
+    config[ATTR_PRESET_MODES] = ["eco", "auto"]
+    config[CONF_PRESET_MODE_COMMAND_TOPIC] = "fan/some_preset_mode_command_topic"
+    config[CONF_PERCENTAGE_COMMAND_TOPIC] = "fan/some_percentage_command_topic"
+    config[CONF_OSCILLATION_COMMAND_TOPIC] = "fan/some_oscillation_command_topic"
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        fan.DOMAIN,
+        config,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )
 
 
 async def test_attributes(hass, mqtt_mock, caplog):

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -11,6 +11,13 @@ from homeassistant.components.mqtt.vacuum import schema_legacy as mqttvacuum
 from homeassistant.components.mqtt.vacuum.schema import services_to_strings
 from homeassistant.components.mqtt.vacuum.schema_legacy import (
     ALL_SERVICES,
+    CONF_BATTERY_LEVEL_TOPIC,
+    CONF_CHARGING_TOPIC,
+    CONF_CLEANING_TOPIC,
+    CONF_DOCKED_TOPIC,
+    CONF_ERROR_TOPIC,
+    CONF_FAN_SPEED_TOPIC,
+    CONF_SUPPORTED_FEATURES,
     MQTT_LEGACY_VACUUM_ATTRIBUTES_BLOCKED,
     SERVICE_TO_STRING,
 )
@@ -34,6 +41,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -830,3 +838,57 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = vacuum.DOMAIN
     config = DEFAULT_CONFIG
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        (CONF_BATTERY_LEVEL_TOPIC, '{ "battery_level": 60 }', "battery_level", 60),
+        (CONF_CHARGING_TOPIC, '{ "charging": true }', "status", "Stopped"),
+        (CONF_CLEANING_TOPIC, '{ "cleaning": true }', "status", "Cleaning"),
+        (CONF_DOCKED_TOPIC, '{ "docked": true }', "status", "Docked"),
+        (
+            CONF_ERROR_TOPIC,
+            '{ "error": "some error" }',
+            "status",
+            "Error: some error",
+        ),
+        (
+            CONF_FAN_SPEED_TOPIC,
+            '{ "fan_speed": "medium" }',
+            "fan_speed",
+            "medium",
+        ),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    config = deepcopy(DEFAULT_CONFIG)
+    config[CONF_SUPPORTED_FEATURES] = [
+        "turn_on",
+        "turn_off",
+        "pause",
+        "stop",
+        "return_home",
+        "battery",
+        "status",
+        "locate",
+        "clean_spot",
+        "fan_speed",
+        "send_command",
+    ]
+
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        vacuum.DOMAIN,
+        config,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+        skip_raw_test=True,
+    )

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -116,6 +116,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -1971,3 +1972,44 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = light.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value,init_payload",
+    [
+        (
+            "state_topic",
+            '{ "state": "ON", "brightness": 200 }',
+            "brightness",
+            200,
+            None,
+        ),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value, init_payload
+):
+    """Test handling of incoming encoded payload."""
+    config = copy.deepcopy(DEFAULT_CONFIG[light.DOMAIN])
+    config["color_mode"] = True
+    config["supported_color_modes"] = [
+        "color_temp",
+        "hs",
+        "xy",
+        "rgb",
+        "rgbw",
+        "rgbww",
+    ]
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        light.DOMAIN,
+        config,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+        init_payload,
+        skip_raw_test=True,
+    )

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -54,6 +54,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -1154,3 +1155,29 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = light.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value,init_payload",
+    [
+        ("state_topic", "on", None, "on", None),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value, init_payload
+):
+    """Test handling of incoming encoded payload."""
+    config = copy.deepcopy(DEFAULT_CONFIG[light.DOMAIN])
+    config["state_template"] = "{{ value }}"
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        light.DOMAIN,
+        config,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+        init_payload,
+    )

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -30,6 +30,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -638,3 +639,26 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = LOCK_DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "LOCKED", None, "locked"),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        LOCK_DOMAIN,
+        DEFAULT_CONFIG[LOCK_DOMAIN],
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -36,6 +36,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -689,3 +690,27 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = number.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "10", None, "10"),
+        ("state_topic", "60", None, "60"),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        "number",
+        DEFAULT_CONFIG["number"],
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -1,4 +1,5 @@
 """The tests for mqtt select component."""
+import copy
 import json
 from unittest.mock import patch
 
@@ -26,6 +27,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -567,3 +569,29 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = select.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "milk", None, "milk"),
+        ("state_topic", "beer", None, "beer"),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    config = copy.deepcopy(DEFAULT_CONFIG["select"])
+    config["options"] = ["milk", "beer"]
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        "select",
+        config,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -29,6 +29,7 @@ from .test_common import (
     help_test_discovery_update_attr,
     help_test_discovery_update_availability,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_category,
     help_test_entity_debug_info,
     help_test_entity_debug_info_max_messages,
@@ -927,3 +928,27 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = sensor.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "2.21", None, "2.21"),
+        ("state_topic", "beer", None, "beer"),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        sensor.DOMAIN,
+        DEFAULT_CONFIG[sensor.DOMAIN],
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -44,6 +44,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -591,3 +592,38 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = vacuum.DOMAIN
     config = DEFAULT_CONFIG
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        (
+            "state_topic",
+            '{"battery_level": 61, "state": "docked", "fan_speed": "off"}',
+            None,
+            "docked",
+        ),
+        (
+            "state_topic",
+            '{"battery_level": 61, "state": "cleaning", "fan_speed": "medium"}',
+            None,
+            "cleaning",
+        ),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        vacuum.DOMAIN,
+        DEFAULT_CONFIG,
+        topic,
+        value,
+        attribute,
+        attribute_value,
+        skip_raw_test=True,
+    )

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -25,6 +25,7 @@ from .test_common import (
     help_test_discovery_update,
     help_test_discovery_update_attr,
     help_test_discovery_update_unchanged,
+    help_test_encoding_subscribable_topics,
     help_test_entity_debug_info_message,
     help_test_entity_device_info_remove,
     help_test_entity_device_info_update,
@@ -523,3 +524,26 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     domain = switch.DOMAIN
     config = DEFAULT_CONFIG[domain]
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
+
+
+@pytest.mark.parametrize(
+    "topic,value,attribute,attribute_value",
+    [
+        ("state_topic", "ON", None, "on"),
+    ],
+)
+async def test_encoding_subscribable_topics(
+    hass, mqtt_mock, caplog, topic, value, attribute, attribute_value
+):
+    """Test handling of incoming encoded payload."""
+    await help_test_encoding_subscribable_topics(
+        hass,
+        mqtt_mock,
+        caplog,
+        switch.DOMAIN,
+        DEFAULT_CONFIG[switch.DOMAIN],
+        topic,
+        value,
+        attribute,
+        attribute_value,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MQTT encoding defaults to 'utf-8'. In some cases topics receive payload in a different encoding. The `encoding`config parameter enables a user to change the default `encoding` from `utf-8` to a different encoding.
If `encoding` is set to `''` the incoming payload will not be decoded but will passed as raw bytes.

This PR us a follow up to #60470 that implemented `encoding` for `sensor` and `availability`. This PR will bring the `encoding` parameter to the other platforms.

PR #62739 will handle the encoding for MQTT publishing. The docs PR is shared.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20745

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
