### PR TITLE
Don't add Fronius entities with unknown state

### DIFF
--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -98,6 +98,8 @@ class FroniusCoordinatorBase(
                 for key in self.unregistered_keys[solar_net_id].intersection(
                     device_data
                 ):
+                    if device_data[key]["value"] is None:
+                        continue
                     new_entities.append(entity_constructor(self, key, solar_net_id))
                     self.unregistered_keys[solar_net_id].remove(key)
             if new_entities:

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -148,7 +148,7 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
     ),
     SensorEntityDescription(
         key="current_ac",
-        name="AC Current",
+        name="AC current",
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -163,7 +163,7 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
     ),
     SensorEntityDescription(
         key="current_dc_2",
-        name="DC Current 2",
+        name="DC current 2",
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -6,7 +6,6 @@ from homeassistant.components.fronius.coordinator import (
     FroniusPowerFlowUpdateCoordinator,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt
 
@@ -26,11 +25,11 @@ async def test_symo_inverter(hass, aioclient_mock):
     mock_responses(aioclient_mock, night=True)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 23
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 20
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusInverterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 52
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 0)
     assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", 10828)
     assert_state("sensor.energy_total_fronius_inverter_1_http_fronius", 44186900)
@@ -43,11 +42,11 @@ async def test_symo_inverter(hass, aioclient_mock):
         hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 57
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusInverterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     # 4 additional AC entities
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 2.19)
     assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", 1113)
@@ -81,13 +80,7 @@ async def test_symo_logger(hass, aioclient_mock):
 
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
-
-    # ignored constant entities:
-    # hardware_platform, hardware_version, product_type
-    # software_version, time_zone, time_zone_location
-    # time_stamp, unique_identifier, utc_offset
-    #
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 24
     # states are rounded to 4 decimals
     assert_state(
         "sensor.cash_factor_fronius_logger_info_0_http_fronius",
@@ -114,14 +107,11 @@ async def test_symo_meter(hass, aioclient_mock):
     mock_responses(aioclient_mock)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 24
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusMeterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
-    # ignored entities:
-    # manufacturer, model, serial, enable, timestamp, visible, meter_location
-    #
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     # states are rounded to 4 decimals
     assert_state("sensor.current_ac_phase_1_fronius_meter_0_http_fronius", 7.755)
     assert_state("sensor.current_ac_phase_2_fronius_meter_0_http_fronius", 6.68)
@@ -179,13 +169,11 @@ async def test_symo_power_flow(hass, aioclient_mock):
     mock_responses(aioclient_mock, night=True)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 23
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 20
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusInverterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
-    # ignored: location, mode, timestamp
-    #
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 52
     # states are rounded to 4 decimals
     assert_state(
         "sensor.energy_day_fronius_power_flow_0_http_fronius",
@@ -200,10 +188,6 @@ async def test_symo_power_flow(hass, aioclient_mock):
         25507686,
     )
     assert_state(
-        "sensor.power_battery_fronius_power_flow_0_http_fronius",
-        STATE_UNKNOWN,
-    )
-    assert_state(
         "sensor.power_grid_fronius_power_flow_0_http_fronius",
         975.31,
     )
@@ -212,16 +196,8 @@ async def test_symo_power_flow(hass, aioclient_mock):
         -975.31,
     )
     assert_state(
-        "sensor.power_photovoltaics_fronius_power_flow_0_http_fronius",
-        STATE_UNKNOWN,
-    )
-    assert_state(
         "sensor.relative_autonomy_fronius_power_flow_0_http_fronius",
         0,
-    )
-    assert_state(
-        "sensor.relative_self_consumption_fronius_power_flow_0_http_fronius",
-        STATE_UNKNOWN,
     )
 
     # Second test at daytime when inverter is producing
@@ -230,8 +206,8 @@ async def test_symo_power_flow(hass, aioclient_mock):
         hass, dt.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
-    # still 55 because power_flow update interval is shorter than others
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
+    # 54 because power_flow `rel_SelfConsumption` and `P_PV` is not `null` anymore
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
     assert_state(
         "sensor.energy_day_fronius_power_flow_0_http_fronius",
         1101.7001,
@@ -243,10 +219,6 @@ async def test_symo_power_flow(hass, aioclient_mock):
     assert_state(
         "sensor.energy_year_fronius_power_flow_0_http_fronius",
         25508788,
-    )
-    assert_state(
-        "sensor.power_battery_fronius_power_flow_0_http_fronius",
-        STATE_UNKNOWN,
     )
     assert_state(
         "sensor.power_grid_fronius_power_flow_0_http_fronius",
@@ -281,17 +253,15 @@ async def test_gen24(hass, aioclient_mock):
     mock_responses(aioclient_mock, fixture_set="gen24")
     config_entry = await setup_fronius_integration(hass, is_logger=False)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 22
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusMeterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 57
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 52
     # inverter 1
-    assert_state("sensor.energy_year_fronius_inverter_1_http_fronius", STATE_UNKNOWN)
     assert_state("sensor.current_ac_fronius_inverter_1_http_fronius", 0.1589)
     assert_state("sensor.current_dc_2_fronius_inverter_1_http_fronius", 0.0754)
     assert_state("sensor.status_code_fronius_inverter_1_http_fronius", 7)
-    assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", STATE_UNKNOWN)
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 0.0783)
     assert_state("sensor.voltage_dc_2_fronius_inverter_1_http_fronius", 403.4312)
     assert_state("sensor.power_ac_fronius_inverter_1_http_fronius", 37.3204)
@@ -356,11 +326,6 @@ async def test_gen24(hass, aioclient_mock):
     assert_state("sensor.power_load_fronius_power_flow_0_http_fronius", -695.6827)
     assert_state("sensor.meter_mode_fronius_power_flow_0_http_fronius", "meter")
     assert_state("sensor.relative_autonomy_fronius_power_flow_0_http_fronius", 5.3592)
-    assert_state(
-        "sensor.power_battery_fronius_power_flow_0_http_fronius", STATE_UNKNOWN
-    )
-    assert_state("sensor.energy_year_fronius_power_flow_0_http_fronius", STATE_UNKNOWN)
-    assert_state("sensor.energy_day_fronius_power_flow_0_http_fronius", STATE_UNKNOWN)
     assert_state("sensor.energy_total_fronius_power_flow_0_http_fronius", 1530193.42)
 
 
@@ -377,19 +342,17 @@ async def test_gen24_storage(hass, aioclient_mock):
         hass, is_logger=False, unique_id="12345678"
     )
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 36
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 34
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusMeterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 68
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 64
     # inverter 1
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 0.3952)
     assert_state("sensor.voltage_dc_2_fronius_inverter_1_http_fronius", 318.8103)
     assert_state("sensor.current_dc_2_fronius_inverter_1_http_fronius", 0.3564)
-    assert_state("sensor.energy_year_fronius_inverter_1_http_fronius", STATE_UNKNOWN)
     assert_state("sensor.current_ac_fronius_inverter_1_http_fronius", 1.1087)
     assert_state("sensor.power_ac_fronius_inverter_1_http_fronius", 250.9093)
-    assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", STATE_UNKNOWN)
     assert_state("sensor.error_code_fronius_inverter_1_http_fronius", 0)
     assert_state("sensor.status_code_fronius_inverter_1_http_fronius", 7)
     assert_state("sensor.energy_total_fronius_inverter_1_http_fronius", 7512794.0117)
@@ -463,8 +426,6 @@ async def test_gen24_storage(hass, aioclient_mock):
     )
     assert_state("sensor.relative_autonomy_fronius_power_flow_0_http_fronius", 7.4984)
     assert_state("sensor.meter_mode_fronius_power_flow_0_http_fronius", "bidirectional")
-    assert_state("sensor.energy_year_fronius_power_flow_0_http_fronius", STATE_UNKNOWN)
-    assert_state("sensor.energy_day_fronius_power_flow_0_http_fronius", STATE_UNKNOWN)
     assert_state("sensor.energy_total_fronius_power_flow_0_http_fronius", 7512664.4042)
     # storage
     assert_state("sensor.current_dc_fronius_storage_0_http_fronius", 0.0)
@@ -519,11 +480,11 @@ async def test_primo_s0(hass, aioclient_mock):
     mock_responses(aioclient_mock, fixture_set="primo_s0", inverter_ids=[1, 2])
     config_entry = await setup_fronius_integration(hass, is_logger=True)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 30
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 29
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusMeterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 41
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 40
     # logger
     assert_state("sensor.cash_factor_fronius_logger_info_0_http_fronius", 1)
     assert_state("sensor.co2_factor_fronius_logger_info_0_http_fronius", 0.53)
@@ -561,9 +522,6 @@ async def test_primo_s0(hass, aioclient_mock):
     assert_state("sensor.power_real_fronius_meter_0_http_fronius", -2216.7487)
     # power_flow
     assert_state("sensor.power_load_fronius_power_flow_0_http_fronius", -2218.9349)
-    assert_state(
-        "sensor.power_battery_fronius_power_flow_0_http_fronius", STATE_UNKNOWN
-    )
     assert_state("sensor.meter_mode_fronius_power_flow_0_http_fronius", "vague-meter")
     assert_state("sensor.power_photovoltaics_fronius_power_flow_0_http_fronius", 1834)
     assert_state("sensor.power_grid_fronius_power_flow_0_http_fronius", 384.9349)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some keys of some endpoints are always `null` - eg. `power_battery` from the power_flow endpoint when no battery is installed. These would keep their `unknown` state forever.
With this change an entity is first created when it would get a known state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
