### PR TITLE
Mark camera unavailable when keepalive stream fails

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -447,6 +447,13 @@ class Camera(Entity):
             return None
         return STREAM_TYPE_HLS
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if self.stream and not self.stream.available:
+            return self.stream.available
+        return super().available
+
     async def create_stream(self) -> Stream | None:
         """Create a Stream for stream_source."""
         # There is at most one stream (a decode worker) per camera
@@ -456,6 +463,7 @@ class Camera(Entity):
             if not source:
                 return None
             self.stream = create_stream(self.hass, source, options=self.stream_options)
+            self.stream.set_update_callback(self.async_write_ha_state)
         return self.stream
 
     async def stream_source(self) -> str | None:

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -261,9 +261,9 @@ class Stream:
         """Return False if the stream is started and known to be unavailable."""
         return self._available
 
-    def set_update_callback(self, cb: Callable[[], None]) -> None:
+    def set_update_callback(self, update_callback: Callable[[], None]) -> None:
         """Set callback to run when state changes."""
-        self._update_callback = cb
+        self._update_callback = update_callback
 
     @callback
     def _async_update_state(self, available: bool) -> None:

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -304,7 +304,7 @@ class Stream:
         wait_timeout = 0
         while not self._thread_quit.wait(timeout=wait_timeout):
             start_time = time.time()
-            self.hass.loop.call_soon_threadsafe(self._async_update_state, True)
+            self.hass.add_job(self._async_update_state, True)
             try:
                 stream_worker(
                     self.source,
@@ -324,7 +324,7 @@ class Stream:
                     continue
                 break
 
-            self.hass.loop.call_soon_threadsafe(self._async_update_state, False)
+            self.hass.add_job(self._async_update_state, False)
             # To avoid excessive restarts, wait before restarting
             # As the required recovery time may be different for different setups, start
             # with trying a short wait_timeout and increase it on each reconnection attempt.

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -23,7 +23,7 @@ import secrets
 import threading
 import time
 from types import MappingProxyType
-from typing import cast
+from typing import Callable, cast
 
 import voluptuous as vol
 
@@ -204,7 +204,8 @@ class Stream:
         self._thread_quit = threading.Event()
         self._outputs: dict[str, StreamOutput] = {}
         self._fast_restart_once = False
-        self._available = True
+        self._available: bool = True
+        self._update_callback: Callable[[], None] | None = None
 
     def endpoint_url(self, fmt: str) -> str:
         """Start the stream and returns a url for the output format."""
@@ -260,6 +261,16 @@ class Stream:
         """Return False if the stream is started and known to be unavailable."""
         return self._available
 
+    def set_update_callback(self, callback: Callable[[], None]) -> None:
+        """Set callback to run when state changes."""
+        self._update_callback = callback
+
+    def _async_update_state(self, available: bool) -> None:
+        """Set state and Run callback to notify state has been updated."""
+        self._available = available
+        if self._update_callback:
+            self._update_callback()
+
     def start(self) -> None:
         """Start a stream."""
         if self._thread is None or not self._thread.is_alive():
@@ -292,8 +303,7 @@ class Stream:
         wait_timeout = 0
         while not self._thread_quit.wait(timeout=wait_timeout):
             start_time = time.time()
-
-            self._available = True
+            self.hass.loop.call_soon_threadsafe(self._async_update_state, True)
             try:
                 stream_worker(
                     self.source,
@@ -303,7 +313,6 @@ class Stream:
                 )
             except StreamWorkerError as err:
                 _LOGGER.error("Error from stream worker: %s", str(err))
-                self._available = False
 
             stream_state.discontinuity()
             if not self.keepalive or self._thread_quit.is_set():
@@ -314,6 +323,7 @@ class Stream:
                     continue
                 break
 
+            self.hass.loop.call_soon_threadsafe(self._async_update_state, False)
             # To avoid excessive restarts, wait before restarting
             # As the required recovery time may be different for different setups, start
             # with trying a short wait_timeout and increase it on each reconnection attempt.

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -16,14 +16,14 @@ to always keep workers active.
 """
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 import logging
 import re
 import secrets
 import threading
 import time
 from types import MappingProxyType
-from typing import Callable, cast
+from typing import cast
 
 import voluptuous as vol
 
@@ -261,10 +261,11 @@ class Stream:
         """Return False if the stream is started and known to be unavailable."""
         return self._available
 
-    def set_update_callback(self, callback: Callable[[], None]) -> None:
+    def set_update_callback(self, cb: Callable[[], None]) -> None:
         """Set callback to run when state changes."""
-        self._update_callback = callback
+        self._update_callback = cb
 
+    @callback
     def _async_update_state(self, available: bool) -> None:
         """Set state and Run callback to notify state has been updated."""
         self._available = available

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -16,7 +16,11 @@ from homeassistant.components.camera.const import (
 from homeassistant.components.camera.prefs import CameraEntityPreferences
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_START,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
@@ -633,3 +637,56 @@ async def test_websocket_web_rtc_offer_invalid_stream_type(
     assert response["type"] == TYPE_RESULT
     assert not response["success"]
     assert response["error"]["code"] == "web_rtc_offer_failed"
+
+
+async def test_state_streaming(hass, hass_ws_client, mock_camera):
+    """Camera state."""
+    demo_camera = hass.states.get("camera.demo_camera")
+    assert demo_camera is not None
+    assert demo_camera.state == camera.STATE_STREAMING
+
+
+async def test_stream_unavailable(hass, hass_ws_client, mock_camera, mock_stream):
+    """Camera state."""
+    await async_setup_component(hass, "camera", {})
+
+    with patch(
+        "homeassistant.components.camera.Stream.endpoint_url",
+        return_value="http://home.assistant/playlist.m3u8",
+    ), patch(
+        "homeassistant.components.demo.camera.DemoCamera.stream_source",
+        return_value="http://example.com",
+    ), patch(
+        "homeassistant.components.camera.Stream.set_update_callback",
+    ) as mock_update_callback:
+        # Request playlist through WebSocket. We just want to create the stream
+        # but don't care about the result.
+        client = await hass_ws_client(hass)
+        await client.send_json(
+            {"id": 10, "type": "camera/stream", "entity_id": "camera.demo_camera"}
+        )
+        await client.receive_json()
+        assert mock_update_callback.called
+
+    # Simluate the stream going unavailable
+    callback = mock_update_callback.call_args.args[0]
+    with patch(
+        "homeassistant.components.camera.Stream.available", new_callable=lambda: False
+    ):
+        callback()
+        await hass.async_block_till_done()
+
+    demo_camera = hass.states.get("camera.demo_camera")
+    assert demo_camera is not None
+    assert demo_camera.state == STATE_UNAVAILABLE
+
+    # Simulate stream becomes available
+    with patch(
+        "homeassistant.components.camera.Stream.available", new_callable=lambda: True
+    ):
+        callback()
+        await hass.async_block_till_done()
+
+    demo_camera = hass.states.get("camera.demo_camera")
+    assert demo_camera is not None
+    assert demo_camera.state == camera.STATE_STREAMING

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -179,6 +179,14 @@ async def test_stream_timeout(hass, hass_client, stream_worker_sync):
     source = generate_h264_video()
     stream = create_stream(hass, source, {})
 
+    available_states = []
+
+    def update_callback() -> None:
+        nonlocal available_states
+        available_states.append(stream.available)
+
+    stream.set_update_callback(update_callback)
+
     # Request stream
     stream.add_provider(HLS_PROVIDER)
     stream.start()
@@ -209,6 +217,9 @@ async def test_stream_timeout(hass, hass_client, stream_worker_sync):
     # Ensure playlist not accessible
     fail_response = await http_client.get(parsed_url.path)
     assert fail_response.status == HTTPStatus.NOT_FOUND
+
+    # Streams only marked as failure when keepalive is true
+    assert available_states == [True]
 
 
 async def test_stream_timeout_after_stop(hass, hass_client, stream_worker_sync):
@@ -242,13 +253,21 @@ async def test_stream_keepalive(hass):
     # Setup demo HLS track
     source = "test_stream_keepalive_source"
     stream = create_stream(hass, source, {})
-    assert stream.available
     track = stream.add_provider(HLS_PROVIDER)
     track.num_segments = 2
+
+    available_states = []
+
+    def update_callback() -> None:
+        nonlocal available_states
+        available_states.append(stream.available)
+
+    stream.set_update_callback(update_callback)
 
     cur_time = 0
 
     def time_side_effect():
+        print("stream.available=%s", stream.available)
         nonlocal cur_time
         if cur_time >= 80:
             stream.keepalive = False  # Thread should exit and be joinable.
@@ -268,11 +287,14 @@ async def test_stream_keepalive(hass):
         stream._thread.join()
         stream._thread = None
         assert av_open.call_count == 2
-        assert not stream.available
+        await hass.async_block_till_done()
 
     # Stop stream, if it hasn't quit already
     stream.stop()
-    assert not stream.available
+
+    # Stream marked initially available, then marked as failed, then marked available
+    # before the final failure that exits the stream.
+    assert available_states == [True, False, True]
 
 
 async def test_hls_playlist_view_no_output(hass, hls_stream):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a listener in stream that notifies camera when the stream state has changed, and
use that to inform the camera `available` property. Update the property to be set
only from the main loop where it is read to reduce thread safety races.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Issue #54659
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
