### PR TITLE
Add support for changing Magic Home socket power restore state

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -45,7 +45,7 @@ PLATFORMS_BY_TYPE: Final = {
         Platform.NUMBER,
         Platform.SWITCH,
     ],
-    DeviceType.Switch: [Platform.BUTTON, Platform.SWITCH],
+    DeviceType.Switch: [Platform.BUTTON, Platform.SELECT, Platform.SWITCH],
 }
 DISCOVERY_INTERVAL: Final = timedelta(minutes=15)
 REQUEST_REFRESH_DELAY: Final = 1.5

--- a/homeassistant/components/flux_led/button.py
+++ b/homeassistant/components/flux_led/button.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import FluxLedUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import FluxLedUpdateCoordinator
 from .entity import FluxBaseEntity
 
 

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -1,0 +1,67 @@
+"""Support for Magic Home select."""
+from __future__ import annotations
+
+from flux_led.aio import AIOWifiLedBulb
+from flux_led.protocol import PowerRestoreState
+
+from homeassistant import config_entries
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import FluxLedUpdateCoordinator
+from .entity import FluxBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Flux selects."""
+    coordinator: FluxLedUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([FluxPowerState(coordinator.device, entry)])
+
+
+def _human_readable_option(const_option: str) -> str:
+    return const_option.replace("_", " ").title()
+
+
+class FluxPowerState(FluxBaseEntity, SelectEntity):
+    """Representation of a Flux power restore state option."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        device: AIOWifiLedBulb,
+        entry: config_entries.ConfigEntry,
+    ) -> None:
+        """Initialize the power state select."""
+        super().__init__(device, entry)
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_name = f"{entry.data[CONF_NAME]} Power Restored"
+        if entry.unique_id:
+            self._attr_unique_id = f"{entry.unique_id}_power_restored"
+        self._name_to_state = {
+            _human_readable_option(option.name): option for option in PowerRestoreState
+        }
+        self._attr_options = list(self._name_to_state)
+        self._async_set_current_option_from_device()
+
+    @callback
+    def _async_set_current_option_from_device(self) -> None:
+        """Set the option from the current power state."""
+        restore_states = self._device.power_restore_states
+        assert restore_states is not None
+        assert restore_states.channel1 is not None
+        self._attr_current_option = _human_readable_option(restore_states.channel1.name)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the power state."""
+        await self._device.async_set_power_restore(channel1=self._name_to_state[option])
+        self._async_set_current_option_from_device()
+        self.async_write_ha_state()

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -14,7 +14,7 @@ from flux_led.const import (
     COLOR_MODE_RGB as FLUX_COLOR_MODE_RGB,
 )
 from flux_led.models_db import MODEL_MAP
-from flux_led.protocol import LEDENETRawState
+from flux_led.protocol import LEDENETRawState, PowerRestoreState, PowerRestoreStates
 from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant.components import dhcp
@@ -124,9 +124,16 @@ def _mocked_switch() -> AIOWifiLedBulb:
         switch.data_receive_callback = callback
 
     switch.device_type = DeviceType.Switch
+    switch.power_restore_states = PowerRestoreStates(
+        channel1=PowerRestoreState.LAST_STATE,
+        channel2=PowerRestoreState.LAST_STATE,
+        channel3=PowerRestoreState.LAST_STATE,
+        channel4=PowerRestoreState.LAST_STATE,
+    )
     switch.requires_turn_on = True
     switch.async_reboot = AsyncMock()
     switch.async_setup = AsyncMock(side_effect=_save_setup_callback)
+    switch.async_set_power_restore = AsyncMock()
     switch.async_stop = AsyncMock()
     switch.async_update = AsyncMock()
     switch.async_turn_off = AsyncMock()

--- a/tests/components/flux_led/test_select.py
+++ b/tests/components/flux_led/test_select.py
@@ -1,0 +1,49 @@
+"""Tests for select platform."""
+from flux_led.protocol import PowerRestoreState
+
+from homeassistant.components import flux_led
+from homeassistant.components.flux_led.const import DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import (
+    DEFAULT_ENTRY_TITLE,
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    _mocked_switch,
+    _patch_discovery,
+    _patch_wifibulb,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_switch_power_restore_state(hass: HomeAssistant) -> None:
+    """Test a smart plug power restore state."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    switch = _mocked_switch()
+    with _patch_discovery(), _patch_wifibulb(device=switch):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.bulb_rgbcw_ddeeff_power_restored"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "Last State"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "Always On"},
+        blocking=True,
+    )
+    switch.async_set_power_restore.assert_called_once_with(
+        channel1=PowerRestoreState.ALWAYS_ON
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for changing Magic Home socket power restore state.

These sockets have the option of : Last State, Always Off, Always On

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20755

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
