### PR TITLE
Fix missing agent_dvr profile

### DIFF
--- a/homeassistant/components/agent_dvr/alarm_control_panel.py
+++ b/homeassistant/components/agent_dvr/alarm_control_panel.py
@@ -62,12 +62,14 @@ class AgentBaseStation(AlarmControlPanelEntity):
             self._attr_state = None
             return
         if armed:
-            prof = (await self._client.get_active_profile()).lower()
+            prof = await self._client.get_active_profile()
             self._attr_state = STATE_ALARM_ARMED_AWAY
-            if prof == CONF_HOME_MODE_NAME:
-                self._attr_state = STATE_ALARM_ARMED_HOME
-            elif prof == CONF_NIGHT_MODE_NAME:
-                self._attr_state = STATE_ALARM_ARMED_NIGHT
+            if prof is not None:
+                prof = prof.lower()
+                if prof == CONF_HOME_MODE_NAME:
+                    self._attr_state = STATE_ALARM_ARMED_HOME
+                elif prof == CONF_NIGHT_MODE_NAME:
+                    self._attr_state = STATE_ALARM_ARMED_NIGHT
         else:
             self._attr_state = STATE_ALARM_DISARMED
 

--- a/tests/components/agent_dvr/test_alarm_control_panel.py
+++ b/tests/components/agent_dvr/test_alarm_control_panel.py
@@ -1,0 +1,31 @@
+"""Tests for the Agent DVR alarm control panel."""
+from typing import Optional
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.components.agent_dvr.alarm_control_panel import AgentBaseStation
+
+
+def client_mock(profile: Optional[str] = "home"):
+    """Use this to mock the agent client."""
+    api = Mock()
+    api.update = AsyncMock()
+    api.get_active_profile = AsyncMock(return_value=profile)
+    return api
+
+
+async def test_update():
+    """Test update happy path."""
+    with patch("homeassistant.components.agent_dvr"):
+        api = client_mock()
+        alarm = AgentBaseStation(api)
+        await alarm.async_update()
+        assert alarm.state == "armed_home"
+
+
+async def test_update_none_profile():
+    """Test update none profile."""
+    with patch("homeassistant.components.agent_dvr"):
+        api = client_mock(None)
+        alarm = AgentBaseStation(api)
+        await alarm.async_update()
+        assert alarm.state == "armed_away"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Prevent an exception being thrown when `agent_dvr` returns a `None` profile

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
__N/A__

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
__N/A__

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->
__N/A__

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
