### PR TITLE
Use EntityCategory enum for MusicCast entity types

### DIFF
--- a/homeassistant/components/yamaha_musiccast/const.py
+++ b/homeassistant/components/yamaha_musiccast/const.py
@@ -50,7 +50,6 @@ ENTITY_CATEGORY_MAPPING = {
     EntityType.CONFIG: EntityCategory.CONFIG,
     EntityType.REGULAR: None,
     EntityType.DIAGNOSTIC: EntityCategory.DIAGNOSTIC,
-    EntityType.SYSTEM: EntityCategory.SYSTEM,
 }
 
 DEVICE_CLASS_MAPPING = {

--- a/homeassistant/components/yamaha_musiccast/const.py
+++ b/homeassistant/components/yamaha_musiccast/const.py
@@ -9,11 +9,7 @@ from homeassistant.components.media_player.const import (
     REPEAT_MODE_OFF,
     REPEAT_MODE_ONE,
 )
-from homeassistant.const import (
-    ENTITY_CATEGORY_CONFIG,
-    ENTITY_CATEGORY_DIAGNOSTIC,
-    ENTITY_CATEGORY_SYSTEM,
-)
+from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "yamaha_musiccast"
 
@@ -51,10 +47,10 @@ MEDIA_CLASS_MAPPING = {
 }
 
 ENTITY_CATEGORY_MAPPING = {
-    EntityType.CONFIG: ENTITY_CATEGORY_CONFIG,
+    EntityType.CONFIG: EntityCategory.CONFIG,
     EntityType.REGULAR: None,
-    EntityType.DIAGNOSTIC: ENTITY_CATEGORY_DIAGNOSTIC,
-    EntityType.SYSTEM: ENTITY_CATEGORY_SYSTEM,
+    EntityType.DIAGNOSTIC: EntityCategory.DIAGNOSTIC,
+    EntityType.SYSTEM: EntityCategory.SYSTEM,
 }
 
 DEVICE_CLASS_MAPPING = {

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": [
-    "aiomusiccast==0.14.2"
+    "aiomusiccast==0.14.3"
   ],
   "ssdp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -219,7 +219,7 @@ aiolyric==1.0.8
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.14.2
+aiomusiccast==0.14.3
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aiolyric==1.0.8
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.14.2
+aiomusiccast==0.14.3
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For cleaner code we use the EntityCategory enum instead of the constants. In addition we removed the EntityType.System in aiomusiccast ([release notes](https://github.com/vigonotion/aiomusiccast/releases/tag/0.14.3)) and its mapping in Home Assistant, as it is not used anywhere and should not be used in aiomusiccast anyway. This is a follow up of #61218.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
