### PR TITLE
Signal messenger attachments as bytes support

### DIFF
--- a/homeassistant/components/signal_messenger/manifest.json
+++ b/homeassistant/components/signal_messenger/manifest.json
@@ -3,6 +3,6 @@
   "name": "Signal Messenger",
   "documentation": "https://www.home-assistant.io/integrations/signal_messenger",
   "codeowners": ["@bbernhard"],
-  "requirements": ["pysignalclirestapi==0.3.17"],
+  "requirements": ["pysignalclirestapi==0.3.17", "future==0.18.2"],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/signal_messenger/manifest.json
+++ b/homeassistant/components/signal_messenger/manifest.json
@@ -2,7 +2,11 @@
   "domain": "signal_messenger",
   "name": "Signal Messenger",
   "documentation": "https://www.home-assistant.io/integrations/signal_messenger",
-  "codeowners": ["@bbernhard"],
-  "requirements": ["pysignalclirestapi==0.3.17", "future==0.18.2"],
+  "codeowners": [
+    "@bbernhard"
+  ],
+  "requirements": [
+    "pysignalclirestapi==0.3.18"
+  ],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/signal_messenger/manifest.json
+++ b/homeassistant/components/signal_messenger/manifest.json
@@ -3,6 +3,6 @@
   "name": "Signal Messenger",
   "documentation": "https://www.home-assistant.io/integrations/signal_messenger",
   "codeowners": ["@bbernhard"],
-  "requirements": ["pysignalclirestapi==0.3.4"],
+  "requirements": ["pysignalclirestapi==0.3.17"],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -25,7 +25,7 @@ CONF_SIGNAL_CLI_REST_API = "url"
 CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES = 52428800
 ATTR_FILENAMES = "attachments"
 ATTR_URLS = "urls"
-ATTR_VERIFY_URLS = "verifyUrls"
+ATTR_VERIFY_SSL = "verifySsl"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -112,8 +112,8 @@ class SignalNotificationService(BaseNotificationService):
 
         verify = True
 
-        if ATTR_VERIFY_URLS in data and isinstance(data[ATTR_VERIFY_URLS], bool):
-            verify = data[ATTR_VERIFY_URLS]
+        if ATTR_VERIFY_SSL in data and isinstance(data[ATTR_VERIFY_SSL], bool):
+            verify = data[ATTR_VERIFY_SSL]
 
         attachments_as_bytes: list[bytearray] = []
 

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -1,5 +1,8 @@
 """Signal Messenger for notify component."""
+from __future__ import annotations
+
 import logging
+from typing import Any
 
 from pysignalclirestapi import SignalCliRestApi, SignalCliRestApiError
 import requests
@@ -10,7 +13,9 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,7 +23,6 @@ CONF_SENDER_NR = "number"
 CONF_RECP_NR = "recipients"
 CONF_SIGNAL_CLI_REST_API = "url"
 CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES = 52428800
-ATTR_FILENAME = "attachment"
 ATTR_FILENAMES = "attachments"
 ATTR_URLS = "urls"
 
@@ -31,7 +35,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def get_service(hass, config, discovery_info=None):
+def get_service(
+    hass: HomeAssistant,
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> SignalNotificationService:
     """Get the SignalMessenger notification service."""
 
     sender_nr = config[CONF_SENDER_NR]
@@ -46,13 +54,17 @@ def get_service(hass, config, discovery_info=None):
 class SignalNotificationService(BaseNotificationService):
     """Implement the notification service for SignalMessenger."""
 
-    def __init__(self, recp_nrs, signal_cli_rest_api):
+    def __init__(
+        self,
+        recp_nrs: list[str],
+        signal_cli_rest_api: SignalCliRestApi,
+    ) -> None:
         """Initialize the service."""
 
         self._recp_nrs = recp_nrs
         self._signal_cli_rest_api = signal_cli_rest_api
 
-    def send_message(self, message="", **kwargs):
+    def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a one or more recipients. Additionally a file can be attached."""
 
         _LOGGER.debug("Sending signal message")
@@ -73,33 +85,35 @@ class SignalNotificationService(BaseNotificationService):
             raise ex
 
     @staticmethod
-    def get_filenames(data):
+    def get_filenames(data: Any) -> list[str] | None:
         """Extract attachment filenames from data."""
-        filenames = None
-
         if data is None:
             return None
-        if ATTR_FILENAMES in data:
-            filenames = data[ATTR_FILENAMES]
-        if ATTR_FILENAME in data:
-            _LOGGER.warning(
-                "The 'attachment' option is deprecated, please replace it with 'attachments'. "
-                "This option will become invalid in version 0.108"
-            )
-            if filenames is None:
-                filenames = [data[ATTR_FILENAME]]
-            else:
-                filenames.append(data[ATTR_FILENAME])
 
-        return filenames
+        if ATTR_FILENAMES in data:
+            if isinstance(data[ATTR_FILENAMES], list):
+                return data[ATTR_FILENAMES]
+            else:
+                raise ValueError(
+                    "'{property}' property must be a list".format(
+                        property=ATTR_FILENAMES
+                    )
+                )
+
+        return None
 
     @staticmethod
-    def get_attachments_as_bytes(data, attachment_size_limit):
+    def get_attachments_as_bytes(
+        data: Any, attachment_size_limit: int
+    ) -> list[bytearray] | None:
         """Retrieve attachments from URLs defined in data."""
-        attachments_as_bytes = []
-
         if data is None or ATTR_URLS not in data:
-            return attachments_as_bytes
+            return None
+
+        if not isinstance(data[ATTR_URLS], list):
+            raise ValueError(f"'{ATTR_URLS}' property must be a list")
+
+        attachments_as_bytes: list[bytearray] = []
 
         urls = data[ATTR_URLS]
         for url in urls:
@@ -109,7 +123,8 @@ class SignalNotificationService(BaseNotificationService):
 
                 if (
                     resp.headers.get("Content-Length") is not None
-                    and int(resp.headers.get("Content-Length")) > attachment_size_limit
+                    and int(str(resp.headers.get("Content-Length")))
+                    > attachment_size_limit
                 ):
                     raise ValueError("Attachment too large (Content-Length)")
 

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -93,12 +93,8 @@ class SignalNotificationService(BaseNotificationService):
         if ATTR_FILENAMES in data:
             if isinstance(data[ATTR_FILENAMES], list):
                 return data[ATTR_FILENAMES]
-            else:
-                raise ValueError(
-                    "'{property}' property must be a list".format(
-                        property=ATTR_FILENAMES
-                    )
-                )
+
+            raise ValueError(f"'{ATTR_FILENAMES}' property must be a list")
 
         return None
 

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -25,6 +25,7 @@ CONF_SIGNAL_CLI_REST_API = "url"
 CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES = 52428800
 ATTR_FILENAMES = "attachments"
 ATTR_URLS = "urls"
+ATTR_VERIFY_URLS = "verifyUrls"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -109,12 +110,17 @@ class SignalNotificationService(BaseNotificationService):
         if not isinstance(data[ATTR_URLS], list):
             raise ValueError(f"'{ATTR_URLS}' property must be a list")
 
+        verify = True
+
+        if ATTR_VERIFY_URLS in data and isinstance(data[ATTR_VERIFY_URLS], bool):
+            verify = data[ATTR_VERIFY_URLS]
+
         attachments_as_bytes: list[bytearray] = []
 
         urls = data[ATTR_URLS]
         for url in urls:
             try:
-                resp = requests.get(url, verify=False, timeout=10, stream=True)
+                resp = requests.get(url, verify=verify, timeout=10, stream=True)
                 resp.raise_for_status()
 
                 if (

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -150,14 +150,23 @@ class SignalNotificationService(BaseNotificationService):
                     and int(str(resp.headers.get("Content-Length")))
                     > attachment_size_limit
                 ):
-                    raise ValueError("Attachment too large (Content-Length)")
+                    raise ValueError(
+                        "Attachment too large (Content-Length reports {}). Max size: {} bytes".format(
+                            int(str(resp.headers.get("Content-Length"))),
+                            CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES,
+                        )
+                    )
 
                 size = 0
                 chunks = bytearray()
                 for chunk in resp.iter_content(1024):
                     size += len(chunk)
                     if size > attachment_size_limit:
-                        raise ValueError("Attachment too large (Stream)")
+                        raise ValueError(
+                            "Attachment too large (Stream reports {}). Max size: {} bytes".format(
+                                size, CONF_MAX_ALLOWED_DOWNLOAD_SIZE_BYTES
+                            )
+                        )
 
                     chunks.extend(chunk)
 

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -1,8 +1,8 @@
 """Signal Messenger for notify component."""
 import logging
-import requests
 
 from pysignalclirestapi import SignalCliRestApi, SignalCliRestApiError
+import requests
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -52,9 +52,7 @@ class SignalNotificationService(BaseNotificationService):
         self._signal_cli_rest_api = signal_cli_rest_api
 
     def send_message(self, message="", **kwargs):
-        """Send a message to a one or more recipients.
-        Additionally a file can be attached.
-        """
+        """Send a message to a one or more recipients. Additionally a file can be attached."""
 
         _LOGGER.debug("Sending signal message")
 
@@ -74,18 +72,21 @@ class SignalNotificationService(BaseNotificationService):
                     filenames = [data[ATTR_FILENAME]]
                 else:
                     filenames.append(data[ATTR_FILENAME])
-            
             if ATTR_URLS in data:
                 urls = data[ATTR_URLS]
                 for url in urls:
                     try:
-                        attachments_as_bytes.append((requests.get(url, verify=False, timeout=10)).content)
+                        attachments_as_bytes.append(
+                            (requests.get(url, verify=False, timeout=10)).content
+                        )
                     except Exception as ex:
                         _LOGGER.error("%s", ex)
                         raise ex
 
         try:
-            self._signal_cli_rest_api.send_message(message, self._recp_nrs, filenames, attachments_as_bytes)
+            self._signal_cli_rest_api.send_message(
+                message, self._recp_nrs, filenames, attachments_as_bytes
+            )
         except SignalCliRestApiError as ex:
             _LOGGER.error("%s", ex)
             raise ex

--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -1,5 +1,6 @@
 """Signal Messenger for notify component."""
 import logging
+import requests
 
 from pysignalclirestapi import SignalCliRestApi, SignalCliRestApiError
 import voluptuous as vol
@@ -18,6 +19,7 @@ CONF_RECP_NR = "recipients"
 CONF_SIGNAL_CLI_REST_API = "url"
 ATTR_FILENAME = "attachment"
 ATTR_FILENAMES = "attachments"
+ATTR_URLS = "urls"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -51,7 +53,6 @@ class SignalNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to a one or more recipients.
-
         Additionally a file can be attached.
         """
 
@@ -60,6 +61,8 @@ class SignalNotificationService(BaseNotificationService):
         data = kwargs.get(ATTR_DATA)
 
         filenames = None
+        attachments_as_bytes = []
+
         if data is not None:
             if ATTR_FILENAMES in data:
                 filenames = data[ATTR_FILENAMES]
@@ -71,9 +74,18 @@ class SignalNotificationService(BaseNotificationService):
                     filenames = [data[ATTR_FILENAME]]
                 else:
                     filenames.append(data[ATTR_FILENAME])
+            
+            if ATTR_URLS in data:
+                urls = data[ATTR_URLS]
+                for url in urls:
+                    try:
+                        attachments_as_bytes.append((requests.get(url, verify=False, timeout=10)).content)
+                    except Exception as ex:
+                        _LOGGER.error("%s", ex)
+                        raise ex
 
         try:
-            self._signal_cli_rest_api.send_message(message, self._recp_nrs, filenames)
+            self._signal_cli_rest_api.send_message(message, self._recp_nrs, filenames, attachments_as_bytes)
         except SignalCliRestApiError as ex:
             _LOGGER.error("%s", ex)
             raise ex

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1811,7 +1811,7 @@ pysher==1.0.1
 pysiaalarm==3.0.2
 
 # homeassistant.components.signal_messenger
-pysignalclirestapi==0.3.17
+pysignalclirestapi==0.3.18
 
 # homeassistant.components.sky_hub
 pyskyqhub==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1811,7 +1811,7 @@ pysher==1.0.1
 pysiaalarm==3.0.2
 
 # homeassistant.components.signal_messenger
-pysignalclirestapi==0.3.4
+pysignalclirestapi==0.3.17
 
 # homeassistant.components.sky_hub
 pyskyqhub==0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1118,7 +1118,7 @@ pyserial==3.5
 pysiaalarm==3.0.2
 
 # homeassistant.components.signal_messenger
-pysignalclirestapi==0.3.17
+pysignalclirestapi==0.3.18
 
 # homeassistant.components.sma
 pysma==0.6.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1118,7 +1118,7 @@ pyserial==3.5
 pysiaalarm==3.0.2
 
 # homeassistant.components.signal_messenger
-pysignalclirestapi==0.3.4
+pysignalclirestapi==0.3.17
 
 # homeassistant.components.sma
 pysma==0.6.9

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -25,45 +25,36 @@ URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
 
 
 @pytest.fixture
-def signal_requests_mock(requests_mock):
-    """Prepare signal service mock."""
-    requests_mock.register_uri(
-        "POST",
-        "http://127.0.0.1:8080" + SIGNAL_SEND_PATH_SUFIX,
-        status_code=HTTPStatus.CREATED,
-    )
-    requests_mock.register_uri(
-        "GET",
-        "http://127.0.0.1:8080/v1/about",
-        status_code=HTTPStatus.OK,
-        json={"versions": ["v1", "v2"]},
-    )
-    return requests_mock
+def signal_requests_mock_factory(requests_mock):
+    """Create signal service mock from factory."""
 
+    def _signal_requests_mock_factory(content_length_header=None):
+        requests_mock.register_uri(
+            "POST",
+            "http://127.0.0.1:8080" + SIGNAL_SEND_PATH_SUFIX,
+            status_code=HTTPStatus.CREATED,
+        )
+        requests_mock.register_uri(
+            "GET",
+            "http://127.0.0.1:8080/v1/about",
+            status_code=HTTPStatus.OK,
+            json={"versions": ["v1", "v2"]},
+        )
+        if content_length_header is not None:
+            requests_mock.register_uri(
+                "GET",
+                URL_ATTACHMENT,
+                status_code=HTTPStatus.OK,
+                content=CONTENT,
+                headers={"Content-Length": content_length_header},
+            )
+        else:
+            requests_mock.register_uri(
+                "GET",
+                URL_ATTACHMENT,
+                status_code=HTTPStatus.OK,
+                content=CONTENT,
+            )
+        return requests_mock
 
-@pytest.fixture
-def signal_attachment_requests_mock(signal_requests_mock):
-    """Prepare attachment signal service mock."""
-    requests_mock = signal_requests_mock
-    requests_mock.register_uri(
-        "GET",
-        URL_ATTACHMENT,
-        status_code=HTTPStatus.OK,
-        content=CONTENT,
-        headers={"Content-Length": "2048"},
-    )
-    return requests_mock
-
-
-@pytest.fixture
-def signal_large_attachment_requests_mock(signal_requests_mock):
-    """Prepare large attachment signal service mock."""
-    requests_mock = signal_requests_mock
-    requests_mock.register_uri(
-        "GET",
-        URL_ATTACHMENT,
-        status_code=HTTPStatus.OK,
-        content=CONTENT,
-        headers={"Content-Length": "52428801"},
-    )
-    return requests_mock
+    return _signal_requests_mock_factory

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -28,18 +28,27 @@ URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
 def signal_requests_mock_factory(requests_mock):
     """Create signal service mock from factory."""
 
-    def _signal_requests_mock_factory(content_length_header=None):
-        requests_mock.register_uri(
-            "POST",
-            "http://127.0.0.1:8080" + SIGNAL_SEND_PATH_SUFIX,
-            status_code=HTTPStatus.CREATED,
-        )
+    def _signal_requests_mock_factory(
+        success_send_result=True, content_length_header=None
+    ):
         requests_mock.register_uri(
             "GET",
             "http://127.0.0.1:8080/v1/about",
             status_code=HTTPStatus.OK,
             json={"versions": ["v1", "v2"]},
         )
+        if success_send_result:
+            requests_mock.register_uri(
+                "POST",
+                "http://127.0.0.1:8080" + SIGNAL_SEND_PATH_SUFIX,
+                status_code=HTTPStatus.CREATED,
+            )
+        else:
+            requests_mock.register_uri(
+                "POST",
+                "http://127.0.0.1:8080" + SIGNAL_SEND_PATH_SUFIX,
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
         if content_length_header is not None:
             requests_mock.register_uri(
                 "GET",

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -38,10 +38,32 @@ def signal_requests_mock(requests_mock):
         status_code=HTTPStatus.OK,
         json={"versions": ["v1", "v2"]},
     )
+    return requests_mock
+
+
+@pytest.fixture
+def signal_attachment_requests_mock(signal_requests_mock):
+    """Prepare attachment signal service mock."""
+    requests_mock = signal_requests_mock
     requests_mock.register_uri(
         "GET",
         URL_ATTACHMENT,
         status_code=HTTPStatus.OK,
         content=CONTENT,
+        headers={"Content-Length": "2048"},
+    )
+    return requests_mock
+
+
+@pytest.fixture
+def signal_large_attachment_requests_mock(signal_requests_mock):
+    """Prepare large attachment signal service mock."""
+    requests_mock = signal_requests_mock
+    requests_mock.register_uri(
+        "GET",
+        URL_ATTACHMENT,
+        status_code=HTTPStatus.OK,
+        content=CONTENT,
+        headers={"Content-Length": "52428801"},
     )
     return requests_mock

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 
 from pysignalclirestapi import SignalCliRestApi
 import pytest
+from requests_mock.mocker import Mocker
 
 from homeassistant.components.signal_messenger.notify import SignalNotificationService
 
@@ -25,12 +26,12 @@ URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
 
 
 @pytest.fixture
-def signal_requests_mock_factory(requests_mock):
+def signal_requests_mock_factory(requests_mock: Mocker) -> Mocker:
     """Create signal service mock from factory."""
 
     def _signal_requests_mock_factory(
-        success_send_result=True, content_length_header=None
-    ):
+        success_send_result: bool = True, content_length_header: bool = None
+    ) -> Mocker:
         requests_mock.register_uri(
             "GET",
             "http://127.0.0.1:8080/v1/about",

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -30,7 +30,7 @@ def signal_requests_mock_factory(requests_mock: Mocker) -> Mocker:
     """Create signal service mock from factory."""
 
     def _signal_requests_mock_factory(
-        success_send_result: bool = True, content_length_header: bool = None
+        success_send_result: bool = True, content_length_header: str = None
     ) -> Mocker:
         requests_mock.register_uri(
             "GET",

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -6,16 +6,7 @@ import pytest
 from requests_mock.mocker import Mocker
 
 from homeassistant.components.signal_messenger.notify import SignalNotificationService
-
-
-@pytest.fixture
-def signal_notification_service():
-    """Set up signal notification service."""
-    recipients = ["+435565656565"]
-    number = "+43443434343"
-    client = SignalCliRestApi("http://127.0.0.1:8080", number)
-    return SignalNotificationService(recipients, client)
-
+from homeassistant.core import HomeAssistant
 
 SIGNAL_SEND_PATH_SUFIX = "/v2/send"
 MESSAGE = "Testing Signal Messenger platform :)"
@@ -23,6 +14,16 @@ CONTENT = b"TestContent"
 NUMBER_FROM = "+43443434343"
 NUMBERS_TO = ["+435565656565"]
 URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
+
+
+@pytest.fixture
+def signal_notification_service(hass: HomeAssistant) -> SignalNotificationService:
+    """Set up signal notification service."""
+    hass.config.allowlist_external_urls.add(URL_ATTACHMENT)
+    recipients = ["+435565656565"]
+    number = "+43443434343"
+    client = SignalCliRestApi("http://127.0.0.1:8080", number)
+    return SignalNotificationService(hass, recipients, client)
 
 
 @pytest.fixture

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -18,6 +18,7 @@ def signal_notification_service():
 
 SIGNAL_SEND_PATH_SUFIX = "/v2/send"
 MESSAGE = "Testing Signal Messenger platform :)"
+CONTENT = b"TestContent"
 NUMBER_FROM = "+43443434343"
 NUMBERS_TO = ["+435565656565"]
 URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
@@ -39,8 +40,8 @@ def signal_requests_mock(requests_mock):
     )
     requests_mock.register_uri(
         "GET",
-        "http://127.0.0.1:8080/image.jpg",
+        URL_ATTACHMENT,
         status_code=HTTPStatus.OK,
-        content=None,
+        content=CONTENT,
     )
     return requests_mock

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -20,7 +20,7 @@ SIGNAL_SEND_PATH_SUFIX = "/v2/send"
 MESSAGE = "Testing Signal Messenger platform :)"
 NUMBER_FROM = "+43443434343"
 NUMBERS_TO = ["+435565656565"]
-URL = "https://www.home-assistant.io/images/favicon-192x192-full.png"
+URL_ATTACHMENT = "https://www.home-assistant.io/images/favicon-192x192-full.png"
 
 
 @pytest.fixture

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -20,6 +20,7 @@ SIGNAL_SEND_PATH_SUFIX = "/v2/send"
 MESSAGE = "Testing Signal Messenger platform :)"
 NUMBER_FROM = "+43443434343"
 NUMBERS_TO = ["+435565656565"]
+URL = "https://www.home-assistant.io/images/favicon-192x192-full.png"
 
 
 @pytest.fixture

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -20,7 +20,7 @@ SIGNAL_SEND_PATH_SUFIX = "/v2/send"
 MESSAGE = "Testing Signal Messenger platform :)"
 NUMBER_FROM = "+43443434343"
 NUMBERS_TO = ["+435565656565"]
-URL_ATTACHMENT = "https://www.home-assistant.io/images/favicon-192x192-full.png"
+URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
 
 
 @pytest.fixture
@@ -36,5 +36,11 @@ def signal_requests_mock(requests_mock):
         "http://127.0.0.1:8080/v1/about",
         status_code=HTTPStatus.OK,
         json={"versions": ["v1", "v2"]},
+    )
+    requests_mock.register_uri(
+        "GET",
+        "http://127.0.0.1:8080/image.jpg",
+        status_code=HTTPStatus.OK,
+        content=None,
     )
     return requests_mock

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -41,8 +41,11 @@ async def test_signal_messenger_init(hass):
         assert hass.services.has_service(BASE_COMPONENT, "test")
 
 
-def test_send_message(signal_notification_service, signal_requests_mock, caplog):
+def test_send_message(
+    signal_notification_service, signal_requests_mock_factory, caplog
+):
     """Test send message."""
+    signal_requests_mock = signal_requests_mock_factory()
     with caplog.at_level(
         logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
     ):
@@ -54,9 +57,10 @@ def test_send_message(signal_notification_service, signal_requests_mock, caplog)
 
 
 def test_send_message_should_show_deprecation_warning(
-    signal_notification_service, signal_requests_mock, caplog
+    signal_notification_service, signal_requests_mock_factory, caplog
 ):
     """Test send message should show deprecation warning."""
+    signal_requests_mock = signal_requests_mock_factory()
     with caplog.at_level(
         logging.WARNING, logger="homeassistant.components.signal_messenger.notify"
     ):
@@ -72,9 +76,10 @@ def test_send_message_should_show_deprecation_warning(
 
 
 def test_send_message_with_attachment(
-    signal_notification_service, signal_requests_mock, caplog
+    signal_notification_service, signal_requests_mock_factory, caplog
 ):
     """Test send message with attachment."""
+    signal_requests_mock = signal_requests_mock_factory()
     with caplog.at_level(
         logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
     ):
@@ -97,45 +102,106 @@ def send_message_with_attachment(signal_notification_service, deprecated=False):
 
 
 def test_send_message_with_attachment_as_url(
-    signal_notification_service, signal_attachment_requests_mock, caplog
+    signal_notification_service, signal_requests_mock_factory, caplog
 ):
     """Test send message with attachment as URL."""
+    signal_requests_mock = signal_requests_mock_factory(str(len(CONTENT)))
     with caplog.at_level(
         logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
     ):
-        send_message_with_attachment_as_url(signal_notification_service)
+        data = {"urls": [URL_ATTACHMENT]}
+        signal_notification_service.send_message(MESSAGE, **{"data": data})
 
     assert "Sending signal message" in caplog.text
-    assert signal_attachment_requests_mock.called
-    assert signal_attachment_requests_mock.call_count == 3
-    assert_sending_requests(signal_attachment_requests_mock, 1)
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 3
+    assert_sending_requests(signal_requests_mock, 1)
 
 
-def test_send_message_with_large_attachment_as_url(
-    signal_notification_service, signal_large_attachment_requests_mock, caplog
-):
-    """Test send message with large attachment as URL throws error."""
-    with caplog.at_level(
-        logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
-    ):
-        with pytest.raises(ValueError) as exc:
-            send_message_with_attachment_as_url(signal_notification_service)
-
-    assert "Sending signal message" in caplog.text
-    assert signal_large_attachment_requests_mock.called
-    assert signal_large_attachment_requests_mock.call_count == 1
-    assert "Attachment too large" in str(exc.value)
-
-
-def send_message_with_attachment_as_url(signal_notification_service):
-    """Send message with attachment from URL."""
+def test_get_attachments(signal_notification_service, signal_requests_mock_factory):
+    """Test getting attachments as URL."""
+    signal_requests_mock = signal_requests_mock_factory(str(len(CONTENT)))
     data = {"urls": [URL_ATTACHMENT]}
-    signal_notification_service.send_message(MESSAGE, **{"data": data})
+    result = signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert result == [bytearray(CONTENT)]
 
 
-def assert_sending_requests(signal_requests_mock, attachments_num=0):
+def test_get_attachments_with_large_attachment(
+    signal_notification_service, signal_requests_mock_factory
+):
+    """Test getting attachments as URL with large attachment (per Content-Length header) throws error."""
+    signal_requests_mock = signal_requests_mock_factory(str(len(CONTENT) + 1))
+    with pytest.raises(ValueError) as exc:
+        data = {"urls": [URL_ATTACHMENT]}
+        signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert "Attachment too large (Content-Length)" in str(exc.value)
+
+
+def test_get_attachments_with_large_attachment_no_header(
+    signal_notification_service, signal_requests_mock_factory
+):
+    """Test getting attachments as URL with large attachment (per content length) throws error."""
+    signal_requests_mock = signal_requests_mock_factory()
+    with pytest.raises(ValueError) as exc:
+        data = {"urls": [URL_ATTACHMENT]}
+        signal_notification_service.get_attachments_as_bytes(data, len(CONTENT) - 1)
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert "Attachment too large (Stream)" in str(exc.value)
+
+
+def test_get_filenames_with_none_data(signal_notification_service):
+    """Test getting filenames with None data returns None."""
+    data = None
+    result = signal_notification_service.get_filenames(data)
+
+    assert result is None
+
+
+def test_get_filenames_with_attachments_data(signal_notification_service):
+    """Test getting filenames with 'attachments' in data."""
+    data = {"attachments": ["test"]}
+    result = signal_notification_service.get_filenames(data)
+
+    assert result == ["test"]
+
+
+def test_get_filenames_with_multiple_attachments_data(signal_notification_service):
+    """Test getting filenames with multiple 'attachments' in data."""
+    data = {"attachments": ["test", "test2"]}
+    result = signal_notification_service.get_filenames(data)
+
+    assert result == ["test", "test2"]
+
+
+def test_get_filenames_with_attachment_data(signal_notification_service):
+    """Test getting filenames with 'attachment' in data."""
+    data = {"attachment": "test"}
+    result = signal_notification_service.get_filenames(data)
+
+    assert result == ["test"]
+
+
+def test_get_filenames_with_attachment_and_attachments_data(
+    signal_notification_service,
+):
+    """Test getting filenames with both 'attachment' and 'attachments' in data."""
+    data = {"attachment": "test", "attachments": ["test2"]}
+    result = signal_notification_service.get_filenames(data)
+
+    assert result == ["test2", "test"]
+
+
+def assert_sending_requests(signal_requests_mock_factory, attachments_num=0):
     """Assert message was send with correct parameters."""
-    send_request = signal_requests_mock.request_history[-1]
+    send_request = signal_requests_mock_factory.request_history[-1]
     assert send_request.path == SIGNAL_SEND_PATH_SUFIX
 
     body_request = json.loads(send_request.text)

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -6,6 +6,8 @@ import os
 import tempfile
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.setup import async_setup_component
 
 from tests.components.signal_messenger.conftest import (
@@ -95,18 +97,34 @@ def send_message_with_attachment(signal_notification_service, deprecated=False):
 
 
 def test_send_message_with_attachment_as_url(
-    signal_notification_service, signal_requests_mock, caplog
+    signal_notification_service, signal_attachment_requests_mock, caplog
 ):
-    """Test send message with attachment."""
+    """Test send message with attachment as URL."""
     with caplog.at_level(
         logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
     ):
         send_message_with_attachment_as_url(signal_notification_service)
 
     assert "Sending signal message" in caplog.text
-    assert signal_requests_mock.called
-    assert signal_requests_mock.call_count == 3
-    assert_sending_requests(signal_requests_mock, 1)
+    assert signal_attachment_requests_mock.called
+    assert signal_attachment_requests_mock.call_count == 3
+    assert_sending_requests(signal_attachment_requests_mock, 1)
+
+
+def test_send_message_with_large_attachment_as_url(
+    signal_notification_service, signal_large_attachment_requests_mock, caplog
+):
+    """Test send message with large attachment as URL throws error."""
+    with caplog.at_level(
+        logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
+    ):
+        with pytest.raises(ValueError) as exc:
+            send_message_with_attachment_as_url(signal_notification_service)
+
+    assert "Sending signal message" in caplog.text
+    assert signal_large_attachment_requests_mock.called
+    assert signal_large_attachment_requests_mock.call_count == 1
+    assert "Attachment too large" in str(exc.value)
 
 
 def send_message_with_attachment_as_url(signal_notification_service):

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -222,6 +222,58 @@ def test_get_attachments_with_non_list_throws_error(
     assert "'urls' property must be a list" in str(exc.value)
 
 
+def test_get_attachments_with_verify_unset(
+    signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
+) -> None:
+    """Test getting attachments as URL with verifyUrls unset results in verify=true."""
+    signal_requests_mock = signal_requests_mock_factory()
+    data = {"urls": [URL_ATTACHMENT]}
+    signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert signal_requests_mock.last_request.verify is True
+
+
+def test_get_attachments_with_verify_set_true(
+    signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
+) -> None:
+    """Test getting attachments as URL with verifyUrls set to true results in verify=true."""
+    signal_requests_mock = signal_requests_mock_factory()
+    data = {"verifyUrls": True, "urls": [URL_ATTACHMENT]}
+    signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert signal_requests_mock.last_request.verify is True
+
+
+def test_get_attachments_with_verify_set_false(
+    signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
+) -> None:
+    """Test getting attachments as URL with verifyUrls set to false results in verify=false."""
+    signal_requests_mock = signal_requests_mock_factory()
+    data = {"verifyUrls": False, "urls": [URL_ATTACHMENT]}
+    signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert signal_requests_mock.last_request.verify is False
+
+
+def test_get_attachments_with_verify_set_garbage(
+    signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
+) -> None:
+    """Test getting attachments as URL with verifyUrls set to garbage results in verify=true."""
+    signal_requests_mock = signal_requests_mock_factory()
+    data = {"verifyUrls": "test", "urls": [URL_ATTACHMENT]}
+    signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
+
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 1
+    assert signal_requests_mock.last_request.verify is True
+
+
 def assert_sending_requests(
     signal_requests_mock_factory: Mocker, attachments_num: int = 0
 ) -> None:

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -190,7 +190,7 @@ def test_get_attachments_with_large_attachment(
 
     assert signal_requests_mock.called
     assert signal_requests_mock.call_count == 1
-    assert "Attachment too large (Content-Length)" in str(exc.value)
+    assert "Attachment too large (Content-Length reports" in str(exc.value)
 
 
 def test_get_attachments_with_large_attachment_no_header(
@@ -208,7 +208,7 @@ def test_get_attachments_with_large_attachment_no_header(
 
     assert signal_requests_mock.called
     assert signal_requests_mock.call_count == 1
-    assert "Attachment too large (Stream)" in str(exc.value)
+    assert "Attachment too large (Stream reports" in str(exc.value)
 
 
 def test_get_filenames_with_none_data(

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -225,7 +225,7 @@ def test_get_attachments_with_non_list_throws_error(
 def test_get_attachments_with_verify_unset(
     signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
 ) -> None:
-    """Test getting attachments as URL with verifyUrls unset results in verify=true."""
+    """Test getting attachments as URL with verifySsl unset results in verify=true."""
     signal_requests_mock = signal_requests_mock_factory()
     data = {"urls": [URL_ATTACHMENT]}
     signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
@@ -238,9 +238,9 @@ def test_get_attachments_with_verify_unset(
 def test_get_attachments_with_verify_set_true(
     signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
 ) -> None:
-    """Test getting attachments as URL with verifyUrls set to true results in verify=true."""
+    """Test getting attachments as URL with verifySsl set to true results in verify=true."""
     signal_requests_mock = signal_requests_mock_factory()
-    data = {"verifyUrls": True, "urls": [URL_ATTACHMENT]}
+    data = {"verifySsl": True, "urls": [URL_ATTACHMENT]}
     signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
 
     assert signal_requests_mock.called
@@ -251,9 +251,9 @@ def test_get_attachments_with_verify_set_true(
 def test_get_attachments_with_verify_set_false(
     signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
 ) -> None:
-    """Test getting attachments as URL with verifyUrls set to false results in verify=false."""
+    """Test getting attachments as URL with verifySsl set to false results in verify=false."""
     signal_requests_mock = signal_requests_mock_factory()
-    data = {"verifyUrls": False, "urls": [URL_ATTACHMENT]}
+    data = {"verifySsl": False, "urls": [URL_ATTACHMENT]}
     signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
 
     assert signal_requests_mock.called
@@ -264,9 +264,9 @@ def test_get_attachments_with_verify_set_false(
 def test_get_attachments_with_verify_set_garbage(
     signal_notification_service: SignalCliRestApi, signal_requests_mock_factory: Mocker
 ) -> None:
-    """Test getting attachments as URL with verifyUrls set to garbage results in verify=true."""
+    """Test getting attachments as URL with verifySsl set to garbage results in verify=true."""
     signal_requests_mock = signal_requests_mock_factory()
-    data = {"verifyUrls": "test", "urls": [URL_ATTACHMENT]}
+    data = {"verifySsl": "test", "urls": [URL_ATTACHMENT]}
     signal_notification_service.get_attachments_as_bytes(data, len(CONTENT))
 
     assert signal_requests_mock.called

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -1,4 +1,5 @@
 """The tests for the signal_messenger platform."""
+import base64
 import json
 import logging
 import os
@@ -8,6 +9,7 @@ from unittest.mock import patch
 from homeassistant.setup import async_setup_component
 
 from tests.components.signal_messenger.conftest import (
+    CONTENT,
     MESSAGE,
     NUMBER_FROM,
     NUMBERS_TO,
@@ -123,3 +125,7 @@ def assert_sending_requests(signal_requests_mock, attachments_num=0):
     assert body_request["number"] == NUMBER_FROM
     assert body_request["recipients"] == NUMBERS_TO
     assert len(body_request["base64_attachments"]) == attachments_num
+
+    for attachment in body_request["base64_attachments"]:
+        if len(attachment) > 0:
+            assert base64.b64decode(attachment) == CONTENT

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -12,7 +12,7 @@ from tests.components.signal_messenger.conftest import (
     NUMBER_FROM,
     NUMBERS_TO,
     SIGNAL_SEND_PATH_SUFIX,
-    URL,
+    URL_ATTACHMENT,
 )
 
 BASE_COMPONENT = "notify"
@@ -108,7 +108,7 @@ def test_send_message_with_attachment_as_url(
 
 def send_message_with_attachment_as_url(signal_notification_service):
     """Send message with attachment from URL."""
-    data = {"urls": [URL]}
+    data = {"urls": [URL_ATTACHMENT]}
     signal_notification_service.send_message(MESSAGE, **{"data": data})
 
 

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -12,6 +12,7 @@ from tests.components.signal_messenger.conftest import (
     NUMBER_FROM,
     NUMBERS_TO,
     SIGNAL_SEND_PATH_SUFIX,
+    URL,
 )
 
 BASE_COMPONENT = "notify"
@@ -89,6 +90,26 @@ def send_message_with_attachment(signal_notification_service, deprecated=False):
         tf.write("attachment_data")
         data = {"attachment": tf.name} if deprecated else {"attachments": [tf.name]}
         signal_notification_service.send_message(MESSAGE, **{"data": data})
+
+def test_send_message_with_attachment_as_url(
+    signal_notification_service, signal_requests_mock, caplog
+):
+    """Test send message with attachment."""
+    with caplog.at_level(
+        logging.DEBUG, logger="homeassistant.components.signal_messenger.notify"
+    ):
+        send_message_with_attachment_as_url(signal_notification_service)
+
+    assert "Sending signal message" in caplog.text
+    assert signal_requests_mock.called
+    assert signal_requests_mock.call_count == 2
+    assert_sending_requests(signal_requests_mock, 1)
+
+
+def send_message_with_attachment_as_url(signal_notification_service):
+    """Send message with attachment from URL."""
+    data = {"urls": [URL]}
+    signal_notification_service.send_message(MESSAGE, **{"data": data})
 
 
 def assert_sending_requests(signal_requests_mock, attachments_num=0):

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -91,6 +91,7 @@ def send_message_with_attachment(signal_notification_service, deprecated=False):
         data = {"attachment": tf.name} if deprecated else {"attachments": [tf.name]}
         signal_notification_service.send_message(MESSAGE, **{"data": data})
 
+
 def test_send_message_with_attachment_as_url(
     signal_notification_service, signal_requests_mock, caplog
 ):
@@ -102,7 +103,7 @@ def test_send_message_with_attachment_as_url(
 
     assert "Sending signal message" in caplog.text
     assert signal_requests_mock.called
-    assert signal_requests_mock.call_count == 2
+    assert signal_requests_mock.call_count == 3
     assert_sending_requests(signal_requests_mock, 1)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

This is my first ever PR for any open source project - I have no idea if I'm doing the right things, so please go easy on me if I've done something wrong! :)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds the ability for the Signal Messenger integration to support attachments downloaded from a URL/API. Previously this integration would only allow you to attach files read from disk.  This means you can attach images from the camera snapshot API or from Frigate's notifcation API to a Signal message

[Git diff](https://github.com/bbernhard/pysignalclirestapi/compare/6f148bb..0697626) between `0.3.4` and `0.3.17` of the [pysignalclirestapi package](https://github.com/bbernhard/pysignalclirestapi)

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

BREAKING CHANGE: We have removed the deprecated **Attachment** option, which accepted a single file path.  This was replaced by the **Attachments** option several months ago, which accepts a list of file paths for multiple attachment support.  Use of the **Attachment** option previously returned a warning indicating that this was deprecated.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
[Pull Request for Documentation Update](https://github.com/home-assistant/home-assistant.io/pull/20762)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
I bumped the version of https://github.com/bbernhard/pysignalclirestapi from 0.3.4 to 0.3.17 to take advantage of the new attachment functionality provided by the API.

- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

I'm more of a scripter than a developer - it took me weeks to get this thing working! I don't even really know how to review PRs.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
