### PR TITLE
Use on_level when turning an Insteon dimmer on

### DIFF
--- a/homeassistant/components/insteon/insteon_entity.py
+++ b/homeassistant/components/insteon/insteon_entity.py
@@ -3,7 +3,6 @@ import functools
 import logging
 
 from pyinsteon import devices
-from pyinsteon.extended_property import ON_LEVEL, RAMP_RATE
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (

--- a/homeassistant/components/insteon/insteon_entity.py
+++ b/homeassistant/components/insteon/insteon_entity.py
@@ -3,6 +3,7 @@ import functools
 import logging
 
 from pyinsteon import devices
+from pyinsteon.extended_property import ON_LEVEL, RAMP_RATE
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -75,7 +76,14 @@ class InsteonEntity(Entity):
     @property
     def extra_state_attributes(self):
         """Provide attributes for display on device card."""
-        return {"insteon_address": self.address, "insteon_group": self.group}
+        ramprate = self.get_device_property(RAMP_RATE)
+        onamount = self.get_device_property(ON_LEVEL)
+        return {
+            "insteon_address": self.address,
+            "insteon_group": self.group,
+            "insteon_ramprate": ramprate,
+            "insteon_onlevel": onamount,
+        }
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -147,6 +155,15 @@ class InsteonEntity(Entity):
     def _print_aldb(self):
         """Print the device ALDB to the log file."""
         print_aldb_to_log(self._insteon_device.aldb)
+
+    def get_device_property(self, name: str):
+        """Get a single Insteon device property value (raw)."""
+        value = None
+        if name in self._insteon_device.properties:
+            prop = self._insteon_device.properties[name]
+            if prop is not None:
+                value = prop.value if prop.new_value is None else prop.new_value
+        return value
 
     def _get_label(self):
         """Get the device label for grouped devices."""

--- a/homeassistant/components/insteon/insteon_entity.py
+++ b/homeassistant/components/insteon/insteon_entity.py
@@ -154,10 +154,8 @@ class InsteonEntity(Entity):
     def get_device_property(self, name: str):
         """Get a single Insteon device property value (raw)."""
         value = None
-        if name in self._insteon_device.properties:
-            prop = self._insteon_device.properties[name]
-            if prop is not None:
-                value = prop.value if prop.new_value is None else prop.new_value
+        if (prop := self._insteon_device.properties.get(name)) is not None:
+            value = prop.value if prop.new_value is None else prop.new_value
         return value
 
     def _get_label(self):

--- a/homeassistant/components/insteon/insteon_entity.py
+++ b/homeassistant/components/insteon/insteon_entity.py
@@ -76,13 +76,9 @@ class InsteonEntity(Entity):
     @property
     def extra_state_attributes(self):
         """Provide attributes for display on device card."""
-        ramprate = self.get_device_property(RAMP_RATE)
-        onamount = self.get_device_property(ON_LEVEL)
         return {
             "insteon_address": self.address,
             "insteon_group": self.group,
-            "insteon_ramprate": ramprate,
-            "insteon_onlevel": onamount,
         }
 
     @property

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -1,5 +1,7 @@
 """Support for Insteon lights via PowerLinc Modem."""
 
+from pyinsteon.extended_property import ON_LEVEL
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     DOMAIN as LIGHT_DOMAIN,
@@ -53,6 +55,9 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
         """Turn light on."""
         if ATTR_BRIGHTNESS in kwargs:
             brightness = int(kwargs[ATTR_BRIGHTNESS])
+        else:
+            brightness = self.get_device_property(ON_LEVEL)
+        if brightness is not None:
             await self._insteon_device.async_on(
                 on_level=brightness, group=self._insteon_device_group.group
             )


### PR DESCRIPTION
Insteon lights let the user pick the on-level it goes to when physically turned on. This should be mimicked in the GUI so this change uses the known on_level property instead of turning on to full.

It also adds display of on_level and raw ramp_rate for info.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes the on/off switch act just like a physical switch instead of incorrectly always going to full on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ X] The code change is tested and works locally.
- [ X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ X] There is no commented out code in this PR.
- [ X] I have followed the [development checklist][dev-checklist]
- [ X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
