### PR TITLE
Add support for setting RGB and RGBW values for Twinkly lights

### DIFF
--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -1,6 +1,6 @@
 """The twinkly component."""
 
-import twinkly_client
+from ttls.client import Twinkly
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -20,7 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     uuid = entry.data[CONF_ENTRY_ID]
     host = entry.data[CONF_ENTRY_HOST]
 
-    hass.data.setdefault(DOMAIN, {})[uuid] = twinkly_client.TwinklyClient(
+    hass.data.setdefault(DOMAIN, {})[uuid] = Twinkly(
         host, async_get_clientsession(hass)
     )
 

--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -1,28 +1,41 @@
 """The twinkly component."""
 
+import asyncio
+
+from aiohttp import ClientError
 from ttls.client import Twinkly
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_ENTRY_HOST, CONF_ENTRY_ID, DOMAIN
+from .const import CONF_ENTRY_HOST, CONF_ENTRY_ID, DATA_CLIENT, DATA_DEVICE_INFO, DOMAIN
 
 PLATFORMS = [Platform.LIGHT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up entries from config flow."""
+    hass.data.setdefault(DOMAIN, {})
 
     # We setup the client here so if at some point we add any other entity for this device,
     # we will be able to properly share the connection.
     uuid = entry.data[CONF_ENTRY_ID]
     host = entry.data[CONF_ENTRY_HOST]
 
-    hass.data.setdefault(DOMAIN, {})[uuid] = Twinkly(
-        host, async_get_clientsession(hass)
-    )
+    hass.data[DOMAIN].setdefault(uuid, {})
+
+    client = Twinkly(host, async_get_clientsession(hass))
+
+    try:
+        device_info = await client.get_details()
+    except (asyncio.TimeoutError, ClientError) as exception:
+        raise ConfigEntryNotReady from exception
+
+    hass.data[DOMAIN][uuid][DATA_CLIENT] = client
+    hass.data[DOMAIN][uuid][DATA_DEVICE_INFO] = device_info
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from aiohttp import ClientError
-import twinkly_client
+from ttls.client import Twinkly
 from voluptuous import Required, Schema
 
 from homeassistant import config_entries, data_entry_flow
@@ -45,7 +45,7 @@ class TwinklyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if host is not None:
             try:
-                device_info = await twinkly_client.TwinklyClient(host).get_device_info()
+                device_info = await Twinkly(host).get_device_info()
 
                 await self.async_set_unique_id(device_info[DEV_ID])
                 self._abort_if_unique_id_configured()
@@ -65,9 +65,7 @@ class TwinklyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> data_entry_flow.FlowResult:
         """Handle dhcp discovery for twinkly."""
         self._async_abort_entries_match({CONF_ENTRY_HOST: discovery_info.ip})
-        device_info = await twinkly_client.TwinklyClient(
-            discovery_info.ip
-        ).get_device_info()
+        device_info = await Twinkly(discovery_info.ip).get_device_info()
         await self.async_set_unique_id(device_info[DEV_ID])
         self._abort_if_unique_id_configured(
             updates={CONF_ENTRY_HOST: discovery_info.ip}

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -48,7 +48,7 @@ class TwinklyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 device_info = await Twinkly(
                     host, async_get_clientsession(self.hass)
-                ).get_device_info()
+                ).get_details()
 
                 await self.async_set_unique_id(device_info[DEV_ID])
                 self._abort_if_unique_id_configured()
@@ -70,7 +70,7 @@ class TwinklyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_ENTRY_HOST: discovery_info.ip})
         device_info = await Twinkly(
             discovery_info.ip, async_get_clientsession(self.hass)
-        ).get_device_info()
+        ).get_details()
         await self.async_set_unique_id(device_info[DEV_ID])
         self._abort_if_unique_id_configured(
             updates={CONF_ENTRY_HOST: discovery_info.ip}

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -12,6 +12,7 @@ from voluptuous import Required, Schema
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_ENTRY_HOST,
@@ -45,7 +46,9 @@ class TwinklyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if host is not None:
             try:
-                device_info = await Twinkly(host).get_device_info()
+                device_info = await Twinkly(
+                    host, async_get_clientsession(self.hass)
+                ).get_device_info()
 
                 await self.async_set_unique_id(device_info[DEV_ID])
                 self._abort_if_unique_id_configured()
@@ -65,7 +68,9 @@ class TwinklyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> data_entry_flow.FlowResult:
         """Handle dhcp discovery for twinkly."""
         self._async_abort_entries_match({CONF_ENTRY_HOST: discovery_info.ip})
-        device_info = await Twinkly(discovery_info.ip).get_device_info()
+        device_info = await Twinkly(
+            discovery_info.ip, async_get_clientsession(self.hass)
+        ).get_device_info()
         await self.async_set_unique_id(device_info[DEV_ID])
         self._abort_if_unique_id_configured(
             updates={CONF_ENTRY_HOST: discovery_info.ip}

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -15,6 +15,12 @@ ATTR_HOST = "host"
 DEV_ID = "uuid"
 DEV_NAME = "device_name"
 DEV_MODEL = "product_code"
+DEV_LED_PROFILE = "led_profile"
+
+DEV_PROFILE_RGBW = "RGBW"
+
+DATA_CLIENT = "client"
+DATA_DEVICE_INFO = "device_info"
 
 HIDDEN_DEV_VALUES = (
     "code",  # This is the internal status code of the API response

--- a/homeassistant/components/twinkly/const.py
+++ b/homeassistant/components/twinkly/const.py
@@ -17,6 +17,7 @@ DEV_NAME = "device_name"
 DEV_MODEL = "product_code"
 DEV_LED_PROFILE = "led_profile"
 
+DEV_PROFILE_RGB = "RGB"
 DEV_PROFILE_RGBW = "RGBW"
 
 DATA_CLIENT = "client"

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -9,8 +9,10 @@ from ttls.client import Twinkly
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
     COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     LightEntity,
 )
@@ -29,6 +31,7 @@ from .const import (
     DEV_LED_PROFILE,
     DEV_MODEL,
     DEV_NAME,
+    DEV_PROFILE_RGB,
     DEV_PROFILE_RGBW,
     DOMAIN,
     HIDDEN_DEV_VALUES,
@@ -67,6 +70,10 @@ class TwinklyLight(LightEntity):
             self._attr_supported_color_modes = {COLOR_MODE_RGBW}
             self._attr_color_mode = COLOR_MODE_RGBW
             self._attr_rgbw_color = (255, 255, 255, 0)
+        elif device_info.get(DEV_LED_PROFILE) == DEV_PROFILE_RGB:
+            self._attr_supported_color_modes = {COLOR_MODE_RGB}
+            self._attr_color_mode = COLOR_MODE_RGB
+            self._attr_rgb_color = (255, 255, 255)
         else:
             self._attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
             self._attr_color_mode = COLOR_MODE_BRIGHTNESS
@@ -174,6 +181,16 @@ class TwinklyLight(LightEntity):
                             self._attr_rgbw_color[2],
                         )
                     )
+
+        if ATTR_RGB_COLOR in kwargs:
+            if kwargs[ATTR_RGB_COLOR] != self._attr_rgb_color:
+                self._attr_rgb_color = kwargs[ATTR_RGB_COLOR]
+
+                if isinstance(self._attr_rgb_color, tuple):
+
+                    await self._client.interview()
+                    # Reagarrange from rgbw to wrgb
+                    await self._client.set_static_colour(self._attr_rgb_color)
 
         if not self._is_on:
             await self._client.turn_on()

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -148,31 +148,32 @@ class TwinklyLight(LightEntity):
             # If brightness is 0, the twinkly will only "disable" the brightness,
             # which means that it will be 100%.
             if brightness == 0:
-                await self._client.set_is_on(False)
+                await self._client.turn_off()
                 return
 
             await self._client.set_brightness(brightness)
 
-        await self._client.set_is_on(True)
+        await self._client.turn_on()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn device off."""
-        await self._client.set_is_on(False)
+        await self._client.turn_off()
 
     async def async_update(self) -> None:
         """Asynchronously updates the device properties."""
         _LOGGER.info("Updating '%s'", self._client.host)
 
         try:
-            self._is_on = await self._client.get_is_on()
+            self._is_on = await self._client.is_on()
 
-            self._brightness = (
-                int(round((await self._client.get_brightness()) * 2.55))
-                if self._is_on
-                else 0
+            brightness = await self._client.get_brightness()
+            brightness_value = (
+                int(brightness["value"]) if brightness["mode"] == "enabled" else 100
             )
 
-            device_info = await self._client.get_device_info()
+            self._brightness = int(round(brightness_value * 2.55)) if self._is_on else 0
+
+            device_info = await self._client.get_details()
 
             if (
                 DEV_NAME in device_info

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -170,7 +170,7 @@ class TwinklyLight(LightEntity):
                         )
                     )
 
-        if not kwargs:
+        if not self._is_on:
             await self._client.turn_on()
 
     async def async_turn_off(self, **kwargs) -> None:

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -70,7 +70,6 @@ class TwinklyLight(LightEntity):
 
         # Set default state before any update
         self._is_on = False
-        self._brightness = 0
         self._is_available = False
         self._attributes = {ATTR_HOST: self._client.host}
 
@@ -124,11 +123,6 @@ class TwinklyLight(LightEntity):
         return self._is_on
 
     @property
-    def brightness(self) -> int | None:
-        """Return the brightness of the light."""
-        return self._brightness
-
-    @property
     def extra_state_attributes(self) -> dict:
         """Return device specific state attributes."""
 
@@ -136,7 +130,7 @@ class TwinklyLight(LightEntity):
 
         # Make sure to update any normalized property
         attributes[ATTR_HOST] = self._client.host
-        attributes[ATTR_BRIGHTNESS] = self._brightness
+        attributes[ATTR_BRIGHTNESS] = self._attr_brightness
 
         return attributes
 
@@ -189,7 +183,9 @@ class TwinklyLight(LightEntity):
                 int(brightness["value"]) if brightness["mode"] == "enabled" else 100
             )
 
-            self._brightness = int(round(brightness_value * 2.55)) if self._is_on else 0
+            self._attr_brightness = (
+                int(round(brightness_value * 2.55)) if self._is_on else 0
+            )
 
             device_info = await self._client.get_details()
 

--- a/homeassistant/components/twinkly/manifest.json
+++ b/homeassistant/components/twinkly/manifest.json
@@ -2,7 +2,7 @@
   "domain": "twinkly",
   "name": "Twinkly",
   "documentation": "https://www.home-assistant.io/integrations/twinkly",
-  "requirements": ["twinkly-client==0.0.2"],
+  "requirements": ["ttls==1.4.2"],
   "dependencies": [],
   "codeowners": ["@dr1rrb"],
   "config_flow": true,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2357,6 +2357,9 @@ tp-connected==0.0.4
 # homeassistant.components.transmission
 transmissionrpc==0.11
 
+# homeassistant.components.twinkly
+ttls==1.4.2
+
 # homeassistant.components.tuya
 tuya-iot-py-sdk==0.6.3
 
@@ -2365,9 +2368,6 @@ twentemilieu==0.5.0
 
 # homeassistant.components.twilio
 twilio==6.32.0
-
-# homeassistant.components.twinkly
-twinkly-client==0.0.2
 
 # homeassistant.components.rainforest_eagle
 uEagle==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1397,6 +1397,9 @@ total_connect_client==2021.12
 # homeassistant.components.transmission
 transmissionrpc==0.11
 
+# homeassistant.components.twinkly
+ttls==1.4.2
+
 # homeassistant.components.tuya
 tuya-iot-py-sdk==0.6.3
 
@@ -1405,9 +1408,6 @@ twentemilieu==0.5.0
 
 # homeassistant.components.twilio
 twilio==6.32.0
-
-# homeassistant.components.twinkly
-twinkly-client==0.0.2
 
 # homeassistant.components.rainforest_eagle
 uEagle==0.0.2

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -21,6 +21,7 @@ class ClientMock:
         self.is_offline = False
         self.state = True
         self.brightness = {"mode": "enabled", "value": 10}
+        self.color = None
 
         self.id = str(uuid4())
         self.device_info = {
@@ -73,3 +74,10 @@ class ClientMock:
     def change_name(self, new_name: str) -> None:
         """Change the name of this virtual device."""
         self.device_info[DEV_NAME] = new_name
+
+    async def set_static_colour(self, colour) -> None:
+        """Set static color."""
+        self.color = colour
+
+    async def interview(self) -> None:
+        """Interview."""

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -19,8 +19,8 @@ class ClientMock:
     def __init__(self) -> None:
         """Create a mocked client."""
         self.is_offline = False
-        self.is_on = True
-        self.brightness = 10
+        self.state = True
+        self.brightness = {"mode": "enabled", "value": 10}
 
         self.id = str(uuid4())
         self.device_info = {
@@ -36,21 +36,27 @@ class ClientMock:
 
     async def get_details(self):
         """Get the mocked device info."""
-        # if self.is_offline:
-        #     raise ClientConnectionError()
+        if self.is_offline:
+            raise ClientConnectionError()
         return self.device_info
 
-    async def get_is_on(self) -> bool:
+    async def is_on(self) -> bool:
         """Get the mocked on/off state."""
         if self.is_offline:
             raise ClientConnectionError()
-        return self.is_on
+        return self.state
 
-    async def set_is_on(self, is_on: bool) -> None:
-        """Set the mocked on/off state."""
+    async def turn_on(self) -> None:
+        """Set the mocked on state."""
         if self.is_offline:
             raise ClientConnectionError()
-        self.is_on = is_on
+        self.state = True
+
+    async def turn_off(self) -> None:
+        """Set the mocked off state."""
+        if self.is_offline:
+            raise ClientConnectionError()
+        self.state = False
 
     async def get_brightness(self) -> int:
         """Get the mocked brightness."""

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -68,7 +68,7 @@ class ClientMock:
         """Set the mocked brightness."""
         if self.is_offline:
             raise ClientConnectionError()
-        self.brightness = brightness
+        self.brightness = {"mode": "enabled", "value": brightness}
 
     def change_name(self, new_name: str) -> None:
         """Change the name of this virtual device."""

--- a/tests/components/twinkly/__init__.py
+++ b/tests/components/twinkly/__init__.py
@@ -14,7 +14,7 @@ TEST_MODEL = "twinkly_test_device_model"
 
 
 class ClientMock:
-    """A mock of the twinkly_client.TwinklyClient."""
+    """A mock of the ttls.client.Twinkly."""
 
     def __init__(self) -> None:
         """Create a mocked client."""
@@ -34,10 +34,10 @@ class ClientMock:
         """Get the mocked host."""
         return TEST_HOST
 
-    async def get_device_info(self):
+    async def get_details(self):
         """Get the mocked device info."""
-        if self.is_offline:
-            raise ClientConnectionError()
+        # if self.is_offline:
+        #     raise ClientConnectionError()
         return self.device_info
 
     async def get_is_on(self) -> bool:

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_invalid_host(hass):
     """Test the failure when invalid host provided."""
     client = ClientMock()
     client.is_offline = True
-    with patch("twinkly_client.TwinklyClient", return_value=client):
+    with patch("ttls.client.Twinkly", return_value=client):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -40,7 +40,7 @@ async def test_invalid_host(hass):
 async def test_success_flow(hass):
     """Test that an entity is created when the flow completes."""
     client = ClientMock()
-    with patch("twinkly_client.TwinklyClient", return_value=client):
+    with patch("ttls.client.Twinkly", return_value=client):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN, context={"source": config_entries.SOURCE_USER}
         )

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -20,7 +20,9 @@ async def test_invalid_host(hass):
     """Test the failure when invalid host provided."""
     client = ClientMock()
     client.is_offline = True
-    with patch("ttls.client.Twinkly", return_value=client):
+    with patch(
+        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+    ):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -40,7 +42,9 @@ async def test_invalid_host(hass):
 async def test_success_flow(hass):
     """Test that an entity is created when the flow completes."""
     client = ClientMock()
-    with patch("ttls.client.Twinkly", return_value=client):
+    with patch(
+        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+    ), patch("homeassistant.components.twinkly.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -67,7 +71,9 @@ async def test_success_flow(hass):
 async def test_dhcp_can_confirm(hass):
     """Test DHCP discovery flow can confirm right away."""
     client = ClientMock()
-    with patch("twinkly_client.TwinklyClient", return_value=client):
+    with patch(
+        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+    ):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -86,7 +92,9 @@ async def test_dhcp_can_confirm(hass):
 async def test_dhcp_success(hass):
     """Test DHCP discovery flow success."""
     client = ClientMock()
-    with patch("twinkly_client.TwinklyClient", return_value=client):
+    with patch(
+        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+    ), patch("homeassistant.components.twinkly.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -129,7 +137,9 @@ async def test_dhcp_already_exists(hass):
     )
     entry.add_to_hass(hass)
 
-    with patch("twinkly_client.TwinklyClient", return_value=client):
+    with patch(
+        "homeassistant.components.twinkly.config_flow.Twinkly", return_value=client
+    ):
         result = await hass.config_entries.flow.async_init(
             TWINKLY_DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -38,7 +38,7 @@ async def test_setup_entry(hass: HomeAssistant):
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
         side_effect=setup_mock,
-    ):
+    ), patch("homeassistant.components.twinkly.Twinkly", return_value=True):
         await async_setup_entry(hass, config_entry)
 
     assert hass.data[TWINKLY_DOMAIN][id] is not None

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -11,14 +11,21 @@ from homeassistant.components.twinkly.const import (
     CONF_ENTRY_NAME,
     DOMAIN as TWINKLY_DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
-from tests.components.twinkly import TEST_HOST, TEST_MODEL, TEST_NAME_ORIGINAL
+from tests.components.twinkly import (
+    TEST_HOST,
+    TEST_MODEL,
+    TEST_NAME_ORIGINAL,
+    ClientMock,
+)
 
 
 async def test_setup_entry(hass: HomeAssistant):
     """Validate that setup entry also configure the client."""
+    client = ClientMock()
 
     id = str(uuid4())
     config_entry = MockConfigEntry(
@@ -38,7 +45,7 @@ async def test_setup_entry(hass: HomeAssistant):
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setup",
         side_effect=setup_mock,
-    ), patch("homeassistant.components.twinkly.Twinkly", return_value=True):
+    ), patch("homeassistant.components.twinkly.Twinkly", return_value=client):
         await async_setup_entry(hass, config_entry)
 
     assert hass.data[TWINKLY_DOMAIN][id] is not None
@@ -65,3 +72,26 @@ async def test_unload_entry(hass: HomeAssistant):
     await async_unload_entry(hass, config_entry)
 
     assert hass.data[TWINKLY_DOMAIN].get(id) is None
+
+
+async def test_config_entry_not_ready(hass: HomeAssistant):
+    """Validate that config entry is retried."""
+    client = ClientMock()
+    client.is_offline = True
+
+    config_entry = MockConfigEntry(
+        domain=TWINKLY_DOMAIN,
+        data={
+            CONF_ENTRY_HOST: TEST_HOST,
+            CONF_ENTRY_ID: id,
+            CONF_ENTRY_NAME: TEST_NAME_ORIGINAL,
+            CONF_ENTRY_MODEL: TEST_MODEL,
+        },
+    )
+
+    config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.twinkly.Twinkly", return_value=client):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -103,7 +103,7 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
     assert state.attributes["brightness"] == 0
 
 
-async def test_turn_on_with_color(hass: HomeAssistant):
+async def test_turn_on_with_color_rgbw(hass: HomeAssistant):
     """Test support of the light.turn_on service with a brightness parameter."""
     client = ClientMock()
     client.state = False
@@ -124,6 +124,29 @@ async def test_turn_on_with_color(hass: HomeAssistant):
 
     assert state.state == "on"
     assert client.color == (0, 128, 64, 32)
+
+
+async def test_turn_on_with_color_rgb(hass: HomeAssistant):
+    """Test support of the light.turn_on service with a brightness parameter."""
+    client = ClientMock()
+    client.state = False
+    client.device_info["led_profile"] = "RGB"
+    client.brightness = {"mode": "enabled", "value": 255}
+    entity, _, _ = await _create_entries(hass, client)
+
+    assert hass.states.get(entity.entity_id).state == "off"
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        service_data={"entity_id": entity.entity_id, "rgb_color": (128, 64, 32)},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+
+    assert state.state == "on"
+    assert client.color == (128, 64, 32)
 
 
 async def test_turn_off(hass: HomeAssistant):

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -128,8 +128,30 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
 
     state = hass.states.get(entity.entity_id)
 
-    # assert state.state == "on"
+    assert state.state == "on"
     assert state.attributes["brightness"] == 255
+
+
+async def test_turn_on_with_color(hass: HomeAssistant):
+    """Test support of the light.turn_on service with a brightness parameter."""
+    client = ClientMock()
+    client.state = False
+    client.brightness = {"mode": "enabled", "value": 255}
+    entity, _, _ = await _create_entries(hass, client)
+
+    assert hass.states.get(entity.entity_id).state == "off"
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        service_data={"entity_id": entity.entity_id, "rgbw_color": (128, 64, 32, 0)},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+
+    assert state.state == "on"
+    assert client.color == (0, 128, 64, 32)
 
 
 async def test_turn_off(hass: HomeAssistant):

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -90,7 +90,7 @@ async def test_initial_state_offline(hass: HomeAssistant):
     assert device.manufacturer == "LEDWORKS"
 
 
-async def test_turn_on(hass: HomeAssistant):
+async def test_turn_on_off(hass: HomeAssistant):
     """Test support of the light.turn_on service."""
     client = ClientMock()
     client.state = False
@@ -108,6 +108,15 @@ async def test_turn_on(hass: HomeAssistant):
 
     assert state.state == "on"
     assert state.attributes["brightness"] == 51
+
+    await hass.services.async_call(
+        "light", "turn_off", service_data={"entity_id": entity.entity_id}
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+
+    assert state.state == "off"
 
 
 async def test_turn_on_with_brightness(hass: HomeAssistant):

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -93,8 +93,8 @@ async def test_initial_state_offline(hass: HomeAssistant):
 async def test_turn_on(hass: HomeAssistant):
     """Test support of the light.turn_on service."""
     client = ClientMock()
-    client.is_on = False
-    client.brightness = 20
+    client.state = False
+    client.brightness = {"mode": "enabled", "value": 20}
     entity, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
@@ -113,8 +113,8 @@ async def test_turn_on(hass: HomeAssistant):
 async def test_turn_on_with_brightness(hass: HomeAssistant):
     """Test support of the light.turn_on service with a brightness parameter."""
     client = ClientMock()
-    client.is_on = False
-    client.brightness = 20
+    client.state = False
+    client.brightness = {"mode": "enabled", "value": 20}
     entity, _, _ = await _create_entries(hass, client)
 
     assert hass.states.get(entity.entity_id).state == "off"
@@ -197,7 +197,7 @@ async def _create_entries(
     def get_client_mock(client, _):
         return client
 
-    with patch("twinkly_client.TwinklyClient", side_effect=get_client_mock):
+    with patch("homeassistant.components.twinkly.Twinkly", return_value=client):
         config_entry = MockConfigEntry(
             domain=TWINKLY_DOMAIN,
             data={

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -134,7 +134,7 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
     await hass.services.async_call(
         "light",
         "turn_on",
-        service_data={"entity_id": entity.entity_id, "brightness": 0},
+        service_data={"entity_id": entity.entity_id, "brightness": 1},
     )
     await hass.async_block_till_done()
 

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -128,7 +128,7 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
 
     state = hass.states.get(entity.entity_id)
 
-    assert state.state == "on"
+    # assert state.state == "on"
     assert state.attributes["brightness"] == 255
 
 

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -109,15 +109,6 @@ async def test_turn_on_off(hass: HomeAssistant):
     assert state.state == "on"
     assert state.attributes["brightness"] == 51
 
-    await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity.entity_id}
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity.entity_id)
-
-    assert state.state == "off"
-
 
 async def test_turn_on_with_brightness(hass: HomeAssistant):
     """Test support of the light.turn_on service with a brightness parameter."""
@@ -139,6 +130,18 @@ async def test_turn_on_with_brightness(hass: HomeAssistant):
 
     assert state.state == "on"
     assert state.attributes["brightness"] == 255
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        service_data={"entity_id": entity.entity_id, "brightness": 0},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+
+    assert state.state == "off"
+    assert state.attributes["brightness"] == 0
 
 
 async def test_turn_on_with_color(hass: HomeAssistant):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change library from twinkly-client to ttls. It covers same functionality and more and has required functions to set RGBW values.
Add support in the light entity for setting RGBW values.
Update all tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
