### PR TITLE
Remove deprecated yaml config from co2signal

### DIFF
--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -6,11 +6,11 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_TOKEN
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
-from . import APIRatelimitExceeded, CO2Error, InvalidAuth, get_data
+from . import APIRatelimitExceeded, InvalidAuth, get_data
 from .const import CONF_COUNTRY_CODE, DOMAIN
 from .util import get_extra_name
 
@@ -19,70 +19,11 @@ TYPE_SPECIFY_COORDINATES = "Specify coordinates"
 TYPE_SPECIFY_COUNTRY = "Specify country code"
 
 
-def _get_entry_type(config: dict) -> str:
-    """Get entry type from the configuration."""
-    if CONF_LATITUDE in config:
-        return TYPE_SPECIFY_COORDINATES
-
-    if CONF_COUNTRY_CODE in config:
-        return TYPE_SPECIFY_COUNTRY
-
-    return TYPE_USE_HOME
-
-
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Co2signal."""
 
     VERSION = 1
     _data: dict | None
-
-    async def async_step_import(self, import_info):
-        """Set the config entry up from yaml."""
-        data = {CONF_API_KEY: import_info[CONF_TOKEN]}
-
-        if CONF_COUNTRY_CODE in import_info:
-            data[CONF_COUNTRY_CODE] = import_info[CONF_COUNTRY_CODE]
-            new_entry_type = TYPE_SPECIFY_COUNTRY
-        elif (
-            CONF_LATITUDE in import_info
-            and import_info[CONF_LATITUDE] != self.hass.config.latitude
-            and import_info[CONF_LONGITUDE] != self.hass.config.longitude
-        ):
-            data[CONF_LATITUDE] = import_info[CONF_LATITUDE]
-            data[CONF_LONGITUDE] = import_info[CONF_LONGITUDE]
-            new_entry_type = TYPE_SPECIFY_COORDINATES
-        else:
-            new_entry_type = TYPE_USE_HOME
-
-        for entry in self._async_current_entries(include_ignore=False):
-
-            if (cur_entry_type := _get_entry_type(entry.data)) != new_entry_type:
-                continue
-
-            if cur_entry_type == TYPE_USE_HOME and new_entry_type == TYPE_USE_HOME:
-                return self.async_abort(reason="already_configured")
-
-            if (
-                cur_entry_type == TYPE_SPECIFY_COUNTRY
-                and data[CONF_COUNTRY_CODE] == entry.data[CONF_COUNTRY_CODE]
-            ):
-                return self.async_abort(reason="already_configured")
-
-            if (
-                cur_entry_type == TYPE_SPECIFY_COORDINATES
-                and data[CONF_LATITUDE] == entry.data[CONF_LATITUDE]
-                and data[CONF_LONGITUDE] == entry.data[CONF_LONGITUDE]
-            ):
-                return self.async_abort(reason="already_configured")
-
-        try:
-            await self.hass.async_add_executor_job(get_data, self.hass, data)
-        except CO2Error:
-            return self.async_abort(reason="unknown")
-
-        return self.async_create_entry(
-            title=get_extra_name(data) or "CO2 Signal", data=data
-        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/co2signal/const.py
+++ b/homeassistant/components/co2signal/const.py
@@ -4,8 +4,3 @@
 DOMAIN = "co2signal"
 CONF_COUNTRY_CODE = "country_code"
 ATTRIBUTION = "Data provided by CO2signal"
-MSG_LOCATION = (
-    "Please use either coordinates or the country code. "
-    "For the coordinates, "
-    "you need to use both latitude and longitude."
-)

--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -5,39 +5,18 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import cast
 
-import voluptuous as vol
-
 from homeassistant import config_entries
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorEntity,
-    SensorStateClass,
-)
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_TOKEN,
-    PERCENTAGE,
-)
-from homeassistant.helpers import config_validation as cv, update_coordinator
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.const import ATTR_ATTRIBUTION, PERCENTAGE
+from homeassistant.helpers import update_coordinator
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import StateType
 
 from . import CO2SignalCoordinator, CO2SignalResponse
-from .const import ATTRIBUTION, CONF_COUNTRY_CODE, DOMAIN, MSG_LOCATION
+from .const import ATTRIBUTION, DOMAIN
 
 SCAN_INTERVAL = timedelta(minutes=3)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_TOKEN): cv.string,
-        vol.Inclusive(CONF_LATITUDE, "coords", msg=MSG_LOCATION): cv.latitude,
-        vol.Inclusive(CONF_LONGITUDE, "coords", msg=MSG_LOCATION): cv.longitude,
-        vol.Optional(CONF_COUNTRY_CODE): cv.string,
-    }
-)
 
 
 @dataclass


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the CO2Signal integration has been removed.

CO2Signal is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated yaml config from co2signal

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
