### PR TITLE
Remove deprecated yaml config from dunehd

### DIFF
--- a/homeassistant/components/dunehd/config_flow.py
+++ b/homeassistant/components/dunehd/config_flow.py
@@ -72,23 +72,6 @@ class DuneHDConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(
-        self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
-        """Handle configuration by yaml file."""
-        assert user_input is not None
-        host: str = user_input[CONF_HOST]
-
-        self._async_abort_entries_match({CONF_HOST: host})
-
-        try:
-            await self.init_device(host)
-        except CannotConnect:
-            _LOGGER.error("Import aborted, cannot connect to %s", host)
-            return self.async_abort(reason="cannot_connect")
-        else:
-            return self.async_create_entry(title=host, data=user_input)
-
     def host_already_configured(self, host: str) -> bool:
         """See if we already have a dunehd entry matching user input configured."""
         existing_hosts = {

--- a/homeassistant/components/dunehd/media_player.py
+++ b/homeassistant/components/dunehd/media_player.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 from typing import Any, Final
 
 from pdunehd import DuneHDPlayer
-import voluptuous as vol
 
-from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
-    MediaPlayerEntity,
-)
+from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
@@ -18,32 +14,13 @@ from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    STATE_OFF,
-    STATE_ON,
-    STATE_PAUSED,
-    STATE_PLAYING,
-)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import ATTR_MANUFACTURER, DEFAULT_NAME, DOMAIN
-
-CONF_SOURCES: Final = "sources"
-
-PLATFORM_SCHEMA: Final = PARENT_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_SOURCES): vol.Schema({cv.string: cv.string}),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
 
 DUNEHD_PLAYER_SUPPORT: Final[int] = (
     SUPPORT_PAUSE
@@ -53,22 +30,6 @@ DUNEHD_PLAYER_SUPPORT: Final[int] = (
     | SUPPORT_NEXT_TRACK
     | SUPPORT_PLAY
 )
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the Dune HD media player platform."""
-    host: str = config[CONF_HOST]
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_HOST: host}
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/dunehd/test_config_flow.py
+++ b/tests/components/dunehd/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.dunehd.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
@@ -12,49 +12,6 @@ CONFIG_HOSTNAME = {CONF_HOST: "dunehd-host"}
 CONFIG_IP = {CONF_HOST: "10.10.10.12"}
 
 DUNEHD_STATE = {"protocol_version": "4", "player_state": "navigator"}
-
-
-async def test_import(hass):
-    """Test that the import works."""
-    with patch("homeassistant.components.dunehd.async_setup_entry"), patch(
-        "pdunehd.DuneHDPlayer.update_state", return_value=DUNEHD_STATE
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONFIG_HOSTNAME
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "dunehd-host"
-        assert result["data"] == {CONF_HOST: "dunehd-host"}
-
-
-async def test_import_cannot_connect(hass):
-    """Test that errors are shown when cannot connect to the host during import."""
-    with patch("pdunehd.DuneHDPlayer.update_state", return_value={}):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONFIG_HOSTNAME
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "cannot_connect"
-
-
-async def test_import_duplicate_error(hass):
-    """Test that errors are shown when duplicates are added during import."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_HOST: "dunehd-host"},
-        title="dunehd-host",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch("pdunehd.DuneHDPlayer.update_state", return_value=DUNEHD_STATE):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONFIG_HOSTNAME
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
 
 
 async def test_user_invalid_host(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the Dune HD integration has been removed.

Dune HD is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
