### PR TITLE
Bump pywemo==0.7.0

### DIFF
--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Belkin WeMo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wemo",
-  "requirements": ["pywemo==0.6.7"],
+  "requirements": ["pywemo==0.7.0"],
   "ssdp": [
     {
       "manufacturer": "Belkin International Inc."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2019,7 +2019,7 @@ pyvolumio==0.1.3
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.6.7
+pywemo==0.7.0
 
 # homeassistant.components.wilight
 pywilight==0.0.70

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1218,7 +1218,7 @@ pyvolumio==0.1.3
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.6.7
+pywemo==0.7.0
 
 # homeassistant.components.wilight
 pywilight==0.0.70

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -57,7 +57,7 @@ def pywemo_device_fixture(pywemo_registry, pywemo_model):
     device.port = MOCK_PORT
     device.name = MOCK_NAME
     device.serialnumber = MOCK_SERIAL_NUMBER
-    device.model_name = pywemo_model
+    device.model_name = pywemo_model.replace("LongPress", "")
     device.get_state.return_value = 0  # Default to Off
     device.supports_long_press.return_value = cls.supports_long_press()
 

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -3,7 +3,6 @@ import pytest
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.wemo.const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -11,6 +10,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_PLATFORM,
     CONF_TYPE,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -26,8 +26,8 @@ DATA_MESSAGE = {"message": "service-called"}
 
 @pytest.fixture
 def pywemo_model():
-    """Pywemo Dimmer models use the light platform (WemoDimmer class)."""
-    return "Dimmer"
+    """Pywemo LightSwitch models use the switch platform."""
+    return "LightSwitchLongPress"
 
 
 async def setup_automation(hass, device_id, trigger_type):
@@ -67,14 +67,14 @@ async def test_get_triggers(hass, wemo_entity):
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
-            CONF_DOMAIN: LIGHT_DOMAIN,
+            CONF_DOMAIN: Platform.SWITCH,
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_off",
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
-            CONF_DOMAIN: LIGHT_DOMAIN,
+            CONF_DOMAIN: Platform.SWITCH,
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_on",

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -26,8 +26,8 @@ asyncio.set_event_loop_policy(runner.HassEventLoopPolicy(True))
 
 @pytest.fixture
 def pywemo_model():
-    """Pywemo Dimmer models use the light platform (WemoDimmer class)."""
-    return "Dimmer"
+    """Pywemo LightSwitch models use the switch platform."""
+    return "LightSwitchLongPress"
 
 
 async def test_async_register_device_longpress_fails(hass, pywemo_device):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Version bump for pywemo to 0.7.0. This fixes #62259.

Changes: https://github.com/pywemo/pywemo/compare/0.6.7...0.7.0
* [0.7.0](https://github.com/pywemo/pywemo/releases/tag/0.7.0) - Add extra validation for xml & services
* [0.6.8](https://github.com/pywemo/pywemo/releases/tag/0.6.8) - Wemo CrockPot Slow Cooker

I needed to update a few tests to account for the new classes added in https://github.com/pywemo/pywemo/pull/298 & https://github.com/pywemo/pywemo/pull/305.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #62259 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
