### PR TITLE
2021.12.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -517,10 +517,15 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ matrix.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements_test.txt') }}-${{ hashFiles('requirements_all.txt') }}-
-            ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements_test.txt') }}-
-            ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-
+          # Temporary disabling the restore of environments when bumping
+          # a dependency. It seems that we are experiencing issues with
+          # restoring environments in GitHub Actions, although unclear why.
+          # First attempt: https://github.com/home-assistant/core/pull/62383
+          #
+          # restore-keys: |
+          #   ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements_test.txt') }}-${{ hashFiles('requirements_all.txt') }}-
+          #   ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements_test.txt') }}-
+          #   ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create full Python ${{ matrix.python-version }} virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,10 +155,15 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_test.txt') }}-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements.txt') }}-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-
+          # Temporary disabling the restore of environments when bumping
+          # a dependency. It seems that we are experiencing issues with
+          # restoring environments in GitHub Actions, although unclear why.
+          # First attempt: https://github.com/home-assistant/core/pull/62383
+          #
+          # restore-keys: |
+          #   ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_test.txt') }}-
+          #   ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-${{ hashFiles('requirements.txt') }}-
+          #   ${{ runner.os }}-${{ steps.python.outputs.python-version }}-base-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bmw_connected_drive",
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
-  "requirements": ["bimmer_connected==0.8.5"],
+  "requirements": ["bimmer_connected==0.8.7"],
   "codeowners": ["@gerard33", "@rikroe"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             async with async_timeout.timeout(10):
                 things = await bapi.async_get_things(force=True)
-                return {thing.SERIAL: thing for thing in things}
+                return {thing.serial: thing for thing in things}
         except ServerDisconnectedError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         except ClientResponseError as err:

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -100,7 +100,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         self._remove_update_listener = None
 
-        self._attr_name = self._thing.NAME
+        self._attr_name = self._thing.name
         self._attr_device_class = DEVICE_CLASS_SHADE
         self._attr_supported_features = COVER_FEATURES
         self._attr_attribution = ATTRIBUTION
@@ -109,8 +109,8 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
             name=self._attr_name,
             via_device=(DOMAIN, self._entry_id),
             manufacturer="Brunt",
-            sw_version=self._thing.FW_VERSION,
-            model=self._thing.MODEL,
+            sw_version=self._thing.fw_version,
+            model=self._thing.model,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -127,8 +127,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self.unique_id].currentPosition
-        return int(pos) if pos is not None else None
+        return self.coordinator.data[self.unique_id].current_position
 
     @property
     def request_cover_position(self) -> int | None:
@@ -139,8 +138,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         to Brunt, at times there is a diff of 1 to current
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self.unique_id].requestPosition
-        return int(pos) if pos is not None else None
+        return self.coordinator.data[self.unique_id].request_position
 
     @property
     def move_state(self) -> int | None:
@@ -149,8 +147,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 when stopped, 1 when opening, 2 when closing
         """
-        mov = self.coordinator.data[self.unique_id].moveState
-        return int(mov) if mov is not None else None
+        return self.coordinator.data[self.unique_id].move_state
 
     @property
     def is_opening(self) -> bool:
@@ -190,11 +187,11 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         """Set the cover to the new position and wait for the update to be reflected."""
         try:
             await self._bapi.async_change_request_position(
-                position, thingUri=self._thing.thingUri
+                position, thing_uri=self._thing.thing_uri
             )
         except ClientResponseError as exc:
             raise HomeAssistantError(
-                f"Unable to reposition {self._thing.NAME}"
+                f"Unable to reposition {self._thing.name}"
             ) from exc
         self.coordinator.update_interval = FAST_INTERVAL
         await self.coordinator.async_request_refresh()
@@ -204,7 +201,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         """Update the update interval after each refresh."""
         if (
             self.request_cover_position
-            == self._bapi.last_requested_positions[self._thing.thingUri]
+            == self._bapi.last_requested_positions[self._thing.thing_uri]
             and self.move_state == 0
         ):
             self.coordinator.update_interval = REGULAR_INTERVAL

--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brunt Blind Engine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/brunt",
-  "requirements": ["brunt==1.0.2"],
+  "requirements": ["brunt==1.1.0"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -161,6 +161,9 @@ class WebDavCalendarData:
         )
         event_list = []
         for event in vevent_list:
+            if not hasattr(event.instance, "vevent"):
+                _LOGGER.warning("Skipped event with missing 'vevent' property")
+                continue
             vevent = event.instance.vevent
             if not self.is_matching(vevent, self.search):
                 continue
@@ -198,6 +201,9 @@ class WebDavCalendarData:
         # and they would not be properly parsed using their original start/end dates.
         new_events = []
         for event in results:
+            if not hasattr(event.instance, "vevent"):
+                _LOGGER.warning("Skipped event with missing 'vevent' property")
+                continue
             vevent = event.instance.vevent
             for start_dt in vevent.getrruleset() or []:
                 _start_of_today = start_of_today

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==10.2.1"],
+  "requirements": ["pychromecast==10.2.2"],
   "after_dependencies": [
     "cloud",
     "http",

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -526,7 +526,7 @@ class CastDevice(MediaPlayerEntity):
             controller.play_media(media)
         else:
             app_data = {"media_id": media_id, "media_type": media_type, **extra}
-            quick_play(self._chromecast, "homeassistant_media", app_data)
+            quick_play(self._chromecast, "default_media_receiver", app_data)
 
     def _media_status(self):
         """

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -395,11 +395,14 @@ class CastDevice(MediaPlayerEntity):
             return
 
         if self._chromecast.app_id is not None:
-            # Quit the previous app before starting splash screen
+            # Quit the previous app before starting splash screen or media player
             self._chromecast.quit_app()
 
         # The only way we can turn the Chromecast is on is by launching an app
-        self._chromecast.play_media(CAST_SPLASH, pychromecast.STREAM_TYPE_BUFFERED)
+        if self._chromecast.cast_type == pychromecast.const.CAST_TYPE_CHROMECAST:
+            self._chromecast.play_media(CAST_SPLASH, pychromecast.STREAM_TYPE_BUFFERED)
+        else:
+            self._chromecast.start_app(pychromecast.config.APP_MEDIA_RECEIVER)
 
     def turn_off(self):
         """Turn off the cast device."""
@@ -674,9 +677,9 @@ class CastDevice(MediaPlayerEntity):
         support = SUPPORT_CAST
         media_status = self._media_status()[0]
 
-        if (
-            self._chromecast
-            and self._chromecast.cast_type == pychromecast.const.CAST_TYPE_CHROMECAST
+        if self._chromecast and self._chromecast.cast_type in (
+            pychromecast.const.CAST_TYPE_CHROMECAST,
+            pychromecast.const.CAST_TYPE_AUDIO,
         ):
             support |= SUPPORT_TURN_ON
 

--- a/homeassistant/components/dexcom/manifest.json
+++ b/homeassistant/components/dexcom/manifest.json
@@ -3,7 +3,7 @@
   "name": "Dexcom",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dexcom",
-  "requirements": ["pydexcom==0.2.1"],
+  "requirements": ["pydexcom==0.2.2"],
   "codeowners": ["@gagebenne"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Renderer",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
-  "requirements": ["async-upnp-client==0.23.0"],
+  "requirements": ["async-upnp-client==0.23.1"],
   "dependencies": ["ssdp"],
   "ssdp": [
     {

--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Renderer",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
-  "requirements": ["async-upnp-client==0.22.12"],
+  "requirements": ["async-upnp-client==0.23.0"],
   "dependencies": ["ssdp"],
   "ssdp": [
     {

--- a/homeassistant/components/fitbit/sensor.py
+++ b/homeassistant/components/fitbit/sensor.py
@@ -112,10 +112,11 @@ def request_app_setup(
                        Then come back here and hit the below button.
                        """
     except NoURLAvailableError:
-        error_msg = """Could not find a SSL enabled URL for your Home Assistant instance.
-                     Fitbit requires that your Home Assistant instance is accessible via HTTPS.
-                     """
-        configurator.notify_errors(_CONFIGURING["fitbit"], error_msg)
+        _LOGGER.error(
+            "Could not find an SSL enabled URL for your Home Assistant instance. "
+            "Fitbit requires that your Home Assistant instance is accessible via HTTPS"
+        )
+        return
 
     submit = "I have saved my Client ID and Client Secret into fitbit.conf."
 

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flux LED/MagicHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.26.15"],
+  "requirements": ["flux_led==0.27.8"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch"],
   "iot_class": "local_push",

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20211215.0"
+    "home-assistant-frontend==20211220.0"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -122,7 +122,7 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
     async_add_entities(
         [
             HoneywellUSThermostat(data, device, cool_away_temp, heat_away_temp)
-            for device in data.devices
+            for device in data.devices.values()
         ]
     )
 

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -3,7 +3,7 @@
   "name": "Philips Hue",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/hue",
-  "requirements": ["aiohue==3.0.6"],
+  "requirements": ["aiohue==3.0.7"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -47,20 +47,9 @@ class HueBaseEntity(Entity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self.device.id)},
             )
-        # some (3th party) Hue lights report their connection status incorrectly
-        # causing the zigbee availability to report as disconnected while in fact
-        # it can be controlled. Although this is in fact something the device manufacturer
-        # should fix, we work around it here. If the light is reported unavailable at
-        # startup, we ignore the availability status of the zigbee connection
-        self._ignore_availability = False
-        if self.device is None:
-            return
-        if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
-            self._ignore_availability = (
-                # Official Hue lights are reliable
-                self.device.product_data.manufacturer_name != "Signify Netherlands B.V."
-                and zigbee.status != ConnectivityServiceStatus.CONNECTED
-            )
+        # used for availability workaround
+        self._ignore_availability = None
+        self._last_state = None
 
     @property
     def name(self) -> str:
@@ -82,6 +71,7 @@ class HueBaseEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
+        self._check_availability_workaround()
         # Add value_changed callbacks.
         self.async_on_remove(
             self.controller.subscribe(
@@ -140,5 +130,50 @@ class HueBaseEntity(Entity):
             ent_reg.async_remove(self.entity_id)
         else:
             self.logger.debug("Received status update for %s", self.entity_id)
+            self._check_availability_workaround()
             self.on_update()
             self.async_write_ha_state()
+
+    @callback
+    def _check_availability_workaround(self):
+        """Check availability of the device."""
+        if self.resource.type != ResourceTypes.LIGHT:
+            return
+        if self._ignore_availability is not None:
+            # already processed
+            return
+        cur_state = self.resource.on.on
+        if self._last_state is None:
+            self._last_state = cur_state
+            return
+        # some (3th party) Hue lights report their connection status incorrectly
+        # causing the zigbee availability to report as disconnected while in fact
+        # it can be controlled. Although this is in fact something the device manufacturer
+        # should fix, we work around it here. If the light is reported unavailable
+        # by the zigbee connectivity but the state changesm its considered as a
+        # malfunctioning device and we report it.
+        # while the user should actually fix this issue instead of ignoring it, we
+        # ignore the availability for this light from this point.
+        if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
+            if (
+                self._last_state != cur_state
+                and zigbee.status != ConnectivityServiceStatus.CONNECTED
+            ):
+                # the device state changed from on->off or off->on
+                # while it was reported as not connected!
+                self.logger.warning(
+                    "Light %s changed state while reported as disconnected. "
+                    "This is an indicator that routing is not working properly for this device. "
+                    "Home Assistant will ignore availability for this light from now on. "
+                    "Device details: %s - %s (%s) fw: %s",
+                    self.name,
+                    self.device.product_data.manufacturer_name,
+                    self.device.product_data.product_name,
+                    self.device.product_data.model_id,
+                    self.device.product_data.software_version,
+                )
+                # do we want to store this in some persistent storage?
+                self._ignore_availability = True
+            else:
+                self._ignore_availability = False
+        self._last_state = cur_state

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/knx",
   "requirements": [
-    "xknx==0.18.13"
+    "xknx==0.18.14"
   ],
   "codeowners": [
     "@Julius2342",

--- a/homeassistant/components/lyric/api.py
+++ b/homeassistant/components/lyric/api.py
@@ -8,6 +8,18 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
+class OAuth2SessionLyric(config_entry_oauth2_flow.OAuth2Session):
+    """OAuth2Session for Lyric."""
+
+    async def force_refresh_token(self) -> None:
+        """Force a token refresh."""
+        new_token = await self.implementation.async_refresh_token(self.token)
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry, data={**self.config_entry.data, "token": new_token}
+        )
+
+
 class ConfigEntryLyricClient(LyricClient):
     """Provide Honeywell Lyric authentication tied to an OAuth2 based config entry."""
 

--- a/homeassistant/components/netgear/manifest.json
+++ b/homeassistant/components/netgear/manifest.json
@@ -2,7 +2,7 @@
   "domain": "netgear",
   "name": "NETGEAR",
   "documentation": "https://www.home-assistant.io/integrations/netgear",
-  "requirements": ["pynetgear==0.7.0"],
+  "requirements": ["pynetgear==0.8.0"],
   "codeowners": ["@hacf-fr", "@Quentame", "@starkillerOG"],
   "iot_class": "local_polling",
   "config_flow": true,

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -11,6 +11,7 @@ from nexia.const import (
     SYSTEM_STATUS_IDLE,
     UNIT_FAHRENHEIT,
 )
+from nexia.util import find_humidity_setpoint
 import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity
@@ -57,6 +58,8 @@ from .const import (
 from .coordinator import NexiaDataUpdateCoordinator
 from .entity import NexiaThermostatZoneEntity
 from .util import percent_conv
+
+PARALLEL_UPDATES = 1  # keep data in sync with only one connection at a time
 
 SERVICE_SET_AIRCLEANER_MODE = "set_aircleaner_mode"
 SERVICE_SET_HUMIDIFY_SETPOINT = "set_humidify_setpoint"
@@ -231,9 +234,9 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
     def set_humidity(self, humidity):
         """Dehumidify target."""
         if self._thermostat.has_dehumidify_support():
-            self._thermostat.set_dehumidify_setpoint(humidity / 100.0)
+            self.set_dehumidify_setpoint(humidity)
         else:
-            self._thermostat.set_humidify_setpoint(humidity / 100.0)
+            self.set_humidify_setpoint(humidity)
         self._signal_thermostat_update()
 
     @property
@@ -453,7 +456,22 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
 
     def set_humidify_setpoint(self, humidity):
         """Set the humidify setpoint."""
-        self._thermostat.set_humidify_setpoint(humidity / 100.0)
+        target_humidity = find_humidity_setpoint(humidity / 100.0)
+        if self._thermostat.get_humidify_setpoint() == target_humidity:
+            # Trying to set the humidify setpoint to the
+            # same value will cause the api to timeout
+            return
+        self._thermostat.set_humidify_setpoint(target_humidity)
+        self._signal_thermostat_update()
+
+    def set_dehumidify_setpoint(self, humidity):
+        """Set the dehumidify setpoint."""
+        target_humidity = find_humidity_setpoint(humidity / 100.0)
+        if self._thermostat.get_dehumidify_setpoint() == target_humidity:
+            # Trying to set the dehumidify setpoint to the
+            # same value will cause the api to timeout
+            return
+        self._thermostat.set_dehumidify_setpoint(target_humidity)
         self._signal_thermostat_update()
 
     def _signal_thermostat_update(self):

--- a/homeassistant/components/nexia/manifest.json
+++ b/homeassistant/components/nexia/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nexia",
   "name": "Nexia/American Standard/Trane",
-  "requirements": ["nexia==0.9.11"],
+  "requirements": ["nexia==0.9.12"],
   "codeowners": ["@bdraco"],
   "documentation": "https://www.home-assistant.io/integrations/nexia",
   "config_flow": true,

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -85,7 +85,7 @@ class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ):
                 await self.async_set_unique_id(controller.mac)
                 self._abort_if_unique_id_configured(
-                    updates={CONF_IP_ADDRESS: ip_address}
+                    updates={CONF_IP_ADDRESS: ip_address}, reload_on_update=False
                 )
 
         # A new rain machine: We will change out the unique id

--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_FORCE_UPDATE,
     CONF_NAME,
 )
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.event as evt
 
@@ -81,6 +82,7 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorEntity):
 
         if self._state and self._off_delay is not None:
 
+            @callback
             def off_delay_listener(now):
                 """Switch device off after a delay."""
                 self._delay_listener = None

--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ring",
   "name": "Ring",
   "documentation": "https://www.home-assistant.io/integrations/ring",
-  "requirements": ["ring_doorbell==0.7.1"],
+  "requirements": ["ring_doorbell==0.7.2"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@balloob"],
   "config_flow": true,

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -69,7 +69,6 @@ async def async_setup_climate_entities(
 ) -> None:
     """Set up online climate devices."""
 
-    _LOGGER.info("Setup online climate device %s", wrapper.name)
     device_block: Block | None = None
     sensor_block: Block | None = None
 
@@ -82,6 +81,7 @@ async def async_setup_climate_entities(
             sensor_block = block
 
     if sensor_block and device_block:
+        _LOGGER.debug("Setup online climate device %s", wrapper.name)
         async_add_entities([BlockSleepingClimate(wrapper, sensor_block, device_block)])
 
 
@@ -92,7 +92,6 @@ async def async_restore_climate_entities(
     wrapper: BlockDeviceWrapper,
 ) -> None:
     """Restore sleeping climate devices."""
-    _LOGGER.info("Setup sleeping climate device %s", wrapper.name)
 
     ent_reg = await entity_registry.async_get_registry(hass)
     entries = entity_registry.async_entries_for_config_entry(
@@ -104,6 +103,7 @@ async def async_restore_climate_entities(
         if entry.domain != CLIMATE_DOMAIN:
             continue
 
+        _LOGGER.debug("Setup sleeping climate device %s", wrapper.name)
         _LOGGER.debug("Found entry %s [%s]", entry.original_name, entry.domain)
         async_add_entities([BlockSleepingClimate(wrapper, None, None, entry)])
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -12,6 +12,7 @@ from simplipy.errors import (
     EndpointUnavailableError,
     InvalidCredentialsError,
     SimplipyError,
+    WebsocketError,
 )
 from simplipy.system import SystemNotification
 from simplipy.system.v3 import (
@@ -472,6 +473,7 @@ class SimpliSafe:
         self._api = api
         self._hass = hass
         self._system_notifications: dict[int, set[SystemNotification]] = {}
+        self._websocket_reconnect_task: asyncio.Task | None = None
         self.entry = entry
         self.initial_event_to_use: dict[int, dict[str, Any]] = {}
         self.systems: dict[int, SystemType] = {}
@@ -516,11 +518,29 @@ class SimpliSafe:
 
         self._system_notifications[system.system_id] = latest_notifications
 
-    async def _async_websocket_on_connect(self) -> None:
+    async def _async_start_websocket_loop(self) -> None:
         """Define a callback for connecting to the websocket."""
         if TYPE_CHECKING:
             assert self._api.websocket
-        await self._api.websocket.async_listen()
+
+        should_reconnect = True
+
+        try:
+            await self._api.websocket.async_reconnect()
+            await self._api.websocket.async_listen()
+        except asyncio.CancelledError:
+            LOGGER.debug("Request to cancel websocket loop received")
+            raise
+        except WebsocketError as err:
+            LOGGER.error("Failed to connect to websocket: %s", err)
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.error("Unknown exception while connecting to websocket: %s", err)
+
+        if should_reconnect:
+            LOGGER.info("Disconnected from websocket; reconnecting")
+            self._websocket_reconnect_task = self._hass.async_create_task(
+                self._async_start_websocket_loop()
+            )
 
     @callback
     def _async_websocket_on_event(self, event: WebsocketEvent) -> None:
@@ -560,17 +580,25 @@ class SimpliSafe:
             assert self._api.refresh_token
             assert self._api.websocket
 
-        self._api.websocket.add_connect_callback(self._async_websocket_on_connect)
         self._api.websocket.add_event_callback(self._async_websocket_on_event)
-        asyncio.create_task(self._api.websocket.async_connect())
+        self._websocket_reconnect_task = asyncio.create_task(
+            self._async_start_websocket_loop()
+        )
 
         async def async_websocket_disconnect_listener(_: Event) -> None:
             """Define an event handler to disconnect from the websocket."""
             if TYPE_CHECKING:
                 assert self._api.websocket
 
-            if self._api.websocket.connected:
-                await self._api.websocket.async_disconnect()
+            if self._websocket_reconnect_task:
+                self._websocket_reconnect_task.cancel()
+                try:
+                    await self._websocket_reconnect_task
+                except asyncio.CancelledError:
+                    LOGGER.debug("Websocket reconnection task successfully canceled")
+                    self._websocket_reconnect_task = None
+
+            await self._api.websocket.async_disconnect()
 
         self.entry.async_on_unload(
             self._hass.bus.async_listen_once(
@@ -620,10 +648,10 @@ class SimpliSafe:
             if TYPE_CHECKING:
                 assert self._api.websocket
 
-            if self._api.websocket.connected:
-                # If a websocket connection is open, reconnect it to use the
-                # new access token:
-                asyncio.create_task(self._api.websocket.async_reconnect())
+            # Open a new websocket connection with the fresh token:
+            self._websocket_reconnect_task = self._hass.async_create_task(
+                self._async_start_websocket_loop()
+            )
 
         self.entry.async_on_unload(
             self._api.add_refresh_token_callback(async_handle_refresh_token)

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==2021.12.1"],
+  "requirements": ["simplisafe-python==2021.12.2"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling",
   "dhcp": [

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["async-upnp-client==0.23.0"],
+  "requirements": ["async-upnp-client==0.23.1"],
   "dependencies": ["network"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["async-upnp-client==0.22.12"],
+  "requirements": ["async-upnp-client==0.23.0"],
   "dependencies": ["network"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],

--- a/homeassistant/components/tailscale/manifest.json
+++ b/homeassistant/components/tailscale/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tailscale",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tailscale",
-  "requirements": ["tailscale==0.1.5"],
+  "requirements": ["tailscale==0.1.6"],
   "codeowners": ["@frenck"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -3,7 +3,7 @@
   "name": "UPnP/IGD",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "requirements": ["async-upnp-client==0.23.0"],
+  "requirements": ["async-upnp-client==0.23.1"],
   "dependencies": ["network", "ssdp"],
   "codeowners": ["@StevenLooman","@ehendrix23"],
   "ssdp": [

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -3,7 +3,7 @@
   "name": "UPnP/IGD",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "requirements": ["async-upnp-client==0.22.12"],
+  "requirements": ["async-upnp-client==0.23.0"],
   "dependencies": ["network", "ssdp"],
   "codeowners": ["@StevenLooman","@ehendrix23"],
   "ssdp": [

--- a/homeassistant/components/velbus/climate.py
+++ b/homeassistant/components/velbus/climate.py
@@ -61,6 +61,11 @@ class VelbusClimate(VelbusEntity, ClimateEntity):
             None,
         )
 
+    @property
+    def current_temperature(self) -> int | None:
+        """Return the current temperature."""
+        return self._channel.get_state()
+
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -49,7 +49,7 @@ class VelbusLight(VelbusEntity, LightEntity):
     """Representation of a Velbus light."""
 
     _channel: VelbusDimmer
-    _attr_supported_feature = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+    _attr_supported_features = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 
     @property
     def is_on(self) -> bool:
@@ -96,7 +96,7 @@ class VelbusButtonLight(VelbusEntity, LightEntity):
 
     _channel: VelbusButton
     _attr_entity_registry_enabled_default = False
-    _attr_supported_feature = SUPPORT_FLASH
+    _attr_supported_features = SUPPORT_FLASH
 
     def __init__(self, channel: VelbusChannel) -> None:
         """Initialize the button light (led)."""

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -1,0 +1,26 @@
+{
+    "config": {
+        "flow_title": "{name} ({host})",
+        "step": {
+            "user": {
+                "title": "{name}",
+                "description": "Set up ViCare integration. To generate API key go to https://developer.viessmann.com",
+                "data": {
+                    "name": "[%key:common::config_flow::data::name%]",
+                    "scan_interval": "Scan Interval (seconds)",
+                    "username": "[%key:common::config_flow::data::email%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "client_id": "[%key:common::config_flow::data::api_key%]",
+                    "heating_type": "Heating type"
+                }
+            }
+        },
+        "error": {
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+        },
+        "abort": {
+          "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+          "unknown": "[%key:common::config_flow::error::unknown%]"
+        }
+    }
+}

--- a/homeassistant/components/vicare/translations/en.json
+++ b/homeassistant/components/vicare/translations/en.json
@@ -1,0 +1,26 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Already configured. Only a single configuration possible.",
+            "unknown": "Unexpected error"
+        },
+        "error": {
+            "invalid_auth": "Invalid authentication"
+        },
+        "flow_title": "{name} ({host})",
+        "step": {
+            "user": {
+                "data": {
+                    "name": "Name",
+                    "scan_interval": "Scan Interval (seconds)",
+                    "client_id": "API Key",
+                    "heating_type": "Heating type",
+                    "password": "Password",
+                    "username": "Email"
+                },
+                "title": "{name}",
+                "description": "Set up ViCare integration. To generate API key go to https://developer.viessmann.com"
+            }
+        }
+    }
+}

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Belkin WeMo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wemo",
-  "requirements": ["pywemo==0.6.7"],
+  "requirements": ["pywemo==0.7.0"],
   "ssdp": [
     {
       "manufacturer": "Belkin International Inc."

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.8", "async-upnp-client==0.23.0"],
+  "requirements": ["yeelight==0.7.8", "async-upnp-client==0.23.1"],
   "codeowners": ["@rytilahti", "@zewelor", "@shenxn", "@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.8", "async-upnp-client==0.22.12"],
+  "requirements": ["yeelight==0.7.8", "async-upnp-client==0.23.0"],
   "codeowners": ["@rytilahti", "@zewelor", "@shenxn", "@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -490,7 +490,7 @@ async def async_setup_entry(hass, config_entry):  # noqa: C901
             await platform.async_add_entities([entity])
 
         if entity.unique_id:
-            hass.async_add_job(_add_node_to_component())
+            hass.create_task(_add_node_to_component())
             return
 
         @callback

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from homeassistant.backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "3"
+PATCH_VERSION: Final = "4"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodiscover==1.4.5
 aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2
-async-upnp-client==0.23.0
+async-upnp-client==0.23.1
 async_timeout==4.0.0
 atomicwrites==1.4.0
 attrs==21.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodiscover==1.4.5
 aiohttp==3.8.1
 aiohttp_cors==0.7.0
 astral==2.2
-async-upnp-client==0.22.12
+async-upnp-client==0.23.0
 async_timeout==4.0.0
 atomicwrites==1.4.0
 attrs==21.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -30,7 +30,7 @@ pyyaml==6.0
 requests==2.26.0
 scapy==2.4.5
 sqlalchemy==1.4.27
-voluptuous-serialize==2.4.0
+voluptuous-serialize==2.5.0
 voluptuous==0.12.2
 yarl==1.6.3
 zeroconf==0.37.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ ciso8601==2.2.0
 cryptography==35.0.0
 emoji==1.5.0
 hass-nabucasa==0.50.0
-home-assistant-frontend==20211215.0
+home-assistant-frontend==20211220.0
 httpx==0.21.0
 ifaddr==0.1.7
 jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ python-slugify==4.0.1
 pyyaml==6.0
 requests==2.26.0
 voluptuous==0.12.2
-voluptuous-serialize==2.4.0
+voluptuous-serialize==2.5.0
 yarl==1.6.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -440,7 +440,7 @@ brother==1.1.0
 brottsplatskartan==0.0.1
 
 # homeassistant.components.brunt
-brunt==1.0.2
+brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2146,7 +2146,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==2021.12.1
+simplisafe-python==2021.12.2
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2272,7 +2272,7 @@ systembridge==2.2.3
 tahoma-api==0.0.16
 
 # homeassistant.components.tailscale
-tailscale==0.1.5
+tailscale==0.1.6
 
 # homeassistant.components.tank_utility
 tank_utility==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1661,7 +1661,7 @@ pymyq==3.1.4
 pymysensors==0.22.1
 
 # homeassistant.components.netgear
-pynetgear==0.7.0
+pynetgear==0.8.0
 
 # homeassistant.components.netio
 pynetio==0.1.9.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -819,7 +819,7 @@ hole==0.7.0
 holidays==0.11.3.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20211215.0
+home-assistant-frontend==20211220.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1396,7 +1396,7 @@ pycfdns==1.2.2
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==10.2.1
+pychromecast==10.2.2
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -336,7 +336,7 @@ asterisk_mbox==0.5.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.22.12
+async-upnp-client==0.23.0
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2007,7 +2007,7 @@ pyvolumio==0.1.3
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.6.7
+pywemo==0.7.0
 
 # homeassistant.components.wilight
 pywilight==0.0.70

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1065,7 +1065,7 @@ nettigo-air-monitor==1.2.1
 neurio==0.3.1
 
 # homeassistant.components.nexia
-nexia==0.9.11
+nexia==0.9.12
 
 # homeassistant.components.nextcloud
 nextcloudmonitor==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1435,7 +1435,7 @@ pydeconz==85
 pydelijn==0.6.1
 
 # homeassistant.components.dexcom
-pydexcom==0.2.1
+pydexcom==0.2.2
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -387,7 +387,7 @@ beautifulsoup4==4.10.0
 bellows==0.29.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.5
+bimmer_connected==0.8.7
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -658,7 +658,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.26.15
+flux_led==0.27.8
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -186,7 +186,7 @@ aiohomekit==0.6.4
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==3.0.6
+aiohue==3.0.7
 
 # homeassistant.components.imap
 aioimaplib==0.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2058,7 +2058,7 @@ rfk101py==0.0.1
 rflink==0.0.58
 
 # homeassistant.components.ring
-ring_doorbell==0.7.1
+ring_doorbell==0.7.2
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -336,7 +336,7 @@ asterisk_mbox==0.5.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.23.0
+async-upnp-client==0.23.1
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2448,7 +2448,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.knx
-xknx==0.18.13
+xknx==0.18.14
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -654,7 +654,7 @@ netmap==0.7.0.2
 nettigo-air-monitor==1.2.1
 
 # homeassistant.components.nexia
-nexia==0.9.11
+nexia==0.9.12
 
 # homeassistant.components.nfandroidtv
 notifications-android-tv==0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,7 +131,7 @@ aiohomekit==0.6.4
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==3.0.6
+aiohue==3.0.7
 
 # homeassistant.components.apache_kafka
 aiokafka==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -868,7 +868,7 @@ pydaikin==2.6.0
 pydeconz==85
 
 # homeassistant.components.dexcom
-pydexcom==0.2.1
+pydexcom==0.2.2
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1273,7 +1273,7 @@ sharkiqpy==0.1.8
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==2021.12.1
+simplisafe-python==2021.12.2
 
 # homeassistant.components.slack
 slackclient==2.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -236,7 +236,7 @@ arcam-fmj==0.12.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.22.12
+async-upnp-client==0.23.0
 
 # homeassistant.components.aurora
 auroranoaa==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1450,7 +1450,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.knx
-xknx==0.18.13
+xknx==0.18.14
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -236,7 +236,7 @@ arcam-fmj==0.12.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.23.0
+async-upnp-client==0.23.1
 
 # homeassistant.components.aurora
 auroranoaa==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1230,7 +1230,7 @@ restrictedpython==5.2
 rflink==0.0.58
 
 # homeassistant.components.ring
-ring_doorbell==0.7.1
+ring_doorbell==0.7.2
 
 # homeassistant.components.roku
 rokuecp==0.8.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1352,7 +1352,7 @@ surepy==0.7.2
 systembridge==2.2.3
 
 # homeassistant.components.tailscale
-tailscale==0.1.5
+tailscale==0.1.6
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -515,7 +515,7 @@ hole==0.7.0
 holidays==0.11.3.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20211215.0
+home-assistant-frontend==20211220.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -850,7 +850,7 @@ pybotvac==0.0.22
 pycfdns==1.2.2
 
 # homeassistant.components.cast
-pychromecast==10.2.1
+pychromecast==10.2.2
 
 # homeassistant.components.climacell
 pyclimacell==0.18.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ pyvolumio==0.1.3
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.6.7
+pywemo==0.7.0
 
 # homeassistant.components.wilight
 pywilight==0.0.70

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,7 +399,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.26.15
+flux_led==0.27.8
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -257,7 +257,7 @@ base36==0.1.1
 bellows==0.29.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.5
+bimmer_connected==0.8.7
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1019,7 +1019,7 @@ pymyq==3.1.4
 pymysensors==0.22.1
 
 # homeassistant.components.netgear
-pynetgear==0.7.0
+pynetgear==0.8.0
 
 # homeassistant.components.nuki
 pynuki==1.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ broadlink==0.18.0
 brother==1.1.0
 
 # homeassistant.components.brunt
-brunt==1.0.2
+brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ REQUIRES = [
     "pyyaml==6.0",
     "requests==2.26.0",
     "voluptuous==0.12.2",
-    "voluptuous-serialize==2.4.0",
+    "voluptuous-serialize==2.5.0",
     "yarl==1.6.3",
 ]
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -683,10 +683,12 @@ async def test_entity_cast_status(hass: HomeAssistant):
             | SUPPORT_PLAY_MEDIA
             | SUPPORT_STOP
             | SUPPORT_TURN_OFF
+            | SUPPORT_TURN_ON
             | SUPPORT_VOLUME_MUTE
             | SUPPORT_VOLUME_SET,
             SUPPORT_PLAY_MEDIA
             | SUPPORT_TURN_OFF
+            | SUPPORT_TURN_ON
             | SUPPORT_VOLUME_MUTE
             | SUPPORT_VOLUME_SET,
         ),

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -791,7 +791,7 @@ async def test_entity_play_media(hass: HomeAssistant, quick_play_mock):
     chromecast.media_controller.play_media.assert_not_called()
     quick_play_mock.assert_called_once_with(
         chromecast,
-        "homeassistant_media",
+        "default_media_receiver",
         {
             "media_id": "best.mp3",
             "media_type": "audio",
@@ -907,7 +907,7 @@ async def test_entity_play_media_sign_URL(hass: HomeAssistant, quick_play_mock):
     # Play_media
     await common.async_play_media(hass, "audio", "/best.mp3", entity_id)
     quick_play_mock.assert_called_once_with(
-        chromecast, "homeassistant_media", {"media_id": ANY, "media_type": "audio"}
+        chromecast, "default_media_receiver", {"media_id": ANY, "media_type": "audio"}
     )
     assert quick_play_mock.call_args[0][2]["media_id"].startswith(
         "http://example.com:8123/best.mp3?authSig="
@@ -1311,7 +1311,7 @@ async def test_group_media_control(hass, mz_mock, quick_play_mock):
     assert not chromecast.media_controller.play_media.called
     quick_play_mock.assert_called_once_with(
         chromecast,
-        "homeassistant_media",
+        "default_media_receiver",
         {"media_id": "best.mp3", "media_type": "music"},
     )
 

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -381,7 +381,7 @@ async def test_event_subscribe_rejected(
 
     Device state will instead be obtained via polling in async_update.
     """
-    dmr_device_mock.async_subscribe_services.side_effect = UpnpResponseError(501)
+    dmr_device_mock.async_subscribe_services.side_effect = UpnpResponseError(status=501)
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     mock_state = hass.states.get(mock_entity_id)

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -1,6 +1,8 @@
 """Test honeywell setup process."""
 
-from unittest.mock import patch
+from unittest.mock import create_autospec, patch
+
+import somecomfort
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -29,3 +31,20 @@ async def test_setup_multiple_thermostats(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.async_entity_ids_count() == 2
+
+
+@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 0)
+async def test_setup_multiple_thermostats_with_same_deviceid(
+    hass: HomeAssistant, caplog, config_entry: MockConfigEntry, device, client
+) -> None:
+    """Test Honeywell TCC API returning duplicate device IDs."""
+    mock_location2 = create_autospec(somecomfort.Location, instance=True)
+    mock_location2.locationid.return_value = "location2"
+    mock_location2.devices_by_id = {device.deviceid: device}
+    client.locations_by_id["location2"] = mock_location2
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert hass.states.async_entity_ids_count() == 1
+    assert "Platform honeywell does not generate unique IDs" not in caplog.text

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -28,7 +28,15 @@ from tests.common import MockConfigEntry
 
 def _gateway_descriptor(ip: str, port: int) -> GatewayDescriptor:
     """Get mock gw descriptor."""
-    return GatewayDescriptor("Test", ip, port, "eth0", "127.0.0.1", True)
+    return GatewayDescriptor(
+        "Test",
+        ip,
+        port,
+        "eth0",
+        "127.0.0.1",
+        supports_routing=True,
+        supports_tunnelling=True,
+    )
 
 
 async def test_user_single_instance(hass):

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -57,7 +57,7 @@ def pywemo_device_fixture(pywemo_registry, pywemo_model):
     device.port = MOCK_PORT
     device.name = MOCK_NAME
     device.serialnumber = MOCK_SERIAL_NUMBER
-    device.model_name = pywemo_model
+    device.model_name = pywemo_model.replace("LongPress", "")
     device.get_state.return_value = 0  # Default to Off
     device.supports_long_press.return_value = cls.supports_long_press()
 

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -3,7 +3,6 @@ import pytest
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.wemo.const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -11,6 +10,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_PLATFORM,
     CONF_TYPE,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -26,8 +26,8 @@ DATA_MESSAGE = {"message": "service-called"}
 
 @pytest.fixture
 def pywemo_model():
-    """Pywemo Dimmer models use the light platform (WemoDimmer class)."""
-    return "Dimmer"
+    """Pywemo LightSwitch models use the switch platform."""
+    return "LightSwitchLongPress"
 
 
 async def setup_automation(hass, device_id, trigger_type):
@@ -67,14 +67,14 @@ async def test_get_triggers(hass, wemo_entity):
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
-            CONF_DOMAIN: LIGHT_DOMAIN,
+            CONF_DOMAIN: Platform.SWITCH,
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_off",
         },
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
-            CONF_DOMAIN: LIGHT_DOMAIN,
+            CONF_DOMAIN: Platform.SWITCH,
             CONF_ENTITY_ID: wemo_entity.entity_id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_on",

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -26,8 +26,8 @@ asyncio.set_event_loop_policy(runner.HassEventLoopPolicy(True))
 
 @pytest.fixture
 def pywemo_model():
-    """Pywemo Dimmer models use the light platform (WemoDimmer class)."""
-    return "Dimmer"
+    """Pywemo LightSwitch models use the switch platform."""
+    return "LightSwitchLongPress"
 
 
 async def test_async_register_device_longpress_fails(hass, pywemo_device):


### PR DESCRIPTION
- Honeywell unique id fix ([@rdfurman] - [#59393]) ([honeywell docs])
- Add vicare strings ([@oischinger] - [#61593]) ([vicare docs])
- Fix "vevent" KeyError in caldav component ([@jkuettner] - [#61718]) ([caldav docs])
- Silently retry Fronius inverter endpoint 2 times ([@farmio] - [#61826]) ([fronius docs])
- Avoid setting nexia humidity to the same value since it causes the api to fail ([@bdraco] - [#61843]) ([nexia docs])
- Force Lyric token refresh on first authentication failure ([@timmo001] - [#62100]) ([lyric docs])
- Bump pydexcom to 0.2.2 ([@gagebenne] - [#62207]) ([dexcom docs])
- Fix spurious RainMachine config entry reload ([@bachya] - [#62215]) ([rainmachine docs])
- Fix bug in which SimpliSafe websocket won't reconnect on error ([@bachya] - [#62241]) ([simplisafe docs])
- bump pynetgear to 0.8.0 ([@starkillerOG] - [#62261]) ([netgear docs])
- Fix logging for Shelly climate platform ([@chemelli74] - [#62264]) ([shelly docs])
- Upgrade tailscale to 0.1.6 ([@frenck] - [#62267]) ([tailscale docs])
- Fix fitbit no SSL URL handling ([@MartinHjelmare] - [#62270]) ([fitbit docs])
- Fix Non-thread-safe operation in rflink binary_sensor ([@bdraco] - [#62286]) ([rflink docs])
- Fix Non-thread-safe operation in zwave node_added ([@bdraco] - [#62287]) ([zwave docs])
- Bump flux_led to 0.27.8 to fix discovery of older devices ([@bdraco] - [#62292]) ([flux_led docs])
- Bump async-upnp-client to 0.23.0 ([@Flameeyes] - [#62223]) ([upnp docs]) ([yeelight docs]) ([dlna_dmr docs]) ([ssdp docs])
- Update async-upnp-client library to 0.23.1 ([@chishm] - [#62298]) ([upnp docs]) ([yeelight docs]) ([dlna_dmr docs]) ([ssdp docs])
- Bump ring to 0.7.2 ([@balloob] - [#62299]) ([ring docs])
- Fix missing brightness for Velbus entities ([@wlcrs] - [#62314]) ([velbus docs])
- Fix velbus climate current temp ([@Cereal2nd] - [#62329]) ([velbus docs])
- Ensure existing SimpliSafe websocket tasks are cancelled appropriately ([@bachya] - [#62347]) ([simplisafe docs])
- Bump pywemo==0.7.0 ([@esev] - [#62360]) ([wemo docs])
- Bump voluptuous_serialize to 2.5.0 ([@balloob] - [#62363])
- Don't use the homeassistant media app when casting media ([@emontnemery] - [#62385]) ([cast docs])
- Bump brunt to 1.1.0 ([@eavanvalkenburg] - [#62386]) ([brunt docs])
- Update frontend to 20211220.0 ([@bramkragten] - [#62389]) ([frontend docs])
- Bump pychromecast to 10.2.2 ([@emontnemery] - [#62390]) ([cast docs])
- Update xknx to 0.18.14 ([@farmio] - [#62411]) ([knx docs])
- Invalidate CI cache when bumping dependencies, part 2 ([@frenck] - [#62412])
- Invalidate CI cache when bumping dependencies ([@frenck] - [#62394])
- Make it possible to turn on audio only google cast devices ([@emontnemery] - [#62420]) ([cast docs])
- Bump bimmer_connected to 0.8.7 ([@rikroe] - [#62435]) ([bmw_connected_drive docs])
- bump aiohue to 3.0.7 ([@marcelveldt] - [#62444]) ([hue docs])
- Change Hue availability blacklist logic a bit ([@marcelveldt] - [#62446]) ([hue docs])

[#59393]: https://github.com/home-assistant/core/pull/59393
[#61593]: https://github.com/home-assistant/core/pull/61593
[#61718]: https://github.com/home-assistant/core/pull/61718
[#61826]: https://github.com/home-assistant/core/pull/61826
[#61843]: https://github.com/home-assistant/core/pull/61843
[#62100]: https://github.com/home-assistant/core/pull/62100
[#62207]: https://github.com/home-assistant/core/pull/62207
[#62215]: https://github.com/home-assistant/core/pull/62215
[#62223]: https://github.com/home-assistant/core/pull/62223
[#62241]: https://github.com/home-assistant/core/pull/62241
[#62261]: https://github.com/home-assistant/core/pull/62261
[#62264]: https://github.com/home-assistant/core/pull/62264
[#62267]: https://github.com/home-assistant/core/pull/62267
[#62270]: https://github.com/home-assistant/core/pull/62270
[#62286]: https://github.com/home-assistant/core/pull/62286
[#62287]: https://github.com/home-assistant/core/pull/62287
[#62292]: https://github.com/home-assistant/core/pull/62292
[#62298]: https://github.com/home-assistant/core/pull/62298
[#62299]: https://github.com/home-assistant/core/pull/62299
[#62314]: https://github.com/home-assistant/core/pull/62314
[#62329]: https://github.com/home-assistant/core/pull/62329
[#62347]: https://github.com/home-assistant/core/pull/62347
[#62360]: https://github.com/home-assistant/core/pull/62360
[#62363]: https://github.com/home-assistant/core/pull/62363
[#62385]: https://github.com/home-assistant/core/pull/62385
[#62386]: https://github.com/home-assistant/core/pull/62386
[#62389]: https://github.com/home-assistant/core/pull/62389
[#62390]: https://github.com/home-assistant/core/pull/62390
[#62394]: https://github.com/home-assistant/core/pull/62394
[#62411]: https://github.com/home-assistant/core/pull/62411
[#62412]: https://github.com/home-assistant/core/pull/62412
[#62420]: https://github.com/home-assistant/core/pull/62420
[#62435]: https://github.com/home-assistant/core/pull/62435
[#62444]: https://github.com/home-assistant/core/pull/62444
[#62446]: https://github.com/home-assistant/core/pull/62446
[@Cereal2nd]: https://github.com/Cereal2nd
[@Flameeyes]: https://github.com/Flameeyes
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@chemelli74]: https://github.com/chemelli74
[@chishm]: https://github.com/chishm
[@eavanvalkenburg]: https://github.com/eavanvalkenburg
[@emontnemery]: https://github.com/emontnemery
[@esev]: https://github.com/esev
[@farmio]: https://github.com/farmio
[@frenck]: https://github.com/frenck
[@gagebenne]: https://github.com/gagebenne
[@jkuettner]: https://github.com/jkuettner
[@marcelveldt]: https://github.com/marcelveldt
[@oischinger]: https://github.com/oischinger
[@rdfurman]: https://github.com/rdfurman
[@rikroe]: https://github.com/rikroe
[@starkillerOG]: https://github.com/starkillerOG
[@timmo001]: https://github.com/timmo001
[@wlcrs]: https://github.com/wlcrs
[bmw_connected_drive docs]: https://www.home-assistant.io/integrations/bmw_connected_drive/
[brunt docs]: https://www.home-assistant.io/integrations/brunt/
[caldav docs]: https://www.home-assistant.io/integrations/caldav/
[cast docs]: https://www.home-assistant.io/integrations/cast/
[dexcom docs]: https://www.home-assistant.io/integrations/dexcom/
[dlna_dmr docs]: https://www.home-assistant.io/integrations/dlna_dmr/
[fitbit docs]: https://www.home-assistant.io/integrations/fitbit/
[flux_led docs]: https://www.home-assistant.io/integrations/flux_led/
[fronius docs]: https://www.home-assistant.io/integrations/fronius/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[honeywell docs]: https://www.home-assistant.io/integrations/honeywell/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[lyric docs]: https://www.home-assistant.io/integrations/lyric/
[netgear docs]: https://www.home-assistant.io/integrations/netgear/
[nexia docs]: https://www.home-assistant.io/integrations/nexia/
[rainmachine docs]: https://www.home-assistant.io/integrations/rainmachine/
[rflink docs]: https://www.home-assistant.io/integrations/rflink/
[ring docs]: https://www.home-assistant.io/integrations/ring/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[simplisafe docs]: https://www.home-assistant.io/integrations/simplisafe/
[ssdp docs]: https://www.home-assistant.io/integrations/ssdp/
[tailscale docs]: https://www.home-assistant.io/integrations/tailscale/
[upnp docs]: https://www.home-assistant.io/integrations/upnp/
[velbus docs]: https://www.home-assistant.io/integrations/velbus/
[vicare docs]: https://www.home-assistant.io/integrations/vicare/
[wemo docs]: https://www.home-assistant.io/integrations/wemo/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/
[zwave docs]: https://www.home-assistant.io/integrations/zwave/