### PR TITLE
Bump brunt to 1.1.0

### DIFF
--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             async with async_timeout.timeout(10):
                 things = await bapi.async_get_things(force=True)
-                return {thing.SERIAL: thing for thing in things}
+                return {thing.serial: thing for thing in things}
         except ServerDisconnectedError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         except ClientResponseError as err:

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -100,8 +100,8 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         self._remove_update_listener = None
 
-        self._attr_name = self._thing.NAME
-        self._attr_device_class = CoverDeviceClass.SHADE
+        self._attr_name = self._thing.name
+        self._attr_device_class = CoverDeviceClass.BLIND
         self._attr_supported_features = COVER_FEATURES
         self._attr_attribution = ATTRIBUTION
         self._attr_device_info = DeviceInfo(
@@ -109,8 +109,8 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
             name=self._attr_name,
             via_device=(DOMAIN, self._entry_id),
             manufacturer="Brunt",
-            sw_version=self._thing.FW_VERSION,
-            model=self._thing.MODEL,
+            sw_version=self._thing.fw_version,
+            model=self._thing.model,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -127,8 +127,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self.unique_id].currentPosition
-        return int(pos) if pos is not None else None
+        return self.coordinator.data[self.unique_id].current_position
 
     @property
     def request_cover_position(self) -> int | None:
@@ -139,8 +138,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         to Brunt, at times there is a diff of 1 to current
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self.unique_id].requestPosition
-        return int(pos) if pos is not None else None
+        return self.coordinator.data[self.unique_id].request_position
 
     @property
     def move_state(self) -> int | None:
@@ -149,8 +147,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 when stopped, 1 when opening, 2 when closing
         """
-        mov = self.coordinator.data[self.unique_id].moveState
-        return int(mov) if mov is not None else None
+        return self.coordinator.data[self.unique_id].move_state
 
     @property
     def is_opening(self) -> bool:
@@ -190,11 +187,11 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         """Set the cover to the new position and wait for the update to be reflected."""
         try:
             await self._bapi.async_change_request_position(
-                position, thingUri=self._thing.thingUri
+                position, thing_uri=self._thing.thing_uri
             )
         except ClientResponseError as exc:
             raise HomeAssistantError(
-                f"Unable to reposition {self._thing.NAME}"
+                f"Unable to reposition {self._thing.name}"
             ) from exc
         self.coordinator.update_interval = FAST_INTERVAL
         await self.coordinator.async_request_refresh()
@@ -204,7 +201,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         """Update the update interval after each refresh."""
         if (
             self.request_cover_position
-            == self._bapi.last_requested_positions[self._thing.thingUri]
+            == self._bapi.last_requested_positions[self._thing.thing_uri]
             and self.move_state == 0
         ):
             self.coordinator.update_interval = REGULAR_INTERVAL

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -101,7 +101,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         self._remove_update_listener = None
 
         self._attr_name = self._thing.name
-        self._attr_device_class = CoverDeviceClass.BLIND
+        self._attr_device_class = CoverDeviceClass.SHADE
         self._attr_supported_features = COVER_FEATURES
         self._attr_attribution = ATTRIBUTION
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brunt Blind Engine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/brunt",
-  "requirements": ["brunt==1.0.2"],
+  "requirements": ["brunt==1.1.0"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -443,7 +443,7 @@ brother==1.1.0
 brottsplatskartan==0.0.1
 
 # homeassistant.components.brunt
-brunt==1.0.2
+brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -284,7 +284,7 @@ broadlink==0.18.0
 brother==1.1.0
 
 # homeassistant.components.brunt
-brunt==1.0.2
+brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump package to v1.1.0, changes: This version introduces a new create function for the Thing objects, it also renames the attributes of the thing into python style snake format (lower case words seperated by underscores). It casts some fields to int, so no longer necessary to do that in user code. Finally it sets Python 3.8 as the minimum. [release](https://github.com/eavanvalkenburg/brunt-api/releases/tag/v1.1.0)

As a result of these changes some small changes in the HA code, fieldnames updated and no longer needed to cast fields in the cover entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
	- closes #62214 
	- closes #62355
	- closes #62019
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
