### PR TITLE
Fix picnic sensor time unit

### DIFF
--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Literal
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
 from homeassistant.const import CURRENCY_EURO
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 
 DOMAIN = "picnic"
 
@@ -42,7 +44,7 @@ class PicnicRequiredKeysMixin:
     """Mixin for required keys."""
 
     data_type: Literal["cart_data", "slot_data", "last_order_data"]
-    value_fn: Callable[[Any], StateType]
+    value_fn: Callable[[Any], StateType | datetime]
 
 
 @dataclass
@@ -73,7 +75,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:calendar-start",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        value_fn=lambda slot: slot.get("window_start"),
+        value_fn=lambda slot: dt_util.parse_datetime(str(slot.get("window_start"))),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_END,
@@ -81,7 +83,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:calendar-end",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        value_fn=lambda slot: slot.get("window_end"),
+        value_fn=lambda slot: dt_util.parse_datetime(str(slot.get("window_end"))),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_MAX_ORDER_TIME,
@@ -89,7 +91,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:clock-alert-outline",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        value_fn=lambda slot: slot.get("cut_off_time"),
+        value_fn=lambda slot: dt_util.parse_datetime(str(slot.get("cut_off_time"))),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_MIN_ORDER_VALUE,
@@ -108,14 +110,18 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:calendar-start",
         data_type="last_order_data",
-        value_fn=lambda last_order: last_order.get("slot", {}).get("window_start"),
+        value_fn=lambda last_order: dt_util.parse_datetime(
+            str(last_order.get("slot", {}).get("window_start"))
+        ),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_SLOT_END,
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:calendar-end",
         data_type="last_order_data",
-        value_fn=lambda last_order: last_order.get("slot", {}).get("window_end"),
+        value_fn=lambda last_order: dt_util.parse_datetime(
+            str(last_order.get("slot", {}).get("window_end"))
+        ),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_STATUS,
@@ -129,7 +135,9 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:clock-start",
         entity_registry_enabled_default=True,
         data_type="last_order_data",
-        value_fn=lambda last_order: last_order.get("eta", {}).get("start"),
+        value_fn=lambda last_order: dt_util.parse_datetime(
+            str(last_order.get("eta", {}).get("start"))
+        ),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_ETA_END,
@@ -137,7 +145,9 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:clock-end",
         entity_registry_enabled_default=True,
         data_type="last_order_data",
-        value_fn=lambda last_order: last_order.get("eta", {}).get("end"),
+        value_fn=lambda last_order: dt_util.parse_datetime(
+            str(last_order.get("eta", {}).get("end"))
+        ),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_DELIVERY_TIME,
@@ -145,7 +155,9 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:timeline-clock",
         entity_registry_enabled_default=True,
         data_type="last_order_data",
-        value_fn=lambda last_order: last_order.get("delivery_time", {}).get("start"),
+        value_fn=lambda last_order: dt_util.parse_datetime(
+            str(last_order.get("delivery_time", {}).get("start"))
+        ),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_TOTAL_PRICE,

--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -36,6 +36,8 @@ SENSOR_LAST_ORDER_ETA_END = "last_order_eta_end"
 SENSOR_LAST_ORDER_DELIVERY_TIME = "last_order_delivery_time"
 SENSOR_LAST_ORDER_TOTAL_PRICE = "last_order_total_price"
 
+DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
 
 @dataclass
 class PicnicRequiredKeysMixin:

--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -36,8 +36,6 @@ SENSOR_LAST_ORDER_ETA_END = "last_order_eta_end"
 SENSOR_LAST_ORDER_DELIVERY_TIME = "last_order_delivery_time"
 SENSOR_LAST_ORDER_TOTAL_PRICE = "last_order_total_price"
 
-DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
-
 
 @dataclass
 class PicnicRequiredKeysMixin:

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -60,11 +60,11 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         """Fetch the data from the Picnic API and return a flat dict with only needed sensor data."""
         # Fetch from the API and pre-process the data
         cart = self.picnic_api_client.get_cart()
-        last_order = self._get_last_order()
 
-        if not cart or not last_order:
+        if not cart:
             raise UpdateFailed("API response doesn't contain expected data.")
 
+        last_order = self._get_last_order()
         slot_data = self._get_slot_data(cart)
 
         return {
@@ -102,11 +102,12 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         """Get data of the last order from the list of deliveries."""
         # Get the deliveries
         deliveries = self.picnic_api_client.get_deliveries(summary=True)
-        if not deliveries:
-            return {}
 
-        # Determine the last order
-        last_order = copy.deepcopy(deliveries[0])
+        # Determine the last order and return an empty dict if there is none
+        try:
+            last_order = copy.deepcopy(deliveries[0])
+        except KeyError:
+            return {}
 
         #  Get the position details if the order is not delivered yet
         delivery_position = {}

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -60,11 +60,11 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         """Fetch the data from the Picnic API and return a flat dict with only needed sensor data."""
         # Fetch from the API and pre-process the data
         cart = self.picnic_api_client.get_cart()
+        last_order = self._get_last_order()
 
-        if not cart:
+        if not cart or not last_order:
             raise UpdateFailed("API response doesn't contain expected data.")
 
-        last_order = self._get_last_order()
         slot_data = self._get_slot_data(cart)
 
         return {
@@ -102,12 +102,11 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         """Get data of the last order from the list of deliveries."""
         # Get the deliveries
         deliveries = self.picnic_api_client.get_deliveries(summary=True)
-
-        # Determine the last order and return an empty dict if there is none
-        try:
-            last_order = copy.deepcopy(deliveries[0])
-        except KeyError:
+        if not deliveries:
             return {}
+
+        # Determine the last order
+        last_order = copy.deepcopy(deliveries[0])
 
         #  Get the position details if the order is not delivered yet
         delivery_position = {}

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, cast
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -14,7 +14,6 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-from homeassistant.util import dt as dt_util
 
 from .const import (
     ADDRESS,
@@ -64,8 +63,8 @@ class PicnicSensor(SensorEntity, CoordinatorEntity):
         self._attr_unique_id = f"{config_entry.unique_id}.{description.key}"
 
     @property
-    def _api_value(self):
-        """Return the value reported by the API."""
+    def native_value(self) -> StateType | datetime:
+        """Return the value reported by the sensor."""
         data_set = (
             self.coordinator.data.get(self.entity_description.data_type, {})
             if self.coordinator.data is not None
@@ -74,18 +73,9 @@ class PicnicSensor(SensorEntity, CoordinatorEntity):
         return self.entity_description.value_fn(data_set)
 
     @property
-    def native_value(self) -> StateType | datetime:
-        """Return the value reported by the sensor."""
-        if not self._api_value or self.device_class != SensorDeviceClass.TIMESTAMP:
-            return self._api_value
-
-        # Convert to datetime object if the device class is timestamp
-        return dt_util.parse_datetime(self._api_value)
-
-    @property
     def available(self) -> bool:
         """Return True if last update was successful."""
-        return self.coordinator.last_update_success and self._api_value is not None
+        return self.coordinator.last_update_success
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -1,9 +1,10 @@
 """Definition of Picnic sensors."""
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, cast
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -18,6 +19,7 @@ from .const import (
     ADDRESS,
     ATTRIBUTION,
     CONF_COORDINATOR,
+    DATE_TIME_FORMAT,
     DOMAIN,
     SENSOR_TYPES,
     PicnicSensorEntityDescription,
@@ -69,7 +71,17 @@ class PicnicSensor(SensorEntity, CoordinatorEntity):
             if self.coordinator.data is not None
             else {}
         )
-        return self.entity_description.value_fn(data_set)
+        value = self.entity_description.value_fn(data_set)
+
+        # Convert to datetime object if the device class is timestamp
+        if value and self.device_class == SensorDeviceClass.TIMESTAMP:
+            try:
+                value = datetime.strptime(value, DATE_TIME_FORMAT)
+            except ValueError:
+                value = None
+
+        # Return the value
+        return value
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -64,7 +64,7 @@ class PicnicSensor(SensorEntity, CoordinatorEntity):
         self._attr_unique_id = f"{config_entry.unique_id}.{description.key}"
 
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> StateType | datetime:
         """Return the state of the entity."""
         data_set = (
             self.coordinator.data.get(self.entity_description.data_type, {})
@@ -73,15 +73,14 @@ class PicnicSensor(SensorEntity, CoordinatorEntity):
         )
         value = self.entity_description.value_fn(data_set)
 
-        # Convert to datetime object if the device class is timestamp
-        if value and self.device_class == SensorDeviceClass.TIMESTAMP:
-            try:
-                value = datetime.strptime(value, DATE_TIME_FORMAT)
-            except ValueError:
-                value = None
+        if not value or self.device_class != SensorDeviceClass.TIMESTAMP:
+            return value
 
-        # Return the value
-        return value
+        # Convert to datetime object if the device class is timestamp
+        try:
+            return datetime.strptime(str(value), DATE_TIME_FORMAT)
+        except ValueError:
+            return None
 
     @property
     def available(self) -> bool:

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -390,21 +390,6 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
-    async def test_sensors_malformed_delivery_data(self):
-        """Test sensor states when the delivery api returns not a list."""
-        # Setup platform with default responses
-        await self._setup_platform(use_default_responses=True)
-
-        # Change mock responses to empty data and refresh the coordinator
-        self.picnic_mock().get_deliveries.return_value = {"error": "message"}
-        await self._coordinator.async_refresh()
-
-        # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
-        assert self._coordinator.last_update_success is True
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
-
     async def test_sensors_malformed_response(self):
         """Test coordinator update fails when API yields ValueError."""
         # Setup platform with default responses

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -1,8 +1,8 @@
 """The tests for the Picnic sensor platform."""
 import copy
-from dataclasses import dataclass
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+import unittest
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -18,11 +18,14 @@ from homeassistant.const import (
     DEVICE_CLASS_TIMESTAMP,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.util import dt
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_test_home_assistant,
+)
 
 DEFAULT_USER_RESPONSE = {
     "user_id": "295-6y3-1nf4",
@@ -88,365 +91,337 @@ DEFAULT_DELIVERY_RESPONSE = {
 SENSOR_KEYS = [desc.key for desc in SENSOR_TYPES]
 
 
-@dataclass
-class PicnicTestData:
-    """A dataclass containing the objects necessary for each test."""
+@pytest.mark.usefixtures("hass_storage")
+class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
+    """Test the Picnic sensor."""
 
-    hass: HomeAssistant
-    api_client: MagicMock
-    config_entry: ConfigEntry
+    async def asyncSetUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = await async_test_home_assistant(None)
+        self.entity_registry = (
+            await self.hass.helpers.entity_registry.async_get_registry()
+        )
 
+        # Patch the api client
+        self.picnic_patcher = patch("homeassistant.components.picnic.PicnicAPI")
+        self.picnic_mock = self.picnic_patcher.start()
 
-@pytest.fixture
-def picnic(hass: HomeAssistant):
-    """Yield a PicnicTestData object with the dependencies needed for each test."""
-    with patch("homeassistant.components.picnic.PicnicAPI") as picnic_api:
-        api_client = picnic_api()
-        api_client.session.auth_token = "3q29fpwhulzes"
+        # Add a config entry and setup the integration
+        config_data = {
+            CONF_ACCESS_TOKEN: "x-original-picnic-auth-token",
+            CONF_COUNTRY_CODE: "NL",
+        }
+        self.config_entry = MockConfigEntry(
+            domain=const.DOMAIN,
+            data=config_data,
+            unique_id="295-6y3-1nf4",
+        )
+        self.config_entry.add_to_hass(self.hass)
 
-        config_entry = _get_config_entry(hass)
+    async def asyncTearDown(self):
+        """Tear down the test setup, stop hass/patchers."""
+        await self.hass.async_stop(force=True)
+        self.picnic_patcher.stop()
 
-        yield PicnicTestData(hass, api_client, config_entry)
+    @property
+    def _coordinator(self):
+        return self.hass.data[const.DOMAIN][self.config_entry.entry_id][
+            const.CONF_COORDINATOR
+        ]
 
+    def _assert_sensor(self, name, state=None, cls=None, unit=None, disabled=False):
+        sensor = self.hass.states.get(name)
+        if disabled:
+            assert sensor is None
+            return
 
-def _get_config_entry(hass: HomeAssistant):
-    # Add a config entry and setup the integration
-    config_data = {
-        CONF_ACCESS_TOKEN: "x-original-picnic-auth-token",
-        CONF_COUNTRY_CODE: "NL",
-    }
-    config_entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        data=config_data,
-        unique_id="295-6y3-1nf4",
-    )
-    config_entry.add_to_hass(hass)
+        assert sensor.state == state
+        if cls:
+            assert sensor.attributes["device_class"] == cls
+        if unit:
+            assert sensor.attributes["unit_of_measurement"] == unit
 
-    return config_entry
+        assert sensor.attributes["attribution"] == "Data provided by Picnic"
 
+    async def _setup_platform(
+        self, use_default_responses=False, enable_all_sensors=True
+    ):
+        """Set up the Picnic sensor platform."""
+        if use_default_responses:
+            self.picnic_mock().get_user.return_value = copy.deepcopy(
+                DEFAULT_USER_RESPONSE
+            )
+            self.picnic_mock().get_cart.return_value = copy.deepcopy(
+                DEFAULT_CART_RESPONSE
+            )
+            self.picnic_mock().get_deliveries.return_value = [
+                copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+            ]
+            self.picnic_mock().get_delivery_position.return_value = {}
 
-def _get_coordinator(picnic: PicnicTestData):
-    return picnic.hass.data[const.DOMAIN][picnic.config_entry.entry_id][
-        const.CONF_COORDINATOR
-    ]
+        await self.hass.config_entries.async_setup(self.config_entry.entry_id)
+        await self.hass.async_block_till_done()
 
+        if enable_all_sensors:
+            await self._enable_all_sensors()
 
-def _assert_sensor(hass, name, state=None, cls=None, unit=None, disabled=False):
-    sensor = hass.states.get(name)
-    if disabled:
-        assert sensor is None
-        return
+    async def _enable_all_sensors(self):
+        """Enable all sensors of the Picnic integration."""
+        # Enable the sensors
+        for sensor_type in SENSOR_KEYS:
+            updated_entry = self.entity_registry.async_update_entity(
+                f"sensor.picnic_{sensor_type}", disabled_by=None
+            )
+            assert updated_entry.disabled is False
+        await self.hass.async_block_till_done()
 
-    assert sensor.state == state
-    if cls:
-        assert sensor.attributes["device_class"] == cls
-    if unit:
-        assert sensor.attributes["unit_of_measurement"] == unit
+        # Trigger a reload of the data
+        async_fire_time_changed(
+            self.hass,
+            dt.utcnow()
+            + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
+        )
+        await self.hass.async_block_till_done()
 
-    assert sensor.attributes["attribution"] == "Data provided by Picnic"
+    async def test_sensor_setup_platform_not_available(self):
+        """Test the set-up of the sensor platform if API is not available."""
+        # Configure mock requests to yield exceptions
+        self.picnic_mock().get_user.side_effect = requests.exceptions.ConnectionError
+        self.picnic_mock().get_cart.side_effect = requests.exceptions.ConnectionError
+        self.picnic_mock().get_deliveries.side_effect = (
+            requests.exceptions.ConnectionError
+        )
+        self.picnic_mock().get_delivery_position.side_effect = (
+            requests.exceptions.ConnectionError
+        )
+        await self._setup_platform(enable_all_sensors=False)
 
+        # Assert that sensors are not set up
+        assert (
+            self.hass.states.get("sensor.picnic_selected_slot_max_order_time") is None
+        )
+        assert self.hass.states.get("sensor.picnic_last_order_status") is None
+        assert self.hass.states.get("sensor.picnic_last_order_total_price") is None
 
-async def _setup_platform(
-    picnic: PicnicTestData,
-    use_default_responses=False,
-    enable_all_sensors=True,
-):
-    """Set up the Picnic sensor platform."""
-    if use_default_responses:
-        picnic.api_client.get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
-        picnic.api_client.get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
-        picnic.api_client.get_deliveries.return_value = [
+    async def test_sensors_setup(self):
+        """Test the default sensor setup behaviour."""
+        await self._setup_platform(use_default_responses=True)
+
+        self._assert_sensor("sensor.picnic_cart_items_count", "10")
+        self._assert_sensor(
+            "sensor.picnic_cart_total_price", "25.35", unit=CURRENCY_EURO
+        )
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_start",
+            "2021-03-03T13:45:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_end",
+            "2021-03-03T14:45:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_max_order_time",
+            "2021-03-02T21:00:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor("sensor.picnic_selected_slot_min_order_value", "35.0")
+        self._assert_sensor(
+            "sensor.picnic_last_order_slot_start",
+            "2021-02-26T19:15:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_slot_end",
+            "2021-02-26T20:15:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor("sensor.picnic_last_order_status", "COMPLETED")
+        self._assert_sensor(
+            "sensor.picnic_last_order_eta_start",
+            "2021-02-26T19:54:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_eta_end",
+            "2021-02-26T20:14:00+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_delivery_time",
+            "2021-02-26T19:54:05+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_total_price", "41.33", unit=CURRENCY_EURO
+        )
+
+    async def test_sensors_setup_disabled_by_default(self):
+        """Test that some sensors are disabled by default."""
+        await self._setup_platform(use_default_responses=True, enable_all_sensors=False)
+
+        self._assert_sensor("sensor.picnic_cart_items_count", disabled=True)
+        self._assert_sensor("sensor.picnic_last_order_slot_start", disabled=True)
+        self._assert_sensor("sensor.picnic_last_order_slot_end", disabled=True)
+        self._assert_sensor("sensor.picnic_last_order_status", disabled=True)
+        self._assert_sensor("sensor.picnic_last_order_total_price", disabled=True)
+
+    async def test_sensors_no_selected_time_slot(self):
+        """Test sensor states with no explicit selected time slot."""
+        # Adjust cart response
+        cart_response = copy.deepcopy(DEFAULT_CART_RESPONSE)
+        cart_response["selected_slot"]["state"] = "IMPLICIT"
+
+        # Set mock responses
+        self.picnic_mock().get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
+        self.picnic_mock().get_cart.return_value = cart_response
+        self.picnic_mock().get_deliveries.return_value = [
             copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
         ]
-        picnic.api_client.get_delivery_position.return_value = {}
+        self.picnic_mock().get_delivery_position.return_value = {}
+        await self._setup_platform()
 
-    await picnic.hass.config_entries.async_setup(picnic.config_entry.entry_id)
-    await picnic.hass.async_block_till_done()
-
-    if enable_all_sensors:
-        await _enable_all_sensors(picnic.hass)
-
-
-async def _enable_all_sensors(hass):
-    """Enable all sensors of the Picnic integration."""
-    # Enable the sensors
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-
-    for sensor_type in SENSOR_KEYS:
-        updated_entry = entity_registry.async_update_entity(
-            f"sensor.picnic_{sensor_type}", disabled_by=None
+        # Assert sensors are unknown
+        self._assert_sensor("sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
         )
-        assert updated_entry.disabled is False
-    await hass.async_block_till_done()
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
+        )
 
-    # Trigger a reload of the data
-    async_fire_time_changed(
-        hass,
-        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
+    async def test_sensors_last_order_in_future(self):
+        """Test sensor states when last order is not yet delivered."""
+        # Adjust default delivery response
+        delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+        del delivery_response["delivery_time"]
 
+        # Set mock responses
+        self.picnic_mock().get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
+        self.picnic_mock().get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
+        self.picnic_mock().get_deliveries.return_value = [delivery_response]
+        self.picnic_mock().get_delivery_position.return_value = {}
+        await self._setup_platform()
 
-async def test_sensor_setup_platform_not_available(picnic: PicnicTestData):
-    """Test the set-up of the sensor platform if API is not available."""
+        # Assert delivery time is not available, but eta is
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+        self._assert_sensor(
+            "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
+        )
 
-    # Configure mock requests to yield exceptions
-    picnic.api_client.get_user.side_effect = requests.exceptions.ConnectionError
-    picnic.api_client.get_cart.side_effect = requests.exceptions.ConnectionError
-    picnic.api_client.get_deliveries.side_effect = requests.exceptions.ConnectionError
-    picnic.api_client.get_delivery_position.side_effect = (
-        requests.exceptions.ConnectionError
-    )
-    await _setup_platform(picnic, enable_all_sensors=False)
+    async def test_sensors_use_detailed_eta_if_available(self):
+        """Test sensor states when last order is not yet delivered."""
+        # Set-up platform with default mock responses
+        await self._setup_platform(use_default_responses=True)
 
-    # Assert that sensors are not set up
-    assert picnic.hass.states.get("sensor.picnic_selected_slot_max_order_time") is None
-    assert picnic.hass.states.get("sensor.picnic_last_order_status") is None
-    assert picnic.hass.states.get("sensor.picnic_last_order_total_price") is None
-
-
-async def test_sensors_setup(picnic: PicnicTestData):
-    """Test the default sensor setup behaviour."""
-    await _setup_platform(picnic, use_default_responses=True)
-
-    _assert_sensor(picnic.hass, "sensor.picnic_cart_items_count", "10")
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_cart_total_price", "25.35", unit=CURRENCY_EURO
-    )
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_selected_slot_start",
-        "2021-03-03T13:45:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_selected_slot_end",
-        "2021-03-03T14:45:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_selected_slot_max_order_time",
-        "2021-03-02T21:00:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_min_order_value", "35.0")
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_last_order_slot_start",
-        "2021-02-26T19:15:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_last_order_slot_end",
-        "2021-02-26T20:15:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_status", "COMPLETED")
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_last_order_eta_start",
-        "2021-02-26T19:54:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_last_order_eta_end",
-        "2021-02-26T20:14:00+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(
-        picnic.hass,
-        "sensor.picnic_last_order_delivery_time",
-        "2021-02-26T19:54:05+00:00",
-        cls=SensorDeviceClass.TIMESTAMP,
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_total_price", "41.33", unit=CURRENCY_EURO
-    )
-
-
-async def test_sensors_setup_disabled_by_default(picnic: PicnicTestData):
-    """Test that some sensors are disabled by default."""
-    await _setup_platform(picnic, use_default_responses=True, enable_all_sensors=False)
-
-    _assert_sensor(picnic.hass, "sensor.picnic_cart_items_count", disabled=True)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_slot_start", disabled=True)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_slot_end", disabled=True)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_status", disabled=True)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_total_price", disabled=True)
-
-
-async def test_sensors_no_selected_time_slot(picnic: PicnicTestData):
-    """Test sensor states with no explicit selected time slot."""
-    # Adjust cart response
-    cart_response = copy.deepcopy(DEFAULT_CART_RESPONSE)
-    cart_response["selected_slot"]["state"] = "IMPLICIT"
-
-    # Set mock responses
-    picnic.api_client.get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
-    picnic.api_client.get_cart.return_value = cart_response
-    picnic.api_client.get_deliveries.return_value = [
-        copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
-    ]
-    picnic.api_client.get_delivery_position.return_value = {}
-    await _setup_platform(picnic)
-
-    # Assert sensors are unknown
-    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
-    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
-    )
-
-
-async def test_sensors_last_order_in_future(picnic: PicnicTestData):
-    """Test sensor states when last order is not yet delivered."""
-    # Adjust default delivery response
-    delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
-    del delivery_response["delivery_time"]
-
-    # Set mock responses
-    picnic.api_client.get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
-    picnic.api_client.get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
-    picnic.api_client.get_deliveries.return_value = [delivery_response]
-    picnic.api_client.get_delivery_position.return_value = {}
-    await _setup_platform(picnic)
-
-    # Assert delivery time is not available, but eta is
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
-    )
-
-
-async def test_sensors_use_detailed_eta_if_available(picnic: PicnicTestData):
-    """Test sensor states when last order is not yet delivered."""
-    # Set-up platform with default mock responses
-    await _setup_platform(picnic, use_default_responses=True)
-
-    # Provide a delivery position response with different ETA and remove delivery time from response
-    delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
-    del delivery_response["delivery_time"]
-    picnic.api_client.get_deliveries.return_value = [delivery_response]
-    picnic.api_client.get_delivery_position.return_value = {
-        "eta_window": {
-            "start": "2021-03-05T10:19:20.452+00:00",
-            "end": "2021-03-05T10:39:20.452+00:00",
+        # Provide a delivery position response with different ETA and remove delivery time from response
+        delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+        del delivery_response["delivery_time"]
+        self.picnic_mock().get_deliveries.return_value = [delivery_response]
+        self.picnic_mock().get_delivery_position.return_value = {
+            "eta_window": {
+                "start": "2021-03-05T10:19:20.452+00:00",
+                "end": "2021-03-05T10:39:20.452+00:00",
+            }
         }
-    }
-    await _get_coordinator(picnic).async_refresh()
+        await self._coordinator.async_refresh()
 
-    # Assert detailed ETA is used
-    picnic.api_client.get_delivery_position.assert_called_with(
-        delivery_response["delivery_id"]
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_eta_start", "2021-03-05T10:19:20+00:00"
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_eta_end", "2021-03-05T10:39:20+00:00"
-    )
+        # Assert detailed ETA is used
+        self.picnic_mock().get_delivery_position.assert_called_with(
+            delivery_response["delivery_id"]
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_eta_start", "2021-03-05T10:19:20+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_eta_end", "2021-03-05T10:39:20+00:00"
+        )
 
+    async def test_sensors_no_data(self):
+        """Test sensor states when the api only returns empty objects."""
+        # Setup platform with default responses
+        await self._setup_platform(use_default_responses=True)
 
-async def test_sensors_no_data(picnic: PicnicTestData):
-    """Test sensor states when the api only returns empty objects."""
-    # Setup platform with default responses
-    await _setup_platform(picnic, use_default_responses=True)
+        # Change mock responses to empty data and refresh the coordinator
+        self.picnic_mock().get_user.return_value = {}
+        self.picnic_mock().get_cart.return_value = None
+        self.picnic_mock().get_deliveries.return_value = None
+        self.picnic_mock().get_delivery_position.side_effect = ValueError
+        await self._coordinator.async_refresh()
 
-    # Change mock responses to empty data and refresh the coordinator
-    picnic.api_client.get_user.return_value = {}
-    picnic.api_client.get_cart.return_value = None
-    picnic.api_client.get_deliveries.return_value = None
-    picnic.api_client.get_delivery_position.side_effect = ValueError
-    await _get_coordinator(picnic).async_refresh()
+        # Assert all default-enabled sensors have STATE_UNAVAILABLE because the last update failed
+        assert self._coordinator.last_update_success is False
+        self._assert_sensor("sensor.picnic_cart_total_price", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
+        )
+        self._assert_sensor(
+            "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
+        )
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
-    # Assert all default-enabled sensors have STATE_UNAVAILABLE because the last update failed
-    assert _get_coordinator(picnic).last_update_success is False
-    _assert_sensor(picnic.hass, "sensor.picnic_cart_total_price", STATE_UNAVAILABLE)
-    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
-    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
-    )
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
-    )
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
-    )
+    async def test_sensors_malformed_delivery_data(self):
+        """Test sensor states when the delivery api returns not a list."""
+        # Setup platform with default responses
+        await self._setup_platform(use_default_responses=True)
 
+        # Change mock responses to empty data and refresh the coordinator
+        self.picnic_mock().get_deliveries.return_value = {"error": "message"}
+        await self._coordinator.async_refresh()
 
-async def test_sensors_malformed_delivery_data(picnic: PicnicTestData):
-    """Test sensor states when the delivery api returns not a list."""
-    # Setup platform with default responses
-    await _setup_platform(picnic, use_default_responses=True)
+        # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
+        assert self._coordinator.last_update_success is True
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
-    # Change mock responses to empty data and refresh the coordinator
-    picnic.api_client.get_deliveries.return_value = {"error": "message"}
-    await _get_coordinator(picnic).async_refresh()
+    async def test_sensors_malformed_response(self):
+        """Test coordinator update fails when API yields ValueError."""
+        # Setup platform with default responses
+        await self._setup_platform(use_default_responses=True)
 
-    # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
-    assert _get_coordinator(picnic).last_update_success is True
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
-    )
+        # Change mock responses to empty data and refresh the coordinator
+        self.picnic_mock().get_user.side_effect = ValueError
+        self.picnic_mock().get_cart.side_effect = ValueError
+        await self._coordinator.async_refresh()
 
+        # Assert coordinator update failed
+        assert self._coordinator.last_update_success is False
 
-async def test_sensors_malformed_response(picnic: PicnicTestData):
-    """Test coordinator update fails when API yields ValueError."""
-    # Setup platform with default responses
-    await _setup_platform(picnic, use_default_responses=True)
+    async def test_device_registry_entry(self):
+        """Test if device registry entry is populated correctly."""
+        # Setup platform and default mock responses
+        await self._setup_platform(use_default_responses=True)
 
-    # Change mock responses to empty data and refresh the coordinator
-    picnic.api_client.get_user.side_effect = ValueError
-    picnic.api_client.get_cart.side_effect = ValueError
-    await _get_coordinator(picnic).async_refresh()
+        device_registry = await self.hass.helpers.device_registry.async_get_registry()
+        picnic_service = device_registry.async_get_device(
+            identifiers={(const.DOMAIN, DEFAULT_USER_RESPONSE["user_id"])}
+        )
+        assert picnic_service.model == DEFAULT_USER_RESPONSE["user_id"]
+        assert picnic_service.name == "Picnic: Commonstreet 123a"
+        assert picnic_service.entry_type is DeviceEntryType.SERVICE
 
-    # Assert coordinator update failed
-    assert _get_coordinator(picnic).last_update_success is False
+    async def test_auth_token_is_saved_on_update(self):
+        """Test that auth-token changes in the session object are reflected by the config entry."""
+        # Setup platform and default mock responses
+        await self._setup_platform(use_default_responses=True)
 
+        # Set a different auth token in the session mock
+        updated_auth_token = "x-updated-picnic-auth-token"
+        self.picnic_mock().session.auth_token = updated_auth_token
 
-async def test_device_registry_entry(picnic: PicnicTestData):
-    """Test if device registry entry is populated correctly."""
-    # Setup platform and default mock responses
-    await _setup_platform(picnic, use_default_responses=True)
+        # Verify the updated auth token is not set and fetch data using the coordinator
+        assert self.config_entry.data.get(CONF_ACCESS_TOKEN) != updated_auth_token
+        await self._coordinator.async_refresh()
 
-    device_registry = await picnic.hass.helpers.device_registry.async_get_registry()
-    picnic_service = device_registry.async_get_device(
-        identifiers={(const.DOMAIN, DEFAULT_USER_RESPONSE["user_id"])}
-    )
-    assert picnic_service.model == DEFAULT_USER_RESPONSE["user_id"]
-    assert picnic_service.name == "Picnic: Commonstreet 123a"
-    assert picnic_service.entry_type is DeviceEntryType.SERVICE
-
-
-async def test_auth_token_is_saved_on_update(picnic: PicnicTestData):
-    """Test that auth-token changes in the session object are reflected by the config entry."""
-    # Setup platform and default mock responses
-    await _setup_platform(picnic, use_default_responses=True)
-
-    # Set a different auth token in the session mock
-    updated_auth_token = "x-updated-picnic-auth-token"
-    picnic.api_client.session.auth_token = updated_auth_token
-
-    # Verify the updated auth token is not set and fetch data using the coordinator
-    assert picnic.config_entry.data.get(CONF_ACCESS_TOKEN) != updated_auth_token
-    await _get_coordinator(picnic).async_refresh()
-
-    # Verify that the updated auth token is saved in the config entry
-    assert picnic.config_entry.data.get(CONF_ACCESS_TOKEN) == updated_auth_token
+        # Verify that the updated auth token is saved in the config entry
+        assert self.config_entry.data.get(CONF_ACCESS_TOKEN) == updated_auth_token

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -286,13 +286,11 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         await self._setup_platform()
 
         # Assert sensors are unknown
-        self._assert_sensor("sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_selected_slot_start", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_selected_slot_end", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_selected_slot_max_order_time", STATE_UNKNOWN)
         self._assert_sensor(
-            "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
-        )
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
+            "sensor.picnic_selected_slot_min_order_value", STATE_UNKNOWN
         )
 
     async def test_sensors_last_order_in_future(self):
@@ -309,7 +307,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         await self._setup_platform()
 
         # Assert delivery time is not available, but eta is
-        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
         self._assert_sensor(
             "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
         )

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -12,11 +12,9 @@ from homeassistant import config_entries
 from homeassistant.components.picnic import const
 from homeassistant.components.picnic.const import CONF_COUNTRY_CODE, SENSOR_TYPES
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CURRENCY_EURO,
-    DEVICE_CLASS_TIMESTAMP,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -363,6 +363,21 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
+    async def test_sensors_malformed_delivery_data(self):
+        """Test sensor states when the delivery api returns not a list."""
+        # Setup platform with default responses
+        await self._setup_platform(use_default_responses=True)
+
+        # Change mock responses to empty data and refresh the coordinator
+        self.picnic_mock().get_deliveries.return_value = {"error": "message"}
+        await self._coordinator.async_refresh()
+
+        # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
+        assert self._coordinator.last_update_success is True
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+
     async def test_sensors_malformed_response(self):
         """Test coordinator update fails when API yields ValueError."""
         # Setup platform with default responses

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -1,6 +1,7 @@
 """The tests for the Picnic sensor platform."""
 import copy
 from datetime import timedelta
+from typing import Dict
 import unittest
 from unittest.mock import patch
 
@@ -105,6 +106,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         # Patch the api client
         self.picnic_patcher = patch("homeassistant.components.picnic.PicnicAPI")
         self.picnic_mock = self.picnic_patcher.start()
+        self.picnic_mock().session.auth_token = "3q29fpwhulzes"
 
         # Add a config entry and setup the integration
         config_data = {
@@ -313,6 +315,25 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor(
             "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
         )
+
+    async def test_sensors_eta_date_malformed(self):
+        """Test sensor states when last order eta dates are malformed."""
+        # Set-up platform with default mock responses
+        await self._setup_platform(use_default_responses=True)
+
+        # Set non-datetime strings as eta
+        eta_dates: Dict[str, str] = {
+            "start": "wrong-time",
+            "end": "other-malformed-datetime",
+        }
+        delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+        delivery_response["eta2"] = eta_dates
+        self.picnic_mock().get_deliveries.return_value = [delivery_response]
+        await self._coordinator.async_refresh()
+
+        # Assert eta times are not available due to malformed date strings
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
 
     async def test_sensors_use_detailed_eta_if_available(self):
         """Test sensor states when last order is not yet delivered."""

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -2,6 +2,7 @@
 import copy
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Dict
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -330,6 +331,26 @@ async def test_sensors_last_order_in_future(picnic: PicnicTestData):
     )
 
 
+async def test_sensors_eta_date_malformed(picnic: PicnicTestData):
+    """Test sensor states when last order eta dates are malformed."""
+    # Set-up platform with default mock responses
+    await _setup_platform(picnic, use_default_responses=True)
+
+    # Set non-datetime strings as eta
+    eta_dates: Dict[str, str] = {
+        "start": "wrong-time",
+        "end": "other-malformed-datetime",
+    }
+    delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+    delivery_response["eta2"] = eta_dates
+    picnic.api_client.get_deliveries.return_value = [delivery_response]
+    await _get_coordinator(picnic).async_refresh()
+
+    # Assert eta times are not available due to malformed date strings
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+
+
 async def test_sensors_use_detailed_eta_if_available(picnic: PicnicTestData):
     """Test sensor states when last order is not yet delivered."""
     # Set-up platform with default mock responses
@@ -382,24 +403,6 @@ async def test_sensors_no_data(picnic: PicnicTestData):
     _assert_sensor(
         picnic.hass, "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
     )
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-    _assert_sensor(
-        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
-    )
-
-
-async def test_sensors_malformed_delivery_data(picnic: PicnicTestData):
-    """Test sensor states when the delivery api returns not a list."""
-    # Setup platform with default responses
-    await _setup_platform(picnic, use_default_responses=True)
-
-    # Change mock responses to empty data and refresh the coordinator
-    picnic.api_client.get_deliveries.return_value = {"error": "message"}
-    await _get_coordinator(picnic).async_refresh()
-
-    # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
-    assert _get_coordinator(picnic).last_update_success is True
     _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
     _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
     _assert_sensor(

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CURRENCY_EURO,
     DEVICE_CLASS_TIMESTAMP,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.util import dt
@@ -332,8 +333,8 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         await self._coordinator.async_refresh()
 
         # Assert eta times are not available due to malformed date strings
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
 
     async def test_sensors_use_detailed_eta_if_available(self):
         """Test sensor states when last order is not yet delivered."""

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -1,8 +1,8 @@
 """The tests for the Picnic sensor platform."""
 import copy
+from dataclasses import dataclass
 from datetime import timedelta
-import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -11,15 +11,18 @@ from homeassistant import config_entries
 from homeassistant.components.picnic import const
 from homeassistant.components.picnic.const import CONF_COUNTRY_CODE, SENSOR_TYPES
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import CONF_ACCESS_TOKEN, CURRENCY_EURO, STATE_UNAVAILABLE
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CURRENCY_EURO,
+    DEVICE_CLASS_TIMESTAMP,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.util import dt
 
-from tests.common import (
-    MockConfigEntry,
-    async_fire_time_changed,
-    async_test_home_assistant,
-)
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 DEFAULT_USER_RESPONSE = {
     "user_id": "295-6y3-1nf4",
@@ -85,337 +88,365 @@ DEFAULT_DELIVERY_RESPONSE = {
 SENSOR_KEYS = [desc.key for desc in SENSOR_TYPES]
 
 
-@pytest.mark.usefixtures("hass_storage")
-class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
-    """Test the Picnic sensor."""
+@dataclass
+class PicnicTestData:
+    """A dataclass containing the objects necessary for each test."""
 
-    async def asyncSetUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = await async_test_home_assistant(None)
-        self.entity_registry = (
-            await self.hass.helpers.entity_registry.async_get_registry()
-        )
+    hass: HomeAssistant
+    api_client: MagicMock
+    config_entry: ConfigEntry
 
-        # Patch the api client
-        self.picnic_patcher = patch("homeassistant.components.picnic.PicnicAPI")
-        self.picnic_mock = self.picnic_patcher.start()
 
-        # Add a config entry and setup the integration
-        config_data = {
-            CONF_ACCESS_TOKEN: "x-original-picnic-auth-token",
-            CONF_COUNTRY_CODE: "NL",
-        }
-        self.config_entry = MockConfigEntry(
-            domain=const.DOMAIN,
-            data=config_data,
-            unique_id="295-6y3-1nf4",
-        )
-        self.config_entry.add_to_hass(self.hass)
+@pytest.fixture
+def picnic(hass: HomeAssistant):
+    """Yield a PicnicTestData object with the dependencies needed for each test."""
+    with patch("homeassistant.components.picnic.PicnicAPI") as picnic_api:
+        api_client = picnic_api()
+        api_client.session.auth_token = "3q29fpwhulzes"
 
-    async def asyncTearDown(self):
-        """Tear down the test setup, stop hass/patchers."""
-        await self.hass.async_stop(force=True)
-        self.picnic_patcher.stop()
+        config_entry = _get_config_entry(hass)
 
-    @property
-    def _coordinator(self):
-        return self.hass.data[const.DOMAIN][self.config_entry.entry_id][
-            const.CONF_COORDINATOR
-        ]
+        yield PicnicTestData(hass, api_client, config_entry)
 
-    def _assert_sensor(self, name, state=None, cls=None, unit=None, disabled=False):
-        sensor = self.hass.states.get(name)
-        if disabled:
-            assert sensor is None
-            return
 
-        assert sensor.state == state
-        if cls:
-            assert sensor.attributes["device_class"] == cls
-        if unit:
-            assert sensor.attributes["unit_of_measurement"] == unit
+def _get_config_entry(hass: HomeAssistant):
+    # Add a config entry and setup the integration
+    config_data = {
+        CONF_ACCESS_TOKEN: "x-original-picnic-auth-token",
+        CONF_COUNTRY_CODE: "NL",
+    }
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        data=config_data,
+        unique_id="295-6y3-1nf4",
+    )
+    config_entry.add_to_hass(hass)
 
-        assert sensor.attributes["attribution"] == "Data provided by Picnic"
+    return config_entry
 
-    async def _setup_platform(
-        self, use_default_responses=False, enable_all_sensors=True
-    ):
-        """Set up the Picnic sensor platform."""
-        if use_default_responses:
-            self.picnic_mock().get_user.return_value = copy.deepcopy(
-                DEFAULT_USER_RESPONSE
-            )
-            self.picnic_mock().get_cart.return_value = copy.deepcopy(
-                DEFAULT_CART_RESPONSE
-            )
-            self.picnic_mock().get_deliveries.return_value = [
-                copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
-            ]
-            self.picnic_mock().get_delivery_position.return_value = {}
 
-        await self.hass.config_entries.async_setup(self.config_entry.entry_id)
-        await self.hass.async_block_till_done()
+def _get_coordinator(picnic: PicnicTestData):
+    return picnic.hass.data[const.DOMAIN][picnic.config_entry.entry_id][
+        const.CONF_COORDINATOR
+    ]
 
-        if enable_all_sensors:
-            await self._enable_all_sensors()
 
-    async def _enable_all_sensors(self):
-        """Enable all sensors of the Picnic integration."""
-        # Enable the sensors
-        for sensor_type in SENSOR_KEYS:
-            updated_entry = self.entity_registry.async_update_entity(
-                f"sensor.picnic_{sensor_type}", disabled_by=None
-            )
-            assert updated_entry.disabled is False
-        await self.hass.async_block_till_done()
+def _assert_sensor(hass, name, state=None, cls=None, unit=None, disabled=False):
+    sensor = hass.states.get(name)
+    if disabled:
+        assert sensor is None
+        return
 
-        # Trigger a reload of the data
-        async_fire_time_changed(
-            self.hass,
-            dt.utcnow()
-            + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await self.hass.async_block_till_done()
+    assert sensor.state == state
+    if cls:
+        assert sensor.attributes["device_class"] == cls
+    if unit:
+        assert sensor.attributes["unit_of_measurement"] == unit
 
-    async def test_sensor_setup_platform_not_available(self):
-        """Test the set-up of the sensor platform if API is not available."""
-        # Configure mock requests to yield exceptions
-        self.picnic_mock().get_user.side_effect = requests.exceptions.ConnectionError
-        self.picnic_mock().get_cart.side_effect = requests.exceptions.ConnectionError
-        self.picnic_mock().get_deliveries.side_effect = (
-            requests.exceptions.ConnectionError
-        )
-        self.picnic_mock().get_delivery_position.side_effect = (
-            requests.exceptions.ConnectionError
-        )
-        await self._setup_platform(enable_all_sensors=False)
+    assert sensor.attributes["attribution"] == "Data provided by Picnic"
 
-        # Assert that sensors are not set up
-        assert (
-            self.hass.states.get("sensor.picnic_selected_slot_max_order_time") is None
-        )
-        assert self.hass.states.get("sensor.picnic_last_order_status") is None
-        assert self.hass.states.get("sensor.picnic_last_order_total_price") is None
 
-    async def test_sensors_setup(self):
-        """Test the default sensor setup behaviour."""
-        await self._setup_platform(use_default_responses=True)
-
-        self._assert_sensor("sensor.picnic_cart_items_count", "10")
-        self._assert_sensor(
-            "sensor.picnic_cart_total_price", "25.35", unit=CURRENCY_EURO
-        )
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_start",
-            "2021-03-03T13:45:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_end",
-            "2021-03-03T14:45:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_max_order_time",
-            "2021-03-02T21:00:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor("sensor.picnic_selected_slot_min_order_value", "35.0")
-        self._assert_sensor(
-            "sensor.picnic_last_order_slot_start",
-            "2021-02-26T19:15:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_slot_end",
-            "2021-02-26T20:15:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor("sensor.picnic_last_order_status", "COMPLETED")
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_start",
-            "2021-02-26T19:54:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_end",
-            "2021-02-26T20:14:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_delivery_time",
-            "2021-02-26T19:54:05+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_total_price", "41.33", unit=CURRENCY_EURO
-        )
-
-    async def test_sensors_setup_disabled_by_default(self):
-        """Test that some sensors are disabled by default."""
-        await self._setup_platform(use_default_responses=True, enable_all_sensors=False)
-
-        self._assert_sensor("sensor.picnic_cart_items_count", disabled=True)
-        self._assert_sensor("sensor.picnic_last_order_slot_start", disabled=True)
-        self._assert_sensor("sensor.picnic_last_order_slot_end", disabled=True)
-        self._assert_sensor("sensor.picnic_last_order_status", disabled=True)
-        self._assert_sensor("sensor.picnic_last_order_total_price", disabled=True)
-
-    async def test_sensors_no_selected_time_slot(self):
-        """Test sensor states with no explicit selected time slot."""
-        # Adjust cart response
-        cart_response = copy.deepcopy(DEFAULT_CART_RESPONSE)
-        cart_response["selected_slot"]["state"] = "IMPLICIT"
-
-        # Set mock responses
-        self.picnic_mock().get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
-        self.picnic_mock().get_cart.return_value = cart_response
-        self.picnic_mock().get_deliveries.return_value = [
+async def _setup_platform(
+    picnic: PicnicTestData,
+    use_default_responses=False,
+    enable_all_sensors=True,
+):
+    """Set up the Picnic sensor platform."""
+    if use_default_responses:
+        picnic.api_client.get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
+        picnic.api_client.get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
+        picnic.api_client.get_deliveries.return_value = [
             copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
         ]
-        self.picnic_mock().get_delivery_position.return_value = {}
-        await self._setup_platform()
+        picnic.api_client.get_delivery_position.return_value = {}
 
-        # Assert sensors are unknown
-        self._assert_sensor("sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
+    await picnic.hass.config_entries.async_setup(picnic.config_entry.entry_id)
+    await picnic.hass.async_block_till_done()
+
+    if enable_all_sensors:
+        await _enable_all_sensors(picnic.hass)
+
+
+async def _enable_all_sensors(hass):
+    """Enable all sensors of the Picnic integration."""
+    # Enable the sensors
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    for sensor_type in SENSOR_KEYS:
+        updated_entry = entity_registry.async_update_entity(
+            f"sensor.picnic_{sensor_type}", disabled_by=None
         )
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
-        )
+        assert updated_entry.disabled is False
+    await hass.async_block_till_done()
 
-    async def test_sensors_last_order_in_future(self):
-        """Test sensor states when last order is not yet delivered."""
-        # Adjust default delivery response
-        delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
-        del delivery_response["delivery_time"]
+    # Trigger a reload of the data
+    async_fire_time_changed(
+        hass,
+        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
 
-        # Set mock responses
-        self.picnic_mock().get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
-        self.picnic_mock().get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
-        self.picnic_mock().get_deliveries.return_value = [delivery_response]
-        self.picnic_mock().get_delivery_position.return_value = {}
-        await self._setup_platform()
 
-        # Assert delivery time is not available, but eta is
-        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
-        )
+async def test_sensor_setup_platform_not_available(picnic: PicnicTestData):
+    """Test the set-up of the sensor platform if API is not available."""
 
-    async def test_sensors_use_detailed_eta_if_available(self):
-        """Test sensor states when last order is not yet delivered."""
-        # Set-up platform with default mock responses
-        await self._setup_platform(use_default_responses=True)
+    # Configure mock requests to yield exceptions
+    picnic.api_client.get_user.side_effect = requests.exceptions.ConnectionError
+    picnic.api_client.get_cart.side_effect = requests.exceptions.ConnectionError
+    picnic.api_client.get_deliveries.side_effect = requests.exceptions.ConnectionError
+    picnic.api_client.get_delivery_position.side_effect = (
+        requests.exceptions.ConnectionError
+    )
+    await _setup_platform(picnic, enable_all_sensors=False)
 
-        # Provide a delivery position response with different ETA and remove delivery time from response
-        delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
-        del delivery_response["delivery_time"]
-        self.picnic_mock().get_deliveries.return_value = [delivery_response]
-        self.picnic_mock().get_delivery_position.return_value = {
-            "eta_window": {
-                "start": "2021-03-05T10:19:20.452+00:00",
-                "end": "2021-03-05T10:39:20.452+00:00",
-            }
+    # Assert that sensors are not set up
+    assert picnic.hass.states.get("sensor.picnic_selected_slot_max_order_time") is None
+    assert picnic.hass.states.get("sensor.picnic_last_order_status") is None
+    assert picnic.hass.states.get("sensor.picnic_last_order_total_price") is None
+
+
+async def test_sensors_setup(picnic: PicnicTestData):
+    """Test the default sensor setup behaviour."""
+    await _setup_platform(picnic, use_default_responses=True)
+
+    _assert_sensor(picnic.hass, "sensor.picnic_cart_items_count", "10")
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_cart_total_price", "25.35", unit=CURRENCY_EURO
+    )
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_selected_slot_start",
+        "2021-03-03T13:45:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_selected_slot_end",
+        "2021-03-03T14:45:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_selected_slot_max_order_time",
+        "2021-03-02T21:00:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_min_order_value", "35.0")
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_last_order_slot_start",
+        "2021-02-26T19:15:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_last_order_slot_end",
+        "2021-02-26T20:15:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_status", "COMPLETED")
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_last_order_eta_start",
+        "2021-02-26T19:54:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_last_order_eta_end",
+        "2021-02-26T20:14:00+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(
+        picnic.hass,
+        "sensor.picnic_last_order_delivery_time",
+        "2021-02-26T19:54:05+00:00",
+        cls=SensorDeviceClass.TIMESTAMP,
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_total_price", "41.33", unit=CURRENCY_EURO
+    )
+
+
+async def test_sensors_setup_disabled_by_default(picnic: PicnicTestData):
+    """Test that some sensors are disabled by default."""
+    await _setup_platform(picnic, use_default_responses=True, enable_all_sensors=False)
+
+    _assert_sensor(picnic.hass, "sensor.picnic_cart_items_count", disabled=True)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_slot_start", disabled=True)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_slot_end", disabled=True)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_status", disabled=True)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_total_price", disabled=True)
+
+
+async def test_sensors_no_selected_time_slot(picnic: PicnicTestData):
+    """Test sensor states with no explicit selected time slot."""
+    # Adjust cart response
+    cart_response = copy.deepcopy(DEFAULT_CART_RESPONSE)
+    cart_response["selected_slot"]["state"] = "IMPLICIT"
+
+    # Set mock responses
+    picnic.api_client.get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
+    picnic.api_client.get_cart.return_value = cart_response
+    picnic.api_client.get_deliveries.return_value = [
+        copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+    ]
+    picnic.api_client.get_delivery_position.return_value = {}
+    await _setup_platform(picnic)
+
+    # Assert sensors are unknown
+    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
+    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
+    )
+
+
+async def test_sensors_last_order_in_future(picnic: PicnicTestData):
+    """Test sensor states when last order is not yet delivered."""
+    # Adjust default delivery response
+    delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+    del delivery_response["delivery_time"]
+
+    # Set mock responses
+    picnic.api_client.get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
+    picnic.api_client.get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
+    picnic.api_client.get_deliveries.return_value = [delivery_response]
+    picnic.api_client.get_delivery_position.return_value = {}
+    await _setup_platform(picnic)
+
+    # Assert delivery time is not available, but eta is
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
+    )
+
+
+async def test_sensors_use_detailed_eta_if_available(picnic: PicnicTestData):
+    """Test sensor states when last order is not yet delivered."""
+    # Set-up platform with default mock responses
+    await _setup_platform(picnic, use_default_responses=True)
+
+    # Provide a delivery position response with different ETA and remove delivery time from response
+    delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+    del delivery_response["delivery_time"]
+    picnic.api_client.get_deliveries.return_value = [delivery_response]
+    picnic.api_client.get_delivery_position.return_value = {
+        "eta_window": {
+            "start": "2021-03-05T10:19:20.452+00:00",
+            "end": "2021-03-05T10:39:20.452+00:00",
         }
-        await self._coordinator.async_refresh()
+    }
+    await _get_coordinator(picnic).async_refresh()
 
-        # Assert detailed ETA is used
-        self.picnic_mock().get_delivery_position.assert_called_with(
-            delivery_response["delivery_id"]
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_start", "2021-03-05T10:19:20+00:00"
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_end", "2021-03-05T10:39:20+00:00"
-        )
+    # Assert detailed ETA is used
+    picnic.api_client.get_delivery_position.assert_called_with(
+        delivery_response["delivery_id"]
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_eta_start", "2021-03-05T10:19:20+00:00"
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_eta_end", "2021-03-05T10:39:20+00:00"
+    )
 
-    async def test_sensors_no_data(self):
-        """Test sensor states when the api only returns empty objects."""
-        # Setup platform with default responses
-        await self._setup_platform(use_default_responses=True)
 
-        # Change mock responses to empty data and refresh the coordinator
-        self.picnic_mock().get_user.return_value = {}
-        self.picnic_mock().get_cart.return_value = None
-        self.picnic_mock().get_deliveries.return_value = None
-        self.picnic_mock().get_delivery_position.side_effect = ValueError
-        await self._coordinator.async_refresh()
+async def test_sensors_no_data(picnic: PicnicTestData):
+    """Test sensor states when the api only returns empty objects."""
+    # Setup platform with default responses
+    await _setup_platform(picnic, use_default_responses=True)
 
-        # Assert all default-enabled sensors have STATE_UNAVAILABLE because the last update failed
-        assert self._coordinator.last_update_success is False
-        self._assert_sensor("sensor.picnic_cart_total_price", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
-        )
-        self._assert_sensor(
-            "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
-        )
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+    # Change mock responses to empty data and refresh the coordinator
+    picnic.api_client.get_user.return_value = {}
+    picnic.api_client.get_cart.return_value = None
+    picnic.api_client.get_deliveries.return_value = None
+    picnic.api_client.get_delivery_position.side_effect = ValueError
+    await _get_coordinator(picnic).async_refresh()
 
-    async def test_sensors_malformed_delivery_data(self):
-        """Test sensor states when the delivery api returns not a list."""
-        # Setup platform with default responses
-        await self._setup_platform(use_default_responses=True)
+    # Assert all default-enabled sensors have STATE_UNAVAILABLE because the last update failed
+    assert _get_coordinator(picnic).last_update_success is False
+    _assert_sensor(picnic.hass, "sensor.picnic_cart_total_price", STATE_UNAVAILABLE)
+    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_start", STATE_UNAVAILABLE)
+    _assert_sensor(picnic.hass, "sensor.picnic_selected_slot_end", STATE_UNAVAILABLE)
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_selected_slot_max_order_time", STATE_UNAVAILABLE
+    )
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
+    )
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
+    )
 
-        # Change mock responses to empty data and refresh the coordinator
-        self.picnic_mock().get_deliveries.return_value = {"error": "message"}
-        await self._coordinator.async_refresh()
 
-        # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
-        assert self._coordinator.last_update_success is True
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+async def test_sensors_malformed_delivery_data(picnic: PicnicTestData):
+    """Test sensor states when the delivery api returns not a list."""
+    # Setup platform with default responses
+    await _setup_platform(picnic, use_default_responses=True)
 
-    async def test_sensors_malformed_response(self):
-        """Test coordinator update fails when API yields ValueError."""
-        # Setup platform with default responses
-        await self._setup_platform(use_default_responses=True)
+    # Change mock responses to empty data and refresh the coordinator
+    picnic.api_client.get_deliveries.return_value = {"error": "message"}
+    await _get_coordinator(picnic).async_refresh()
 
-        # Change mock responses to empty data and refresh the coordinator
-        self.picnic_mock().get_user.side_effect = ValueError
-        self.picnic_mock().get_cart.side_effect = ValueError
-        await self._coordinator.async_refresh()
+    # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
+    assert _get_coordinator(picnic).last_update_success is True
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+    _assert_sensor(picnic.hass, "sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+    _assert_sensor(
+        picnic.hass, "sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE
+    )
 
-        # Assert coordinator update failed
-        assert self._coordinator.last_update_success is False
 
-    async def test_device_registry_entry(self):
-        """Test if device registry entry is populated correctly."""
-        # Setup platform and default mock responses
-        await self._setup_platform(use_default_responses=True)
+async def test_sensors_malformed_response(picnic: PicnicTestData):
+    """Test coordinator update fails when API yields ValueError."""
+    # Setup platform with default responses
+    await _setup_platform(picnic, use_default_responses=True)
 
-        device_registry = await self.hass.helpers.device_registry.async_get_registry()
-        picnic_service = device_registry.async_get_device(
-            identifiers={(const.DOMAIN, DEFAULT_USER_RESPONSE["user_id"])}
-        )
-        assert picnic_service.model == DEFAULT_USER_RESPONSE["user_id"]
-        assert picnic_service.name == "Picnic: Commonstreet 123a"
-        assert picnic_service.entry_type is DeviceEntryType.SERVICE
+    # Change mock responses to empty data and refresh the coordinator
+    picnic.api_client.get_user.side_effect = ValueError
+    picnic.api_client.get_cart.side_effect = ValueError
+    await _get_coordinator(picnic).async_refresh()
 
-    async def test_auth_token_is_saved_on_update(self):
-        """Test that auth-token changes in the session object are reflected by the config entry."""
-        # Setup platform and default mock responses
-        await self._setup_platform(use_default_responses=True)
+    # Assert coordinator update failed
+    assert _get_coordinator(picnic).last_update_success is False
 
-        # Set a different auth token in the session mock
-        updated_auth_token = "x-updated-picnic-auth-token"
-        self.picnic_mock().session.auth_token = updated_auth_token
 
-        # Verify the updated auth token is not set and fetch data using the coordinator
-        assert self.config_entry.data.get(CONF_ACCESS_TOKEN) != updated_auth_token
-        await self._coordinator.async_refresh()
+async def test_device_registry_entry(picnic: PicnicTestData):
+    """Test if device registry entry is populated correctly."""
+    # Setup platform and default mock responses
+    await _setup_platform(picnic, use_default_responses=True)
 
-        # Verify that the updated auth token is saved in the config entry
-        assert self.config_entry.data.get(CONF_ACCESS_TOKEN) == updated_auth_token
+    device_registry = await picnic.hass.helpers.device_registry.async_get_registry()
+    picnic_service = device_registry.async_get_device(
+        identifiers={(const.DOMAIN, DEFAULT_USER_RESPONSE["user_id"])}
+    )
+    assert picnic_service.model == DEFAULT_USER_RESPONSE["user_id"]
+    assert picnic_service.name == "Picnic: Commonstreet 123a"
+    assert picnic_service.entry_type is DeviceEntryType.SERVICE
+
+
+async def test_auth_token_is_saved_on_update(picnic: PicnicTestData):
+    """Test that auth-token changes in the session object are reflected by the config entry."""
+    # Setup platform and default mock responses
+    await _setup_platform(picnic, use_default_responses=True)
+
+    # Set a different auth token in the session mock
+    updated_auth_token = "x-updated-picnic-auth-token"
+    picnic.api_client.session.auth_token = updated_auth_token
+
+    # Verify the updated auth token is not set and fetch data using the coordinator
+    assert picnic.config_entry.data.get(CONF_ACCESS_TOKEN) != updated_auth_token
+    await _get_coordinator(picnic).async_refresh()
+
+    # Verify that the updated auth token is saved in the config entry
+    assert picnic.config_entry.data.get(CONF_ACCESS_TOKEN) == updated_auth_token


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Return a `datetime` object for sensors which `device_class` is `TIMESTAMP`
- Rewrite tests using fixtures instead of a `TestCase` subclass (this was a comment on the previous PR after it was merged).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61662
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
