### PR TITLE
Change Hue availability blacklist logic a bit

### DIFF
--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -164,8 +164,13 @@ class HueBaseEntity(Entity):
                 self.logger.warning(
                     "Light %s changed state while reported as disconnected on the Zigbee mesh. "
                     "This is an indicator that routing is not working properly for this device. "
-                    "Home Assistant will ignore availability for this light from now on.",
+                    "Home Assistant will ignore availability for this light from now on. ",
+                    "Device details: %s %s (%s) fw: %s",
                     self.name,
+                    self.device.product_data.manufacturer_name,
+                    self.device.product_data.product_name,
+                    self.device.product_data.model_id,
+                    self.device.product_data.software_version,
                 )
                 # do we want to store this in some persistent storage?
                 self._ignore_availability = True

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -162,10 +162,12 @@ class HueBaseEntity(Entity):
                 # the device state changed from on->off or off->on
                 # while it was reported as not connected!
                 self.logger.warning(
-                    "Light %s changed state while reported as disconnected on the Zigbee mesh. "
-                    "This is an indicator that routing is not working properly for this device. "
-                    "Home Assistant will ignore availability for this light from now on. ",
-                    "Device details: %s %s (%s) fw: %s",
+                    (
+                        "Light %s changed state while reported as disconnected. "
+                        "This is an indicator that routing is not working properly for this device. "
+                        "Home Assistant will ignore availability for this light from now on. ",
+                        "Device details: %s - %s (%s) fw: %s",
+                    ),
                     self.name,
                     self.device.product_data.manufacturer_name,
                     self.device.product_data.product_name,

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -162,12 +162,10 @@ class HueBaseEntity(Entity):
                 # the device state changed from on->off or off->on
                 # while it was reported as not connected!
                 self.logger.warning(
-                    (
-                        "Light %s changed state while reported as disconnected. "
-                        "This is an indicator that routing is not working properly for this device. "
-                        "Home Assistant will ignore availability for this light from now on. ",
-                        "Device details: %s - %s (%s) fw: %s",
-                    ),
+                    "Light %s changed state while reported as disconnected. "
+                    "This is an indicator that routing is not working properly for this device. "
+                    "Home Assistant will ignore availability for this light from now on. "
+                    "Device details: %s - %s (%s) fw: %s",
                     self.name,
                     self.device.product_data.manufacturer_name,
                     self.device.product_data.product_name,

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -47,20 +47,9 @@ class HueBaseEntity(Entity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self.device.id)},
             )
-        # some (3th party) Hue lights report their connection status incorrectly
-        # causing the zigbee availability to report as disconnected while in fact
-        # it can be controlled. Although this is in fact something the device manufacturer
-        # should fix, we work around it here. If the light is reported unavailable at
-        # startup, we ignore the availability status of the zigbee connection
-        self._ignore_availability = False
-        if self.device is None:
-            return
-        if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
-            self._ignore_availability = (
-                # Official Hue lights are reliable
-                self.device.product_data.manufacturer_name != "Signify Netherlands B.V."
-                and zigbee.status != ConnectivityServiceStatus.CONNECTED
-            )
+        # used for availability workaround
+        self._ignore_availability = None
+        self._last_state = None
 
     @property
     def name(self) -> str:
@@ -82,6 +71,7 @@ class HueBaseEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
+        self._check_availability_workaround()
         # Add value_changed callbacks.
         self.async_on_remove(
             self.controller.subscribe(
@@ -140,5 +130,45 @@ class HueBaseEntity(Entity):
             ent_reg.async_remove(self.entity_id)
         else:
             self.logger.debug("Received status update for %s", self.entity_id)
+            self._check_availability_workaround()
             self.on_update()
             self.async_write_ha_state()
+
+    @callback
+    def _check_availability_workaround(self):
+        """Check availability of the device."""
+        if self.resource.type != ResourceTypes.LIGHT:
+            return
+        if self._ignore_availability is not None:
+            # already processed
+            return
+        cur_state = self.resource.on.on
+        if self._last_state is None:
+            self._last_state = cur_state
+            return
+        # some (3th party) Hue lights report their connection status incorrectly
+        # causing the zigbee availability to report as disconnected while in fact
+        # it can be controlled. Although this is in fact something the device manufacturer
+        # should fix, we work around it here. If the light is reported unavailable
+        # by the zigbee connectivity but the state changesm its considered as a
+        # malfunctioning device and we report it.
+        # while the user should actually fix this issue instead of ignoring it, we
+        # ignore the availability for this light from this point.
+        if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
+            if (
+                self._last_state != cur_state
+                and zigbee.status != ConnectivityServiceStatus.CONNECTED
+            ):
+                # the device state changed from on->off or off->on
+                # while it was reported as not connected!
+                self.logger.warning(
+                    "Light %s changed state while reported as disconnected on the Zigbee mesh. "
+                    "This is an indicator that routing is not working properly for this device. "
+                    "Home Assistant will ignore availability for this light from now on.",
+                    self.name,
+                )
+                # do we want to store this in some persistent storage?
+                self._ignore_availability = True
+            else:
+                self._ignore_availability = False
+        self._last_state = cur_state


### PR DESCRIPTION
## Proposed change

Yet another take on the blacklist logic where misbehaving lights report as disconnected on the zigbee stack while they actually can be controlled. 

The current blacklist trick blacklists all lights that are Non-Philips and unavailable at startup but that upsets a few users that actually have third party lights that do route correctly.

I was thinking about a static list of device types to check but I have no idea what device types exactly are affected and its also different between firmware versions.

This change takes another approach by just looking at the behavior of the symptom:
A light that is not routing properly is reported as disconnected (or connection error) on the zigbee sensors but does report its state changes to on/off. So if we detect a state change while the light is disconnected, we mark is at misbehaving.

A proper warning will be logged (once) to inform the user they should actually fix this issue (because their mesh is routed incorrectly) and the availability will be ignored for the light.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
