### PR TITLE
Use DeviceAutomationType in tests/components/[s-z]*

### DIFF
--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -3,6 +3,7 @@ import pytest
 import voluptuous_serialize
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.select import DOMAIN
 from homeassistant.components.select.device_action import async_get_action_capabilities
 from homeassistant.core import HomeAssistant
@@ -56,7 +57,9 @@ async def test_get_actions(
             "entity_id": "select.test_5678",
         }
     ]
-    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
     assert_lists_same(actions, expected_actions)
 
 

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -5,6 +5,7 @@ import pytest
 import voluptuous_serialize
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.select import DOMAIN
 from homeassistant.components.select.device_condition import (
     async_get_condition_capabilities,
@@ -67,7 +68,9 @@ async def test_get_conditions(
             "entity_id": f"{DOMAIN}.test_5678",
         }
     ]
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     assert_lists_same(conditions, expected_conditions)
 
 

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -5,6 +5,7 @@ import pytest
 import voluptuous_serialize
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.select import DOMAIN
 from homeassistant.components.select.device_trigger import (
     async_get_trigger_capabilities,
@@ -64,7 +65,9 @@ async def test_get_triggers(
             "entity_id": f"{DOMAIN}.test_5678",
         }
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, expected_triggers)
 
 

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -2,6 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN, SensorDeviceClass
 from homeassistant.components.sensor.device_condition import ENTITY_CONDITIONS
 from homeassistant.const import CONF_PLATFORM, PERCENTAGE, STATE_UNKNOWN
@@ -73,7 +74,9 @@ async def test_get_conditions(hass, device_reg, entity_reg, enable_custom_integr
         for condition in ENTITY_CONDITIONS[device_class]
         if device_class != "none"
     ]
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     assert conditions == expected_conditions
 
 
@@ -111,7 +114,9 @@ async def test_get_conditions_no_state(hass, device_reg, entity_reg):
         for condition in ENTITY_CONDITIONS[device_class]
         if device_class != "none"
     ]
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     assert conditions == expected_conditions
 
 
@@ -173,11 +178,13 @@ async def test_get_condition_capabilities(
             },
         ]
     }
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     assert len(conditions) == 1
     for condition in conditions:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "condition", condition
+            hass, DeviceAutomationType.CONDITION, condition
         )
         assert capabilities == expected_capabilities
 
@@ -215,7 +222,7 @@ async def test_get_condition_capabilities_none(
     expected_capabilities = {}
     for condition in conditions:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "condition", condition
+            hass, DeviceAutomationType.CONDITION, condition
         )
         assert capabilities == expected_capabilities
 

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN, SensorDeviceClass
 from homeassistant.components.sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.const import CONF_PLATFORM, PERCENTAGE, STATE_UNKNOWN
@@ -77,7 +78,9 @@ async def test_get_triggers(hass, device_reg, entity_reg, enable_custom_integrat
         for trigger in ENTITY_TRIGGERS[device_class]
         if device_class != "none"
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert len(triggers) == 24
     assert triggers == expected_triggers
 
@@ -141,11 +144,13 @@ async def test_get_trigger_capabilities(
             {"name": "for", "optional": True, "type": "positive_time_period_dict"},
         ]
     }
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert len(triggers) == 1
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "trigger", trigger
+            hass, DeviceAutomationType.TRIGGER, trigger
         )
         assert capabilities == expected_capabilities
 
@@ -183,7 +188,7 @@ async def test_get_trigger_capabilities_none(
     expected_capabilities = {}
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "trigger", trigger
+            hass, DeviceAutomationType.TRIGGER, trigger
         )
         assert capabilities == expected_capabilities
 

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -49,7 +50,7 @@ async def test_get_triggers_block_device(hass, coap_wrapper):
     ]
 
     triggers = await async_get_device_automations(
-        hass, "trigger", coap_wrapper.device_id
+        hass, DeviceAutomationType.TRIGGER, coap_wrapper.device_id
     )
 
     assert_lists_same(triggers, expected_triggers)
@@ -97,7 +98,7 @@ async def test_get_triggers_rpc_device(hass, rpc_wrapper):
     ]
 
     triggers = await async_get_device_automations(
-        hass, "trigger", rpc_wrapper.device_id
+        hass, DeviceAutomationType.TRIGGER, rpc_wrapper.device_id
     )
 
     assert_lists_same(triggers, expected_triggers)
@@ -162,7 +163,7 @@ async def test_get_triggers_button(hass):
     ]
 
     triggers = await async_get_device_automations(
-        hass, "trigger", coap_wrapper.device_id
+        hass, DeviceAutomationType.TRIGGER, coap_wrapper.device_id
     )
 
     assert_lists_same(triggers, expected_triggers)
@@ -179,7 +180,9 @@ async def test_get_triggers_for_invalid_device_id(hass, device_reg, coap_wrapper
     )
 
     with pytest.raises(InvalidDeviceAutomationConfig):
-        await async_get_device_automations(hass, "trigger", invalid_device.id)
+        await async_get_device_automations(
+            hass, DeviceAutomationType.TRIGGER, invalid_device.id
+        )
 
 
 async def test_if_fires_on_click_event_block_device(hass, calls, coap_wrapper):

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -2,6 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
@@ -64,7 +65,9 @@ async def test_get_actions(hass, device_reg, entity_reg):
             "entity_id": f"{DOMAIN}.test_5678",
         },
     ]
-    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
     assert actions == expected_actions
 
 

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
@@ -65,7 +66,9 @@ async def test_get_conditions(hass, device_reg, entity_reg):
             "entity_id": f"{DOMAIN}.test_5678",
         },
     ]
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     assert conditions == expected_conditions
 
 
@@ -83,10 +86,12 @@ async def test_get_condition_capabilities(hass, device_reg, entity_reg):
             {"name": "for", "optional": True, "type": "positive_time_period_dict"}
         ]
     }
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     for condition in conditions:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "condition", condition
+            hass, DeviceAutomationType.CONDITION, condition
         )
         assert capabilities == expected_capabilities
 

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry
@@ -65,7 +66,9 @@ async def test_get_triggers(hass, device_reg, entity_reg):
             "entity_id": f"{DOMAIN}.test_5678",
         },
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert triggers == expected_triggers
 
 
@@ -83,10 +86,12 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
             {"name": "for", "optional": True, "type": "positive_time_period_dict"}
         ]
     }
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "trigger", trigger
+            hass, DeviceAutomationType.TRIGGER, trigger
         )
         assert capabilities == expected_capabilities
 

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -7,6 +7,7 @@ from hatasmota.switch import TasmotaSwitchTriggerConfig
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.tasmota import _LOGGER
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
 from homeassistant.helpers import device_registry as dr
@@ -56,7 +57,9 @@ async def test_get_triggers_btn(hass, device_reg, entity_reg, mqtt_mock, setup_t
             "subtype": "button_2",
         },
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, expected_triggers)
 
 
@@ -82,7 +85,9 @@ async def test_get_triggers_swc(hass, device_reg, entity_reg, mqtt_mock, setup_t
             "subtype": "switch_1",
         },
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, expected_triggers)
 
 
@@ -125,7 +130,9 @@ async def test_get_unknown_triggers(
         },
     )
 
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, [])
 
 
@@ -144,7 +151,9 @@ async def test_get_non_existing_triggers(
     device_entry = device_reg.async_get_device(
         set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
     )
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, [])
 
 
@@ -170,7 +179,9 @@ async def test_discover_bad_triggers(
     device_entry = device_reg.async_get_device(
         set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
     )
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, [])
 
     # Trigger an exception when the entity is discovered
@@ -204,7 +215,9 @@ async def test_discover_bad_triggers(
     device_entry = device_reg.async_get_device(
         set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
     )
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, [])
 
     # Rediscover without exception
@@ -221,7 +234,9 @@ async def test_discover_bad_triggers(
             "subtype": "switch_1",
         },
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, expected_triggers)
 
 
@@ -270,7 +285,9 @@ async def test_update_remove_triggers(
     expected_triggers2 = copy.deepcopy(expected_triggers1)
     expected_triggers2[1]["type"] = "button_double_press"
 
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     for expected in expected_triggers1:
         assert expected in triggers
 
@@ -278,7 +295,9 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config2))
     await hass.async_block_till_done()
 
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     for expected in expected_triggers2:
         assert expected in triggers
 
@@ -286,7 +305,9 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config3))
     await hass.async_block_till_done()
 
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert triggers == []
 
 

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -2,6 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
@@ -52,7 +53,9 @@ async def test_get_actions(hass, device_reg, entity_reg):
             "entity_id": "vacuum.test_5678",
         },
     ]
-    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
     assert_lists_same(actions, expected_actions)
 
 

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -2,6 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import (
     DOMAIN,
     STATE_CLEANING,
@@ -65,7 +66,9 @@ async def test_get_conditions(hass, device_reg, entity_reg):
             "entity_id": f"{DOMAIN}.test_5678",
         },
     ]
-    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
     assert_lists_same(conditions, expected_conditions)
 
 

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN, STATE_CLEANING, STATE_DOCKED
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
@@ -65,7 +66,9 @@ async def test_get_triggers(hass, device_reg, entity_reg):
             "entity_id": f"{DOMAIN}.test_5678",
         },
     ]
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert_lists_same(triggers, expected_triggers)
 
 
@@ -79,11 +82,13 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
 
-    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
     assert len(triggers) == 2
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
-            hass, "trigger", trigger
+            hass, DeviceAutomationType.TRIGGER, trigger
         )
         assert capabilities == {
             "extra_fields": [

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -2,6 +2,7 @@
 import pytest
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.water_heater import DOMAIN
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
@@ -52,7 +53,9 @@ async def test_get_actions(hass, device_reg, entity_reg):
             "entity_id": "water_heater.test_5678",
         },
     ]
-    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
     assert_lists_same(actions, expected_actions)
 
 

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -3,6 +3,7 @@ import pytest
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.wemo.const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -81,7 +82,7 @@ async def test_get_triggers(hass, wemo_entity):
         },
     ]
     triggers = await async_get_device_automations(
-        hass, "trigger", wemo_entity.device_id
+        hass, DeviceAutomationType.TRIGGER, wemo_entity.device_id
     )
     assert_lists_same(triggers, expected_triggers)
 

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -8,6 +8,7 @@ import zigpy.zcl.clusters.security as security
 import zigpy.zcl.foundation as zcl_f
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.zha import DOMAIN
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -51,7 +52,9 @@ async def test_get_actions(hass, device_ias):
     ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
 
-    actions = await async_get_device_automations(hass, "action", reg_device.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, reg_device.id
+    )
 
     expected_actions = [
         {"domain": DOMAIN, "type": "squawk", "device_id": reg_device.id},

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -7,6 +7,7 @@ import zigpy.profiles.zha
 import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.automation as automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -90,7 +91,9 @@ async def test_triggers(hass, mock_devices):
     ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
-    triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, reg_device.id
+    )
 
     expected_triggers = [
         {
@@ -148,7 +151,9 @@ async def test_no_triggers(hass, mock_devices):
     ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
-    triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, reg_device.id
+    )
     assert triggers == [
         {
             "device_id": reg_device.id,

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -6,6 +6,7 @@ from zwave_js_server.const import CommandClass
 from zwave_js_server.model.node import Node
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.zwave_js import DOMAIN, device_action
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import ConfigEntry
@@ -66,7 +67,9 @@ async def test_get_actions(
             "subtype": f"{node.node_id}-112-0-3 (Beeper)",
         },
     ]
-    actions = await async_get_device_automations(hass, "action", device.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device.id
+    )
     for action in expected_actions:
         assert action in actions
 
@@ -82,7 +85,9 @@ async def test_get_actions_meter(
     dev_reg = device_registry.async_get(hass)
     device = dev_reg.async_get_device({get_device_id(client, node)})
     assert device
-    actions = await async_get_device_automations(hass, "action", device.id)
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device.id
+    )
     filtered_actions = [action for action in actions if action["type"] == "reset_meter"]
     assert len(filtered_actions) > 0
 

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -10,6 +10,7 @@ from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -60,7 +61,9 @@ async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> 
             "device_id": device.id,
         },
     ]
-    conditions = await async_get_device_automations(hass, "condition", device.id)
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device.id
+    )
     for condition in expected_conditions:
         assert condition in conditions
 

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -8,6 +8,7 @@ from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
 
 from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -50,7 +51,9 @@ async def test_get_notification_notification_triggers(
         "device_id": device.id,
         "command_class": CommandClass.NOTIFICATION,
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 
@@ -314,7 +317,9 @@ async def test_get_node_status_triggers(hass, client, lock_schlage_be469, integr
         "device_id": device.id,
         "entity_id": entity_id,
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 
@@ -466,7 +471,9 @@ async def test_get_basic_value_notification_triggers(
         "endpoint": 0,
         "subtype": "Endpoint 0",
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 
@@ -631,7 +638,9 @@ async def test_get_central_scene_value_notification_triggers(
         "endpoint": 0,
         "subtype": "Endpoint 0 Scene 001",
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 
@@ -802,7 +811,9 @@ async def test_get_scene_activation_value_notification_triggers(
         "endpoint": 0,
         "subtype": "Endpoint 0",
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 
@@ -962,7 +973,9 @@ async def test_get_value_updated_value_triggers(
         "type": "zwave_js.value_updated.value",
         "device_id": device.id,
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 
@@ -1121,7 +1134,9 @@ async def test_get_value_updated_config_parameter_triggers(
         "command_class": CommandClass.CONFIGURATION.value,
         "subtype": f"{node.node_id}-112-0-3 (Beeper)",
     }
-    triggers = await async_get_device_automations(hass, "trigger", device.id)
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
     assert expected_trigger in triggers
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #62354
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
