### PR TITLE
Cast types in wemo rather than converting

### DIFF
--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -1,5 +1,6 @@
 """Support for WeMo binary sensors."""
 import asyncio
+from typing import cast
 
 from pywemo import Insight, Maker
 
@@ -46,7 +47,7 @@ class WemoBinarySensor(WemoEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the state is on. Standby is on."""
-        return bool(self.wemo.get_state())
+        return cast(int, self.wemo.get_state()) != 0
 
 
 class MakerBinarySensor(WemoEntity, BinarySensorEntity):
@@ -57,7 +58,7 @@ class MakerBinarySensor(WemoEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the Maker's sensor is pulled low."""
-        return bool(self.wemo.has_sensor) and self.wemo.sensor_state == 0
+        return cast(int, self.wemo.has_sensor) != 0 and self.wemo.sensor_state == 0
 
 
 class InsightBinarySensor(WemoBinarySensor):

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as WEMO_DOMAIN
-from .entity import WemoEntity
+from .entity import WemoBinaryStateEntity, WemoEntity
 from .wemo_device import DeviceCoordinator
 
 
@@ -41,13 +41,8 @@ async def async_setup_entry(
     )
 
 
-class WemoBinarySensor(WemoEntity, BinarySensorEntity):
+class WemoBinarySensor(WemoBinaryStateEntity, BinarySensorEntity):
     """Representation a WeMo binary sensor."""
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the state is on. Standby is on."""
-        return cast(int, self.wemo.get_state()) != 0
 
 
 class MakerBinarySensor(WemoEntity, BinarySensorEntity):

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Generator
 import contextlib
 import logging
+from typing import cast
 
 from pywemo.exceptions import ActionException
 
@@ -84,3 +85,12 @@ class WemoEntity(CoordinatorEntity):
         except ActionException as err:
             _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
             self._available = False
+
+
+class WemoBinaryStateEntity(WemoEntity):
+    """Base for devices that return on/off state via device.get_state()."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the state is on."""
+        return cast(int, self.wemo.get_state()) != 0

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -40,9 +40,10 @@ class WemoEntity(CoordinatorEntity):
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
+        wemo_name: str = self.wemo.name
         if suffix := self.name_suffix:
-            return f"{self.wemo.name} {suffix}"
-        return str(self.wemo.name)
+            return f"{wemo_name} {suffix}"
+        return wemo_name
 
     @property
     def available(self) -> bool:
@@ -59,9 +60,10 @@ class WemoEntity(CoordinatorEntity):
     @property
     def unique_id(self) -> str:
         """Return the id of this WeMo device."""
+        serial_number: str = self.wemo.serialnumber
         if suffix := self.unique_id_suffix:
-            return f"{self.wemo.serialnumber}_{suffix}"
-        return str(self.wemo.serialnumber)
+            return f"{serial_number}_{suffix}"
+        return serial_number
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import math
-from typing import Any, cast
+from typing import Any
 
 import voluptuous as vol
 
@@ -25,7 +25,7 @@ from .const import (
     SERVICE_RESET_FILTER_LIFE,
     SERVICE_SET_HUMIDITY,
 )
-from .entity import WemoEntity
+from .entity import WemoBinaryStateEntity
 from .wemo_device import DeviceCoordinator
 
 SCAN_INTERVAL = timedelta(seconds=10)
@@ -37,10 +37,6 @@ ATTR_FAN_MODE = "fan_mode"
 ATTR_FILTER_LIFE = "filter_life"
 ATTR_FILTER_EXPIRED = "filter_expired"
 ATTR_WATER_LEVEL = "water_level"
-
-# The WEMO_ constants below come from pywemo itself
-WEMO_ON = 1
-WEMO_OFF = 0
 
 WEMO_HUMIDITY_45 = 0
 WEMO_HUMIDITY_50 = 1
@@ -102,7 +98,7 @@ async def async_setup_entry(
     )
 
 
-class WemoHumidifier(WemoEntity, FanEntity):
+class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     """Representation of a WeMo humidifier."""
 
     def __init__(self, coordinator: DeviceCoordinator) -> None:
@@ -151,11 +147,6 @@ class WemoHumidifier(WemoEntity, FanEntity):
         if self.wemo.fan_mode != WEMO_FAN_OFF:
             self._last_fan_on_mode = self.wemo.fan_mode
         super()._handle_coordinator_update()
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the state is on."""
-        return cast(int, self.wemo.get_state()) != WEMO_OFF
 
     def turn_on(
         self,

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import math
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 
@@ -155,7 +155,7 @@ class WemoHumidifier(WemoEntity, FanEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the state is on."""
-        return bool(self.wemo.get_state())
+        return cast(int, self.wemo.get_state()) != WEMO_OFF
 
     def turn_on(
         self,

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, Optional, cast
 
 from pywemo.ouimeaux_device import bridge
 
@@ -101,7 +101,7 @@ class WemoLight(WemoEntity, LightEntity):
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
-        return str(self.light.name)
+        return cast(str, self.light.name)
 
     @property
     def available(self) -> bool:
@@ -111,7 +111,7 @@ class WemoLight(WemoEntity, LightEntity):
     @property
     def unique_id(self) -> str:
         """Return the ID of this light."""
-        return str(self.light.uniqueID)
+        return cast(str, self.light.uniqueID)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -127,7 +127,7 @@ class WemoLight(WemoEntity, LightEntity):
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
-        return int(self.light.state.get("level", 255))
+        return cast(int, self.light.state.get("level", 255))
 
     @property
     def hs_color(self) -> tuple[float, float] | None:
@@ -139,14 +139,12 @@ class WemoLight(WemoEntity, LightEntity):
     @property
     def color_temp(self) -> int | None:
         """Return the color temperature of this light in mireds."""
-        if (temp := self.light.state.get("temperature_mireds")) is not None:
-            return int(temp)
-        return None
+        return cast(Optional[int], self.light.state.get("temperature_mireds"))
 
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return bool(self.light.state.get("onoff") != WEMO_OFF)
+        return cast(int, self.light.state.get("onoff")) != WEMO_OFF
 
     @property
     def supported_features(self) -> int:
@@ -205,13 +203,13 @@ class WemoDimmer(WemoEntity, LightEntity):
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 1 and 100."""
-        wemo_brightness = int(self.wemo.get_brightness())
+        wemo_brightness: int = self.wemo.get_brightness()
         return int((wemo_brightness * 255) / 100)
 
     @property
     def is_on(self) -> bool:
         """Return true if the state is on."""
-        return bool(self.wemo.get_state())
+        return cast(int, self.wemo.get_state()) != WEMO_OFF
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the dimmer on."""

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.color as color_util
 
 from .const import DOMAIN as WEMO_DOMAIN
-from .entity import WemoEntity
+from .entity import WemoBinaryStateEntity, WemoEntity
 from .wemo_device import DeviceCoordinator
 
 SUPPORT_WEMO = (
@@ -192,7 +192,7 @@ class WemoLight(WemoEntity, LightEntity):
         self.schedule_update_ha_state()
 
 
-class WemoDimmer(WemoEntity, LightEntity):
+class WemoDimmer(WemoBinaryStateEntity, LightEntity):
     """Representation of a WeMo dimmer."""
 
     @property
@@ -205,11 +205,6 @@ class WemoDimmer(WemoEntity, LightEntity):
         """Return the brightness of this light between 1 and 100."""
         wemo_brightness: int = self.wemo.get_brightness()
         return int((wemo_brightness * 255) / 100)
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the state is on."""
-        return cast(int, self.wemo.get_state()) != WEMO_OFF
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the dimmer on."""

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -1,5 +1,6 @@
 """Support for power sensors in WeMo Insight devices."""
 import asyncio
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -49,7 +50,7 @@ class InsightSensor(WemoEntity, SensorEntity):
     @property
     def name_suffix(self) -> str:
         """Return the name of the entity if any."""
-        return str(self.entity_description.name)
+        return cast(str, self.entity_description.name)
 
     @property
     def unique_id_suffix(self) -> str:

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -1,6 +1,5 @@
 """Support for power sensors in WeMo Insight devices."""
 import asyncio
-from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -50,7 +49,8 @@ class InsightSensor(WemoEntity, SensorEntity):
     @property
     def name_suffix(self) -> str:
         """Return the name of the entity if any."""
-        return cast(str, self.entity_description.name)
+        assert self.entity_description.name
+        return self.entity_description.name
 
     @property
     def unique_id_suffix(self) -> str:

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -135,7 +135,7 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
         if isinstance(self.wemo, CoffeeMaker):
             return cast(str, self.wemo.mode_string)
         if isinstance(self.wemo, Insight):
-            # TODO(@esev): Remove this conversion.
+            # T-O-D-O(@esev): Remove this conversion.
             standby_state = int(self.wemo.insight_params.get("state", 0))
             if standby_state == WEMO_ON:
                 return STATE_ON

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 from pywemo import CoffeeMaker, Insight, Maker
 
@@ -133,8 +133,9 @@ class WemoSwitch(WemoEntity, SwitchEntity):
     def detail_state(self) -> str:
         """Return the state of the device."""
         if isinstance(self.wemo, CoffeeMaker):
-            return str(self.wemo.mode_string)
+            return cast(str, self.wemo.mode_string)
         if isinstance(self.wemo, Insight):
+            # TODO(@esev): Remove this conversion.
             standby_state = int(self.wemo.insight_params.get("state", 0))
             if standby_state == WEMO_ON:
                 return STATE_ON
@@ -155,7 +156,7 @@ class WemoSwitch(WemoEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the state is on. Standby is on."""
-        return bool(self.wemo.get_state())
+        return cast(int, self.wemo.get_state()) != WEMO_OFF
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -135,7 +135,6 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
         if isinstance(self.wemo, CoffeeMaker):
             return cast(str, self.wemo.mode_string)
         if isinstance(self.wemo, Insight):
-            # T-O-D-O(@esev): Remove this conversion.
             standby_state = int(self.wemo.insight_params.get("state", 0))
             if standby_state == WEMO_ON:
                 return STATE_ON

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import convert
 
 from .const import DOMAIN as WEMO_DOMAIN
-from .entity import WemoEntity
+from .entity import WemoBinaryStateEntity
 from .wemo_device import DeviceCoordinator
 
 SCAN_INTERVAL = timedelta(seconds=10)
@@ -57,7 +57,7 @@ async def async_setup_entry(
     )
 
 
-class WemoSwitch(WemoEntity, SwitchEntity):
+class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
     """Representation of a WeMo switch."""
 
     @property
@@ -152,11 +152,6 @@ class WemoSwitch(WemoEntity, SwitchEntity):
         if isinstance(self.wemo, CoffeeMaker):
             return "mdi:coffee"
         return None
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the state is on. Standby is on."""
-        return cast(int, self.wemo.get_state()) != WEMO_OFF
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Addressing post merge feedback received in #62157. Type casting should be used, not type conversion.

There are some cleanups I need to do regarding the WeMo Insight devices. ~~I've left a TODO comment for myself to clean that up in another PR that is focused on that device.~~

I'm also merging a common `is_on` method into a base class that is shared with the entities that require it. That way it only needs to be updated in one place now and in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #62157
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
