### PR TITLE
Add TotalConnect options flow to auto-bypass low battery

### DIFF
--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -31,6 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     conf = entry.data
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
+    bypass = entry.options.get(AUTO_BYPASS)
 
     if CONF_USERCODES not in conf:
         # should only happen for those who used UI before we added usercodes
@@ -41,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         client = await hass.async_add_executor_job(
-            TotalConnectClient, username, password, usercodes
+            TotalConnectClient, username, password, usercodes, bypass
         )
     except AuthenticationError as exception:
         raise ConfigEntryAuthFailed(

--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -31,10 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     conf = entry.data
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
-    if AUTO_BYPASS in entry.options:
-        bypass = entry.options[AUTO_BYPASS]
-    else:
-        bypass = False
+    bypass = entry.options.get(AUTO_BYPASS, False)
 
     if CONF_USERCODES not in conf:
         # should only happen for those who used UI before we added usercodes
@@ -75,12 +72,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update listener."""
-    if AUTO_BYPASS in entry.options:
-        client = hass.data[DOMAIN][entry.entry_id].client
-        for location_id in client.locations:
-            client.locations[location_id].auto_bypass_low_battery = entry.options[
-                AUTO_BYPASS
-            ]
+    bypass = entry.options.get(AUTO_BYPASS, False)
+    client = hass.data[DOMAIN][entry.entry_id].client
+    for location_id in client.locations:
+        client.locations[location_id].auto_bypass_low_battery = bypass
 
 
 class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):

--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -31,7 +31,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     conf = entry.data
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
-    bypass = entry.options.get(AUTO_BYPASS)
+    if AUTO_BYPASS in entry.options:
+        bypass = entry.options[AUTO_BYPASS]
+    else:
+        bypass = False
 
     if CONF_USERCODES not in conf:
         # should only happen for those who used UI before we added usercodes

--- a/homeassistant/components/totalconnect/config_flow.py
+++ b/homeassistant/components/totalconnect/config_flow.py
@@ -5,8 +5,9 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_LOCATION, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 
-from .const import CONF_USERCODES, DOMAIN
+from .const import AUTO_BYPASS, CONF_USERCODES, DOMAIN
 
 PASSWORD_DATA_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 
@@ -162,3 +163,34 @@ class TotalConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_abort(reason="reauth_successful")
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get options flow."""
+        return TotalConnectOptionsFlowHandler(config_entry)
+
+
+class TotalConnectOptionsFlowHandler(config_entries.OptionsFlow):
+    """TotalConnect options flow handler."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        AUTO_BYPASS,
+                        default=self.config_entry.options.get(AUTO_BYPASS),
+                    ): bool
+                }
+            ),
+        )

--- a/homeassistant/components/totalconnect/config_flow.py
+++ b/homeassistant/components/totalconnect/config_flow.py
@@ -183,13 +183,18 @@ class TotalConnectOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
+        if AUTO_BYPASS in self.config_entry.options:
+            default_value = self.config_entry.options[AUTO_BYPASS]
+        else:
+            default_value = False
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
                         AUTO_BYPASS,
-                        default=self.config_entry.options.get(AUTO_BYPASS),
+                        default=default_value,
                     ): bool
                 }
             ),

--- a/homeassistant/components/totalconnect/config_flow.py
+++ b/homeassistant/components/totalconnect/config_flow.py
@@ -183,18 +183,13 @@ class TotalConnectOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        if AUTO_BYPASS in self.config_entry.options:
-            default_value = self.config_entry.options[AUTO_BYPASS]
-        else:
-            default_value = False
-
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
                         AUTO_BYPASS,
-                        default=default_value,
+                        default=self.config_entry.options.get(AUTO_BYPASS, False),
                     ): bool
                 }
             ),

--- a/homeassistant/components/totalconnect/const.py
+++ b/homeassistant/components/totalconnect/const.py
@@ -2,6 +2,8 @@
 
 DOMAIN = "totalconnect"
 CONF_USERCODES = "usercodes"
+CONF_LOCATION = "location"
+AUTO_BYPASS = "auto_bypass_low_battery"
 
 # Most TotalConnect alarms will work passing '-1' as usercode
 DEFAULT_USERCODE = "-1"

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -28,5 +28,16 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "no_locations": "No locations are available for this user, check TotalConnect settings"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "TotalConnect Options",
+        "description": "Automatically bypass zones the moment they report a low battery.",
+        "data": {
+          "auto_bypass_low_battery": "Auto bypass low battery"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a configuration option to allow TotalConnect to automatically bypass zones immediately when they report low battery.  

Adds test for the options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21397

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
