### PR TITLE
Remove deprecated yaml config from honeywell

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -5,9 +5,8 @@ import datetime
 from typing import Any
 
 import somecomfort
-import voluptuous as vol
 
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
@@ -31,25 +30,12 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_PASSWORD,
-    CONF_REGION,
-    CONF_USERNAME,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
-)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 
 from .const import (
     _LOGGER,
     CONF_COOL_AWAY_TEMPERATURE,
-    CONF_DEV_ID,
     CONF_HEAT_AWAY_TEMPERATURE,
-    CONF_LOC_ID,
-    DEFAULT_COOL_AWAY_TEMPERATURE,
-    DEFAULT_HEAT_AWAY_TEMPERATURE,
     DOMAIN,
 )
 
@@ -58,25 +44,6 @@ ATTR_FAN_ACTION = "fan_action"
 ATTR_PERMANENT_HOLD = "permanent_hold"
 
 PRESET_HOLD = "Hold"
-
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_REGION),
-    PLATFORM_SCHEMA.extend(
-        {
-            vol.Required(CONF_USERNAME): cv.string,
-            vol.Required(CONF_PASSWORD): cv.string,
-            vol.Optional(
-                CONF_COOL_AWAY_TEMPERATURE, default=DEFAULT_COOL_AWAY_TEMPERATURE
-            ): vol.Coerce(int),
-            vol.Optional(
-                CONF_HEAT_AWAY_TEMPERATURE, default=DEFAULT_HEAT_AWAY_TEMPERATURE
-            ): vol.Coerce(int),
-            vol.Optional(CONF_REGION): cv.string,
-            vol.Optional(CONF_DEV_ID): cv.string,
-            vol.Optional(CONF_LOC_ID): cv.string,
-        }
-    ),
-)
 
 HVAC_MODE_TO_HW_MODE = {
     "SwitchOffAllowed": {HVAC_MODE_OFF: "off"},
@@ -125,26 +92,6 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
             for device in data.devices.values()
         ]
     )
-
-
-async def async_setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Honeywell climate platform.
-
-    Honeywell uses config flow for configuration now. If an entry exists in
-    configuration.yaml, the import flow will attempt to import it and create
-    a config entry.
-    """
-
-    if config["platform"] == "honeywell":
-        _LOGGER.warning(
-            "Loading honeywell via platform config is deprecated; The configuration"
-            " has been migrated to a config entry and can be safely removed"
-        )
-        # No config entry exists and configuration.yaml config exists, trigger the import flow.
-        if not hass.config_entries.async_entries(DOMAIN):
-            await hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-            )
 
 
 class HoneywellUSThermostat(ClimateEntity):

--- a/homeassistant/components/honeywell/config_flow.py
+++ b/homeassistant/components/honeywell/config_flow.py
@@ -5,7 +5,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from . import get_somecomfort_client
-from .const import CONF_COOL_AWAY_TEMPERATURE, CONF_HEAT_AWAY_TEMPERATURE, DOMAIN
+from .const import DOMAIN
 
 
 class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -42,14 +42,3 @@ class HoneywellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         return client is not None
-
-    async def async_step_import(self, import_data):
-        """Import entry from configuration.yaml."""
-        return await self.async_step_user(
-            {
-                CONF_USERNAME: import_data[CONF_USERNAME],
-                CONF_PASSWORD: import_data[CONF_PASSWORD],
-                CONF_COOL_AWAY_TEMPERATURE: import_data[CONF_COOL_AWAY_TEMPERATURE],
-                CONF_HEAT_AWAY_TEMPERATURE: import_data[CONF_HEAT_AWAY_TEMPERATURE],
-            }
-        )

--- a/homeassistant/components/honeywell/const.py
+++ b/homeassistant/components/honeywell/const.py
@@ -3,8 +3,6 @@ import logging
 
 DOMAIN = "honeywell"
 
-DEFAULT_COOL_AWAY_TEMPERATURE = 88
-DEFAULT_HEAT_AWAY_TEMPERATURE = 61
 CONF_COOL_AWAY_TEMPERATURE = "away_cool_temperature"
 CONF_HEAT_AWAY_TEMPERATURE = "away_heat_temperature"
 CONF_DEV_ID = "thermostat"

--- a/tests/components/honeywell/test_config_flow.py
+++ b/tests/components/honeywell/test_config_flow.py
@@ -5,7 +5,7 @@ import somecomfort
 
 from homeassistant import data_entry_flow
 from homeassistant.components.honeywell.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 
 FAKE_CONFIG = {
@@ -46,18 +46,6 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=FAKE_CONFIG
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["data"] == FAKE_CONFIG
-
-
-async def test_async_step_import(hass: HomeAssistant) -> None:
-    """Test that the import step works."""
-    with patch(
-        "somecomfort.SomeComfort",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=FAKE_CONFIG
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"] == FAKE_CONFIG


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the Honeywell integration has been removed.

Honeywell is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated yaml config from honeywell

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
