### PR TITLE
Fix repetier crash when printer is offline

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -748,7 +748,7 @@ tests/components/recorder/* @home-assistant/core
 homeassistant/components/rejseplanen/* @DarkFox
 homeassistant/components/renault/* @epenet
 tests/components/renault/* @epenet
-homeassistant/components/repetier/* @MTrab
+homeassistant/components/repetier/* @MTrab @ShadowBr0ther
 homeassistant/components/rflink/* @javicalle
 tests/components/rflink/* @javicalle
 homeassistant/components/rfxtrx/* @danielhiversen @elupus @RobBie1221

--- a/homeassistant/components/repetier/__init__.py
+++ b/homeassistant/components/repetier/__init__.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
-import pyrepetier
+import pyrepetierng as pyrepetier
 import voluptuous as vol
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription

--- a/homeassistant/components/repetier/manifest.json
+++ b/homeassistant/components/repetier/manifest.json
@@ -3,6 +3,6 @@
   "name": "Repetier-Server",
   "documentation": "https://www.home-assistant.io/integrations/repetier",
   "requirements": ["pyrepetierng==0.1.0"],
-  "codeowners": ["@MTrab"],
+  "codeowners": ["@MTrab", "@ShadowBr0ther"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/repetier/manifest.json
+++ b/homeassistant/components/repetier/manifest.json
@@ -2,7 +2,7 @@
   "domain": "repetier",
   "name": "Repetier-Server",
   "documentation": "https://www.home-assistant.io/integrations/repetier",
-  "requirements": ["pyrepetier==3.0.5"],
+  "requirements": ["pyrepetierng==0.1.0"],
   "codeowners": ["@MTrab"],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1765,7 +1765,7 @@ pyrainbird==0.4.3
 pyrecswitch==1.0.2
 
 # homeassistant.components.repetier
-pyrepetier==3.0.5
+pyrepetierng==0.1.0
 
 # homeassistant.components.risco
 pyrisco==0.3.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The old pyrepetier library used is deprecated and discontinued. Also it was removed from github.
Since the licence is MIT I reuploaded the library and made a bugfix.
The new library can be found as "pyrepetierng": https://github.com/ShadowBr0ther/pyrepetier-ng

Since version 1.2.1, Repetier-Server won't report the "activeExtruder" status in its API, when the 3d printer is disconnected or powered off. In the new version of this library there is a check for this case.

A comparison of changes can be found here: 
https://github.com/ShadowBr0ther/pyrepetier-ng/compare/a5fe88b5a1c2616db5cecd0aecda4dfb88e746ec...cbd5ec8d484ec1e9d089d44733529cbdfd531601

The bugfix was made in the file src/pyrepetierng/clsprinter.py

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/59430
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
