### PR TITLE
Use new enums in litterrobot tests

### DIFF
--- a/tests/components/litterrobot/test_button.py
+++ b/tests/components/litterrobot/test_button.py
@@ -4,14 +4,10 @@ from unittest.mock import MagicMock
 from freezegun import freeze_time
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_ICON,
-    ENTITY_CATEGORY_CONFIG,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
 
 from .conftest import setup_integration
 
@@ -31,7 +27,7 @@ async def test_button(hass: HomeAssistant, mock_account: MagicMock) -> None:
 
     entry = entity_registry.async_get(BUTTON_ENTITY)
     assert entry
-    assert entry.entity_category == ENTITY_CATEGORY_CONFIG
+    assert entry.entity_category == EntityCategory.CONFIG
 
     await hass.services.async_call(
         BUTTON_DOMAIN,

--- a/tests/components/litterrobot/test_button.py
+++ b/tests/components/litterrobot/test_button.py
@@ -27,7 +27,7 @@ async def test_button(hass: HomeAssistant, mock_account: MagicMock) -> None:
 
     entry = entity_registry.async_get(BUTTON_ENTITY)
     assert entry
-    assert entry.entity_category == EntityCategory.CONFIG
+    assert entry.entity_category is EntityCategory.CONFIG
 
     await hass.services.async_call(
         BUTTON_DOMAIN,

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -33,7 +33,7 @@ async def test_wait_time_select(hass: HomeAssistant, mock_account):
     ent_reg = entity_registry.async_get(hass)
     entity_entry = ent_reg.async_get(SELECT_ENTITY_ID)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
 
     data = {ATTR_ENTITY_ID: SELECT_ENTITY_ID}
 

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -10,9 +10,10 @@ from homeassistant.components.select import (
     DOMAIN as PLATFORM_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ENTITY_CATEGORY_CONFIG
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.util.dt import utcnow
 
 from .conftest import setup_integration
@@ -32,7 +33,7 @@ async def test_wait_time_select(hass: HomeAssistant, mock_account):
     ent_reg = entity_registry.async_get(hass)
     entity_entry = ent_reg.async_get(SELECT_ENTITY_ID)
     assert entity_entry
-    assert entity_entry.entity_category == ENTITY_CATEGORY_CONFIG
+    assert entity_entry.entity_category == EntityCategory.CONFIG
 
     data = {ATTR_ENTITY_ID: SELECT_ENTITY_ID}
 

--- a/tests/components/litterrobot/test_sensor.py
+++ b/tests/components/litterrobot/test_sensor.py
@@ -2,8 +2,8 @@
 from unittest.mock import Mock
 
 from homeassistant.components.litterrobot.sensor import LitterRobotSleepTimeSensor
-from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
-from homeassistant.const import DEVICE_CLASS_TIMESTAMP, PERCENTAGE
+from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN, SensorDeviceClass
+from homeassistant.const import PERCENTAGE
 
 from .conftest import create_mock_robot, setup_integration
 
@@ -30,7 +30,7 @@ async def test_sleep_time_sensor_with_none_state(hass):
 
     assert sensor
     assert sensor.state is None
-    assert sensor.device_class == DEVICE_CLASS_TIMESTAMP
+    assert sensor.device_class == SensorDeviceClass.TIMESTAMP
 
 
 async def test_gauge_icon():

--- a/tests/components/litterrobot/test_sensor.py
+++ b/tests/components/litterrobot/test_sensor.py
@@ -30,7 +30,7 @@ async def test_sleep_time_sensor_with_none_state(hass):
 
     assert sensor
     assert sensor.state is None
-    assert sensor.device_class == SensorDeviceClass.TIMESTAMP
+    assert sensor.device_class is SensorDeviceClass.TIMESTAMP
 
 
 async def test_gauge_icon():

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -35,7 +35,7 @@ async def test_switch(hass: HomeAssistant, mock_account: MagicMock):
     ent_reg = entity_registry.async_get(hass)
     entity_entry = ent_reg.async_get(NIGHT_LIGHT_MODE_ENTITY_ID)
     assert entity_entry
-    assert entity_entry.entity_category == EntityCategory.CONFIG
+    assert entity_entry.entity_category is EntityCategory.CONFIG
 
 
 @pytest.mark.parametrize(

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -10,14 +10,10 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ENTITY_CATEGORY_CONFIG,
-    STATE_OFF,
-    STATE_ON,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.util.dt import utcnow
 
 from .conftest import setup_integration
@@ -39,7 +35,7 @@ async def test_switch(hass: HomeAssistant, mock_account: MagicMock):
     ent_reg = entity_registry.async_get(hass)
     entity_entry = ent_reg.async_get(NIGHT_LIGHT_MODE_ENTITY_ID)
     assert entity_entry
-    assert entity_entry.entity_category == ENTITY_CATEGORY_CONFIG
+    assert entity_entry.entity_category == EntityCategory.CONFIG
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
