### PR TITLE
Use platform enums in wled tests

### DIFF
--- a/tests/components/wled/test_number.py
+++ b/tests/components/wled/test_number.py
@@ -5,14 +5,14 @@ from unittest.mock import MagicMock
 import pytest
 from wled import Device as WLEDDevice, WLEDConnectionError, WLEDError
 
-from homeassistant.components.number import ATTR_MAX, ATTR_MIN, DOMAIN as NUMBER_DOMAIN
+from homeassistant.components.number import ATTR_MAX, ATTR_MIN
 from homeassistant.components.number.const import (
     ATTR_STEP,
     ATTR_VALUE,
     SERVICE_SET_VALUE,
 )
 from homeassistant.components.wled.const import SCAN_INTERVAL
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
@@ -47,7 +47,7 @@ async def test_speed_segment_change_state(
 ) -> None:
     """Test the value change of the WLED segments."""
     await hass.services.async_call(
-        NUMBER_DOMAIN,
+        Platform.NUMBER,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
@@ -115,7 +115,7 @@ async def test_speed_error(
     mock_wled.segment.side_effect = WLEDError
 
     await hass.services.async_call(
-        NUMBER_DOMAIN,
+        Platform.NUMBER,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
@@ -143,7 +143,7 @@ async def test_speed_connection_error(
     mock_wled.segment.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        NUMBER_DOMAIN,
+        Platform.NUMBER,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_speed",
@@ -188,7 +188,7 @@ async def test_intensity_segment_change_state(
 ) -> None:
     """Test the value change of the WLED segments."""
     await hass.services.async_call(
-        NUMBER_DOMAIN,
+        Platform.NUMBER,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",
@@ -256,7 +256,7 @@ async def test_intensity_error(
     mock_wled.segment.side_effect = WLEDError
 
     await hass.services.async_call(
-        NUMBER_DOMAIN,
+        Platform.NUMBER,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",
@@ -284,7 +284,7 @@ async def test_intensity_connection_error(
     mock_wled.segment.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        NUMBER_DOMAIN,
+        Platform.NUMBER,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: "number.wled_rgb_light_segment_1_intensity",

--- a/tests/components/wled/test_select.py
+++ b/tests/components/wled/test_select.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 from wled import Device as WLEDDevice, WLEDConnectionError, WLEDError
 
-from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.select.const import ATTR_OPTION, ATTR_OPTIONS
 from homeassistant.components.wled.const import SCAN_INTERVAL
 from homeassistant.const import (
@@ -14,6 +13,7 @@ from homeassistant.const import (
     SERVICE_SELECT_OPTION,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -100,7 +100,7 @@ async def test_color_palette_segment_change_state(
 ) -> None:
     """Test the option change of state of the WLED segments."""
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
@@ -167,7 +167,7 @@ async def test_color_palette_select_error(
     mock_wled.segment.side_effect = WLEDError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
@@ -195,7 +195,7 @@ async def test_color_palette_select_connection_error(
     mock_wled.segment.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
@@ -243,7 +243,7 @@ async def test_preset_state(
     assert entry.unique_id == "aabbccddee11_preset"
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
@@ -286,7 +286,7 @@ async def test_preset_select_error(
     mock_wled.preset.side_effect = WLEDError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
@@ -315,7 +315,7 @@ async def test_preset_select_connection_error(
     mock_wled.preset.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgbw_light_preset",
@@ -363,7 +363,7 @@ async def test_playlist_state(
     assert entry.unique_id == "aabbccddee11_playlist"
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
@@ -406,7 +406,7 @@ async def test_playlist_select_error(
     mock_wled.playlist.side_effect = WLEDError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
@@ -435,7 +435,7 @@ async def test_playlist_select_connection_error(
     mock_wled.playlist.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgbw_light_playlist",
@@ -472,7 +472,7 @@ async def test_live_override(
     assert entry.unique_id == "aabbccddeeff_live_override"
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",
@@ -495,7 +495,7 @@ async def test_live_select_error(
     mock_wled.live.side_effect = WLEDError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",
@@ -523,7 +523,7 @@ async def test_live_select_connection_error(
     mock_wled.live.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        SELECT_DOMAIN,
+        Platform.SELECT,
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: "select.wled_rgb_light_live_override",

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.wled.const import DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -15,6 +15,7 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     STATE_UNKNOWN,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -34,7 +35,7 @@ async def test_sensors(
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         "aabbccddeeff_uptime",
         suggested_object_id="wled_rgb_light_uptime",
@@ -42,7 +43,7 @@ async def test_sensors(
     )
 
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         "aabbccddeeff_free_heap",
         suggested_object_id="wled_rgb_light_free_memory",
@@ -50,7 +51,7 @@ async def test_sensors(
     )
 
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         "aabbccddeeff_wifi_signal",
         suggested_object_id="wled_rgb_light_wifi_signal",
@@ -58,7 +59,7 @@ async def test_sensors(
     )
 
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         "aabbccddeeff_wifi_rssi",
         suggested_object_id="wled_rgb_light_wifi_rssi",
@@ -66,7 +67,7 @@ async def test_sensors(
     )
 
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         "aabbccddeeff_wifi_channel",
         suggested_object_id="wled_rgb_light_wifi_channel",
@@ -74,7 +75,7 @@ async def test_sensors(
     )
 
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         "aabbccddeeff_wifi_bssid",
         suggested_object_id="wled_rgb_light_wifi_bssid",
@@ -219,7 +220,7 @@ async def test_no_wifi_support(
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
-        SENSOR_DOMAIN,
+        Platform.SENSOR,
         DOMAIN,
         f"aabbccddeeff_wifi_{key}",
         suggested_object_id=f"wled_rgb_light_wifi_{key}",

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 from wled import Device as WLEDDevice, WLEDConnectionError, WLEDError
 
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.wled.const import (
     ATTR_DURATION,
     ATTR_FADE,
@@ -21,6 +20,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -89,7 +89,7 @@ async def test_switch_change_state(
 
     # Nightlight
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
         blocking=True,
@@ -99,7 +99,7 @@ async def test_switch_change_state(
     mock_wled.nightlight.assert_called_with(on=True)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
         blocking=True,
@@ -110,7 +110,7 @@ async def test_switch_change_state(
 
     # Sync send
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_send"},
         blocking=True,
@@ -120,7 +120,7 @@ async def test_switch_change_state(
     mock_wled.sync.assert_called_with(send=True)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_send"},
         blocking=True,
@@ -131,7 +131,7 @@ async def test_switch_change_state(
 
     # Sync receive
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_receive"},
         blocking=True,
@@ -141,7 +141,7 @@ async def test_switch_change_state(
     mock_wled.sync.assert_called_with(receive=False)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_sync_receive"},
         blocking=True,
@@ -151,7 +151,7 @@ async def test_switch_change_state(
     mock_wled.sync.assert_called_with(receive=True)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_reverse"},
         blocking=True,
@@ -161,7 +161,7 @@ async def test_switch_change_state(
     mock_wled.segment.assert_called_with(segment_id=0, reverse=True)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_reverse"},
         blocking=True,
@@ -181,7 +181,7 @@ async def test_switch_error(
     mock_wled.nightlight.side_effect = WLEDError
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
         blocking=True,
@@ -204,7 +204,7 @@ async def test_switch_connection_error(
     mock_wled.nightlight.side_effect = WLEDConnectionError
 
     await hass.services.async_call(
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: "switch.wled_rgb_light_nightlight"},
         blocking=True,

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     POWER_WATT,
     STATE_UNAVAILABLE,
     TEMP_CELSIUS,
+    Platform,
 )
 from homeassistant.helpers import entity_registry as er
 
@@ -245,7 +246,7 @@ async def test_reset_meter(
 
     # Test successful meter reset call
     await hass.services.async_call(
-        DOMAIN,
+        Platform.SENSOR,
         SERVICE_RESET_METER,
         {
             ATTR_ENTITY_ID: METER_ENERGY_SENSOR,

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -35,7 +35,6 @@ from homeassistant.const import (
     POWER_WATT,
     STATE_UNAVAILABLE,
     TEMP_CELSIUS,
-    Platform,
 )
 from homeassistant.helpers import entity_registry as er
 
@@ -246,7 +245,7 @@ async def test_reset_meter(
 
     # Test successful meter reset call
     await hass.services.async_call(
-        Platform.SENSOR,
+        DOMAIN,
         SERVICE_RESET_METER,
         {
             ATTR_ENTITY_ID: METER_ENERGY_SENSOR,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use platform enums in wled tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
