### PR TITLE
Use platform enums in unifi tests

### DIFF
--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -10,7 +10,6 @@ import aiounifi
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 import pytest
 
-from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_CONTROLLER,
     CONF_SITE_ID,
@@ -223,7 +222,7 @@ async def test_controller_setup(hass, aioclient_mock):
 
     entry = controller.config_entry
     assert len(forward_entry_setup.mock_calls) == len(PLATFORMS)
-    assert forward_entry_setup.mock_calls[0][1] == (entry, TRACKER_DOMAIN)
+    assert forward_entry_setup.mock_calls[0][1] == (entry, Platform.DEVICE_TRACKER)
     assert forward_entry_setup.mock_calls[1][1] == (entry, Platform.SENSOR)
     assert forward_entry_setup.mock_calls[2][1] == (entry, Platform.SWITCH)
 

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -11,8 +11,6 @@ from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 import pytest
 
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_CONTROLLER,
     CONF_SITE_ID,
@@ -40,6 +38,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONTENT_TYPE_JSON,
+    Platform,
 )
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
@@ -225,8 +224,8 @@ async def test_controller_setup(hass, aioclient_mock):
     entry = controller.config_entry
     assert len(forward_entry_setup.mock_calls) == len(PLATFORMS)
     assert forward_entry_setup.mock_calls[0][1] == (entry, TRACKER_DOMAIN)
-    assert forward_entry_setup.mock_calls[1][1] == (entry, SENSOR_DOMAIN)
-    assert forward_entry_setup.mock_calls[2][1] == (entry, SWITCH_DOMAIN)
+    assert forward_entry_setup.mock_calls[1][1] == (entry, Platform.SENSOR)
+    assert forward_entry_setup.mock_calls[2][1] == (entry, Platform.SWITCH)
 
     assert controller.host == CONTROLLER_DATA[CONF_HOST]
     assert controller.site == CONTROLLER_DATA[CONF_SITE_ID]

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -12,7 +12,6 @@ from aiounifi.controller import (
 from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 
 from homeassistant import config_entries
-from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
     CONF_IGNORE_WIRED_BUG,
@@ -22,7 +21,7 @@ from homeassistant.components.unifi.const import (
     CONF_TRACK_WIRED_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
 )
-from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE, Platform
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -35,7 +34,7 @@ async def test_no_entities(hass, aioclient_mock):
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(hass, aioclient_mock)
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 0
 
 
 async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websocket):
@@ -54,7 +53,7 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
     )
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
 
     # State change signalling works without events
@@ -208,7 +207,7 @@ async def test_tracked_clients(hass, aioclient_mock, mock_unifi_websocket):
         known_wireless_clients=(client_4["mac"],),
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 4
     assert hass.states.get("device_tracker.client_1").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.client_2").state == STATE_NOT_HOME
 
@@ -272,7 +271,7 @@ async def test_tracked_devices(hass, aioclient_mock, mock_unifi_websocket):
         devices_response=[device_1, device_2],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.device_1").state == STATE_HOME
     assert hass.states.get("device_tracker.device_2").state == STATE_NOT_HOME
 
@@ -378,7 +377,7 @@ async def test_remove_clients(hass, aioclient_mock, mock_unifi_websocket):
         hass, aioclient_mock, clients_response=[client_1, client_2]
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.client_1")
     assert hass.states.get("device_tracker.client_2")
 
@@ -393,7 +392,7 @@ async def test_remove_clients(hass, aioclient_mock, mock_unifi_websocket):
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert not hass.states.get("device_tracker.client_1")
     assert hass.states.get("device_tracker.client_2")
 
@@ -419,7 +418,7 @@ async def test_remove_client_but_keep_device_entry(
 
     entity_registry = er.async_get(hass)
     other_entity = entity_registry.async_get_or_create(
-        TRACKER_DOMAIN,
+        Platform.DEVICE_TRACKER,
         "other",
         "unique_id",
         device_id=device_entry.id,
@@ -435,7 +434,7 @@ async def test_remove_client_but_keep_device_entry(
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 0
 
     device_entry = device_registry.async_get(other_entity.device_id)
     assert len(device_entry.config_entries) == 1
@@ -475,7 +474,7 @@ async def test_controller_state_change(hass, aioclient_mock, mock_unifi_websocke
         devices_response=[device],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 
@@ -512,7 +511,7 @@ async def test_controller_state_change_client_to_listen_on_all_state_changes(
     )
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
     # Disconnected event
@@ -619,7 +618,7 @@ async def test_option_track_clients(hass, aioclient_mock):
         devices_response=[device],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 3
     assert hass.states.get("device_tracker.wireless_client")
     assert hass.states.get("device_tracker.wired_client")
     assert hass.states.get("device_tracker.device")
@@ -685,7 +684,7 @@ async def test_option_track_wired_clients(hass, aioclient_mock):
         devices_response=[device],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 3
     assert hass.states.get("device_tracker.wireless_client")
     assert hass.states.get("device_tracker.wired_client")
     assert hass.states.get("device_tracker.device")
@@ -741,7 +740,7 @@ async def test_option_track_devices(hass, aioclient_mock):
         devices_response=[device],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.client")
     assert hass.states.get("device_tracker.device")
 
@@ -790,7 +789,7 @@ async def test_option_ssid_filter(hass, aioclient_mock, mock_unifi_websocket):
     )
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
 
     assert hass.states.get("device_tracker.client").state == STATE_HOME
     assert hass.states.get("device_tracker.client_on_ssid2").state == STATE_NOT_HOME
@@ -916,7 +915,7 @@ async def test_wireless_client_go_wired_issue(
     )
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
 
     # Client is wireless
     client_state = hass.states.get("device_tracker.client")
@@ -998,7 +997,7 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock, mock_unifi_websocke
         clients_response=[client],
     )
     controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
 
     # Client is wireless
     client_state = hass.states.get("device_tracker.client")
@@ -1094,7 +1093,7 @@ async def test_restoring_client(hass, aioclient_mock):
 
     registry = er.async_get(hass)
     registry.async_get_or_create(
-        TRACKER_DOMAIN,
+        Platform.DEVICE_TRACKER,
         UNIFI_DOMAIN,
         f'{restored["mac"]}-site_id',
         suggested_object_id=restored["hostname"],
@@ -1109,7 +1108,7 @@ async def test_restoring_client(hass, aioclient_mock):
         clients_all_response=[restored, not_restored],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.client")
     assert hass.states.get("device_tracker.restored")
     assert not hass.states.get("device_tracker.not_restored")
@@ -1158,7 +1157,7 @@ async def test_dont_track_clients(hass, aioclient_mock):
         devices_response=[device],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert not hass.states.get("device_tracker.wireless_client")
     assert not hass.states.get("device_tracker.wired_client")
     assert hass.states.get("device_tracker.device")
@@ -1169,7 +1168,7 @@ async def test_dont_track_clients(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 3
     assert hass.states.get("device_tracker.wireless_client")
     assert hass.states.get("device_tracker.wired_client")
     assert hass.states.get("device_tracker.device")
@@ -1209,7 +1208,7 @@ async def test_dont_track_devices(hass, aioclient_mock):
         devices_response=[device],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert hass.states.get("device_tracker.client")
     assert not hass.states.get("device_tracker.device")
 
@@ -1219,7 +1218,7 @@ async def test_dont_track_devices(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.client")
     assert hass.states.get("device_tracker.device")
 
@@ -1247,7 +1246,7 @@ async def test_dont_track_wired_clients(hass, aioclient_mock):
         clients_response=[wireless_client, wired_client],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert hass.states.get("device_tracker.wireless_client")
     assert not hass.states.get("device_tracker.wired_client")
 
@@ -1257,6 +1256,6 @@ async def test_dont_track_wired_clients(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("device_tracker.wireless_client")
     assert hass.states.get("device_tracker.wired_client")

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 from aiounifi.controller import MESSAGE_CLIENT, MESSAGE_CLIENT_REMOVED
 import pytest
 
-from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_ALLOW_UPTIME_SENSORS,
@@ -298,7 +297,7 @@ async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
 
     assert len(hass.states.async_all()) == 9
     assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 6
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 2
     assert hass.states.get("sensor.wired_client_rx")
     assert hass.states.get("sensor.wired_client_tx")
     assert hass.states.get("sensor.wired_client_uptime")
@@ -318,7 +317,7 @@ async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
 
     assert len(hass.states.async_all()) == 5
     assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 3
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 1
     assert hass.states.get("sensor.wired_client_rx") is None
     assert hass.states.get("sensor.wired_client_tx") is None
     assert hass.states.get("sensor.wired_client_uptime") is None

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -7,7 +7,6 @@ from aiounifi.controller import MESSAGE_CLIENT, MESSAGE_CLIENT_REMOVED
 import pytest
 
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_ALLOW_UPTIME_SENSORS,
@@ -15,6 +14,7 @@ from homeassistant.components.unifi.const import (
     CONF_TRACK_DEVICES,
     DOMAIN as UNIFI_DOMAIN,
 )
+from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityCategory
@@ -34,7 +34,7 @@ async def test_no_clients(hass, aioclient_mock):
         },
     )
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 0
 
 
 async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
@@ -70,7 +70,7 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     )
 
     assert len(hass.states.async_all()) == 5
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 4
     assert hass.states.get("sensor.wired_client_rx").state == "1234.0"
     assert hass.states.get("sensor.wired_client_tx").state == "5678.0"
     assert hass.states.get("sensor.wireless_client_rx").state == "2345.0"
@@ -105,7 +105,7 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 0
     assert hass.states.get("sensor.wireless_client_rx") is None
     assert hass.states.get("sensor.wireless_client_tx") is None
     assert hass.states.get("sensor.wired_client_rx") is None
@@ -118,7 +118,7 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 5
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 4
     assert hass.states.get("sensor.wireless_client_rx")
     assert hass.states.get("sensor.wireless_client_tx")
     assert hass.states.get("sensor.wired_client_rx")
@@ -140,7 +140,7 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 5
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 4
 
 
 @pytest.mark.parametrize(
@@ -184,7 +184,7 @@ async def test_uptime_sensors(
         )
 
     assert len(hass.states.async_all()) == 2
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 1
     assert hass.states.get("sensor.client1_uptime").state == "2021-01-01T01:00:00+00:00"
 
     ent_reg = er.async_get(hass)
@@ -232,7 +232,7 @@ async def test_uptime_sensors(
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 0
     assert hass.states.get("sensor.client1_uptime") is None
 
     # Enable option
@@ -243,7 +243,7 @@ async def test_uptime_sensors(
         await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 2
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 1
     assert hass.states.get("sensor.client1_uptime")
 
     # Try to add the sensors again, using a signal
@@ -262,7 +262,7 @@ async def test_uptime_sensors(
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 2
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 1
 
 
 async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
@@ -297,7 +297,7 @@ async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
     )
 
     assert len(hass.states.async_all()) == 9
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 6
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
     assert hass.states.get("sensor.wired_client_rx")
     assert hass.states.get("sensor.wired_client_tx")
@@ -317,7 +317,7 @@ async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 5
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(Platform.SENSOR)) == 3
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
     assert hass.states.get("sensor.wired_client_rx") is None
     assert hass.states.get("sensor.wired_client_tx") is None

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from aiounifi.controller import MESSAGE_CLIENT_REMOVED, MESSAGE_EVENT
 
 from homeassistant import config_entries, core
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
     CONF_DPI_RESTRICTIONS,
@@ -416,7 +417,7 @@ async def test_switches(hass, aioclient_mock):
     )
 
     await hass.services.async_call(
-        Platform.SWITCH,
+        SWITCH_DOMAIN,
         "turn_off",
         {"entity_id": "switch.block_client_1"},
         blocking=True,
@@ -428,7 +429,7 @@ async def test_switches(hass, aioclient_mock):
     }
 
     await hass.services.async_call(
-        Platform.SWITCH,
+        SWITCH_DOMAIN,
         "turn_on",
         {"entity_id": "switch.block_client_1"},
         blocking=True,
@@ -446,7 +447,7 @@ async def test_switches(hass, aioclient_mock):
     )
 
     await hass.services.async_call(
-        Platform.SWITCH,
+        SWITCH_DOMAIN,
         "turn_off",
         {"entity_id": "switch.block_media_streaming"},
         blocking=True,
@@ -455,7 +456,7 @@ async def test_switches(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[12][2] == {"enabled": False}
 
     await hass.services.async_call(
-        Platform.SWITCH,
+        SWITCH_DOMAIN,
         "turn_on",
         {"entity_id": "switch.block_media_streaming"},
         blocking=True,
@@ -565,7 +566,7 @@ async def test_block_switches(hass, aioclient_mock, mock_unifi_websocket):
     )
 
     await hass.services.async_call(
-        Platform.SWITCH,
+        SWITCH_DOMAIN,
         "turn_off",
         {"entity_id": "switch.block_client_1"},
         blocking=True,
@@ -577,7 +578,7 @@ async def test_block_switches(hass, aioclient_mock, mock_unifi_websocket):
     }
 
     await hass.services.async_call(
-        Platform.SWITCH,
+        SWITCH_DOMAIN,
         "turn_on",
         {"entity_id": "switch.block_client_1"},
         blocking=True,
@@ -764,7 +765,7 @@ async def test_new_client_discovered_on_poe_control(
     )
 
     await hass.services.async_call(
-        Platform.SWITCH, "turn_off", {"entity_id": "switch.poe_client_1"}, blocking=True
+        SWITCH_DOMAIN, "turn_off", {"entity_id": "switch.poe_client_1"}, blocking=True
     )
     assert len(hass.states.async_entity_ids(Platform.SWITCH)) == 2
     assert aioclient_mock.call_count == 11
@@ -773,7 +774,7 @@ async def test_new_client_discovered_on_poe_control(
     }
 
     await hass.services.async_call(
-        Platform.SWITCH, "turn_on", {"entity_id": "switch.poe_client_1"}, blocking=True
+        SWITCH_DOMAIN, "turn_on", {"entity_id": "switch.poe_client_1"}, blocking=True
     )
     assert aioclient_mock.call_count == 12
     assert aioclient_mock.mock_calls[11][2] == {

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from aiounifi.controller import MESSAGE_CLIENT_REMOVED, MESSAGE_EVENT
 
 from homeassistant import config_entries, core
-from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
     CONF_DPI_RESTRICTIONS,
@@ -795,7 +794,7 @@ async def test_ignore_multiple_poe_clients_on_same_port(hass, aioclient_mock):
         devices_response=[DEVICE_1],
     )
 
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(Platform.DEVICE_TRACKER)) == 3
 
     switch_1 = hass.states.get("switch.poe_client_1")
     switch_2 = hass.states.get("switch.poe_client_2")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use platform enums in unifi

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
