### PR TITLE
Use platform enums in vacuum tests

### DIFF
--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -3,6 +3,7 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.vacuum import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
@@ -43,13 +44,13 @@ async def test_get_actions(hass, device_reg, entity_reg):
     )
     expected_actions = [
         {
-            "domain": Platform.VACUUM,
+            "domain": DOMAIN,
             "type": "clean",
             "device_id": device_entry.id,
             "entity_id": "vacuum.test_5678",
         },
         {
-            "domain": Platform.VACUUM,
+            "domain": DOMAIN,
             "type": "dock",
             "device_id": device_entry.id,
             "entity_id": "vacuum.test_5678",
@@ -71,7 +72,7 @@ async def test_action(hass):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event_dock"},
                     "action": {
-                        "domain": Platform.VACUUM,
+                        "domain": DOMAIN,
                         "device_id": "abcdefgh",
                         "entity_id": "vacuum.entity",
                         "type": "dock",
@@ -80,7 +81,7 @@ async def test_action(hass):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event_clean"},
                     "action": {
-                        "domain": Platform.VACUUM,
+                        "domain": DOMAIN,
                         "device_id": "abcdefgh",
                         "entity_id": "vacuum.entity",
                         "type": "clean",

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -3,7 +3,7 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.components.vacuum import DOMAIN
+from homeassistant.const import Platform
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 
@@ -38,16 +38,18 @@ async def test_get_actions(hass, device_reg, entity_reg):
         config_entry_id=config_entry.entry_id,
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    entity_reg.async_get_or_create(
+        Platform.VACUUM, "test", "5678", device_id=device_entry.id
+    )
     expected_actions = [
         {
-            "domain": DOMAIN,
+            "domain": Platform.VACUUM,
             "type": "clean",
             "device_id": device_entry.id,
             "entity_id": "vacuum.test_5678",
         },
         {
-            "domain": DOMAIN,
+            "domain": Platform.VACUUM,
             "type": "dock",
             "device_id": device_entry.id,
             "entity_id": "vacuum.test_5678",
@@ -69,7 +71,7 @@ async def test_action(hass):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event_dock"},
                     "action": {
-                        "domain": DOMAIN,
+                        "domain": Platform.VACUUM,
                         "device_id": "abcdefgh",
                         "entity_id": "vacuum.entity",
                         "type": "dock",
@@ -78,7 +80,7 @@ async def test_action(hass):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event_clean"},
                     "action": {
-                        "domain": DOMAIN,
+                        "domain": Platform.VACUUM,
                         "device_id": "abcdefgh",
                         "entity_id": "vacuum.entity",
                         "type": "clean",

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -7,6 +7,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import STATE_CLEANING, STATE_DOCKED
 from homeassistant.const import Platform
+from homeassistant.core import DOMAIN
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -56,14 +57,14 @@ async def test_get_triggers(hass, device_reg, entity_reg):
     expected_triggers = [
         {
             "platform": "device",
-            "domain": Platform.VACUUM,
+            "domain": DOMAIN,
             "type": "cleaning",
             "device_id": device_entry.id,
             "entity_id": f"{Platform.VACUUM}.test_5678",
         },
         {
             "platform": "device",
-            "domain": Platform.VACUUM,
+            "domain": DOMAIN,
             "type": "docked",
             "device_id": device_entry.id,
             "entity_id": f"{Platform.VACUUM}.test_5678",
@@ -114,7 +115,7 @@ async def test_if_fires_on_state_change(hass, calls):
                 {
                     "trigger": {
                         "platform": "device",
-                        "domain": Platform.VACUUM,
+                        "domain": DOMAIN,
                         "device_id": "",
                         "entity_id": "vacuum.entity",
                         "type": "cleaning",
@@ -133,7 +134,7 @@ async def test_if_fires_on_state_change(hass, calls):
                 {
                     "trigger": {
                         "platform": "device",
-                        "domain": Platform.VACUUM,
+                        "domain": DOMAIN,
                         "device_id": "",
                         "entity_id": "vacuum.entity",
                         "type": "docked",
@@ -183,7 +184,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
                 {
                     "trigger": {
                         "platform": "device",
-                        "domain": Platform.VACUUM,
+                        "domain": DOMAIN,
                         "device_id": "",
                         "entity_id": entity_id,
                         "type": "cleaning",

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -5,7 +5,8 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.components.vacuum import DOMAIN, STATE_CLEANING, STATE_DOCKED
+from homeassistant.components.vacuum import STATE_CLEANING, STATE_DOCKED
+from homeassistant.const import Platform
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -49,21 +50,23 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         config_entry_id=config_entry.entry_id,
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    entity_reg.async_get_or_create(
+        Platform.VACUUM, "test", "5678", device_id=device_entry.id
+    )
     expected_triggers = [
         {
             "platform": "device",
-            "domain": DOMAIN,
+            "domain": Platform.VACUUM,
             "type": "cleaning",
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": f"{Platform.VACUUM}.test_5678",
         },
         {
             "platform": "device",
-            "domain": DOMAIN,
+            "domain": Platform.VACUUM,
             "type": "docked",
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": f"{Platform.VACUUM}.test_5678",
         },
     ]
     triggers = await async_get_device_automations(
@@ -80,7 +83,9 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
         config_entry_id=config_entry.entry_id,
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    entity_reg.async_get_or_create(
+        Platform.VACUUM, "test", "5678", device_id=device_entry.id
+    )
 
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -109,7 +114,7 @@ async def test_if_fires_on_state_change(hass, calls):
                 {
                     "trigger": {
                         "platform": "device",
-                        "domain": DOMAIN,
+                        "domain": Platform.VACUUM,
                         "device_id": "",
                         "entity_id": "vacuum.entity",
                         "type": "cleaning",
@@ -128,7 +133,7 @@ async def test_if_fires_on_state_change(hass, calls):
                 {
                     "trigger": {
                         "platform": "device",
-                        "domain": DOMAIN,
+                        "domain": Platform.VACUUM,
                         "device_id": "",
                         "entity_id": "vacuum.entity",
                         "type": "docked",
@@ -167,7 +172,7 @@ async def test_if_fires_on_state_change(hass, calls):
 
 async def test_if_fires_on_state_change_with_for(hass, calls):
     """Test for triggers firing with delay."""
-    entity_id = f"{DOMAIN}.entity"
+    entity_id = f"{Platform.VACUUM}.entity"
     hass.states.async_set(entity_id, STATE_DOCKED)
 
     assert await async_setup_component(
@@ -178,7 +183,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
                 {
                     "trigger": {
                         "platform": "device",
-                        "domain": DOMAIN,
+                        "domain": Platform.VACUUM,
                         "device_id": "",
                         "entity_id": entity_id,
                         "type": "cleaning",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use platform enums in vacuum

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
