### PR TITLE
Use platform enums in plex tests

### DIFF
--- a/tests/components/plex/const.py
+++ b/tests/components/plex/const.py
@@ -1,5 +1,4 @@
 """Constants used by Plex tests."""
-from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.plex import const
 from homeassistant.const import (
     CONF_CLIENT_ID,
@@ -8,6 +7,7 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_URL,
     CONF_VERIFY_SSL,
+    Platform,
 )
 
 MOCK_SERVERS = [
@@ -55,7 +55,7 @@ SECONDARY_DATA = {
 }
 
 DEFAULT_OPTIONS = {
-    MP_DOMAIN: {
+    Platform.MEDIA_PLAYER: {
         const.CONF_IGNORE_NEW_SHARED_USERS: False,
         const.CONF_MONITORED_USERS: MOCK_USERS,
         const.CONF_USE_EPISODE_ART: False,

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -8,7 +8,6 @@ import plexapi.exceptions
 import pytest
 import requests.exceptions
 
-from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.plex import config_flow
 from homeassistant.components.plex.const import (
     AUTOMATIC_SETUP_STRING,
@@ -36,6 +35,7 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_URL,
     CONF_VERIFY_SSL,
+    Platform,
 )
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN, PLEX_DIRECT_URL
@@ -414,7 +414,7 @@ async def test_option_flow(hass, entry, mock_plex_server):
     )
     assert result["type"] == "create_entry"
     assert result["data"] == {
-        MP_DOMAIN: {
+        Platform.MEDIA_PLAYER: {
             CONF_USE_EPISODE_ART: True,
             CONF_IGNORE_NEW_SHARED_USERS: True,
             CONF_MONITORED_USERS: {
@@ -446,7 +446,7 @@ async def test_missing_option_flow(hass, entry, mock_plex_server):
     )
     assert result["type"] == "create_entry"
     assert result["data"] == {
-        MP_DOMAIN: {
+        Platform.MEDIA_PLAYER: {
             CONF_USE_EPISODE_ART: True,
             CONF_IGNORE_NEW_SHARED_USERS: True,
             CONF_MONITORED_USERS: {
@@ -460,7 +460,9 @@ async def test_missing_option_flow(hass, entry, mock_plex_server):
 async def test_option_flow_new_users_available(hass, entry, setup_plex_server):
     """Test config options multiselect defaults when new Plex users are seen."""
     OPTIONS_OWNER_ONLY = copy.deepcopy(DEFAULT_OPTIONS)
-    OPTIONS_OWNER_ONLY[MP_DOMAIN][CONF_MONITORED_USERS] = {"User 1": {"enabled": True}}
+    OPTIONS_OWNER_ONLY[Platform.MEDIA_PLAYER][CONF_MONITORED_USERS] = {
+        "User 1": {"enabled": True}
+    }
     entry.options = OPTIONS_OWNER_ONLY
 
     mock_plex_server = await setup_plex_server(config_entry=entry)

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -1,7 +1,7 @@
 """Tests for handling the device registry."""
 
-from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 from homeassistant.components.plex.const import DOMAIN
+from homeassistant.const import Platform
 
 
 async def test_cleanup_orphaned_devices(hass, entry, setup_plex_server):
@@ -18,7 +18,7 @@ async def test_cleanup_orphaned_devices(hass, entry, setup_plex_server):
     assert test_device is not None
 
     test_entity = entity_registry.async_get_or_create(
-        MP_DOMAIN, DOMAIN, "entity_unique_id_123", device_id=test_device.id
+        Platform.MEDIA_PLAYER, DOMAIN, "entity_unique_id_123", device_id=test_device.id
     )
     assert test_entity is not None
 
@@ -53,9 +53,9 @@ async def test_migrate_transient_devices(
         identifiers=plexweb_device_id,
         model="Plex Web",
     )
-    # plexweb_entity = entity_registry.async_get_or_create(MP_DOMAIN, DOMAIN, "unique_id_123:plexweb_id", suggested_object_id="plex_plex_web_chrome", device_id=plexweb_device.id)
+
     entity_registry.async_get_or_create(
-        MP_DOMAIN,
+        Platform.MEDIA_PLAYER,
         DOMAIN,
         "unique_id_123:plexweb_id",
         suggested_object_id="plex_plex_web_chrome",
@@ -68,7 +68,7 @@ async def test_migrate_transient_devices(
         model="Plex for Android (TV)",
     )
     entity_registry.async_get_or_create(
-        MP_DOMAIN,
+        Platform.MEDIA_PLAYER,
         DOMAIN,
         "unique_id_123:1234567890123456-com-plexapp-android",
         suggested_object_id="plex_plex_for_android_tv_shield_android_tv",

--- a/tests/components/plex/test_media_search.py
+++ b/tests/components/plex/test_media_search.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from plexapi.exceptions import BadRequest, NotFound
 import pytest
 
-from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
@@ -16,7 +15,7 @@ from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
 )
 from homeassistant.components.plex.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.exceptions import HomeAssistantError
 
 
@@ -30,7 +29,7 @@ async def test_media_lookups(
     requests_mock.get("/player/playback/playMedia", status_code=200)
 
     assert await hass.services.async_call(
-        MP_DOMAIN,
+        Platform.MEDIA_PLAYER,
         SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: media_player_id,
@@ -42,7 +41,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         with patch("plexapi.server.PlexServer.fetchItem", side_effect=NotFound):
             assert await hass.services.async_call(
-                MP_DOMAIN,
+                Platform.MEDIA_PLAYER,
                 SERVICE_PLAY_MEDIA,
                 {
                     ATTR_ENTITY_ID: media_player_id,
@@ -57,7 +56,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         payload = '{"library_name": "Not a Library", "show_name": "TV Show"}'
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -70,7 +69,7 @@ async def test_media_lookups(
 
     with patch("plexapi.library.LibrarySection.search") as search:
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -82,7 +81,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"show.title": "TV Show", "libtype": "show"})
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -96,7 +95,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -110,7 +109,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -129,7 +128,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -141,7 +140,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"artist.title": "Artist", "libtype": "artist"})
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -153,7 +152,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"album.title": "Album", "libtype": "album"})
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -167,7 +166,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -181,7 +180,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -200,7 +199,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -220,7 +219,7 @@ async def test_media_lookups(
 
         # Movie searches
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -232,7 +231,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"movie.title": "Movie 1", "libtype": None})
 
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -248,7 +247,7 @@ async def test_media_lookups(
         payload = '{"library_name": "Movies", "title": "Not a Movie"}'
         with patch("plexapi.library.LibrarySection.search", side_effect=BadRequest):
             assert await hass.services.async_call(
-                MP_DOMAIN,
+                Platform.MEDIA_PLAYER,
                 SERVICE_PLAY_MEDIA,
                 {
                     ATTR_ENTITY_ID: media_player_id,
@@ -262,7 +261,7 @@ async def test_media_lookups(
 
     # Playlist searches
     assert await hass.services.async_call(
-        MP_DOMAIN,
+        Platform.MEDIA_PLAYER,
         SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: media_player_id,
@@ -275,7 +274,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         payload = '{"playlist_name": "Not a Playlist"}'
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -290,7 +289,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         payload = "{}"
         assert await hass.services.async_call(
-            MP_DOMAIN,
+            Platform.MEDIA_PLAYER,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,

--- a/tests/components/plex/test_server.py
+++ b/tests/components/plex/test_server.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from requests.exceptions import ConnectionError, RequestException
 
-from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.plex.const import (
     CONF_IGNORE_NEW_SHARED_USERS,
     CONF_IGNORE_PLEX_WEB_CLIENTS,
@@ -13,6 +12,7 @@ from homeassistant.components.plex.const import (
     DOMAIN,
     SERVERS,
 )
+from homeassistant.const import Platform
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS
 from .helpers import trigger_plex_update, wait_for_debouncer
@@ -22,7 +22,7 @@ async def test_new_users_available(hass, entry, setup_plex_server):
     """Test setting up when new users available on Plex server."""
     MONITORED_USERS = {"User 1": {"enabled": True}}
     OPTIONS_WITH_USERS = copy.deepcopy(DEFAULT_OPTIONS)
-    OPTIONS_WITH_USERS[MP_DOMAIN][CONF_MONITORED_USERS] = MONITORED_USERS
+    OPTIONS_WITH_USERS[Platform.MEDIA_PLAYER][CONF_MONITORED_USERS] = MONITORED_USERS
     entry.options = OPTIONS_WITH_USERS
 
     mock_plex_server = await setup_plex_server(config_entry=entry)
@@ -48,8 +48,8 @@ async def test_new_ignored_users_available(
     """Test setting up when new users available on Plex server but are ignored."""
     MONITORED_USERS = {"User 1": {"enabled": True}}
     OPTIONS_WITH_USERS = copy.deepcopy(DEFAULT_OPTIONS)
-    OPTIONS_WITH_USERS[MP_DOMAIN][CONF_MONITORED_USERS] = MONITORED_USERS
-    OPTIONS_WITH_USERS[MP_DOMAIN][CONF_IGNORE_NEW_SHARED_USERS] = True
+    OPTIONS_WITH_USERS[Platform.MEDIA_PLAYER][CONF_MONITORED_USERS] = MONITORED_USERS
+    OPTIONS_WITH_USERS[Platform.MEDIA_PLAYER][CONF_IGNORE_NEW_SHARED_USERS] = True
     entry.options = OPTIONS_WITH_USERS
 
     mock_plex_server = await setup_plex_server(config_entry=entry)
@@ -151,7 +151,7 @@ async def test_mark_sessions_idle(
 async def test_ignore_plex_web_client(hass, entry, setup_plex_server):
     """Test option to ignore Plex Web clients."""
     OPTIONS = copy.deepcopy(DEFAULT_OPTIONS)
-    OPTIONS[MP_DOMAIN][CONF_IGNORE_PLEX_WEB_CLIENTS] = True
+    OPTIONS[Platform.MEDIA_PLAYER][CONF_IGNORE_PLEX_WEB_CLIENTS] = True
     entry.options = OPTIONS
 
     mock_plex_server = await setup_plex_server(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use platform enums in plex tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
