### PR TITLE
Use platform enums in rest tests

### DIFF
--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -8,7 +8,7 @@ import httpx
 import respx
 
 from homeassistant import config as hass_config
-from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    Platform,
 )
 from homeassistant.setup import async_setup_component
 
@@ -26,7 +27,7 @@ from tests.common import get_fixture_path
 async def test_setup_missing_basic_config(hass):
     """Test setup with configuration missing required entries."""
     assert await async_setup_component(
-        hass, DOMAIN, {"binary_sensor": {"platform": "rest"}}
+        hass, Platform.BINARY_SENSOR, {"binary_sensor": {"platform": "rest"}}
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all("binary_sensor")) == 0
@@ -36,7 +37,7 @@ async def test_setup_missing_config(hass):
     """Test setup with configuration missing required entries."""
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",
@@ -58,7 +59,7 @@ async def test_setup_failed_connect(hass, caplog):
     )
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",
@@ -78,7 +79,7 @@ async def test_setup_timeout(hass):
     respx.get("http://localhost").mock(side_effect=asyncio.TimeoutError())
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",
@@ -97,7 +98,7 @@ async def test_setup_minimum(hass):
     respx.get("http://localhost") % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",
@@ -116,7 +117,7 @@ async def test_setup_minimum_resource_template(hass):
     respx.get("http://localhost") % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",
@@ -134,7 +135,7 @@ async def test_setup_duplicate_resource_template(hass):
     respx.get("http://localhost") % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",
@@ -418,7 +419,7 @@ async def test_setup_query_params(hass):
     respx.get("http://localhost", params={"search": "something"}) % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        DOMAIN,
+        Platform.BINARY_SENSOR,
         {
             "binary_sensor": {
                 "platform": "rest",

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from homeassistant.components.rest import DOMAIN
 import homeassistant.components.rest.switch as rest
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchDeviceClass
+from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import (
     CONF_HEADERS,
     CONF_NAME,
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_RESOURCE,
     CONTENT_TYPE_JSON,
+    Platform,
 )
 from homeassistant.helpers.template import Template
 from homeassistant.setup import async_setup_component
@@ -68,12 +69,12 @@ async def test_setup_timeout(hass, aioclient_mock):
 async def test_setup_minimum(hass, aioclient_mock):
     """Test setup with minimum configuration."""
     aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
-    with assert_setup_component(1, SWITCH_DOMAIN):
+    with assert_setup_component(1, Platform.SWITCH):
         assert await async_setup_component(
             hass,
-            SWITCH_DOMAIN,
+            Platform.SWITCH,
             {
-                SWITCH_DOMAIN: {
+                Platform.SWITCH: {
                     CONF_PLATFORM: DOMAIN,
                     CONF_RESOURCE: "http://localhost",
                 }
@@ -86,12 +87,12 @@ async def test_setup_minimum(hass, aioclient_mock):
 async def test_setup_query_params(hass, aioclient_mock):
     """Test setup with query params."""
     aioclient_mock.get("http://localhost/?search=something", status=HTTPStatus.OK)
-    with assert_setup_component(1, SWITCH_DOMAIN):
+    with assert_setup_component(1, Platform.SWITCH):
         assert await async_setup_component(
             hass,
-            SWITCH_DOMAIN,
+            Platform.SWITCH,
             {
-                SWITCH_DOMAIN: {
+                Platform.SWITCH: {
                     CONF_PLATFORM: DOMAIN,
                     CONF_RESOURCE: "http://localhost",
                     CONF_PARAMS: {"search": "something"},
@@ -109,9 +110,9 @@ async def test_setup(hass, aioclient_mock):
     aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
     assert await async_setup_component(
         hass,
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         {
-            SWITCH_DOMAIN: {
+            Platform.SWITCH: {
                 CONF_PLATFORM: DOMAIN,
                 CONF_NAME: "foo",
                 CONF_RESOURCE: "http://localhost",
@@ -123,7 +124,7 @@ async def test_setup(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
-    assert_setup_component(1, SWITCH_DOMAIN)
+    assert_setup_component(1, Platform.SWITCH)
 
 
 async def test_setup_with_state_resource(hass, aioclient_mock):
@@ -132,9 +133,9 @@ async def test_setup_with_state_resource(hass, aioclient_mock):
     aioclient_mock.get("http://localhost/state", status=HTTPStatus.OK)
     assert await async_setup_component(
         hass,
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         {
-            SWITCH_DOMAIN: {
+            Platform.SWITCH: {
                 CONF_PLATFORM: DOMAIN,
                 CONF_NAME: "foo",
                 CONF_RESOURCE: "http://localhost",
@@ -147,7 +148,7 @@ async def test_setup_with_state_resource(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
-    assert_setup_component(1, SWITCH_DOMAIN)
+    assert_setup_component(1, Platform.SWITCH)
 
 
 async def test_setup_with_templated_headers_params(hass, aioclient_mock):
@@ -155,9 +156,9 @@ async def test_setup_with_templated_headers_params(hass, aioclient_mock):
     aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
     assert await async_setup_component(
         hass,
-        SWITCH_DOMAIN,
+        Platform.SWITCH,
         {
-            SWITCH_DOMAIN: {
+            Platform.SWITCH: {
                 CONF_PLATFORM: DOMAIN,
                 CONF_NAME: "foo",
                 CONF_RESOURCE: "http://localhost",
@@ -178,7 +179,7 @@ async def test_setup_with_templated_headers_params(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[-1][3].get("User-Agent") == "Mozilla/5.0"
     assert aioclient_mock.mock_calls[-1][1].query["start"] == "0"
     assert aioclient_mock.mock_calls[-1][1].query["end"] == "5"
-    assert_setup_component(1, SWITCH_DOMAIN)
+    assert_setup_component(1, Platform.SWITCH)
 
 
 """Tests for REST switch platform."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use platform enums in rest tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
