### PR TITLE
Use platform enums in ring tests

### DIFF
--- a/tests/components/ring/test_light.py
+++ b/tests/components/ring/test_light.py
@@ -1,5 +1,5 @@
 """The tests for the Ring light platform."""
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
@@ -9,7 +9,7 @@ from tests.common import load_fixture
 
 async def test_entity_registry(hass, requests_mock):
     """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, LIGHT_DOMAIN)
+    await setup_platform(hass, Platform.LIGHT)
     entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("light.front_light")
@@ -21,7 +21,7 @@ async def test_entity_registry(hass, requests_mock):
 
 async def test_light_off_reports_correctly(hass, requests_mock):
     """Tests that the initial state of a device that should be off is correct."""
-    await setup_platform(hass, LIGHT_DOMAIN)
+    await setup_platform(hass, Platform.LIGHT)
 
     state = hass.states.get("light.front_light")
     assert state.state == "off"
@@ -30,7 +30,7 @@ async def test_light_off_reports_correctly(hass, requests_mock):
 
 async def test_light_on_reports_correctly(hass, requests_mock):
     """Tests that the initial state of a device that should be on is correct."""
-    await setup_platform(hass, LIGHT_DOMAIN)
+    await setup_platform(hass, Platform.LIGHT)
 
     state = hass.states.get("light.internal_light")
     assert state.state == "on"
@@ -39,7 +39,7 @@ async def test_light_on_reports_correctly(hass, requests_mock):
 
 async def test_light_can_be_turned_on(hass, requests_mock):
     """Tests the light turns on correctly."""
-    await setup_platform(hass, LIGHT_DOMAIN)
+    await setup_platform(hass, Platform.LIGHT)
 
     # Mocks the response for turning a light on
     requests_mock.put(
@@ -61,7 +61,7 @@ async def test_light_can_be_turned_on(hass, requests_mock):
 
 async def test_updates_work(hass, requests_mock):
     """Tests the update service works correctly."""
-    await setup_platform(hass, LIGHT_DOMAIN)
+    await setup_platform(hass, Platform.LIGHT)
     state = hass.states.get("light.front_light")
     assert state.state == "off"
     # Changes the return to indicate that the light is now on.

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -1,5 +1,5 @@
 """The tests for the Ring switch platform."""
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
@@ -9,7 +9,7 @@ from tests.common import load_fixture
 
 async def test_entity_registry(hass, requests_mock):
     """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, SWITCH_DOMAIN)
+    await setup_platform(hass, Platform.SWITCH)
     entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("switch.front_siren")
@@ -21,7 +21,7 @@ async def test_entity_registry(hass, requests_mock):
 
 async def test_siren_off_reports_correctly(hass, requests_mock):
     """Tests that the initial state of a device that should be off is correct."""
-    await setup_platform(hass, SWITCH_DOMAIN)
+    await setup_platform(hass, Platform.SWITCH)
 
     state = hass.states.get("switch.front_siren")
     assert state.state == "off"
@@ -30,7 +30,7 @@ async def test_siren_off_reports_correctly(hass, requests_mock):
 
 async def test_siren_on_reports_correctly(hass, requests_mock):
     """Tests that the initial state of a device that should be on is correct."""
-    await setup_platform(hass, SWITCH_DOMAIN)
+    await setup_platform(hass, Platform.SWITCH)
 
     state = hass.states.get("switch.internal_siren")
     assert state.state == "on"
@@ -40,7 +40,7 @@ async def test_siren_on_reports_correctly(hass, requests_mock):
 
 async def test_siren_can_be_turned_on(hass, requests_mock):
     """Tests the siren turns on correctly."""
-    await setup_platform(hass, SWITCH_DOMAIN)
+    await setup_platform(hass, Platform.SWITCH)
 
     # Mocks the response for turning a siren on
     requests_mock.put(
@@ -62,7 +62,7 @@ async def test_siren_can_be_turned_on(hass, requests_mock):
 
 async def test_updates_work(hass, requests_mock):
     """Tests the update service works correctly."""
-    await setup_platform(hass, SWITCH_DOMAIN)
+    await setup_platform(hass, Platform.SWITCH)
     state = hass.states.get("switch.front_siren")
     assert state.state == "off"
     # Changes the return to indicate that the siren is now on.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use platform enums in ring tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
