### PR TITLE
Add strict typing to Luftdaten

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -78,6 +78,7 @@ homeassistant.components.light.*
 homeassistant.components.local_ip.*
 homeassistant.components.lock.*
 homeassistant.components.lookin.*
+homeassistant.components.luftdaten.*
 homeassistant.components.mailbox.*
 homeassistant.components.media_player.*
 homeassistant.components.modbus.*

--- a/homeassistant/components/luftdaten/__init__.py
+++ b/homeassistant/components/luftdaten/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     luftdaten = Luftdaten(entry.data[CONF_SENSOR_ID])
 
-    async def async_update() -> dict[Any, Any]:
+    async def async_update() -> dict[str, float | int]:
         """Update sensor/binary sensor data."""
         try:
             await luftdaten.get_data()
@@ -43,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not luftdaten.values:
             raise UpdateFailed("Did not receive sensor data from luftdaten.info")
 
-        data = luftdaten.values
+        data: dict[str, float | int] = luftdaten.values
         data.update(luftdaten.meta)
         return data
 

--- a/homeassistant/components/luftdaten/config_flow.py
+++ b/homeassistant/components/luftdaten/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow to configure the Luftdaten component."""
-from collections import OrderedDict
+from __future__ import annotations
+
+from typing import Any
 
 from luftdaten import Luftdaten
 from luftdaten.exceptions import LuftdatenConnectionError
@@ -13,6 +15,7 @@ from homeassistant.const import (
     CONF_SHOW_ON_MAP,
 )
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
 from .const import CONF_SENSOR_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -24,17 +27,22 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     @callback
-    def _show_form(self, errors=None):
+    def _show_form(self, errors: dict[str, str] | None = None) -> FlowResult:
         """Show the form to the user."""
-        data_schema = OrderedDict()
-        data_schema[vol.Required(CONF_SENSOR_ID)] = cv.positive_int
-        data_schema[vol.Optional(CONF_SHOW_ON_MAP, default=False)] = bool
-
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {}
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SENSOR_ID): cv.positive_int,
+                    vol.Optional(CONF_SHOW_ON_MAP, default=False): bool,
+                }
+            ),
+            errors=errors or {},
         )
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the start of the config flow."""
 
         if not user_input:

--- a/homeassistant/components/luftdaten/sensor.py
+++ b/homeassistant/components/luftdaten/sensor.py
@@ -1,6 +1,8 @@
 """Support for Luftdaten sensors."""
 from __future__ import annotations
 
+from typing import cast
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -131,4 +133,4 @@ class LuftdatenSensor(CoordinatorEntity, SensorEntity):
             or (value := self.coordinator.data.get(self.entity_description.key)) is None
         ):
             return None
-        return value
+        return cast(float, value)

--- a/mypy.ini
+++ b/mypy.ini
@@ -869,6 +869,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.luftdaten.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.mailbox.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -1917,9 +1928,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.lovelace.*]
-ignore_errors = true
-
-[mypy-homeassistant.components.luftdaten.*]
 ignore_errors = true
 
 [mypy-homeassistant.components.lutron_caseta.*]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -67,7 +67,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.litejet.*",
     "homeassistant.components.litterrobot.*",
     "homeassistant.components.lovelace.*",
-    "homeassistant.components.luftdaten.*",
     "homeassistant.components.lutron_caseta.*",
     "homeassistant.components.lyric.*",
     "homeassistant.components.melcloud.*",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Strictly type the luftdaten integration.

Note: It might trigger config flow coverage warnings, as this integration never had a 100% coverage. I plan to improve that in the following PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
