### PR TITLE
Improve config flow Luftdaten

### DIFF
--- a/homeassistant/components/luftdaten/config_flow.py
+++ b/homeassistant/components/luftdaten/config_flow.py
@@ -8,17 +8,12 @@ from luftdaten.exceptions import LuftdatenConnectionError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL,
-    CONF_SENSORS,
-    CONF_SHOW_ON_MAP,
-)
+from homeassistant.const import CONF_SHOW_ON_MAP
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_SENSOR_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import CONF_SENSOR_ID, DOMAIN
 
 
 class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -44,8 +39,7 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the start of the config flow."""
-
-        if not user_input:
+        if user_input is None:
             return self._show_form()
 
         await self.async_set_unique_id(str(user_input[CONF_SENSOR_ID]))
@@ -60,18 +54,6 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not valid:
             return self._show_form({CONF_SENSOR_ID: "invalid_sensor"})
-
-        available_sensors = [
-            x for x, x_values in luftdaten.values.items() if x_values is not None
-        ]
-
-        if available_sensors:
-            user_input.update(
-                {CONF_SENSORS: {CONF_MONITORED_CONDITIONS: available_sensors}}
-            )
-
-        scan_interval = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        user_input.update({CONF_SCAN_INTERVAL: scan_interval.total_seconds()})
 
         return self.async_create_entry(
             title=str(user_input[CONF_SENSOR_ID]), data=user_input

--- a/tests/components/luftdaten/test_config_flow.py
+++ b/tests/components/luftdaten/test_config_flow.py
@@ -6,7 +6,7 @@ from luftdaten.exceptions import LuftdatenConnectionError
 from homeassistant.components.luftdaten import DOMAIN
 from homeassistant.components.luftdaten.const import CONF_SENSOR_ID
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_SCAN_INTERVAL, CONF_SHOW_ON_MAP
+from homeassistant.const import CONF_SHOW_ON_MAP
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -60,6 +60,21 @@ async def test_communication_error(hass: HomeAssistant) -> None:
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "cannot_connect"}
 
+    with patch("luftdaten.Luftdaten.get_data", return_value=True), patch(
+        "luftdaten.Luftdaten.validate_sensor", return_value=True
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            user_input={CONF_SENSOR_ID: 12345},
+        )
+
+    assert result3.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result3.get("title") == "12345"
+    assert result3.get("data") == {
+        CONF_SENSOR_ID: 12345,
+        CONF_SHOW_ON_MAP: False,
+    }
+
 
 async def test_invalid_sensor(hass: HomeAssistant) -> None:
     """Test that an invalid sensor throws an error."""
@@ -82,6 +97,22 @@ async def test_invalid_sensor(hass: HomeAssistant) -> None:
     assert result2.get("type") == RESULT_TYPE_FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "invalid_sensor"}
+    assert "flow_id" in result2
+
+    with patch("luftdaten.Luftdaten.get_data", return_value=True), patch(
+        "luftdaten.Luftdaten.validate_sensor", return_value=True
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            user_input={CONF_SENSOR_ID: 12345},
+        )
+
+    assert result3.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result3.get("title") == "12345"
+    assert result3.get("data") == {
+        CONF_SENSOR_ID: 12345,
+        CONF_SHOW_ON_MAP: False,
+    }
 
 
 async def test_step_user(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
@@ -101,7 +132,7 @@ async def test_step_user(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
             result["flow_id"],
             user_input={
                 CONF_SENSOR_ID: 12345,
-                CONF_SHOW_ON_MAP: False,
+                CONF_SHOW_ON_MAP: True,
             },
         )
 
@@ -109,6 +140,5 @@ async def test_step_user(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
     assert result2.get("title") == "12345"
     assert result2.get("data") == {
         CONF_SENSOR_ID: 12345,
-        CONF_SHOW_ON_MAP: False,
-        CONF_SCAN_INTERVAL: 600.0,
+        CONF_SHOW_ON_MAP: True,
     }

--- a/tests/components/luftdaten/test_config_flow.py
+++ b/tests/components/luftdaten/test_config_flow.py
@@ -60,7 +60,7 @@ async def test_communication_error(hass: HomeAssistant) -> None:
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "cannot_connect"}
 
-    with patch("luftdaten.Luftdaten.get_data", return_value=True), patch(
+    with patch("luftdaten.Luftdaten.get_data"), patch(
         "luftdaten.Luftdaten.validate_sensor", return_value=True
     ):
         result3 = await hass.config_entries.flow.async_configure(
@@ -99,7 +99,7 @@ async def test_invalid_sensor(hass: HomeAssistant) -> None:
     assert result2.get("errors") == {CONF_SENSOR_ID: "invalid_sensor"}
     assert "flow_id" in result2
 
-    with patch("luftdaten.Luftdaten.get_data", return_value=True), patch(
+    with patch("luftdaten.Luftdaten.get_data"), patch(
         "luftdaten.Luftdaten.validate_sensor", return_value=True
     ):
         result3 = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves the luftdaten config flow.

- Removes unused monitored conditions and scan interval parameters from the flow and adjusts the tests for that.
- Extends tests on the flow a little to improve coverage and cover scenarios when a user recovers during a flow error.

This brings the coverage of the config flow to 100%

```
----------- coverage: platform linux, python 3.9.9-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
homeassistant/components/luftdaten/config_flow.py      30      0   100%
homeassistant/components/luftdaten/const.py             5      0   100%
---------------------------------------------------------------------------------
TOTAL                                                  35      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
