### PR TITLE
Add base integration tests to Luftdaten

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -607,7 +607,6 @@ omit =
     homeassistant/components/lookin/climate.py
     homeassistant/components/lookin/media_player.py
     homeassistant/components/luci/device_tracker.py
-    homeassistant/components/luftdaten/__init__.py
     homeassistant/components/luftdaten/sensor.py
     homeassistant/components/lupusec/*
     homeassistant/components/lutron/*

--- a/homeassistant/components/luftdaten/__init__.py
+++ b/homeassistant/components/luftdaten/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # For backwards compat, set unique ID
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(
-            entry, unique_id=entry.data[CONF_SENSOR_ID]
+            entry, unique_id=str(entry.data[CONF_SENSOR_ID])
         )
 
     luftdaten = Luftdaten(entry.data[CONF_SENSOR_ID])

--- a/tests/components/luftdaten/conftest.py
+++ b/tests/components/luftdaten/conftest.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.luftdaten import DOMAIN
-from homeassistant.components.luftdaten.const import CONF_SENSOR_ID
+from homeassistant.components.luftdaten.const import CONF_SENSOR_ID, DOMAIN
+from homeassistant.const import CONF_SHOW_ON_MAP
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -18,7 +19,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         title="12345",
         domain=DOMAIN,
-        data={CONF_SENSOR_ID: 123456},
+        data={CONF_SENSOR_ID: 12345, CONF_SHOW_ON_MAP: True},
         unique_id="12345",
     )
 
@@ -30,3 +31,52 @@ def mock_setup_entry() -> Generator[None, None, None]:
         "homeassistant.components.luftdaten.async_setup_entry", return_value=True
     ):
         yield
+
+
+@pytest.fixture
+def mock_luftdaten_config_flow() -> Generator[None, MagicMock, None]:
+    """Return a mocked Luftdaten client."""
+    with patch(
+        "homeassistant.components.luftdaten.config_flow.Luftdaten", autospec=True
+    ) as luftdaten_mock:
+        luftdaten = luftdaten_mock.return_value
+        luftdaten.validate_sensor.return_value = True
+        yield luftdaten
+
+
+@pytest.fixture
+def mock_luftdaten() -> Generator[None, MagicMock, None]:
+    """Return a mocked Luftdaten client."""
+    with patch(
+        "homeassistant.components.luftdaten.Luftdaten", autospec=True
+    ) as luftdaten_mock:
+        luftdaten = luftdaten_mock.return_value
+        luftdaten.sensor_id = 12345
+        luftdaten.meta = {
+            "altitude": 123.456,
+            "latitude": 56.789,
+            "longitude": 12.345,
+            "sensor_id": 12345,
+        }
+        luftdaten.values = {
+            "humidity": 34.70,
+            "P1": 8.5,
+            "P2": 4.07,
+            "pressure_at_sea_level": 103102.13,
+            "pressure": 98545.00,
+            "temperature": 22.30,
+        }
+        yield luftdaten
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_luftdaten: MagicMock
+) -> MockConfigEntry:
+    """Set up the Luftdaten integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/luftdaten/test_config_flow.py
+++ b/tests/components/luftdaten/test_config_flow.py
@@ -1,5 +1,5 @@
 """Define tests for the Luftdaten config flow."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from luftdaten.exceptions import LuftdatenConnectionError
 
@@ -40,7 +40,9 @@ async def test_duplicate_error(
     assert result2.get("reason") == "already_configured"
 
 
-async def test_communication_error(hass: HomeAssistant) -> None:
+async def test_communication_error(
+    hass: HomeAssistant, mock_luftdaten_config_flow: MagicMock
+) -> None:
     """Test that no sensor is added while unable to communicate with API."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -50,23 +52,22 @@ async def test_communication_error(hass: HomeAssistant) -> None:
     assert result.get("step_id") == SOURCE_USER
     assert "flow_id" in result
 
-    with patch("luftdaten.Luftdaten.get_data", side_effect=LuftdatenConnectionError):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_SENSOR_ID: 12345},
-        )
+    mock_luftdaten_config_flow.get_data.side_effect = LuftdatenConnectionError
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_SENSOR_ID: 12345},
+    )
 
     assert result2.get("type") == RESULT_TYPE_FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "cannot_connect"}
+    assert "flow_id" in result2
 
-    with patch("luftdaten.Luftdaten.get_data"), patch(
-        "luftdaten.Luftdaten.validate_sensor", return_value=True
-    ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            user_input={CONF_SENSOR_ID: 12345},
-        )
+    mock_luftdaten_config_flow.get_data.side_effect = None
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        user_input={CONF_SENSOR_ID: 12345},
+    )
 
     assert result3.get("type") == RESULT_TYPE_CREATE_ENTRY
     assert result3.get("title") == "12345"
@@ -76,7 +77,9 @@ async def test_communication_error(hass: HomeAssistant) -> None:
     }
 
 
-async def test_invalid_sensor(hass: HomeAssistant) -> None:
+async def test_invalid_sensor(
+    hass: HomeAssistant, mock_luftdaten_config_flow: MagicMock
+) -> None:
     """Test that an invalid sensor throws an error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -86,26 +89,22 @@ async def test_invalid_sensor(hass: HomeAssistant) -> None:
     assert result.get("step_id") == SOURCE_USER
     assert "flow_id" in result
 
-    with patch("luftdaten.Luftdaten.get_data", return_value=False), patch(
-        "luftdaten.Luftdaten.validate_sensor", return_value=False
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_SENSOR_ID: 12345},
-        )
+    mock_luftdaten_config_flow.validate_sensor.return_value = False
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_SENSOR_ID: 11111},
+    )
 
     assert result2.get("type") == RESULT_TYPE_FORM
     assert result2.get("step_id") == SOURCE_USER
     assert result2.get("errors") == {CONF_SENSOR_ID: "invalid_sensor"}
     assert "flow_id" in result2
 
-    with patch("luftdaten.Luftdaten.get_data"), patch(
-        "luftdaten.Luftdaten.validate_sensor", return_value=True
-    ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            user_input={CONF_SENSOR_ID: 12345},
-        )
+    mock_luftdaten_config_flow.validate_sensor.return_value = True
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        user_input={CONF_SENSOR_ID: 12345},
+    )
 
     assert result3.get("type") == RESULT_TYPE_CREATE_ENTRY
     assert result3.get("title") == "12345"
@@ -115,7 +114,11 @@ async def test_invalid_sensor(hass: HomeAssistant) -> None:
     }
 
 
-async def test_step_user(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
+async def test_step_user(
+    hass: HomeAssistant,
+    mock_setup_entry: MagicMock,
+    mock_luftdaten_config_flow: MagicMock,
+) -> None:
     """Test that the user step works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -125,16 +128,13 @@ async def test_step_user(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
     assert result.get("step_id") == SOURCE_USER
     assert "flow_id" in result
 
-    with patch("luftdaten.Luftdaten.get_data", return_value=True), patch(
-        "luftdaten.Luftdaten.validate_sensor", return_value=True
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_SENSOR_ID: 12345,
-                CONF_SHOW_ON_MAP: True,
-            },
-        )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SENSOR_ID: 12345,
+            CONF_SHOW_ON_MAP: True,
+        },
+    )
 
     assert result2.get("type") == RESULT_TYPE_CREATE_ENTRY
     assert result2.get("title") == "12345"

--- a/tests/components/luftdaten/test_init.py
+++ b/tests/components/luftdaten/test_init.py
@@ -1,0 +1,75 @@
+"""Tests for the Luftdaten integration."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from luftdaten.exceptions import LuftdatenError
+
+from homeassistant.components.luftdaten.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_luftdaten: AsyncMock,
+) -> None:
+    """Test the Luftdaten configuration entry loading/unloading."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.data.get(DOMAIN)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@patch(
+    "homeassistant.components.luftdaten.Luftdaten.get_data",
+    side_effect=LuftdatenError,
+)
+async def test_config_entry_not_ready(
+    mock_get_data: MagicMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the Luftdaten configuration entry not ready."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_get_data.call_count == 1
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_config_entry_not_ready_no_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_luftdaten: MagicMock,
+) -> None:
+    """Test the Luftdaten configuration entry not ready."""
+    mock_luftdaten.values = {}
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_luftdaten.get_data.assert_called()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setting_unique_id(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_luftdaten: MagicMock
+) -> None:
+    """Test we set unique ID if not set yet."""
+    mock_config_entry.unique_id = None
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.unique_id == "12345"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds basic tests and tests fixtures for Luftdaten.

```text
----------- coverage: platform linux, python 3.9.9-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
homeassistant/components/luftdaten/__init__.py         38      0   100%
homeassistant/components/luftdaten/config_flow.py      30      0   100%
homeassistant/components/luftdaten/const.py             5      0   100%
---------------------------------------------------------------------------------
TOTAL                                                  73      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
