### PR TITLE
Allow generic camera conf without still_image_url

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -1,7 +1,6 @@
 """Support for IP Cameras."""
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import httpx
@@ -120,14 +119,6 @@ class GenericCamera(Camera):
     def frame_interval(self):
         """Return the interval between frames of the mjpeg stream."""
         return self._frame_interval
-
-    def camera_image(
-        self, width: int | None = None, height: int | None = None
-    ) -> bytes | None:
-        """Return bytes of camera image."""
-        return asyncio.run_coroutine_threadsafe(
-            self.async_camera_image(), self.hass.loop
-        ).result()
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -125,9 +125,10 @@ class GenericCamera(Camera):
     ) -> bytes | None:
         """Return a still image response from the camera."""
         if not self._still_image_url:
+            if not self.stream:
+                await self.async_create_stream()
             if self.stream:
                 return await self.stream.async_get_image(width, height)
-            await self.async_create_stream()
             return None
         try:
             url = self._still_image_url.async_render(parse_result=False)

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -133,6 +133,11 @@ class GenericCamera(Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return a still image response from the camera."""
+        if not self._still_image_url:
+            if self.stream:
+                return await self.stream.async_get_image(width, height)
+            await self.async_create_stream()
+            return None
         try:
             url = self._still_image_url.async_render(parse_result=False)
         except TemplateError as err:

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -45,8 +45,8 @@ GET_IMAGE_TIMEOUT = 10
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_STILL_IMAGE_URL): cv.template,
-        vol.Optional(CONF_STREAM_SOURCE): cv.template,
+        vol.Required(vol.Any(CONF_STILL_IMAGE_URL, CONF_STREAM_SOURCE)): cv.template,
+        vol.Optional(vol.Any(CONF_STILL_IMAGE_URL, CONF_STREAM_SOURCE)): cv.template,
         vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION): vol.In(
             [HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]
         ),
@@ -81,9 +81,10 @@ class GenericCamera(Camera):
         self.hass = hass
         self._authentication = device_info.get(CONF_AUTHENTICATION)
         self._name = device_info.get(CONF_NAME)
-        self._still_image_url = device_info[CONF_STILL_IMAGE_URL]
+        self._still_image_url = device_info.get(CONF_STILL_IMAGE_URL)
+        if self._still_image_url:
+            self._still_image_url.hass = hass
         self._stream_source = device_info.get(CONF_STREAM_SOURCE)
-        self._still_image_url.hass = hass
         if self._stream_source is not None:
             self._stream_source.hass = hass
         self._limit_refetch = device_info[CONF_LIMIT_REFETCH_TO_URL_CHANGE]

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -437,6 +437,8 @@ class Stream:
         hass.add_executor_job underneath the hood.
         """
 
+        self.add_provider(HLS_PROVIDER)
+        self.start()
         return await self._keyframe_converter.async_get_image(
             width=width, height=height
         )

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -14,7 +14,7 @@ from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.setup import async_setup_component
 
-from tests.common import get_fixture_path
+from tests.common import AsyncMock, Mock, get_fixture_path
 
 
 @respx.mock
@@ -459,3 +459,40 @@ async def test_timeout_cancelled(hass, hass_client):
         assert respx.calls.call_count == total_calls
         assert resp.status == HTTPStatus.OK
         assert await resp.text() == "hello world"
+
+
+async def test_no_still_image_url(hass, hass_client):
+    """Test that the stream source is setup with different config options."""
+    assert await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "stream_source": "rtsp://example.com:554/rtsp/",
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+
+    with patch("homeassistant.components.camera.create_stream") as mock_create_stream:
+
+        mock_stream = Mock()
+        mock_create_stream.return_value = mock_stream
+        mock_stream.async_get_image = AsyncMock()
+        mock_stream.async_get_image.return_value = b"stream_keyframe_image"
+
+        # first request should fail but start the stream
+        resp = await client.get("/api/camera_proxy/camera.config_test")
+        assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+        await hass.async_block_till_done()
+        mock_create_stream.assert_called_once()
+
+        # second request should succeed
+        resp = await client.get("/api/camera_proxy/camera.config_test")
+        mock_stream.async_get_image.assert_called_once()
+        assert resp.status == HTTPStatus.OK
+        assert await resp.read() == b"stream_keyframe_image"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates generic to allow getting the still image from `Stream.get_image()` which was added in #61918. To enable this the config schema was updated to allow `CONF_STILL_IMAGE_URL` to be omitted when `CONF_STREAM_SOURCE` is present.
`GenericCamera.camera_image()` was removed as it was unused and unnecessary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
