### PR TITLE
Change webOS Smart TV PyPi aiopylgtv package to bscpylgtv

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 import logging
 from typing import Any
 
-from aiopylgtv import PyLGTVPairException, WebOsClient
+from bscpylgtv import PyLGTVPairException, WebOsClient
 import voluptuous as vol
 
 from homeassistant.components import notify as hass_notify

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import urlparse
 
-from aiopylgtv import PyLGTVPairException
+from bscpylgtv import PyLGTVPairException
 import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,7 +1,7 @@
 """Constants used for LG webOS Smart TV."""
 import asyncio
 
-from aiopylgtv import PyLGTVCmdException
+from bscpylgtv import PyLGTVCmdException
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 
 DOMAIN = "webostv"

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -3,7 +3,7 @@
   "name": "LG webOS Smart TV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/webostv",
-  "requirements": ["bscpylgtv==0.2.7"],
+  "requirements": ["bscpylgtv==0.2.8"],
   "codeowners": ["@bendavid"],
   "ssdp": [{
     "manufacturer": "LG Electronics.",

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -3,7 +3,7 @@
   "name": "LG webOS Smart TV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/webostv",
-  "requirements": ["aiopylgtv==0.4.0"],
+  "requirements": ["bscpylgtv==0.2.7"],
   "codeowners": ["@bendavid"],
   "ssdp": [{
     "manufacturer": "LG Electronics.",

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from functools import wraps
 import logging
 
-from aiopylgtv import PyLGTVPairException
+from bscpylgtv import PyLGTVPairException, WebOsClient
 
 from homeassistant import util
 from homeassistant.components.media_player import (
@@ -145,7 +145,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
             }
             await getattr(self, data["method"])(**params)
 
-    async def async_handle_state_update(self):
+    async def async_handle_state_update(self, _client: WebOsClient):
         """Update state from WebOsClient."""
         self.update_sources()
         self.async_write_ha_state()

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -1,7 +1,7 @@
 """Support for LG WebOS TV notification service."""
 import logging
 
-from aiopylgtv import PyLGTVPairException
+from bscpylgtv import PyLGTVPairException
 
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
 from homeassistant.const import CONF_ICON, CONF_NAME

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -448,7 +448,7 @@ brunt==1.1.0
 bsblan==0.4.0
 
 # homeassistant.components.webostv
-bscpylgtv==0.2.7
+bscpylgtv==0.2.8
 
 # homeassistant.components.bluetooth_tracker
 bt_proximity==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -241,9 +241,6 @@ aiopvapi==1.6.19
 # homeassistant.components.pvpc_hourly_pricing
 aiopvpc==2.2.4
 
-# homeassistant.components.webostv
-aiopylgtv==0.4.0
-
 # homeassistant.components.recollect_waste
 aiorecollect==1.0.8
 
@@ -449,6 +446,9 @@ brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0
+
+# homeassistant.components.webostv
+bscpylgtv==0.2.7
 
 # homeassistant.components.bluetooth_tracker
 bt_proximity==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -170,9 +170,6 @@ aiopvapi==1.6.19
 # homeassistant.components.pvpc_hourly_pricing
 aiopvpc==2.2.4
 
-# homeassistant.components.webostv
-aiopylgtv==0.4.0
-
 # homeassistant.components.recollect_waste
 aiorecollect==1.0.8
 
@@ -289,6 +286,9 @@ brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0
+
+# homeassistant.components.webostv
+bscpylgtv==0.2.7
 
 # homeassistant.components.buienradar
 buienradar==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ brunt==1.1.0
 bsblan==0.4.0
 
 # homeassistant.components.webostv
-bscpylgtv==0.2.7
+bscpylgtv==0.2.8
 
 # homeassistant.components.buienradar
 buienradar==1.0.5

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the WebOS Tv config flow."""
 from unittest.mock import Mock, patch
 
-from aiopylgtv import PyLGTVPairException
+from bscpylgtv import PyLGTVPairException
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -1,5 +1,5 @@
 """The tests for WebOS TV device triggers."""
-import homeassistant.components.automation as automation
+from homeassistant.components import automation
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Change webOS Smart TV PyPi aiopylgtv package to bscpylgtv**

To complete config flow for webOS Smart TV integration which started at https://github.com/home-assistant/core/pull/53256 Few changes upstream needed, due to lake of time from owner they are not yet there, however another fork has already implemented them and the owner is committed to help making required changes if needed.

Changes needed for the config flow PR which are implemented in `bscpylgtv`:
- Storage class used to store keys is optional and can be replaced by another class to store the keys
- Added method to read the TV UUID to help when importing old `yaml` entries or when SSDP is not available

Other changes:
- Fix: https://github.com/bendavid/aiopylgtv/issues/47
- Numpy package is optional and not needed if calibration functions are not used (not used in Home Assistant)

Full changelog:
https://github.com/chros73/bscpylgtv/blob/master/CHANGELOG.md

Currently the default storage class is used (backward compatible to `aiopylgtv`), follow up PR will replace it with own storage class to allow storing keys in config flow instead of file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
