### PR TITLE
Correct extra attributes trafikverket_train

### DIFF
--- a/homeassistant/components/trafikverket_train/sensor.py
+++ b/homeassistant/components/trafikverket_train/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_WEEKDAY, WEEKDAYS
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.dt import get_time_zone
+from homeassistant.util.dt import as_utc, get_time_zone
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -158,27 +158,39 @@ class TrainSensor(SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        if self._state is None:
+        if not self._state:
             return None
-        state = self._state
-        other_information = None
-        if state.other_information is not None:
-            other_information = ", ".join(state.other_information)
-        deviations = None
-        if state.deviations is not None:
-            deviations = ", ".join(state.deviations)
-        if self._delay_in_minutes is not None:
-            self._delay_in_minutes = self._delay_in_minutes.total_seconds() / 60
-        return {
+        attributes = {
             ATTR_DEPARTURE_STATE: self._departure_state,
-            ATTR_CANCELED: state.canceled,
-            ATTR_DELAY_TIME: self._delay_in_minutes,
-            ATTR_PLANNED_TIME: state.advertised_time_at_location,
-            ATTR_ESTIMATED_TIME: state.estimated_time_at_location,
-            ATTR_ACTUAL_TIME: state.time_at_location,
-            ATTR_OTHER_INFORMATION: other_information,
-            ATTR_DEVIATIONS: deviations,
+            ATTR_CANCELED: self._state.canceled,
+            ATTR_DELAY_TIME: None,
+            ATTR_PLANNED_TIME: None,
+            ATTR_ESTIMATED_TIME: None,
+            ATTR_ACTUAL_TIME: None,
+            ATTR_OTHER_INFORMATION: None,
+            ATTR_DEVIATIONS: None,
         }
+        if self._state.other_information:
+            attributes[ATTR_OTHER_INFORMATION] = ", ".join(
+                self._state.other_information
+            )
+        if self._state.deviations:
+            attributes[ATTR_DEVIATIONS] = ", ".join(self._state.deviations)
+        if self._delay_in_minutes:
+            attributes[ATTR_DELAY_TIME] = self._delay_in_minutes.total_seconds() / 60
+        if self._state.advertised_time_at_location:
+            attributes[ATTR_PLANNED_TIME] = as_utc(
+                self._state.advertised_time_at_location.astimezone(self._timezone)
+            ).isoformat()
+        if self._state.estimated_time_at_location:
+            attributes[ATTR_ESTIMATED_TIME] = as_utc(
+                self._state.estimated_time_at_location.astimezone(self._timezone)
+            ).isoformat()
+        if self._state.time_at_location:
+            attributes[ATTR_ACTUAL_TIME] = as_utc(
+                self._state.time_at_location.astimezone(self._timezone)
+            ).isoformat()
+        return attributes
 
     @property
     def name(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Fix planned time, estimated time and and actual time in sensor device attributes to be datetime UTC isoformatted string which is standard in Home Assistant.
Previously displayed as `'2021-12-23T09:07:00'` and now correctly set as `2021-12-23T09:07:00+00:00`
This can affect templates or automations based on these attributes

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct the extra_state_attributes in sensor to display datetime attributes correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
