### PR TITLE
Allow sending GroupValueResponse telegrams with knx.send service

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -80,9 +80,9 @@ CONF_KNX_FIRE_EVENT: Final = "fire_event"
 CONF_KNX_EVENT_FILTER: Final = "event_filter"
 
 SERVICE_KNX_SEND: Final = "send"
-SERVICE_KNX_RESPOND: Final = "respond"
 SERVICE_KNX_ATTR_PAYLOAD: Final = "payload"
 SERVICE_KNX_ATTR_TYPE: Final = "type"
+SERVICE_KNX_RESPONSE: Final = "response"
 SERVICE_KNX_ATTR_REMOVE: Final = "remove"
 SERVICE_KNX_EVENT_REGISTER: Final = "event_register"
 SERVICE_KNX_EXPOSURE_REGISTER: Final = "exposure_register"
@@ -143,6 +143,7 @@ SERVICE_KNX_SEND_SCHEMA = vol.Any(
             ),
             vol.Required(SERVICE_KNX_ATTR_PAYLOAD): cv.match_all,
             vol.Required(SERVICE_KNX_ATTR_TYPE): sensor_type_validator,
+            vol.Optional(SERVICE_KNX_RESPONSE, default=False): cv.boolean,
         }
     ),
     vol.Schema(
@@ -155,31 +156,7 @@ SERVICE_KNX_SEND_SCHEMA = vol.Any(
             vol.Required(SERVICE_KNX_ATTR_PAYLOAD): vol.Any(
                 cv.positive_int, [cv.positive_int]
             ),
-        }
-    ),
-)
-
-SERVICE_KNX_RESPOND_SCHEMA = vol.Any(
-    vol.Schema(
-        {
-            vol.Required(KNX_ADDRESS): vol.All(
-                cv.ensure_list,
-                [ga_validator],
-            ),
-            vol.Required(SERVICE_KNX_ATTR_PAYLOAD): cv.match_all,
-            vol.Required(SERVICE_KNX_ATTR_TYPE): sensor_type_validator,
-        }
-    ),
-    vol.Schema(
-        # without type given payload is treated as raw bytes
-        {
-            vol.Required(KNX_ADDRESS): vol.All(
-                cv.ensure_list,
-                [ga_validator],
-            ),
-            vol.Required(SERVICE_KNX_ATTR_PAYLOAD): vol.Any(
-                cv.positive_int, [cv.positive_int]
-            ),
+            vol.Optional(SERVICE_KNX_RESPONSE, default=False): cv.boolean,
         }
     ),
 )
@@ -301,13 +278,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         SERVICE_KNX_SEND,
         knx_module.service_send_to_knx_bus,
         schema=SERVICE_KNX_SEND_SCHEMA,
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_KNX_RESPOND,
-        knx_module.service_respond_to_knx_bus,
-        schema=SERVICE_KNX_RESPOND_SCHEMA,
     )
 
     hass.services.async_register(
@@ -584,6 +554,7 @@ class KNXModule:
         attr_address = call.data[KNX_ADDRESS]
         attr_payload = call.data[SERVICE_KNX_ATTR_PAYLOAD]
         attr_type = call.data.get(SERVICE_KNX_ATTR_TYPE)
+        attr_response = call.data[SERVICE_KNX_RESPONSE]
 
         payload: DPTBinary | DPTArray
         if attr_type is not None:
@@ -599,31 +570,9 @@ class KNXModule:
         for address in attr_address:
             telegram = Telegram(
                 destination_address=parse_device_group_address(address),
-                payload=GroupValueWrite(payload),
-            )
-            await self.xknx.telegrams.put(telegram)
-
-    async def service_respond_to_knx_bus(self, call: ServiceCall) -> None:
-        """Service for responding an arbitrary KNX message to the KNX bus."""
-        attr_address = call.data[KNX_ADDRESS]
-        attr_payload = call.data[SERVICE_KNX_ATTR_PAYLOAD]
-        attr_type = call.data.get(SERVICE_KNX_ATTR_TYPE)
-
-        payload: DPTBinary | DPTArray
-        if attr_type is not None:
-            transcoder = DPTBase.parse_transcoder(attr_type)
-            if transcoder is None:
-                raise ValueError(f"Invalid type for knx.respond service: {attr_type}")
-            payload = DPTArray(transcoder.to_knx(attr_payload))
-        elif isinstance(attr_payload, int):
-            payload = DPTBinary(attr_payload)
-        else:
-            payload = DPTArray(attr_payload)
-
-        for address in attr_address:
-            telegram = Telegram(
-                destination_address=parse_device_group_address(address),
-                payload=GroupValueResponse(payload),
+                payload=GroupValueResponse(payload)
+                if attr_response
+                else GroupValueWrite(payload),
             )
             await self.xknx.telegrams.put(telegram)
 

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -82,7 +82,7 @@ CONF_KNX_EVENT_FILTER: Final = "event_filter"
 SERVICE_KNX_SEND: Final = "send"
 SERVICE_KNX_ATTR_PAYLOAD: Final = "payload"
 SERVICE_KNX_ATTR_TYPE: Final = "type"
-SERVICE_KNX_RESPONSE: Final = "response"
+SERVICE_KNX_ATTR_RESPONSE: Final = "response"
 SERVICE_KNX_ATTR_REMOVE: Final = "remove"
 SERVICE_KNX_EVENT_REGISTER: Final = "event_register"
 SERVICE_KNX_EXPOSURE_REGISTER: Final = "exposure_register"
@@ -143,7 +143,7 @@ SERVICE_KNX_SEND_SCHEMA = vol.Any(
             ),
             vol.Required(SERVICE_KNX_ATTR_PAYLOAD): cv.match_all,
             vol.Required(SERVICE_KNX_ATTR_TYPE): sensor_type_validator,
-            vol.Optional(SERVICE_KNX_RESPONSE, default=False): cv.boolean,
+            vol.Optional(SERVICE_KNX_ATTR_RESPONSE, default=False): cv.boolean,
         }
     ),
     vol.Schema(
@@ -156,7 +156,7 @@ SERVICE_KNX_SEND_SCHEMA = vol.Any(
             vol.Required(SERVICE_KNX_ATTR_PAYLOAD): vol.Any(
                 cv.positive_int, [cv.positive_int]
             ),
-            vol.Optional(SERVICE_KNX_RESPONSE, default=False): cv.boolean,
+            vol.Optional(SERVICE_KNX_ATTR_RESPONSE, default=False): cv.boolean,
         }
     ),
 )
@@ -554,7 +554,7 @@ class KNXModule:
         attr_address = call.data[KNX_ADDRESS]
         attr_payload = call.data[SERVICE_KNX_ATTR_PAYLOAD]
         attr_type = call.data.get(SERVICE_KNX_ATTR_TYPE)
-        attr_response = call.data[SERVICE_KNX_RESPONSE]
+        attr_response = call.data[SERVICE_KNX_ATTR_RESPONSE]
 
         payload: DPTBinary | DPTArray
         if attr_type is not None:

--- a/homeassistant/components/knx/services.yaml
+++ b/homeassistant/components/knx/services.yaml
@@ -23,6 +23,31 @@ send:
       example: "temperature"
       selector:
         text:
+respond:
+  name: "Respond to KNX bus"
+  description: "Respond arbitrary data directly to the KNX bus."
+  fields:
+    address:
+      name: "Group address"
+      description: "Group address(es) to respond to. Lists will send to multiple group addresses successively."
+      required: true
+      example: "1/1/0"
+      selector:
+        object:
+    payload:
+      name: "Payload"
+      description: "Payload to send to the bus. Integers are treated as DPT 1/2/3 payloads. For DPTs > 6 bits send a list. Each value represents 1 octet (0-255). Pad with 0 to DPT byte length."
+      required: true
+      example: "[0, 4]"
+      selector:
+        object:
+    type:
+      name: "Value type"
+      description: "If set, the payload will not be sent as raw bytes, but encoded as given DPT. Knx sensor types are valid values (see https://www.home-assistant.io/integrations/sensor.knx)."
+      required: false
+      example: "temperature"
+      selector:
+        text:
 read:
   name: "Read from KNX bus"
   description: "Send GroupValueRead requests to the KNX bus. Response can be used from `knx_event` and will be processed in KNX entities."

--- a/homeassistant/components/knx/services.yaml
+++ b/homeassistant/components/knx/services.yaml
@@ -23,31 +23,12 @@ send:
       example: "temperature"
       selector:
         text:
-respond:
-  name: "Respond to KNX bus"
-  description: "Respond arbitrary data directly to the KNX bus."
-  fields:
-    address:
-      name: "Group address"
-      description: "Group address(es) to respond to. Lists will send to multiple group addresses successively."
-      required: true
-      example: "1/1/0"
+    response:
+      name: "Send as Response"
+      description: "If set to `True`, the telegram will be sent as a `GroupValueResponse` instead of a `GroupValueWrite`."
+      default: false
       selector:
-        object:
-    payload:
-      name: "Payload"
-      description: "Payload to send to the bus. Integers are treated as DPT 1/2/3 payloads. For DPTs > 6 bits send a list. Each value represents 1 octet (0-255). Pad with 0 to DPT byte length."
-      required: true
-      example: "[0, 4]"
-      selector:
-        object:
-    type:
-      name: "Value type"
-      description: "If set, the payload will not be sent as raw bytes, but encoded as given DPT. Knx sensor types are valid values (see https://www.home-assistant.io/integrations/sensor.knx)."
-      required: false
-      example: "temperature"
-      selector:
-        text:
+        boolean:
 read:
   name: "Read from KNX bus"
   description: "Send GroupValueRead requests to the KNX bus. Response can be used from `knx_event` and will be processed in KNX entities."

--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -109,7 +109,7 @@ class KNXTestKit:
     # APCI Service tests
     ####################
 
-    async def _assert_telegram(
+    async def assert_telegram(
         self,
         group_address: str,
         payload: int | tuple[int, ...] | None,
@@ -141,19 +141,19 @@ class KNXTestKit:
 
     async def assert_read(self, group_address: str) -> None:
         """Assert outgoing GroupValueRead telegram. One by one in timely order."""
-        await self._assert_telegram(group_address, None, GroupValueRead)
+        await self.assert_telegram(group_address, None, GroupValueRead)
 
     async def assert_response(
         self, group_address: str, payload: int | tuple[int, ...]
     ) -> None:
         """Assert outgoing GroupValueResponse telegram. One by one in timely order."""
-        await self._assert_telegram(group_address, payload, GroupValueResponse)
+        await self.assert_telegram(group_address, payload, GroupValueResponse)
 
     async def assert_write(
         self, group_address: str, payload: int | tuple[int, ...]
     ) -> None:
         """Assert outgoing GroupValueWrite telegram. One by one in timely order."""
-        await self._assert_telegram(group_address, payload, GroupValueWrite)
+        await self.assert_telegram(group_address, payload, GroupValueWrite)
 
     ####################
     # Incoming telegrams

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -17,13 +17,19 @@ async def test_send(hass: HomeAssistant, knx: KNXTestKit):
 
         # send DPT 1 telegram
         await hass.services.async_call(
-            "knx", "send", {"address": test_address, "payload": True}, blocking=True
+            "knx",
+            "send",
+            {"address": test_address, "payload": True, "response": response},
+            blocking=True,
         )
         await assertion(test_address, True)
 
         # send raw DPT 5 telegram
         await hass.services.async_call(
-            "knx", "send", {"address": test_address, "payload": [99]}, blocking=True
+            "knx",
+            "send",
+            {"address": test_address, "payload": [99], "response": response},
+            blocking=True,
         )
         await assertion(test_address, (99,))
 
@@ -31,7 +37,12 @@ async def test_send(hass: HomeAssistant, knx: KNXTestKit):
         await hass.services.async_call(
             "knx",
             "send",
-            {"address": test_address, "payload": 99, "type": "percent"},
+            {
+                "address": test_address,
+                "payload": 99,
+                "type": "percent",
+                "response": response,
+            },
             blocking=True,
         )
         await assertion(test_address, (0xFC,))
@@ -40,7 +51,12 @@ async def test_send(hass: HomeAssistant, knx: KNXTestKit):
         await hass.services.async_call(
             "knx",
             "send",
-            {"address": test_address, "payload": 21.0, "type": "temperature"},
+            {
+                "address": test_address,
+                "payload": 21.0,
+                "type": "temperature",
+                "response": response,
+            },
             blocking=True,
         )
         await assertion(test_address, (0x0C, 0x1A))
@@ -53,6 +69,7 @@ async def test_send(hass: HomeAssistant, knx: KNXTestKit):
                 "address": [test_address, "2/2/2", "3/3/3"],
                 "payload": 99,
                 "type": "percent",
+                "response": response,
             },
             blocking=True,
         )

--- a/tests/components/knx/test_services.py
+++ b/tests/components/knx/test_services.py
@@ -12,93 +12,53 @@ async def test_send(hass: HomeAssistant, knx: KNXTestKit):
     test_address = "1/2/3"
     await knx.setup_integration({})
 
-    # send DPT 1 telegram
-    await hass.services.async_call(
-        "knx", "send", {"address": test_address, "payload": True}, blocking=True
-    )
-    await knx.assert_write(test_address, True)
+    for response in (False, True):
+        assertion = knx.assert_response if response else knx.assert_write
 
-    # send raw DPT 5 telegram
-    await hass.services.async_call(
-        "knx", "send", {"address": test_address, "payload": [99]}, blocking=True
-    )
-    await knx.assert_write(test_address, (99,))
+        # send DPT 1 telegram
+        await hass.services.async_call(
+            "knx", "send", {"address": test_address, "payload": True}, blocking=True
+        )
+        await assertion(test_address, True)
 
-    # send "percent" DPT 5 telegram
-    await hass.services.async_call(
-        "knx",
-        "send",
-        {"address": test_address, "payload": 99, "type": "percent"},
-        blocking=True,
-    )
-    await knx.assert_write(test_address, (0xFC,))
+        # send raw DPT 5 telegram
+        await hass.services.async_call(
+            "knx", "send", {"address": test_address, "payload": [99]}, blocking=True
+        )
+        await assertion(test_address, (99,))
 
-    # send "temperature" DPT 9 telegram
-    await hass.services.async_call(
-        "knx",
-        "send",
-        {"address": test_address, "payload": 21.0, "type": "temperature"},
-        blocking=True,
-    )
-    await knx.assert_write(test_address, (0x0C, 0x1A))
+        # send "percent" DPT 5 telegram
+        await hass.services.async_call(
+            "knx",
+            "send",
+            {"address": test_address, "payload": 99, "type": "percent"},
+            blocking=True,
+        )
+        await assertion(test_address, (0xFC,))
 
-    # send multiple telegrams
-    await hass.services.async_call(
-        "knx",
-        "send",
-        {"address": [test_address, "2/2/2", "3/3/3"], "payload": 99, "type": "percent"},
-        blocking=True,
-    )
-    await knx.assert_write(test_address, (0xFC,))
-    await knx.assert_write("2/2/2", (0xFC,))
-    await knx.assert_write("3/3/3", (0xFC,))
+        # send "temperature" DPT 9 telegram
+        await hass.services.async_call(
+            "knx",
+            "send",
+            {"address": test_address, "payload": 21.0, "type": "temperature"},
+            blocking=True,
+        )
+        await assertion(test_address, (0x0C, 0x1A))
 
-
-async def test_respond(hass: HomeAssistant, knx: KNXTestKit):
-    """Test `knx.respond` service."""
-    test_address = "1/2/3"
-    await knx.setup_integration({})
-
-    # respond DPT 1 telegram
-    await hass.services.async_call(
-        "knx", "respond", {"address": test_address, "payload": True}, blocking=True
-    )
-    await knx.assert_response(test_address, True)
-
-    # respond raw DPT 5 telegram
-    await hass.services.async_call(
-        "knx", "respond", {"address": test_address, "payload": [99]}, blocking=True
-    )
-    await knx.assert_response(test_address, (99,))
-
-    # respond "percent" DPT 5 telegram
-    await hass.services.async_call(
-        "knx",
-        "respond",
-        {"address": test_address, "payload": 99, "type": "percent"},
-        blocking=True,
-    )
-    await knx.assert_response(test_address, (0xFC,))
-
-    # respond "temperature" DPT 9 telegram
-    await hass.services.async_call(
-        "knx",
-        "respond",
-        {"address": test_address, "payload": 21.0, "type": "temperature"},
-        blocking=True,
-    )
-    await knx.assert_response(test_address, (0x0C, 0x1A))
-
-    # respond multiple telegrams
-    await hass.services.async_call(
-        "knx",
-        "respond",
-        {"address": [test_address, "2/2/2", "3/3/3"], "payload": 99, "type": "percent"},
-        blocking=True,
-    )
-    await knx.assert_response(test_address, (0xFC,))
-    await knx.assert_response("2/2/2", (0xFC,))
-    await knx.assert_response("3/3/3", (0xFC,))
+        # send multiple telegrams
+        await hass.services.async_call(
+            "knx",
+            "send",
+            {
+                "address": [test_address, "2/2/2", "3/3/3"],
+                "payload": 99,
+                "type": "percent",
+            },
+            blocking=True,
+        )
+        await assertion(test_address, (0xFC,))
+        await assertion("2/2/2", (0xFC,))
+        await assertion("3/3/3", (0xFC,))
 
 
 async def test_read(hass: HomeAssistant, knx: KNXTestKit):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When setting up my KNX automations, I noticed that it is currently not possible to send `GroupValueReponse` telegrams via Home Assistant. These are used to respond to `GroupValueRead` telegrams. As they have the same structure as `GroupValueWrite` telegrams, I duplicated the corresponding code and changed the relevant parts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

I was not able to test my code locally, because tox took way too long to even start. As the Home Assistant documentation says that the code is tested via CI, I skipped the local tests. If any errors arise in CI, I will fix them as soon as possible.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

I will happily update the corresponding docs once this PR is ready to merge.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
