### PR TITLE
rfxtrx: Always create all found devices (RFC)

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -152,7 +152,6 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
 
     # Setup some per device config
     devices = _get_device_lookup(config[CONF_DEVICES])
-    pt2262_devices: list[str] = []
 
     device_registry: DeviceRegistry = (
         await hass.helpers.device_registry.async_get_registry()
@@ -185,10 +184,6 @@ async def async_setup_internal(hass, entry: config_entries.ConfigEntry):
                 _add_device(event, device_id)
             else:
                 return
-
-        if event.device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
-            find_possible_pt2262_device(pt2262_devices, event.device.id_string)
-            pt2262_devices.append(event.device.id_string)
 
         device_entry = device_registry.async_get_device(
             identifiers={(DOMAIN, *device_id)},
@@ -343,33 +338,6 @@ def get_device_data_bits(
                 data_bits = bits
                 break
     return data_bits
-
-
-def find_possible_pt2262_device(device_ids: list[str], device_id: str) -> str | None:
-    """Look for the device which id matches the given device_id parameter."""
-    for dev_id in device_ids:
-        if len(dev_id) == len(device_id):
-            size = None
-            for i, (char1, char2) in enumerate(zip(dev_id, device_id)):
-                if char1 != char2:
-                    break
-                size = i
-            if size is not None:
-                size = len(dev_id) - size - 1
-                _LOGGER.info(
-                    "Found possible device %s for %s "
-                    "with the following configuration:\n"
-                    "data_bits=%d\n"
-                    "command_on=0x%s\n"
-                    "command_off=0x%s\n",
-                    device_id,
-                    dev_id,
-                    size * 4,
-                    dev_id[-size:],
-                    device_id[-size:],
-                )
-                return dev_id
-    return None
 
 
 def get_device_id(

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -38,7 +38,6 @@ from homeassistant.helpers.entity_registry import (
 from . import DOMAIN, DeviceTuple, get_device_id, get_rfx_object
 from .binary_sensor import supported as binary_supported
 from .const import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
     CONF_REMOVE_DEVICE,
@@ -96,9 +95,7 @@ class OptionsFlow(config_entries.OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            self._global_options = {
-                CONF_AUTOMATIC_ADD: user_input[CONF_AUTOMATIC_ADD],
-            }
+            self._global_options = {}
             if CONF_DEVICE in user_input:
                 entry_id = user_input[CONF_DEVICE]
                 device_data = self._get_device_data(entry_id)
@@ -168,10 +165,6 @@ class OptionsFlow(config_entries.OptionsFlow):
         }
 
         options = {
-            vol.Optional(
-                CONF_AUTOMATIC_ADD,
-                default=self._config_entry.data[CONF_AUTOMATIC_ADD],
-            ): bool,
             vol.Optional(CONF_EVENT_CODE): str,
             vol.Optional(CONF_DEVICE): vol.In(configure_devices),
             vol.Optional(CONF_REMOVE_DEVICE): cv.multi_select(remove_devices),
@@ -564,7 +557,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_HOST: host,
             CONF_PORT: port,
             CONF_DEVICE: device,
-            CONF_AUTOMATIC_ADD: False,
             CONF_DEVICES: {},
         }
         return data

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -1,7 +1,6 @@
 """Constants for RFXtrx integration."""
 
 CONF_DATA_BITS = "data_bits"
-CONF_AUTOMATIC_ADD = "automatic_add"
 CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 CONF_OFF_DELAY = "off_delay"
 CONF_VENETIAN_BLIND_MODE = "venetian_blind_mode"

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -12,16 +12,28 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
-def create_rfx_test_cfg(device="abcd", automatic_add=False, devices=None):
+def create_rfx_test_cfg(device="abcd", devices=None):
     """Create rfxtrx config entry data."""
     return {
         "device": device,
         "host": None,
         "port": None,
-        "automatic_add": automatic_add,
         "debug": False,
         "devices": devices,
     }
+
+
+async def rfxtrx_mock_entry(hass, device="abcd", devices=None):
+    """Create a mock config entry and run setup."""
+    entry_data = create_rfx_test_cfg(device=device, devices=devices)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+    return mock_entry
 
 
 @pytest.fixture(autouse=True, name="rfxtrx")
@@ -50,14 +62,7 @@ async def rfxtrx_fixture(hass):
 @pytest.fixture(name="rfxtrx_automatic")
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
-    entry_data = create_rfx_test_cfg(automatic_add=True, devices={})
-    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
-
-    mock_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-    await hass.async_start()
+    await rfxtrx_mock_entry(hass, devices={})
     yield rfxtrx
 
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -64,7 +64,6 @@ async def test_setup_network(transport_mock, hass):
         "host": "10.10.0.1",
         "port": 1234,
         "device": None,
-        "automatic_add": False,
         "devices": {},
     }
 
@@ -110,7 +109,6 @@ async def test_setup_serial(com_mock, connect_mock, hass):
         "host": None,
         "port": None,
         "device": port.device,
-        "automatic_add": False,
         "devices": {},
     }
 
@@ -162,7 +160,6 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass):
         "host": None,
         "port": None,
         "device": "/dev/ttyUSB0",
-        "automatic_add": False,
         "devices": {},
     }
 
@@ -285,7 +282,6 @@ async def test_options_global(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -298,14 +294,12 @@ async def test_options_global(hass):
     assert result["step_id"] == "prompt_options"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"automatic_add": True}
+        result["flow_id"], user_input={}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert entry.data["automatic_add"]
 
 
 async def test_options_add_device(hass):
@@ -317,7 +311,6 @@ async def test_options_add_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -332,7 +325,7 @@ async def test_options_add_device(hass):
     # Try with invalid event code
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"automatic_add": True, "event_code": "1234"},
+        user_input={"event_code": "1234"},
     )
 
     assert result["type"] == "form"
@@ -344,7 +337,6 @@ async def test_options_add_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
     )
@@ -359,8 +351,6 @@ async def test_options_add_device(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["signal_repetitions"] == 5
@@ -382,7 +372,6 @@ async def test_options_add_duplicate_device(hass):
             "port": None,
             "device": "/dev/tty123",
             "debug": False,
-            "automatic_add": False,
             "devices": {"0b1100cd0213c7f230010f71": {"signal_repetitions": 1}},
         },
         unique_id=DOMAIN,
@@ -397,7 +386,6 @@ async def test_options_add_duplicate_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
     )
@@ -417,7 +405,6 @@ async def test_options_add_remove_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -432,7 +419,6 @@ async def test_options_add_remove_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
     )
@@ -448,8 +434,6 @@ async def test_options_add_remove_device(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["signal_repetitions"] == 5
@@ -473,7 +457,6 @@ async def test_options_add_remove_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "remove_device": [device_entries[0].id],
         },
     )
@@ -481,8 +464,6 @@ async def test_options_add_remove_device(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert not entry.data["automatic_add"]
 
     assert "0b1100cd0213c7f230010f71" not in entry.data["devices"]
 
@@ -499,7 +480,6 @@ async def test_options_replace_sensor_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {
                 "0a520101f00400e22d0189": {"device_id": ["52", "1", "f0:04"]},
                 "0a520105230400c3260279": {"device_id": ["52", "1", "23:04"]},
@@ -581,7 +561,6 @@ async def test_options_replace_sensor_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": old_device,
         },
     )
@@ -659,7 +638,6 @@ async def test_options_replace_control_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {
                 "0b1100100118cdea02010f70": {
                     "device_id": ["11", "0", "118cdea:2"],
@@ -719,7 +697,6 @@ async def test_options_replace_control_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": old_device,
         },
     )
@@ -767,7 +744,6 @@ async def test_options_remove_multiple_devices(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {
                 "0b1100cd0213c7f230010f71": {"device_id": ["11", "0", "213c7f2:48"]},
                 "0b1100100118cdea02010f70": {"device_id": ["11", "0", "118cdea:2"]},
@@ -811,7 +787,6 @@ async def test_options_remove_multiple_devices(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "remove_device": remove_devices,
         },
     )
@@ -837,7 +812,6 @@ async def test_options_add_and_configure_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -852,7 +826,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0913000022670e013970",
         },
     )
@@ -893,8 +866,6 @@ async def test_options_add_and_configure_device(hass):
 
     await hass.async_block_till_done()
 
-    assert entry.data["automatic_add"]
-
     assert entry.data["devices"]["0913000022670e013970"]
     assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
     assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
@@ -917,7 +888,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": device_entries[0].id,
         },
     )
@@ -953,7 +923,6 @@ async def test_options_configure_rfy_cover_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -971,7 +940,6 @@ async def test_options_configure_rfy_cover_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "071a000001020301",
         },
     )
@@ -1003,7 +971,6 @@ async def test_options_configure_rfy_cover_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": device_entries[0].id,
         },
     )

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
+from homeassistant.helpers import entity_registry
 
 from tests.common import MockConfigEntry, mock_restore_cache
 from tests.components.rfxtrx.conftest import create_rfx_test_cfg
@@ -106,19 +107,30 @@ async def test_several_covers(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "RollerTrol 009ba8:1"
 
 
-async def test_discover_covers(hass, rfxtrx_automatic):
-    """Test with discovery of covers."""
+@pytest.mark.parametrize(
+    "signals,entities",
+    [
+        (
+            ["0a140002f38cae010f0070", "0a1400adf394ab020e0060"],
+            [
+                "cover.lightwaverf_siemens_f38cae_1",
+                "cover.lightwaverf_siemens_f394ab_2",
+            ],
+        ),
+    ],
+)
+async def test_discover(signals, entities, hass, rfxtrx_automatic):
+    """Test with discovery."""
     rfxtrx = rfxtrx_automatic
 
-    await rfxtrx.signal("0a140002f38cae010f0070")
-    state = hass.states.get("cover.lightwaverf_siemens_f38cae_1")
-    assert state
-    assert state.state == "open"
+    for signal in signals:
+        await rfxtrx.signal(signal)
 
-    await rfxtrx.signal("0a1400adf394ab020e0060")
-    state = hass.states.get("cover.lightwaverf_siemens_f394ab_2")
-    assert state
-    assert state.state == "open"
+    for entity in entities:
+        reg = entity_registry.async_get(hass)
+        reg_entry = reg.async_get(entity)
+        assert reg_entry, f"{entity} missing"
+        assert reg_entry.disabled, f"{entity} not disabled"
 
 
 async def test_duplicate_cover(hass, rfxtrx):

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -15,7 +15,6 @@ async def test_fire_event(hass, rfxtrx):
     """Test fire event."""
     entry_data = create_rfx_test_cfg(
         device="/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-        automatic_add=True,
         devices={
             "0b1100cd0213c7f210010f51": {},
             "0716000100900970": {},

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
+from homeassistant.helpers import entity_registry
 
 from tests.common import MockConfigEntry, mock_restore_cache
 from tests.components.rfxtrx.conftest import create_rfx_test_cfg
@@ -183,18 +184,24 @@ async def test_repetitions(hass, rfxtrx, repetitions):
     assert rfxtrx.transport.send.call_count == repetitions
 
 
-async def test_discover_light(hass, rfxtrx_automatic):
-    """Test with discovery of lights."""
+@pytest.mark.parametrize(
+    "signals,entities",
+    [
+        (
+            ["0b11009e00e6116202020070", "0b1100120118cdea02020070"],
+            ["light.ac_0e61162_2", "light.ac_118cdea_2"],
+        ),
+    ],
+)
+async def test_discover(signals, entities, hass, rfxtrx_automatic):
+    """Test with discovery."""
     rfxtrx = rfxtrx_automatic
 
-    await rfxtrx.signal("0b11009e00e6116202020070")
-    state = hass.states.get("light.ac_0e61162_2")
-    assert state
-    assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "AC 0e61162:2"
+    for signal in signals:
+        await rfxtrx.signal(signal)
 
-    await rfxtrx.signal("0b1100120118cdea02020070")
-    state = hass.states.get("light.ac_118cdea_2")
-    assert state
-    assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "AC 118cdea:2"
+    for entity in entities:
+        reg = entity_registry.async_get(hass)
+        reg_entry = reg.async_get(entity)
+        assert reg_entry, f"{entity} missing"
+        assert reg_entry.disabled, f"{entity} not disabled"

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
+from homeassistant.helpers import entity_registry
 
 from tests.common import MockConfigEntry, mock_restore_cache
 from tests.components.rfxtrx.conftest import create_rfx_test_cfg
@@ -181,34 +182,28 @@ async def test_switch_events(hass, rfxtrx):
     assert hass.states.get("switch.ac_213c7f2_16").state == "off"
 
 
-async def test_discover_switch(hass, rfxtrx_automatic):
-    """Test with discovery of switches."""
+@pytest.mark.parametrize(
+    "signals,entities",
+    [
+        (
+            ["0b1100100118cdea02010f70", "0b1100100118cdeb02010f70"],
+            ["switch.ac_118cdea_2", "switch.ac_118cdeb_2"],
+        ),
+        ([EVENT_RFY_DISABLE_SUN_AUTO], ["switch.rfy_030101_1"]),
+    ],
+)
+async def test_discover(signals, entities, hass, rfxtrx_automatic):
+    """Test with discovery."""
     rfxtrx = rfxtrx_automatic
 
-    await rfxtrx.signal("0b1100100118cdea02010f70")
-    state = hass.states.get("switch.ac_118cdea_2")
-    assert state
-    assert state.state == "on"
+    for signal in signals:
+        await rfxtrx.signal(signal)
 
-    await rfxtrx.signal("0b1100100118cdeb02010f70")
-    state = hass.states.get("switch.ac_118cdeb_2")
-    assert state
-    assert state.state == "on"
-
-
-async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
-    """Test with discovery of switches."""
-    rfxtrx = rfxtrx_automatic
-
-    await rfxtrx.signal(EVENT_RFY_DISABLE_SUN_AUTO)
-    state = hass.states.get("switch.rfy_030101_1")
-    assert state
-    assert state.state == "off"
-
-    await rfxtrx.signal(EVENT_RFY_ENABLE_SUN_AUTO)
-    state = hass.states.get("switch.rfy_030101_1")
-    assert state
-    assert state.state == "on"
+    for entity in entities:
+        reg = entity_registry.async_get(hass)
+        reg_entry = reg.async_get(entity)
+        assert reg_entry, f"{entity} missing"
+        assert reg_entry.disabled, f"{entity} not disabled"
 
 
 async def test_unknown_event_code(hass, rfxtrx):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Always create rfxtrx entities and devices. Create them in disabled state by default and use normal UI to enable the ones the user is interested in. This gives better knowledge over what devices are in proximity, without always loading all entities. It also reduces configuration needs in config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
