### PR TITLE
Make Sonos alarm `unique_id` unique with multiple households

### DIFF
--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -214,7 +214,7 @@ class SonosAlarmEntity(SonosEntity, SwitchEntity):
     def __init__(self, alarm_id: str, speaker: SonosSpeaker) -> None:
         """Initialize the switch."""
         super().__init__(speaker)
-        self._attr_unique_id = f"{speaker.household_id}:{alarm_id}"
+        self._attr_unique_id = f"alarm-{speaker.household_id}:{alarm_id}"
         self.alarm_id = alarm_id
         self.household_id = speaker.household_id
         self.entity_id = ENTITY_ID_FORMAT.format(f"sonos_alarm_{self.alarm_id}")
@@ -385,7 +385,7 @@ def async_migrate_alarm_unique_ids(
 
         entry_alarm_id = old_unique_id.split("-")[-1]
         if entry_alarm_id in alarm_ids:
-            new_unique_id = f"{household_id}:{entry_alarm_id}"
+            new_unique_id = f"alarm-{household_id}:{entry_alarm_id}"
             _LOGGER.debug(
                 "Migrating unique_id for %s from %s to %s",
                 alarm_entry.entity_id,

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -91,6 +91,9 @@ async def async_setup_entry(
     """Set up Sonos from a config entry."""
 
     async def _async_create_alarms(speaker: SonosSpeaker, alarm_ids: list[str]) -> None:
+        async_migrate_alarm_unique_ids(
+            hass, config_entry, speaker.household_id, alarm_ids
+        )
         entities = []
         created_alarms = (
             hass.data[DATA_SONOS].alarms[speaker.household_id].created_alarm_ids
@@ -211,7 +214,7 @@ class SonosAlarmEntity(SonosEntity, SwitchEntity):
     def __init__(self, alarm_id: str, speaker: SonosSpeaker) -> None:
         """Initialize the switch."""
         super().__init__(speaker)
-        self._attr_unique_id = f"{SONOS_DOMAIN}-{alarm_id}"
+        self._attr_unique_id = f"{speaker.household_id}:{alarm_id}"
         self.alarm_id = alarm_id
         self.household_id = speaker.household_id
         self.entity_id = ENTITY_ID_FORMAT.format(f"sonos_alarm_{self.alarm_id}")
@@ -355,6 +358,43 @@ class SonosAlarmEntity(SonosEntity, SwitchEntity):
             await self.hass.async_add_executor_job(self.alarm.save)
         except (OSError, SoCoException, SoCoUPnPException) as exc:
             _LOGGER.error("Could not update %s: %s", self.entity_id, exc)
+
+
+@callback
+def async_migrate_alarm_unique_ids(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    household_id: str,
+    alarm_ids: list[str],
+) -> None:
+    """Migrate alarm switch unique_ids in the entity registry to the new format."""
+    entity_registry = er.async_get(hass)
+    registry_entries = er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    )
+
+    alarm_entries = [
+        (entry.unique_id, entry)
+        for entry in registry_entries
+        if entry.domain == Platform.SWITCH and entry.original_icon == "mdi:alarm"
+    ]
+
+    for old_unique_id, alarm_entry in alarm_entries:
+        if ":" in old_unique_id:
+            continue
+
+        entry_alarm_id = old_unique_id.split("-")[-1]
+        if entry_alarm_id in alarm_ids:
+            new_unique_id = f"{household_id}:{entry_alarm_id}"
+            _LOGGER.debug(
+                "Migrating unique_id for %s from %s to %s",
+                alarm_entry.entity_id,
+                old_unique_id,
+                new_unique_id,
+            )
+            entity_registry.async_update_entity(
+                alarm_entry.entity_id, new_unique_id=new_unique_id
+            )
 
 
 @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In very specific scenarios where a user is running multiple Sonos systems (households) and where alarm_id values happen to conflict, the `unique_id` are not unique enough. This PR adds use of the household ID to ensure the `unique_id` is actually unique in these setups.

A migration is also performed for "old" `unique_id` values which should work for ~99% of installations. If an installation uses multiple Sonos households _and_ has an alarm ID duplication, the migration will process the first alarm it sees. This has a possibility of migrating the incorrect alarm, but there is currently not enough information stored to guarantee this step. Either way, this will allow those setups to register entities for both alarms which was not possible previously.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #62447
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
