### PR TITLE
Increase test coverage for google calendar

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -399,7 +399,7 @@ omit =
     homeassistant/components/glances/sensor.py
     homeassistant/components/gntp/notify.py
     homeassistant/components/goalfeed/*
-    homeassistant/components/google/*
+    homeassistant/components/google/__init__.py
     homeassistant/components/google_cloud/tts.py
     homeassistant/components/google_maps/device_tracker.py
     homeassistant/components/google_pubsub/__init__.py

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -121,8 +121,8 @@ class GoogleCalendarData:
     def _prepare_query(self):
         try:
             service = self.calendar_service.get()
-        except ServerNotFoundError:
-            _LOGGER.error("Unable to connect to Google")
+        except ServerNotFoundError as err:
+            _LOGGER.error("Unable to connect to Google: %s", err)
             return None, None
         params = dict(DEFAULT_GOOGLE_SEARCH_PARAMS)
         params["calendarId"] = self.calendar_id

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -29,8 +29,7 @@ def test_calendar():
 @pytest.fixture
 def mock_next_event():
     """Mock the google calendar data."""
-    patch_google_cal = patch(
+    with patch(
         "homeassistant.components.google.calendar.GoogleCalendarData"
-    )
-    with patch_google_cal as google_cal_data:
+    ) as google_cal_data:
         yield google_cal_data

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -29,7 +29,8 @@ def test_calendar():
 @pytest.fixture
 def mock_next_event():
     """Mock the google calendar data."""
-    with patch(
+    patch_google_cal = patch(
         "homeassistant.components.google.calendar.GoogleCalendarData"
-    ) as google_cal_data:
+    )
+    with patch_google_cal as google_cal_data:
         yield google_cal_data

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -1,5 +1,7 @@
 """The tests for the google calendar platform."""
 import copy
+from http import HTTPStatus
+from typing import Any, Callable
 from unittest.mock import Mock, patch
 
 import httplib2
@@ -11,10 +13,12 @@ from homeassistant.components.google import (
     CONF_CLIENT_SECRET,
     CONF_DEVICE_ID,
     CONF_ENTITIES,
+    CONF_IGNORE_AVAILABILITY,
     CONF_NAME,
     CONF_TRACK,
     DEVICE_SCHEMA,
     SERVICE_SCAN_CALENDARS,
+    GoogleCalendarService,
     do_setup,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -22,6 +26,8 @@ from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
+
+from .conftest import TEST_CALENDAR
 
 from tests.common import async_mock_service
 
@@ -69,6 +75,7 @@ def get_calendar_info(calendar):
                     CONF_TRACK: calendar["track"],
                     CONF_NAME: calendar["summary"],
                     CONF_DEVICE_ID: slugify(calendar["summary"]),
+                    CONF_IGNORE_AVAILABILITY: calendar.get("ignore_availability", True),
                 }
             ],
         }
@@ -93,12 +100,6 @@ def mock_google_setup(hass, test_calendar):
 
     with patch_google_auth, patch_google_load, patch_google_services:
         yield
-
-
-@pytest.fixture(autouse=True)
-def mock_http(hass):
-    """Mock the http component."""
-    hass.http = Mock()
 
 
 @pytest.fixture(autouse=True)
@@ -314,3 +315,160 @@ async def test_update_error(hass, google_service):
     state = hass.states.get(TEST_ENTITY)
     assert state.name == TEST_ENTITY_NAME
     assert state.state == "off"
+
+
+async def test_calendars_api(
+    hass, hass_client, google_service
+):  # mock_next_event, hass_client):
+    """Test the Rest API returns the calendar."""
+    assert await async_setup_component(hass, "google", {"google": GOOGLE_CONFIG})
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+    response = await client.get("/api/calendars")
+    assert response.status == HTTPStatus.OK
+    data = await response.json()
+    assert data == [
+        {
+            "entity_id": TEST_ENTITY,
+            "name": TEST_ENTITY_NAME,
+        }
+    ]
+
+
+async def test_http_event_api_failure(hass, hass_client, google_service):
+    """Test the Rest API response during a calendar failure."""
+    google_service.return_value.get = Mock(
+        side_effect=httplib2.ServerNotFoundError("unit test")
+    )
+
+    assert await async_setup_component(hass, "google", {"google": GOOGLE_CONFIG})
+    await hass.async_block_till_done()
+
+    start = dt_util.now().isoformat()
+    end = (dt_util.now() + dt_util.dt.timedelta(minutes=60)).isoformat()
+
+    client = await hass_client()
+    response = await client.get(f"/api/calendars/{TEST_ENTITY}?start={start}&end={end}")
+    assert response.status == HTTPStatus.OK
+    # A failure to talk to the server results in an empty list of events
+    events = await response.json()
+    assert events == []
+
+
+@pytest.fixture
+def mock_events_list(google_service: GoogleCalendarService) -> Callable[[...], None]:
+    """Fixture to construct a fake event list API response."""
+
+    def _put_result(response: dict) -> None:
+        google_service.return_value.get.return_value.events.return_value.list.return_value.execute.return_value = (
+            response
+        )
+        return
+
+    return _put_result
+
+
+async def test_http_api_event(hass, hass_client, google_service, mock_events_list):
+    """Test querying the API and fetching events from the server."""
+    now = dt_util.now()
+
+    mock_events_list(
+        {
+            "items": [
+                {
+                    "summary": "Event title",
+                    "start": {"dateTime": now.isoformat()},
+                    "end": {
+                        "dateTime": (now + dt_util.dt.timedelta(minutes=5)).isoformat()
+                    },
+                }
+            ],
+        }
+    )
+    assert await async_setup_component(hass, "google", {"google": GOOGLE_CONFIG})
+    await hass.async_block_till_done()
+
+    start = (now - dt_util.dt.timedelta(minutes=60)).isoformat()
+    end = (now + dt_util.dt.timedelta(minutes=60)).isoformat()
+
+    client = await hass_client()
+    response = await client.get(f"/api/calendars/{TEST_ENTITY}?start={start}&end={end}")
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert len(events) == 1
+    assert "summary" in events[0]
+    assert events[0]["summary"] == "Event title"
+
+
+def create_ignore_avail_calendar() -> dict[str, Any]:
+    """Create a calendar with ignore_availability set."""
+    calendar = TEST_CALENDAR.copy()
+    calendar["ignore_availability"] = False
+    return calendar
+
+
+@pytest.mark.parametrize("test_calendar", [create_ignore_avail_calendar()])
+async def test_opaque_event(hass, hass_client, google_service, mock_events_list):
+    """Test querying the API and fetching events from the server."""
+    now = dt_util.now()
+
+    mock_events_list(
+        {
+            "items": [
+                {
+                    "summary": "Event title",
+                    "transparency": "opaque",
+                    "start": {"dateTime": now.isoformat()},
+                    "end": {
+                        "dateTime": (now + dt_util.dt.timedelta(minutes=5)).isoformat()
+                    },
+                }
+            ],
+        }
+    )
+    assert await async_setup_component(hass, "google", {"google": GOOGLE_CONFIG})
+    await hass.async_block_till_done()
+
+    start = (now - dt_util.dt.timedelta(minutes=60)).isoformat()
+    end = (now + dt_util.dt.timedelta(minutes=60)).isoformat()
+
+    client = await hass_client()
+    response = await client.get(f"/api/calendars/{TEST_ENTITY}?start={start}&end={end}")
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert len(events) == 1
+    assert "summary" in events[0]
+    assert events[0]["summary"] == "Event title"
+
+
+@pytest.mark.parametrize("test_calendar", [create_ignore_avail_calendar()])
+async def test_transparent_event(hass, hass_client, google_service, mock_events_list):
+    """Test querying the API and fetching events from the server."""
+    now = dt_util.now()
+
+    mock_events_list(
+        {
+            "items": [
+                {
+                    "summary": "Event title",
+                    "transparency": "transparent",
+                    "start": {"dateTime": now.isoformat()},
+                    "end": {
+                        "dateTime": (now + dt_util.dt.timedelta(minutes=5)).isoformat()
+                    },
+                }
+            ],
+        }
+    )
+    assert await async_setup_component(hass, "google", {"google": GOOGLE_CONFIG})
+    await hass.async_block_till_done()
+
+    start = (now - dt_util.dt.timedelta(minutes=60)).isoformat()
+    end = (now + dt_util.dt.timedelta(minutes=60)).isoformat()
+
+    client = await hass_client()
+    response = await client.get(f"/api/calendars/{TEST_ENTITY}?start={start}&end={end}")
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+    assert events == []

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -320,9 +320,7 @@ async def test_update_error(hass, google_service):
     assert state.state == "off"
 
 
-async def test_calendars_api(
-    hass, hass_client, google_service
-):  # mock_next_event, hass_client):
+async def test_calendars_api(hass, hass_client, google_service):
     """Test the Rest API returns the calendar."""
     assert await async_setup_component(hass, "google", {"google": GOOGLE_CONFIG})
     await hass.async_block_till_done()

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -1,4 +1,7 @@
 """The tests for the google calendar platform."""
+
+from __future__ import annotations
+
 import copy
 from http import HTTPStatus
 from typing import Any, Callable

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -357,10 +357,12 @@ async def test_http_event_api_failure(hass, hass_client, google_service):
 
 
 @pytest.fixture
-def mock_events_list(google_service: GoogleCalendarService) -> Callable[[...], None]:
+def mock_events_list(
+    google_service: GoogleCalendarService,
+) -> Callable[[dict[str, Any]], None]:
     """Fixture to construct a fake event list API response."""
 
-    def _put_result(response: dict) -> None:
+    def _put_result(response: dict[str, Any]) -> None:
         google_service.return_value.get.return_value.events.return_value.list.return_value.execute.return_value = (
             response
         )


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update tests to exercise the API responses, getting test coverage
to 97% for calendar.py

Before:
```
----------- coverage: platform linux, python 3.9.6-final-0 -----------
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
homeassistant/components/google/__init__.py     193     84    56%   92, 163-228, 238, 244-247, 254-262, 274, 298-299, 305-347, 387-392, 416-430, 435-437
homeassistant/components/google/calendar.py     114     44    61%   41, 44, 50, 96, 127-134, 138-153, 157-167, 175-192
---------------------------------------------------------------------------
TOTAL                                           307    128    58%

```
After:

```
----------- coverage: platform linux, python 3.9.6-final-0 -----------
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
homeassistant/components/google/__init__.py     193     84    56%   92, 163-228, 238, 244-247, 254-262, 274, 298-299, 305-347, 387-392, 416-430, 435-437
homeassistant/components/google/calendar.py     122      4    97%   41, 45, 51, 135
---------------------------------------------------------------------------
TOTAL                                           315     88    72%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
