### PR TITLE
Support Tuya cover with operation mach_operate

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -206,6 +206,7 @@ class DPCode(str, Enum):
     LIGHT = "light"  # Light
     LIGHT_MODE = "light_mode"
     LOCK = "lock"  # Lock / Child lock
+    MACH_OPERATE = "mach_operate"
     MATERIAL = "material"  # Material
     MODE = "mode"  # Working mode / Mode
     MOTION_RECORD = "motion_record"
@@ -221,6 +222,7 @@ class DPCode(str, Enum):
     PERCENT_STATE = "percent_state"
     PERCENT_STATE_2 = "percent_state_2"
     PERCENT_STATE_3 = "percent_state_3"
+    POSITION = "position"
     PHASE_A = "phase_a"
     PHASE_B = "phase_b"
     PHASE_C = "phase_c"

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, TypedDict
+from typing import Any
 
 from tuya_iot import TuyaDevice, TuyaDeviceManager
 
@@ -30,25 +30,6 @@ from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode
 _LOGGER = logging.getLogger(__name__)
 
 
-class _ControlValues(TypedDict):
-    open: str
-    close: str
-    stop: str
-
-
-CONTROL_VALUES_OPEN_CLOSE_STOP: _ControlValues = {
-    "open": "open",
-    "close": "close",
-    "stop": "stop",
-}
-
-CONTROL_VALUES_FZ_ZZ_STOP: _ControlValues = {
-    "open": "FZ",
-    "close": "ZZ",
-    "stop": "STOP",
-}
-
-
 @dataclass
 class TuyaCoverEntityDescription(CoverEntityDescription):
     """Describe an Tuya cover entity."""
@@ -57,7 +38,9 @@ class TuyaCoverEntityDescription(CoverEntityDescription):
     current_state_inverse: bool = False
     current_position: DPCode | tuple[DPCode, ...] | None = None
     set_position: DPCode | None = None
-    control_values: _ControlValues | None = None
+    open_instruction_value: str | None = None
+    close_instruction_value: str | None = None
+    stop_instruction_value: str | None = None
 
 
 COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
@@ -72,7 +55,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=(DPCode.PERCENT_CONTROL, DPCode.PERCENT_STATE),
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_2,
@@ -80,7 +65,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE_2,
             set_position=DPCode.PERCENT_CONTROL_2,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_3,
@@ -88,7 +75,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE_3,
             set_position=DPCode.PERCENT_CONTROL_3,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.MACH_OPERATE,
@@ -96,7 +85,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.POSITION,
             set_position=DPCode.POSITION,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_FZ_ZZ_STOP,
+            open_instruction_value="FZ",
+            close_instruction_value="ZZ",
+            stop_instruction_value="STOP",
         ),
         # switch_1 is an undocumented code that behaves identically to control
         # It is used by the Kogan Smart Blinds Driver
@@ -106,7 +97,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_CONTROL,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.BLIND,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
     ),
     # Garage Door Opener
@@ -118,7 +111,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_state=DPCode.DOORCONTACT_STATE,
             current_state_inverse=True,
             device_class=CoverDeviceClass.GARAGE,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.SWITCH_2,
@@ -126,7 +121,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_state=DPCode.DOORCONTACT_STATE_2,
             current_state_inverse=True,
             device_class=CoverDeviceClass.GARAGE,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.SWITCH_3,
@@ -134,7 +131,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_state=DPCode.DOORCONTACT_STATE_3,
             current_state_inverse=True,
             device_class=CoverDeviceClass.GARAGE,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
     ),
     # Curtain Switch
@@ -146,7 +145,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_CONTROL,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_2,
@@ -154,7 +155,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_CONTROL_2,
             set_position=DPCode.PERCENT_CONTROL_2,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
     ),
     # Curtain Robot
@@ -165,7 +168,9 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
-            control_values=CONTROL_VALUES_OPEN_CLOSE_STOP,
+            open_instruction_value="open",
+            close_instruction_value="close",
+            stop_instruction_value="stop",
         ),
     ),
 }
@@ -229,16 +234,13 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         # Check if this cover is based on a switch or has controls
         if device.function[description.key].type == "Boolean":
             self._attr_supported_features |= SUPPORT_OPEN | SUPPORT_CLOSE
-        elif (
-            device.function[description.key].type == "Enum"
-            and description.control_values is not None
-        ):
+        elif device.function[description.key].type == "Enum":
             data_type = EnumTypeData.from_json(device.function[description.key].values)
-            if description.control_values["open"] in data_type.range:
+            if description.open_instruction_value in data_type.range:
                 self._attr_supported_features |= SUPPORT_OPEN
-            if description.control_values["close"] in data_type.range:
+            if description.close_instruction_value in data_type.range:
                 self._attr_supported_features |= SUPPORT_CLOSE
-            if description.control_values["stop"] in data_type.range:
+            if description.stop_instruction_value in data_type.range:
                 self._attr_supported_features |= SUPPORT_STOP
 
         # Determine type to use for setting the position
@@ -351,9 +353,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         value: bool | str = True
         if (
             self.device.function[self.entity_description.key].type == "Enum"
-            and self.entity_description.control_values is not None
+            and self.entity_description.open_instruction_value is not None
         ):
-            value = self.entity_description.control_values["open"]
+            value = self.entity_description.open_instruction_value
 
         commands: list[dict[str, str | int]] = [
             {"code": self.entity_description.key, "value": value}
@@ -381,9 +383,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         value: bool | str = False
         if (
             self.device.function[self.entity_description.key].type == "Enum"
-            and self.entity_description.control_values is not None
+            and self.entity_description.close_instruction_value is not None
         ):
-            value = self.entity_description.control_values["close"]
+            value = self.entity_description.close_instruction_value
 
         commands: list[dict[str, str | int]] = [
             {"code": self.entity_description.key, "value": value}
@@ -428,12 +430,12 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        if self.entity_description.control_values is not None:
+        if self.entity_description.stop_instruction_value is not None:
             self._send_command(
                 [
                     {
                         "code": self.entity_description.key,
-                        "value": self.entity_description.control_values["stop"],
+                        "value": self.entity_description.stop_instruction_value,
                     }
                 ]
             )

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -38,9 +38,9 @@ class TuyaCoverEntityDescription(CoverEntityDescription):
     current_state_inverse: bool = False
     current_position: DPCode | tuple[DPCode, ...] | None = None
     set_position: DPCode | None = None
-    open_instruction_value: str | None = None
-    close_instruction_value: str | None = None
-    stop_instruction_value: str | None = None
+    open_instruction_value: str = "open"
+    close_instruction_value: str = "close"
+    stop_instruction_value: str = "stop"
 
 
 COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
@@ -55,9 +55,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=(DPCode.PERCENT_CONTROL, DPCode.PERCENT_STATE),
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_2,
@@ -65,9 +62,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE_2,
             set_position=DPCode.PERCENT_CONTROL_2,
             device_class=CoverDeviceClass.CURTAIN,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_3,
@@ -75,9 +69,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE_3,
             set_position=DPCode.PERCENT_CONTROL_3,
             device_class=CoverDeviceClass.CURTAIN,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.MACH_OPERATE,
@@ -97,9 +88,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_CONTROL,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.BLIND,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
     ),
     # Garage Door Opener
@@ -111,9 +99,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_state=DPCode.DOORCONTACT_STATE,
             current_state_inverse=True,
             device_class=CoverDeviceClass.GARAGE,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.SWITCH_2,
@@ -121,9 +106,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_state=DPCode.DOORCONTACT_STATE_2,
             current_state_inverse=True,
             device_class=CoverDeviceClass.GARAGE,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.SWITCH_3,
@@ -131,9 +113,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_state=DPCode.DOORCONTACT_STATE_3,
             current_state_inverse=True,
             device_class=CoverDeviceClass.GARAGE,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
     ),
     # Curtain Switch
@@ -145,9 +124,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_CONTROL,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL_2,
@@ -155,9 +131,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_CONTROL_2,
             set_position=DPCode.PERCENT_CONTROL_2,
             device_class=CoverDeviceClass.CURTAIN,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
     ),
     # Curtain Robot
@@ -168,9 +141,6 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
-            open_instruction_value="open",
-            close_instruction_value="close",
-            stop_instruction_value="stop",
         ),
     ),
 }
@@ -351,10 +321,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         value: bool | str = True
-        if (
-            self.device.function[self.entity_description.key].type == "Enum"
-            and self.entity_description.open_instruction_value is not None
-        ):
+        if self.device.function[self.entity_description.key].type == "Enum":
             value = self.entity_description.open_instruction_value
 
         commands: list[dict[str, str | int]] = [
@@ -381,10 +348,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
     def close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         value: bool | str = False
-        if (
-            self.device.function[self.entity_description.key].type == "Enum"
-            and self.entity_description.close_instruction_value is not None
-        ):
+        if self.device.function[self.entity_description.key].type == "Enum":
             value = self.entity_description.close_instruction_value
 
         commands: list[dict[str, str | int]] = [
@@ -430,15 +394,14 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        if self.entity_description.stop_instruction_value is not None:
-            self._send_command(
-                [
-                    {
-                        "code": self.entity_description.key,
-                        "value": self.entity_description.stop_instruction_value,
-                    }
-                ]
-            )
+        self._send_command(
+            [
+                {
+                    "code": self.entity_description.key,
+                    "value": self.entity_description.stop_instruction_value,
+                }
+            ]
+        )
 
     def set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for some Tuya covers (cl) that in the latest release (2021.12.4) is marked as unsupported.
The Zemismart BCM500DS-TYW covers are using the `mach_operate` instruction, which is currently not supported by the code.

The following issues seems to be related: 
- https://github.com/home-assistant/core/issues/60486
- https://github.com/home-assistant/core/issues/60444

Here's the instruction and status sets for the cover in the Tuya IoT platform:
![image](https://user-images.githubusercontent.com/540786/147196392-82783a39-4cc5-422f-a201-d17a5b214f32.png)
![image](https://user-images.githubusercontent.com/540786/147196408-42ee5a09-8acc-4931-b2d7-9944bcfb3875.png)

Supported and tested features:
- Open, close and stop
- Reporting position
- Setting position

Please let me know how the code could be improved!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60486 #60444
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
