### PR TITLE
Adjust Hue retry logic to changes in the aiohue library

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from http import HTTPStatus
 import logging
 from typing import Any
 
 from aiohttp import client_exceptions
 from aiohue import HueBridgeV1, HueBridgeV2, LinkButtonNotPressed, Unauthorized
-from aiohue.errors import AiohueException
+from aiohue.errors import AiohueException, BridgeBusy
 import async_timeout
 
 from homeassistant import core
@@ -44,9 +43,6 @@ class HueBridge:
         self.config_entry = config_entry
         self.hass = hass
         self.authorized = False
-        self.parallel_updates_semaphore = asyncio.Semaphore(
-            3 if self.api_version == 1 else 10
-        )
         # Jobs to be executed when API is reset.
         self.reset_jobs: list[core.CALLBACK_TYPE] = []
         self.sensor_manager: SensorManager | None = None
@@ -89,6 +85,7 @@ class HueBridge:
             client_exceptions.ClientOSError,
             client_exceptions.ServerDisconnectedError,
             client_exceptions.ContentTypeError,
+            BridgeBusy,
         ) as err:
             raise ConfigEntryNotReady(
                 f"Error connecting to the Hue bridge at {self.host}"
@@ -121,50 +118,19 @@ class HueBridge:
     async def async_request_call(
         self, task: Callable, *args, allowed_errors: list[str] | None = None, **kwargs
     ) -> Any:
-        """Limit parallel requests to Hue hub.
-
-        The Hue hub can only handle a certain amount of parallel requests, total.
-        Although we limit our parallel requests, we still will run into issues because
-        other products are hitting up Hue.
-
-        ClientOSError means hub closed the socket on us.
-        ContentResponseError means hub raised an error.
-        Since we don't make bad requests, this is on them.
-        """
-        max_tries = 5
-        async with self.parallel_updates_semaphore:
-            for tries in range(max_tries):
-                try:
-                    return await task(*args, **kwargs)
-                except AiohueException as err:
-                    # The new V2 api is a bit more fanatic with throwing errors
-                    # some of which we accept in certain conditions
-                    # handle that here. Note that these errors are strings and do not have
-                    # an identifier or something.
-                    if allowed_errors is not None and str(err) in allowed_errors:
-                        # log only
-                        self.logger.debug(
-                            "Ignored error/warning from Hue API: %s", str(err)
-                        )
-                        return None
-                    raise err
-                except (
-                    client_exceptions.ClientOSError,
-                    client_exceptions.ClientResponseError,
-                    client_exceptions.ServerDisconnectedError,
-                ) as err:
-                    if tries == max_tries:
-                        self.logger.error("Request failed %s times, giving up", tries)
-                        raise
-
-                    # We only retry if it's a server error. So raise on all 4XX errors.
-                    if (
-                        isinstance(err, client_exceptions.ClientResponseError)
-                        and err.status < HTTPStatus.INTERNAL_SERVER_ERROR
-                    ):
-                        raise
-
-                    await asyncio.sleep(HUB_BUSY_SLEEP * tries)
+        """Send request to the Hue bridge, optionally omitting error(s)."""
+        try:
+            return await task(*args, **kwargs)
+        except AiohueException as err:
+            # The (new) Hue api can be a bit fanatic with throwing errors
+            # some of which we accept in certain conditions
+            # handle that here. Note that these errors are strings and do not have
+            # an identifier or something.
+            if allowed_errors is not None and str(err) in allowed_errors:
+                # log only
+                self.logger.debug("Ignored error/warning from Hue API: %s", str(err))
+                return None
+            raise err
 
     async def async_reset(self) -> bool:
         """Reset this bridge to default state.


### PR DESCRIPTION
## Proposed change

The aiohue library has been adjusted to better handle the rate limiting of the Hue bridge.
This logic is now moved to the library itself which will rate limit and retry requests if/when needed.
Also the EventStream now includes a (dirty but working) keepalive to better detect a disconnected state.

This (including the aiohue 3.0.10 bump) should solve all reported state issues with the Hue integration.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #62504 fixes #62465
- This PR is related to issue: #62497 #62478 #61723
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
