### PR TITLE
Fix ghost events for Hue Tap switches

### DIFF
--- a/homeassistant/components/hue/v2/hue_event.py
+++ b/homeassistant/components/hue/v2/hue_event.py
@@ -1,4 +1,5 @@
 """Handle forward of events transmitted by Hue devices to HASS."""
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,11 @@ if TYPE_CHECKING:
     from ..bridge import HueBridge
 
 LOGGER = logging.getLogger(__name__)
+
+BTN_WORKAROUND_NEEDED = [
+    # List of Switch/Button device Model ID's that need the longpress workaround
+    "FOHSWITCH"
+]
 
 
 async def async_setup_hue_events(bridge: "HueBridge"):
@@ -46,9 +52,10 @@ async def async_setup_hue_events(bridge: "HueBridge"):
             return
 
         cur_event = hue_resource.button.last_event
+        last_event = last_state.get(hue_resource.id)
         # ignore the event if the last_event value is exactly the same
         # this may happen if some other metadata of the button resource is adjusted
-        if cur_event == last_state.get(hue_resource.id):
+        if cur_event == last_event:
             return
         if cur_event != ButtonEvent.REPEAT:
             # do not store repeat event
@@ -67,6 +74,32 @@ async def async_setup_hue_events(bridge: "HueBridge"):
             CONF_SUBTYPE: hue_resource.metadata.control_id,
         }
         hass.bus.async_fire(ATTR_HUE_EVENT, data)
+
+        # Handle longpress workaround if needed
+        if (
+            hue_device.product_data.model_id in BTN_WORKAROUND_NEEDED
+            and cur_event == ButtonEvent.INITIAL_PRESS
+        ):
+            asyncio.create_task(handle_longpress_workaround(hue_resource))
+
+    async def handle_longpress_workaround(hue_resource: Button):
+        # Fake `held down` and `long press release` events
+        # This might need to be removed in a future release once Signify
+        # adds this back in their API.
+        await asyncio.sleep(1.5)
+        count = 0
+        while count <= 20:  # = max 10 seconds
+            if hue_resource.button.last_event == ButtonEvent.SHORT_RELEASE:
+                break
+            # send REPEAT until short release is received
+            hue_resource.button.last_event = ButtonEvent.REPEAT
+            handle_button_event(EventType.RESOURCE_UPDATED, hue_resource)
+            await asyncio.sleep(0.5)
+            count += 1
+
+        if count > 1:
+            hue_resource.button.last_event = ButtonEvent.LONG_RELEASE
+            handle_button_event(EventType.RESOURCE_UPDATED, hue_resource)
 
     # add listener for updates from `button` resource
     conf_entry.async_on_unload(

--- a/homeassistant/components/hue/v2/hue_event.py
+++ b/homeassistant/components/hue/v2/hue_event.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
-from aiohue.v2.models.button import Button
+from aiohue.v2.models.button import Button, ButtonEvent
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_ID, CONF_TYPE, CONF_UNIQUE_ID
 from homeassistant.core import callback
@@ -27,6 +27,11 @@ async def async_setup_hue_events(bridge: "HueBridge"):
     api: HueBridgeV2 = bridge.api  # to satisfy typing
     conf_entry = bridge.config_entry
     dev_reg = device_registry.async_get(hass)
+    last_state = {
+        x.id: x.button.last_event
+        for x in api.sensors.button.items
+        if x.button is not None
+    }
 
     # at this time the `button` resource is the only source of hue events
     btn_controller = api.sensors.button
@@ -35,6 +40,20 @@ async def async_setup_hue_events(bridge: "HueBridge"):
     def handle_button_event(evt_type: EventType, hue_resource: Button) -> None:
         """Handle event from Hue devices controller."""
         LOGGER.debug("Received button event: %s", hue_resource)
+
+        # guard for missing button object on the resource
+        if hue_resource.button is None:
+            return
+
+        cur_event = hue_resource.button.last_event
+        # ignore the event if the last_event value is exactly the same
+        # this may happen if some other metadata of the button resource is adjusted
+        if cur_event == last_state.get(hue_resource.id):
+            return
+        if cur_event != ButtonEvent.REPEAT:
+            # do not store repeat event
+            last_state[hue_resource.id] = cur_event
+
         hue_device = btn_controller.get_device(hue_resource.id)
         device = dev_reg.async_get_device({(DOMAIN, hue_device.id)})
 
@@ -44,7 +63,7 @@ async def async_setup_hue_events(bridge: "HueBridge"):
             CONF_ID: slugify(f"{hue_device.metadata.name}: Button"),
             CONF_DEVICE_ID: device.id,  # type: ignore
             CONF_UNIQUE_ID: hue_resource.id,
-            CONF_TYPE: hue_resource.button.last_event.value,
+            CONF_TYPE: cur_event.value,
             CONF_SUBTYPE: hue_resource.metadata.control_id,
         }
         hass.bus.async_fire(ATTR_HUE_EVENT, data)

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -26,7 +26,7 @@ async def test_hue_event(hass, mock_bridge_v2, v2_resources_test_data):
 
     # Emit button update event
     btn_event = {
-        "button": {"last_event": "short_release"},
+        "button": {"last_event": "initial_press"},
         "id": "c658d3d8-a013-4b81-8ac6-78b248537e70",
         "metadata": {"control_id": 1},
         "type": "button",


### PR DESCRIPTION
## Proposed change

Fix ghost events for Hue Tap switches when the connection to the bridge is reconnected.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #62478
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
