### PR TITLE
Give scenes last activated state

### DIFF
--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -1,7 +1,6 @@
 """Allow users to set and activate scenes."""
 from __future__ import annotations
 
-from datetime import datetime
 import functools as ft
 import importlib
 import logging
@@ -94,7 +93,7 @@ class Scene(RestoreEntity):
     """A scene is a group of entities and the states we want them to be."""
 
     _attr_should_poll = False
-    __last_activated: datetime | None = None
+    __last_activated: str | None = None
 
     @property
     @final
@@ -102,7 +101,7 @@ class Scene(RestoreEntity):
         """Return the state of the scene."""
         if self.__last_activated is None:
             return None
-        return self.__last_activated.isoformat()
+        return self.__last_activated
 
     @final
     async def _async_activate(self, **kwargs: Any) -> None:
@@ -110,7 +109,7 @@ class Scene(RestoreEntity):
 
         Should not be overridden, handle setting last press timestamp.
         """
-        self.__last_activated = dt_util.utcnow()
+        self.__last_activated = dt_util.utcnow().isoformat()
         self.async_write_ha_state()
         await self.async_activate(**kwargs)
 
@@ -118,7 +117,7 @@ class Scene(RestoreEntity):
         """Call when the button is added to hass."""
         state = await self.async_get_last_state()
         if state is not None and state.state is not None:
-            self.__last_activated = dt_util.parse_datetime(state.state)
+            self.__last_activated = state.state
 
     def activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -1,10 +1,11 @@
 """Allow users to set and activate scenes."""
 from __future__ import annotations
 
+from datetime import datetime
 import functools as ft
 import importlib
 import logging
-from typing import Any
+from typing import Any, final
 
 import voluptuous as vol
 
@@ -12,14 +13,14 @@ from homeassistant.components.light import ATTR_TRANSITION
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PLATFORM, SERVICE_TURN_ON
 from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
 DOMAIN = "scene"
-STATE = "scening"
 STATES = "states"
 
 
@@ -71,7 +72,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(
         SERVICE_TURN_ON,
         {ATTR_TRANSITION: vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553))},
-        "async_activate",
+        "_async_activate",
     )
 
     return True
@@ -89,18 +90,35 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await component.async_unload_entry(entry)
 
 
-class Scene(Entity):
+class Scene(RestoreEntity):
     """A scene is a group of entities and the states we want them to be."""
 
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed."""
-        return False
+    _attr_should_poll = False
+    __last_activated: datetime | None = None
 
     @property
+    @final
     def state(self) -> str | None:
         """Return the state of the scene."""
-        return STATE
+        if self.__last_activated is None:
+            return None
+        return self.__last_activated.isoformat()
+
+    @final
+    async def _async_activate(self, **kwargs: Any) -> None:
+        """Activate scene.
+
+        Should not be overridden, handle setting last press timestamp.
+        """
+        self.__last_activated = dt_util.utcnow()
+        self.async_write_ha_state()
+        await self.async_activate(**kwargs)
+
+    async def async_added_to_hass(self) -> None:
+        """Call when the button is added to hass."""
+        state = await self.async_get_last_state()
+        if state is not None and state.state is not None:
+            self.__last_activated = dt_util.parse_datetime(state.state)
 
     def activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -800,7 +800,7 @@ async def test_scene_scene(hass):
     assert helpers.get_google_type(scene.DOMAIN, None) is not None
     assert trait.SceneTrait.supported(scene.DOMAIN, 0, None, None)
 
-    trt = trait.SceneTrait(hass, State("scene.bla", scene.STATE), BASIC_CONFIG)
+    trt = trait.SceneTrait(hass, State("scene.bla", STATE_UNKNOWN), BASIC_CONFIG)
     assert trt.sync_attributes() == {}
     assert trt.query_attributes() == {}
     assert trt.can_execute(trait.COMMAND_ACTIVATE_SCENE, {})

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.components.homeassistant import scene as ha_scene
 from homeassistant.components.homeassistant.scene import EVENT_SCENE_RELOADED
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events, async_mock_service
@@ -119,7 +120,7 @@ async def test_create_service(hass, caplog):
     assert scene is not None
     assert scene.domain == "scene"
     assert scene.name == "hallo"
-    assert scene.state == "scening"
+    assert scene.state == STATE_UNKNOWN
     assert scene.attributes.get("entity_id") == ["light.bed_light"]
 
     assert await hass.services.async_call(
@@ -137,7 +138,7 @@ async def test_create_service(hass, caplog):
     assert scene is not None
     assert scene.domain == "scene"
     assert scene.name == "hallo"
-    assert scene.state == "scening"
+    assert scene.state == STATE_UNKNOWN
     assert scene.attributes.get("entity_id") == ["light.kitchen_light"]
 
     assert await hass.services.async_call(
@@ -156,7 +157,7 @@ async def test_create_service(hass, caplog):
     assert scene is not None
     assert scene.domain == "scene"
     assert scene.name == "hallo_2"
-    assert scene.state == "scening"
+    assert scene.state == STATE_UNKNOWN
     assert scene.attributes.get("entity_id") == ["light.kitchen"]
 
 

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -1,6 +1,7 @@
 """Philips Hue scene platform tests for V2 bridge/api."""
 
 
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_platform
@@ -21,7 +22,7 @@ async def test_scene(hass, mock_bridge_v2, v2_resources_test_data):
     test_entity = hass.states.get("scene.test_zone_dynamic_test_scene")
     assert test_entity is not None
     assert test_entity.name == "Test Zone - Dynamic Test Scene"
-    assert test_entity.state == "scening"
+    assert test_entity.state == STATE_UNKNOWN
     assert test_entity.attributes["group_name"] == "Test Zone"
     assert test_entity.attributes["group_type"] == "zone"
     assert test_entity.attributes["name"] == "Dynamic Test Scene"
@@ -33,7 +34,7 @@ async def test_scene(hass, mock_bridge_v2, v2_resources_test_data):
     test_entity = hass.states.get("scene.test_room_regular_test_scene")
     assert test_entity is not None
     assert test_entity.name == "Test Room - Regular Test Scene"
-    assert test_entity.state == "scening"
+    assert test_entity.state == STATE_UNKNOWN
     assert test_entity.attributes["group_name"] == "Test Room"
     assert test_entity.attributes["group_type"] == "room"
     assert test_entity.attributes["name"] == "Regular Test Scene"
@@ -142,7 +143,7 @@ async def test_scene_updates(hass, mock_bridge_v2, v2_resources_test_data):
     # the entity should now be available
     test_entity = hass.states.get(test_entity_id)
     assert test_entity is not None
-    assert test_entity.state == "scening"
+    assert test_entity.state == STATE_UNKNOWN
     assert test_entity.name == "Test Room - Mocked Scene"
     assert test_entity.attributes["brightness"] == 65.0
 

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import scene
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNKNOWN
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
 
@@ -34,7 +34,7 @@ DEFAULT_CONFIG = {
 
 async def test_sending_mqtt_commands(hass, mqtt_mock):
     """Test the sending MQTT commands."""
-    fake_state = ha.State("scene.test", scene.STATE)
+    fake_state = ha.State("scene.test", STATE_UNKNOWN)
 
     with patch(
         "homeassistant.helpers.restore_state.RestoreEntity.async_get_last_state",
@@ -55,7 +55,7 @@ async def test_sending_mqtt_commands(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("scene.test")
-    assert state.state == scene.STATE
+    assert state.state == STATE_UNKNOWN
 
     data = {ATTR_ENTITY_ID: "scene.test"}
     await hass.services.async_call(scene.DOMAIN, SERVICE_TURN_ON, data, blocking=True)

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -289,6 +289,8 @@ def scene_factory_fixture(location):
         scene = Mock(SceneEntity)
         scene.scene_id = str(uuid4())
         scene.name = name
+        scene.icon = None
+        scene.color = None
         scene.location_id = location.location_id
         return scene
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Scene (`scene`) entities currently have a fixed state: `scening`, which is not really useful.
This PR adjusts that by making the state of the scene a timestamp of the last time it was activated.

This is similar to how we handle this in the `button` entity.

This allows to automate on state changes of the scene, or apply other logic based on the timestamp stored in the state.

The state automatically restores on Home Assistant start.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
