### PR TITLE
Fix pylint plugin which checks relative imports

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import threading
 
-from homeassistant.const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
+from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
@@ -27,7 +27,7 @@ def validate_python() -> None:
 def ensure_config_path(config_dir: str) -> None:
     """Validate the configuration directory."""
     # pylint: disable=import-outside-toplevel
-    import homeassistant.config as config_util
+    from . import config as config_util
 
     lib_dir = os.path.join(config_dir, "deps")
 
@@ -61,7 +61,7 @@ def ensure_config_path(config_dir: str) -> None:
 def get_arguments() -> argparse.Namespace:
     """Get parsed passed in arguments."""
     # pylint: disable=import-outside-toplevel
-    import homeassistant.config as config_util
+    from . import config as config_util
 
     parser = argparse.ArgumentParser(
         description="Home Assistant: Observe, Control, Automate."
@@ -282,7 +282,7 @@ def main() -> int:
 
     if args.script is not None:
         # pylint: disable=import-outside-toplevel
-        from homeassistant import scripts
+        from . import scripts
 
         return scripts.run(args.script)
 
@@ -298,7 +298,7 @@ def main() -> int:
         write_pid(args.pid_file)
 
     # pylint: disable=import-outside-toplevel
-    from homeassistant import runner
+    from . import runner
 
     runtime_conf = runner.RuntimeConfig(
         config_dir=config_dir,

--- a/homeassistant/async_timeout_backcompat.py
+++ b/homeassistant/async_timeout_backcompat.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import async_timeout
 
-from homeassistant.helpers.frame import report
+from .helpers.frame import report
 
 
 def timeout(

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -8,12 +8,16 @@ import hmac
 from logging import getLogger
 from typing import Any
 
-from homeassistant.auth.const import ACCESS_TOKEN_EXPIRATION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from . import models
-from .const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY, GROUP_ID_USER
+from .const import (
+    ACCESS_TOKEN_EXPIRATION,
+    GROUP_ID_ADMIN,
+    GROUP_ID_READ_ONLY,
+    GROUP_ID_USER,
+)
 from .permissions import PermissionLookup, system_policies
 from .permissions.types import PolicyType
 

--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -1,7 +1,7 @@
 """Block I/O being done in asyncio."""
 from http.client import HTTPConnection
 
-from homeassistant.util.async_ import protect_loop
+from .util.async_ import protect_loop
 
 
 def enable() -> None:

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -15,27 +15,24 @@ from typing import TYPE_CHECKING, Any
 import voluptuous as vol
 import yarl
 
-from homeassistant import config as conf_util, config_entries, core, loader
-from homeassistant.components import http
-from homeassistant.const import (
-    REQUIRED_NEXT_PYTHON_HA_RELEASE,
-    REQUIRED_NEXT_PYTHON_VER,
-)
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import area_registry, device_registry, entity_registry
-from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.typing import ConfigType
-from homeassistant.setup import (
+from . import config as conf_util, config_entries, core, loader
+from .components import http
+from .const import REQUIRED_NEXT_PYTHON_HA_RELEASE, REQUIRED_NEXT_PYTHON_VER
+from .exceptions import HomeAssistantError
+from .helpers import area_registry, device_registry, entity_registry
+from .helpers.dispatcher import async_dispatcher_send
+from .helpers.typing import ConfigType
+from .setup import (
     DATA_SETUP,
     DATA_SETUP_STARTED,
     DATA_SETUP_TIME,
     async_set_domains_to_be_loaded,
     async_setup_component,
 )
-from homeassistant.util.async_ import gather_with_concurrency
-import homeassistant.util.dt as dt_util
-from homeassistant.util.logging import async_activate_log_queue_handler
-from homeassistant.util.package import async_get_user_site, is_virtual_env
+from .util import dt as dt_util
+from .util.async_ import gather_with_concurrency
+from .util.logging import async_activate_log_queue_handler
+from .util.package import async_get_user_site, is_virtual_env
 
 if TYPE_CHECKING:
     from .runner import RuntimeConfig

--- a/homeassistant/components/zha/core/typing.py
+++ b/homeassistant/components/zha/core/typing.py
@@ -26,20 +26,17 @@ ZigpyGroupType = zigpy.group.Group
 ZigpyZdoType = zigpy.zdo.ZDO
 
 if TYPE_CHECKING:
-    from homeassistant.components.zha.core import channels
-    import homeassistant.components.zha.core.channels
-    import homeassistant.components.zha.core.channels.base as base_channels
-    import homeassistant.components.zha.core.device
-    import homeassistant.components.zha.core.gateway
-    import homeassistant.components.zha.core.group
     import homeassistant.components.zha.entity
+
+    from . import channels, device, gateway, group
+    from .channels import base as base_channels
 
     ChannelType = base_channels.ZigbeeChannel
     ChannelsType = channels.Channels
     ChannelPoolType = channels.ChannelPool
     ClientChannelType = base_channels.ClientChannel
     ZDOChannelType = base_channels.ZDOChannel
-    ZhaDeviceType = homeassistant.components.zha.core.device.ZHADevice
+    ZhaDeviceType = device.ZHADevice
     ZhaEntityType = homeassistant.components.zha.entity.ZhaEntity
-    ZhaGatewayType = homeassistant.components.zha.core.gateway.ZHAGateway
-    ZhaGroupType = homeassistant.components.zha.core.group.ZHAGroup
+    ZhaGatewayType = gateway.ZHAGateway
+    ZhaGroupType = group.ZHAGroup

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -16,12 +16,9 @@ from awesomeversion import AwesomeVersion
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from homeassistant import auth
-from homeassistant.auth import (
-    mfa_modules as auth_mfa_modules,
-    providers as auth_providers,
-)
-from homeassistant.const import (
+from . import auth
+from .auth import mfa_modules as auth_mfa_modules, providers as auth_providers
+from .const import (
     ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
     ATTR_HIDDEN,
@@ -52,25 +49,20 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     __version__,
 )
-from homeassistant.core import (
-    DOMAIN as CONF_CORE,
-    ConfigSource,
-    HomeAssistant,
-    callback,
+from .core import DOMAIN as CONF_CORE, ConfigSource, HomeAssistant, callback
+from .exceptions import HomeAssistantError
+from .helpers import (
+    config_per_platform,
+    config_validation as cv,
+    extract_domain_configs,
 )
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform, extract_domain_configs
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity_values import EntityValues
-from homeassistant.helpers.typing import ConfigType
-from homeassistant.loader import Integration, IntegrationNotFound
-from homeassistant.requirements import (
-    RequirementsNotFound,
-    async_get_integration_with_requirements,
-)
-from homeassistant.util.package import is_docker_env
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
-from homeassistant.util.yaml import SECRET_YAML, Secrets, load_yaml
+from .helpers.entity_values import EntityValues
+from .helpers.typing import ConfigType
+from .loader import Integration, IntegrationNotFound
+from .requirements import RequirementsNotFound, async_get_integration_with_requirements
+from .util.package import is_docker_env
+from .util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from .util.yaml import SECRET_YAML, Secrets, load_yaml
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -930,7 +930,7 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> str | None:
     This method is a coroutine.
     """
     # pylint: disable=import-outside-toplevel
-    from homeassistant.helpers import check_config
+    from .helpers import check_config
 
     res = await check_config.async_check_ha_config_file(hass)
 
@@ -948,7 +948,7 @@ def async_notify_setup_error(
     This method must be run in the event loop.
     """
     # pylint: disable=import-outside-toplevel
-    from homeassistant.components import persistent_notification
+    from .components import persistent_notification
 
     if (errors := hass.data.get(DATA_PERSISTENT_ERRORS)) is None:
         errors = hass.data[DATA_PERSISTENT_ERRORS] = {}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -12,35 +12,26 @@ from types import MappingProxyType, MethodType
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 import weakref
 
-from homeassistant import data_entry_flow, loader
-from homeassistant.backports.enum import StrEnum
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import CALLBACK_TYPE, CoreState, HomeAssistant, callback
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
-    HomeAssistantError,
-)
-from homeassistant.helpers import device_registry, entity_registry
-from homeassistant.helpers.event import Event
-from homeassistant.helpers.frame import report
-from homeassistant.helpers.typing import (
-    UNDEFINED,
-    ConfigType,
-    DiscoveryInfoType,
-    UndefinedType,
-)
-from homeassistant.setup import async_process_deps_reqs, async_setup_component
-from homeassistant.util.decorator import Registry
-import homeassistant.util.uuid as uuid_util
+from . import data_entry_flow, loader
+from .backports.enum import StrEnum
+from .const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
+from .core import CALLBACK_TYPE, CoreState, HomeAssistant, callback
+from .exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady, HomeAssistantError
+from .helpers import device_registry, entity_registry
+from .helpers.event import Event
+from .helpers.frame import report
+from .helpers.typing import UNDEFINED, ConfigType, DiscoveryInfoType, UndefinedType
+from .setup import async_process_deps_reqs, async_setup_component
+from .util import uuid as uuid_util
+from .util.decorator import Registry
 
 if TYPE_CHECKING:
-    from homeassistant.components.dhcp import DhcpServiceInfo
-    from homeassistant.components.hassio import HassioServiceInfo
-    from homeassistant.components.mqtt import MqttServiceInfo
-    from homeassistant.components.ssdp import SsdpServiceInfo
-    from homeassistant.components.usb import UsbServiceInfo
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
+    from .components.dhcp import DhcpServiceInfo
+    from .components.hassio import HassioServiceInfo
+    from .components.mqtt import MqttServiceInfo
+    from .components.ssdp import SsdpServiceInfo
+    from .components.usb import UsbServiceInfo
+    from .components.zeroconf import ZeroconfServiceInfo
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.backports.enum import StrEnum
+from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 2

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -25,9 +25,9 @@ import attr
 import voluptuous as vol
 import yarl
 
-from homeassistant import async_timeout_backcompat, block_async_io, loader, util
-from homeassistant.backports.enum import StrEnum
-from homeassistant.const import (
+from . import async_timeout_backcompat, block_async_io, loader, util
+from .backports.enum import StrEnum
+from .const import (
     ATTR_DOMAIN,
     ATTR_FRIENDLY_NAME,
     ATTR_NOW,
@@ -53,7 +53,7 @@ from homeassistant.const import (
     MAX_LENGTH_STATE_STATE,
     __version__,
 )
-from homeassistant.exceptions import (
+from .exceptions import (
     HomeAssistantError,
     InvalidEntityFormatError,
     InvalidStateError,
@@ -61,22 +61,20 @@ from homeassistant.exceptions import (
     ServiceNotFound,
     Unauthorized,
 )
-from homeassistant.util import location
-from homeassistant.util.async_ import (
+from .util import dt as dt_util, location, uuid as uuid_util
+from .util.async_ import (
     fire_coroutine_threadsafe,
     run_callback_threadsafe,
     shutdown_run_callback_threadsafe,
 )
-import homeassistant.util.dt as dt_util
-from homeassistant.util.timeout import TimeoutManager
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
-import homeassistant.util.uuid as uuid_util
+from .util.timeout import TimeoutManager
+from .util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:
-    from homeassistant.auth import AuthManager
-    from homeassistant.components.http import HomeAssistantHTTP
-    from homeassistant.config_entries import ConfigEntries
+    from .auth import AuthManager
+    from .components.http import HomeAssistantHTTP
+    from .config_entries import ConfigEntries
 
 
 STAGE_1_SHUTDOWN_TIMEOUT = 100
@@ -286,7 +284,7 @@ class HomeAssistant:
         await self.async_start()
         if attach_signals:
             # pylint: disable=import-outside-toplevel
-            from homeassistant.helpers.signal import async_register_signal_handling
+            from .helpers.signal import async_register_signal_handling
 
             async_register_signal_handling(self)
 

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -18,9 +18,10 @@ import async_timeout
 from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers.frame import warn_use
 from homeassistant.loader import bind_hass
 from homeassistant.util import ssl as ssl_util
+
+from .frame import warn_use
 
 DATA_CONNECTOR = "aiohttp_connector"
 DATA_CONNECTOR_NOTVERIFY = "aiohttp_connector_notverify"

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -8,10 +8,10 @@ from typing import cast
 import attr
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.loader import bind_hass
 from homeassistant.util import slugify
 
+from . import device_registry as dr, entity_registry as er
 from .typing import UNDEFINED, UndefinedType
 
 # mypy: disallow-any-generics

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -23,13 +23,14 @@ from homeassistant.config import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.requirements import (
     RequirementsNotFound,
     async_clear_install_history,
     async_get_integration_with_requirements,
 )
 import homeassistant.util.yaml.loader as yaml_loader
+
+from .typing import ConfigType
 
 
 class CheckConfigError(NamedTuple):

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -16,11 +16,12 @@ from homeassistant.components import websocket_api
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.storage import Store
 from homeassistant.util import slugify
+
+from . import entity_registry
+from .entity import Entity
+from .entity_component import EntityComponent
+from .storage import Store
 
 STORAGE_VERSION = 1
 SAVE_DELAY = 10

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -52,13 +52,12 @@ from homeassistant.exceptions import (
     HomeAssistantError,
     TemplateError,
 )
-from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.sun import get_astral_event_date
-from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 
+from . import config_validation as cv, entity_registry as er
+from .sun import get_astral_event_date
+from .template import Template
 from .trace import (
     TraceElement,
     trace_append_element,
@@ -69,6 +68,7 @@ from .trace import (
     trace_stack_push,
     trace_stack_top,
 )
+from .typing import ConfigType, TemplateVarsType
 
 # mypy: disallow-any-generics
 

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -8,7 +8,8 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp, mqtt, ssdp, zeroconf
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.typing import UNDEFINED, DiscoveryInfoType, UndefinedType
+
+from .typing import UNDEFINED, DiscoveryInfoType, UndefinedType
 
 DiscoveryFunctionType = Callable[[HomeAssistant], Union[Awaitable[bool], bool]]
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -25,9 +25,9 @@ from homeassistant import config_entries
 from homeassistant.components import http
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.network import NoURLAvailableError
 
 from .aiohttp_client import async_get_clientsession
+from .network import NoURLAvailableError
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -75,12 +75,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import split_entity_id, valid_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import (
-    script_variables as script_variables_helper,
-    template as template_helper,
-)
 from homeassistant.util import raise_if_invalid_path, slugify as util_slugify
 import homeassistant.util.dt as dt_util
+
+from . import script_variables as script_variables_helper, template as template_helper
 
 # pylint: disable=invalid-name
 

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
-import homeassistant.helpers.config_validation as cv
+
+from . import config_validation as cv
 
 
 class _BaseFlowManagerView(HomeAssistantView):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -12,12 +12,12 @@ from homeassistant.backports.enum import StrEnum
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import RequiredParameterMissing
-from homeassistant.helpers import storage
-from homeassistant.helpers.frame import report
 from homeassistant.loader import bind_hass
 import homeassistant.util.uuid as uuid_util
 
+from . import storage
 from .debounce import Debouncer
+from .frame import report
 from .typing import UNDEFINED, UndefinedType
 
 # mypy: disallow_any_generics

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -37,13 +37,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, NoEntitySpecifiedError
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity_platform import EntityPlatform
-from homeassistant.helpers.event import Event, async_track_entity_registry_updated_event
-from homeassistant.helpers.typing import StateType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
+
+from . import entity_registry as er
+from .device_registry import DeviceEntryType
+from .entity_platform import EntityPlatform
+from .event import Event, async_track_entity_registry_updated_event
+from .typing import StateType
 
 _LOGGER = logging.getLogger(__name__)
 SLOW_UPDATE_WARNING = 10

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -20,18 +20,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import (
-    config_per_platform,
-    config_validation as cv,
-    discovery,
-    entity,
-    service,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.loader import async_get_integration, bind_hass
 from homeassistant.setup import async_prepare_setup_platform
 
+from . import config_per_platform, config_validation as cv, discovery, entity, service
 from .entity_platform import EntityPlatform
+from .typing import ConfigType, DiscoveryInfoType
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 DATA_INSTANCES = "entity_components"

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -38,13 +38,13 @@ from homeassistant.core import (
     valid_entity_id,
 )
 from homeassistant.exceptions import MaxLengthExceeded
-from homeassistant.helpers import device_registry as dr, storage
-from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
-from homeassistant.helpers.frame import report
 from homeassistant.loader import bind_hass
 from homeassistant.util import slugify, uuid as uuid_util
 from homeassistant.util.yaml import load_yaml
 
+from . import device_registry as dr, storage
+from .device_registry import EVENT_DEVICE_REGISTRY_UPDATED
+from .frame import report
 from .typing import UNDEFINED, UndefinedType
 
 if TYPE_CHECKING:

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -9,7 +9,8 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE
 from homeassistant.core import split_entity_id
-from homeassistant.helpers import config_validation as cv
+
+from . import config_validation as cv
 
 CONF_INCLUDE_DOMAINS = "include_domains"
 CONF_INCLUDE_ENTITY_GLOBS = "include_entity_globs"

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -33,14 +33,15 @@ from homeassistant.core import (
     split_entity_id,
 )
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
-from homeassistant.helpers.ratelimit import KeyedRateLimit
-from homeassistant.helpers.sun import get_astral_event_next
-from homeassistant.helpers.template import RenderInfo, Template, result_as_boolean
-from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
+
+from .entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
+from .ratelimit import KeyedRateLimit
+from .sun import get_astral_event_next
+from .template import RenderInfo, Template, result_as_boolean
+from .typing import TemplateVarsType
 
 TRACK_STATE_CHANGE_CALLBACKS = "track_state_change_callbacks"
 TRACK_STATE_CHANGE_LISTENER = "track_state_change_listener"

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -9,8 +9,9 @@ import httpx
 
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers.frame import warn_use
 from homeassistant.loader import bind_hass
+
+from .frame import warn_use
 
 DATA_ASYNC_CLIENT = "httpx_async_client"
 DATA_ASYNC_CLIENT_NOVERIFY = "httpx_async_client_noverify"

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -11,8 +11,9 @@ import voluptuous as vol
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES
 from homeassistant.core import Context, HomeAssistant, State, T, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv
 from homeassistant.loader import bind_hass
+
+from . import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 _SlotsType = Dict[str, Any]

--- a/homeassistant/helpers/location.py
+++ b/homeassistant/helpers/location.py
@@ -86,7 +86,7 @@ def find_coordinates(
     # Check if state is valid coordinate set
     try:
         # Import here, not at top-level to avoid circular import
-        import homeassistant.helpers.config_validation as cv  # pylint: disable=import-outside-toplevel
+        from . import config_validation as cv  # pylint: disable=import-outside-toplevel
 
         cv.gps(entity_state.state.split(","))
     except vol.Invalid:

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -10,11 +10,12 @@ from homeassistant import config as conf_util
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform
-from homeassistant.helpers.entity_platform import EntityPlatform, async_get_platforms
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
+
+from . import config_per_platform
+from .entity_platform import EntityPlatform, async_get_platforms
+from .typing import ConfigType
 
 # mypy: disallow-any-generics
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -9,13 +9,14 @@ from typing import Any, cast
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, State, callback, valid_entity_id
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry, start
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.json import JSONEncoder
-from homeassistant.helpers.singleton import singleton
-from homeassistant.helpers.storage import Store
 import homeassistant.util.dt as dt_util
+
+from . import entity_registry, start
+from .entity import Entity
+from .event import async_track_time_interval
+from .json import JSONEncoder
+from .singleton import singleton
+from .storage import Store
 
 DATA_RESTORE_STATE_TASK = "restore_state_task"
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -56,29 +56,18 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
-from homeassistant.helpers import condition, config_validation as cv, service, template
-from homeassistant.helpers.condition import (
-    ConditionCheckerType,
-    trace_condition_function,
-)
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
-from homeassistant.helpers.event import async_call_later, async_track_template
-from homeassistant.helpers.script_variables import ScriptVariables
-from homeassistant.helpers.trace import script_execution_set
-from homeassistant.helpers.trigger import (
-    async_initialize_triggers,
-    async_validate_trigger_config,
-)
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 from homeassistant.util.dt import utcnow
 
+from . import condition, config_validation as cv, service, template
+from .condition import ConditionCheckerType, trace_condition_function
+from .dispatcher import async_dispatcher_connect, async_dispatcher_send
+from .event import async_call_later, async_track_template
+from .script_variables import ScriptVariables
 from .trace import (
     TraceElement,
     async_trace_path,
+    script_execution_set,
     trace_append_element,
     trace_id_get,
     trace_path,
@@ -90,6 +79,8 @@ from .trace import (
     trace_stack_top,
     trace_update_result,
 )
+from .trigger import async_initialize_triggers, async_validate_trigger_config
+from .typing import ConfigType
 
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -31,14 +31,6 @@ from homeassistant.exceptions import (
     Unauthorized,
     UnknownUser,
 )
-from homeassistant.helpers import (
-    area_registry,
-    config_validation as cv,
-    device_registry,
-    entity_registry,
-    template,
-)
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.loader import (
     MAX_LOAD_CONCURRENTLY,
     Integration,
@@ -49,9 +41,18 @@ from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.yaml import load_yaml
 from homeassistant.util.yaml.loader import JSON_TYPE
 
+from . import (
+    area_registry,
+    config_validation as cv,
+    device_registry,
+    entity_registry,
+    template,
+)
+from .typing import ConfigType, TemplateVarsType
+
 if TYPE_CHECKING:
-    from homeassistant.helpers.entity import Entity
-    from homeassistant.helpers.entity_platform import EntityPlatform
+    from .entity import Entity
+    from .entity_platform import EntityPlatform
 
 
 CONF_SERVICE_ENTITY_ID = "entity_id"

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -197,7 +197,7 @@ class Store:
     def async_delay_save(self, data_func: Callable[[], dict], delay: float = 0) -> None:
         """Save data with an optional delay."""
         # pylint: disable-next=import-outside-toplevel
-        from homeassistant.helpers.event import async_call_later
+        from .event import async_call_later
 
         self._data = {
             "version": self.version,

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -45,13 +45,6 @@ from homeassistant.core import (
     valid_entity_id,
 )
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import (
-    area_registry,
-    device_registry,
-    entity_registry,
-    location as loc_helper,
-)
-from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import (
     convert,
@@ -61,6 +54,9 @@ from homeassistant.util import (
 )
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.thread import ThreadWithException
+
+from . import area_registry, device_registry, entity_registry, location as loc_helper
+from .typing import TemplateVarsType
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -882,9 +878,7 @@ def result_as_boolean(template_result: Any | None) -> bool:
 
     try:
         # Import here, not at top-level to avoid circular import
-        from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
-            config_validation as cv,
-        )
+        from . import config_validation as cv  # pylint: disable=import-outside-toplevel
 
         return cv.boolean(template_result)
     except vol.Invalid:
@@ -952,7 +946,7 @@ def integration_entities(hass: HomeAssistant, entry_name: str) -> Iterable[str]:
 
     # fallback to just returning all entities for a domain
     # pylint: disable=import-outside-toplevel
-    from homeassistant.helpers.entity import entity_sources
+    from .entity import entity_sources
 
     return [
         entity_id
@@ -1014,9 +1008,7 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
     ent_reg = entity_registry.async_get(hass)
     dev_reg = device_registry.async_get(hass)
     # Import here, not at top-level to avoid circular import
-    from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
-        config_validation as cv,
-    )
+    from . import config_validation as cv  # pylint: disable=import-outside-toplevel
 
     try:
         cv.entity_id(lookup_value)
@@ -1054,9 +1046,7 @@ def area_name(hass: HomeAssistant, lookup_value: str) -> str | None:
     dev_reg = device_registry.async_get(hass)
     ent_reg = entity_registry.async_get(hass)
     # Import here, not at top-level to avoid circular import
-    from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
-        config_validation as cv,
-    )
+    from . import config_validation as cv  # pylint: disable=import-outside-toplevel
 
     try:
         cv.entity_id(lookup_value)

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -8,8 +8,9 @@ from contextvars import ContextVar
 from functools import wraps
 from typing import Any, cast
 
-from homeassistant.helpers.typing import TemplateVarsType
 import homeassistant.util.dt as dt_util
+
+from .typing import TemplateVarsType
 
 
 class TraceElement:

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -11,8 +11,9 @@ import voluptuous as vol
 from homeassistant.const import CONF_ID, CONF_PLATFORM
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from homeassistant.loader import IntegrationNotFound, async_get_integration
+
+from .typing import ConfigType, TemplateVarsType
 
 _PLATFORM_ALIASES = {
     "device_automation": ("device",),

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -15,9 +15,9 @@ import requests
 from homeassistant import config_entries
 from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import entity, event
 from homeassistant.util.dt import utcnow
 
+from . import entity, event
 from .debounce import Debouncer
 
 REQUEST_REFRESH_DEFAULT_COOLDOWN = 10

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -23,16 +23,16 @@ from awesomeversion import (
     AwesomeVersionStrategy,
 )
 
-from homeassistant.generated.dhcp import DHCP
-from homeassistant.generated.mqtt import MQTT
-from homeassistant.generated.ssdp import SSDP
-from homeassistant.generated.usb import USB
-from homeassistant.generated.zeroconf import HOMEKIT, ZEROCONF
-from homeassistant.util.async_ import gather_with_concurrency
+from .generated.dhcp import DHCP
+from .generated.mqtt import MQTT
+from .generated.ssdp import SSDP
+from .generated.usb import USB
+from .generated.zeroconf import HOMEKIT, ZEROCONF
+from .util.async_ import gather_with_concurrency
 
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
+    from .core import HomeAssistant
 
 # mypy: disallow-any-generics
 
@@ -167,7 +167,7 @@ async def async_get_custom_components(
 async def async_get_config_flows(hass: HomeAssistant) -> set[str]:
     """Return cached list of config flows."""
     # pylint: disable=import-outside-toplevel
-    from homeassistant.generated.config_flows import FLOWS
+    from .generated.config_flows import FLOWS
 
     flows: set[str] = set()
     flows.update(FLOWS)
@@ -607,7 +607,7 @@ async def _async_get_integration(hass: HomeAssistant, domain: str) -> Integratio
     if integration := (await async_get_custom_components(hass)).get(domain):
         return integration
 
-    from homeassistant import components  # pylint: disable=import-outside-toplevel
+    from . import components  # pylint: disable=import-outside-toplevel
 
     if integration := await hass.async_add_executor_job(
         Integration.resolve_from_root, hass, components, domain

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -7,11 +7,11 @@ import logging
 import os
 from typing import Any, cast
 
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import UNDEFINED, UndefinedType
-from homeassistant.loader import Integration, IntegrationNotFound, async_get_integration
-import homeassistant.util.package as pkg_util
+from .core import HomeAssistant, callback
+from .exceptions import HomeAssistantError
+from .helpers.typing import UNDEFINED, UndefinedType
+from .loader import Integration, IntegrationNotFound, async_get_integration
+from .util import package as pkg_util
 
 # mypy: disallow-any-generics
 

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -8,11 +8,11 @@ import threading
 import traceback
 from typing import Any
 
-from homeassistant import bootstrap
-from homeassistant.core import callback
-from homeassistant.helpers.frame import warn_use
-from homeassistant.util.executor import InterruptibleThreadPoolExecutor
-from homeassistant.util.thread import deadlock_safe_shutdown
+from . import bootstrap
+from .core import callback
+from .helpers.frame import warn_use
+from .util.executor import InterruptibleThreadPoolExecutor
+from .util.thread import deadlock_safe_shutdown
 
 # mypy: disallow-any-generics
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -8,18 +8,18 @@ import logging.handlers
 from timeit import default_timer as timer
 from types import ModuleType
 
-from homeassistant import config as conf_util, core, loader, requirements
-from homeassistant.config import async_notify_setup_error
-from homeassistant.const import (
+from . import config as conf_util, core, loader, requirements
+from .config import async_notify_setup_error
+from .const import (
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_START,
     PLATFORM_FORMAT,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util, ensure_unique_string
+from .core import CALLBACK_TYPE
+from .exceptions import HomeAssistantError
+from .helpers.typing import ConfigType
+from .util import dt as dt_util, ensure_unique_string
 
 # mypy: disallow-any-generics
 

--- a/homeassistant/util/executor.py
+++ b/homeassistant/util/executor.py
@@ -10,7 +10,7 @@ from threading import Thread
 import time
 import traceback
 
-from homeassistant.util.thread import async_raise
+from .thread import async_raise
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -31,7 +31,8 @@ from homeassistant.const import (
     VOLUME_LITERS,
     WIND_SPEED,
 )
-from homeassistant.util import (
+
+from . import (
     distance as distance_util,
     pressure as pressure_util,
     speed as speed_util,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In https://github.com/home-assistant/core/pull/62638 @epenet noticed that this pylint plugin doesn't print some warnings.
It turns out the plugin incorrectly determines the current package to check if relative import can be used.

I don't know if using relative import for root package (`homeassistant`) is desired. If not, I can add an exception for that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
