### PR TITLE
Add button entity to Overkiz integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -803,6 +803,7 @@ omit =
     homeassistant/components/osramlightify/light.py
     homeassistant/components/otp/sensor.py
     homeassistant/components/overkiz/__init__.py
+    homeassistant/components/overkiz/button.py
     homeassistant/components/overkiz/coordinator.py
     homeassistant/components/overkiz/entity.py
     homeassistant/components/overkiz/executor.py

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -47,7 +47,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ):
-    """Set up the Overkiz number from a config entry."""
+    """Set up the Overkiz button from a config entry."""
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
     entities: list[ButtonEntity] = []
 

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -1,11 +1,13 @@
 """Support for Overkiz (virtual) buttons."""
+from __future__ import annotations
+
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.components.overkiz import HomeAssistantOverkizData
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizDescriptiveEntity
 

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -20,7 +20,7 @@ BUTTON_DESCRIPTIONS: list[ButtonEntityDescription] = [
     ),
     # Identify
     ButtonEntityDescription(
-        key="identify",  # startIdentify and identify are reversed... Swap this when fixed server side.
+        key="identify",  # startIdentify and identify are reversed... Swap this when fixed in API.
         name="Start Identify",
         icon="mdi:human-greeting-variant",
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -34,7 +34,7 @@ BUTTON_DESCRIPTIONS: list[ButtonEntityDescription] = [
         entity_registry_enabled_default=False,
     ),
     ButtonEntityDescription(
-        key="startIdentify",  # startIdentify and identify are reversed... Swap this when fixed server side.
+        key="startIdentify",  # startIdentify and identify are reversed... Swap this when fixed in API.
         name="Identify",
         icon="mdi:human-greeting-variant",
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -1,0 +1,79 @@
+"""Support for Overkiz (virtual) buttons."""
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.overkiz import HomeAssistantOverkizData
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
+from .entity import OverkizDescriptiveEntity
+
+BUTTON_DESCRIPTIONS: list[ButtonEntityDescription] = [
+    # My Position (cover, light)
+    ButtonEntityDescription(
+        key="my",
+        name="My Position",
+        icon="mdi:star",
+    ),
+    # Identify
+    ButtonEntityDescription(
+        key="identify",  # startIdentify and identify are reversed... Swap this when fixed server side.
+        name="Start Identify",
+        icon="mdi:human-greeting-variant",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    ButtonEntityDescription(
+        key="stopIdentify",
+        name="Stop Identify",
+        icon="mdi:human-greeting-variant",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    ButtonEntityDescription(
+        key="startIdentify",  # startIdentify and identify are reversed... Swap this when fixed server side.
+        name="Identify",
+        icon="mdi:human-greeting-variant",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up the Overkiz number from a config entry."""
+    data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
+    entities: list[ButtonEntity] = []
+
+    supported_commands = {
+        description.key: description for description in BUTTON_DESCRIPTIONS
+    }
+
+    for device in data.coordinator.data.values():
+        if (
+            device.widget not in IGNORED_OVERKIZ_DEVICES
+            and device.ui_class not in IGNORED_OVERKIZ_DEVICES
+        ):
+            for command in device.definition.commands:
+                if description := supported_commands.get(command.command_name):
+                    entities.append(
+                        OverkizButton(
+                            device.device_url,
+                            data.coordinator,
+                            description,
+                        )
+                    )
+
+    async_add_entities(entities)
+
+
+class OverkizButton(OverkizDescriptiveEntity, ButtonEntity):
+    """Representation of an Overkiz Button."""
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.executor.async_execute_command(self.entity_description.key)

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -18,6 +18,7 @@ UPDATE_INTERVAL: Final = timedelta(seconds=30)
 UPDATE_INTERVAL_ALL_ASSUMED_STATE: Final = timedelta(minutes=60)
 
 PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
     Platform.LOCK,
     Platform.SENSOR,
 ]

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pyoverkiz.enums import OverkizAttribute, OverkizState
 from pyoverkiz.models import Device
 
+from homeassistant.components.button import ButtonEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -99,7 +100,7 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self,
         device_url: str,
         coordinator: OverkizDataUpdateCoordinator,
-        description: OverkizSensorDescription,
+        description: OverkizSensorDescription | ButtonEntityDescription,
     ) -> None:
         """Initialize the device."""
         super().__init__(device_url, coordinator)


### PR DESCRIPTION
## Proposed change
Adds a button entity to Overkiz integration. Mainly used to add the 'my position' button, which was a service before. Adds identify features as well which can be useful for diagnostic purposes.
(please note that Somfy messed up and they switched two commands, thus we did switch them as well until they fix it in a new firmware/web update).

<img width="688" alt="Screen Shot 2021-12-24 at 00 45 05" src="https://user-images.githubusercontent.com/1424596/147300215-201d6239-4edf-4522-b52b-3290847dcd4f.png">

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20841

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
