### PR TITLE
Store wemo device sw_version & upnp connections

### DIFF
--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -16,7 +16,10 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import async_get as async_get_device_registry
+from homeassistant.helpers.device_registry import (
+    CONNECTION_UPNP,
+    async_get as async_get_device_registry,
+)
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -123,10 +126,12 @@ class DeviceCoordinator(DataUpdateCoordinator):
 
 def _device_info(wemo: WeMoDevice) -> DeviceInfo:
     return DeviceInfo(
+        connections={(CONNECTION_UPNP, wemo.udn)},
         identifiers={(DOMAIN, wemo.serialnumber)},
         manufacturer="Belkin",
         model=wemo.model_name,
         name=wemo.name,
+        sw_version=wemo.firmware_version,
     )
 
 

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -14,6 +14,7 @@ MOCK_HOST = "127.0.0.1"
 MOCK_PORT = 50000
 MOCK_NAME = "WemoDeviceName"
 MOCK_SERIAL_NUMBER = "WemoSerialNumber"
+MOCK_FIRMWARE_VERSION = "WeMo_WW_2.00.XXXXX.PVT-OWRT"
 
 
 @pytest.fixture(name="pywemo_model")
@@ -58,6 +59,8 @@ def pywemo_device_fixture(pywemo_registry, pywemo_model):
     device.name = MOCK_NAME
     device.serialnumber = MOCK_SERIAL_NUMBER
     device.model_name = pywemo_model.replace("LongPress", "")
+    device.udn = f"uuid:{device.model_name}-1_0-{device.serialnumber}"
+    device.firmware_version = MOCK_FIRMWARE_VERSION
     device.get_state.return_value = 0  # Default to Off
     device.supports_long_press.return_value = cls.supports_long_press()
 

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -10,7 +10,13 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
-from .conftest import MOCK_HOST, MOCK_NAME, MOCK_PORT, MOCK_SERIAL_NUMBER
+from .conftest import (
+    MOCK_FIRMWARE_VERSION,
+    MOCK_HOST,
+    MOCK_NAME,
+    MOCK_PORT,
+    MOCK_SERIAL_NUMBER,
+)
 
 from tests.common import async_fire_time_changed
 
@@ -109,6 +115,8 @@ async def test_discovery(hass, pywemo_registry):
         device.name = f"{MOCK_NAME}_{counter}"
         device.serialnumber = f"{MOCK_SERIAL_NUMBER}_{counter}"
         device.model_name = "Motion"
+        device.udn = f"uuid:{device.model_name}-1_0-{device.serialnumber}"
+        device.firmware_version = MOCK_FIRMWARE_VERSION
         device.get_state.return_value = 0  # Default to Off
         device.supports_long_press.return_value = False
         return device

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from .conftest import MOCK_HOST
+from .conftest import MOCK_FIRMWARE_VERSION, MOCK_HOST, MOCK_SERIAL_NUMBER
 
 from tests.common import async_fire_time_changed
 
@@ -152,6 +152,20 @@ async def test_async_update_data_subscribed(
     pywemo_device.get_state.reset_mock()
     await device._async_update_data()
     pywemo_device.get_state.assert_not_called()
+
+
+async def test_device_info(hass, wemo_entity):
+    """Verify the DeviceInfo data is set properly."""
+    dr = device_registry.async_get(hass)
+    device_entries = list(dr.devices.values())
+
+    assert len(device_entries) == 1
+    assert device_entries[0].connections == {
+        ("upnp", f"uuid:LightSwitch-1_0-{MOCK_SERIAL_NUMBER}")
+    }
+    assert device_entries[0].manufacturer == "Belkin"
+    assert device_entries[0].model == "LightSwitch"
+    assert device_entries[0].sw_version == MOCK_FIRMWARE_VERSION
 
 
 class TestInsight:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Two additions to the DeviceInfo for WeMo:

1. Adding the sw_version field to display the firmware version in the UI.
2. Adding a UPnP connection.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
