### PR TITLE
Update MQTT light schema template

### DIFF
--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -354,6 +354,9 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             values["red"] = rgb[0]
             values["green"] = rgb[1]
             values["blue"] = rgb[2]
+            values["hue"] = hs_color[0]
+            values["sat"] = hs_color[1]
+            
 
             if self._optimistic:
                 self._hs = kwargs[ATTR_HS_COLOR]

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -356,7 +356,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             values["blue"] = rgb[2]
             values["hue"] = hs_color[0]
             values["sat"] = hs_color[1]
-            
+
             if self._optimistic:
                 self._hs = kwargs[ATTR_HS_COLOR]
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -357,7 +357,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             values["hue"] = hs_color[0]
             values["sat"] = hs_color[1]
             
-
             if self._optimistic:
                 self._hs = kwargs[ATTR_HS_COLOR]
 

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -349,7 +349,9 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
                     "{{ white_value|d }},"
                     "{{ red|d }}-"
                     "{{ green|d }}-"
-                    "{{ blue|d }}",
+                    "{{ blue|d }},"
+                    "{{ hue|d }}-"
+                    "{{ sat|d }}",
                     "command_off_template": "off",
                     "effect_list": ["colorloop", "random"],
                     "optimistic": True,
@@ -384,7 +386,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
 
     await common.async_turn_on(hass, "light.test")
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,--", 2, False
+        "test_light_rgb/set", "on,,,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -393,7 +395,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     # Set color_temp
     await common.async_turn_on(hass, "light.test", color_temp=70)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,70,,--", 2, False
+        "test_light_rgb/set", "on,,70,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -403,7 +405,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     # Set full brightness
     await common.async_turn_on(hass, "light.test", brightness=255)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,255,,,--", 2, False
+        "test_light_rgb/set", "on,255,,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -414,7 +416,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
         hass, "light.test", rgb_color=[255, 128, 0], white_value=80
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,80,255-128-0", 2, False
+        "test_light_rgb/set", "on,,,80,255-128-0,30.118-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -425,7 +427,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     # Full brightness - normalization of RGB values sent over MQTT
     await common.async_turn_on(hass, "light.test", rgb_color=[128, 64, 0])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,255-127-0", 2, False
+        "test_light_rgb/set", "on,,,,255-127-0,30.0-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -435,7 +437,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     # Set half brightness
     await common.async_turn_on(hass, "light.test", brightness=128)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,128,,,--", 2, False
+        "test_light_rgb/set", "on,128,,,--,-", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -446,7 +448,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
         hass, "light.test", rgb_color=[0, 255, 128], white_value=40
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-128-64", 2, False
+        "test_light_rgb/set", "on,,,40,0-128-64,150.118-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -459,7 +461,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
         hass, "light.test", rgb_color=[0, 32, 16], white_value=40
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-128-64", 2, False
+        "test_light_rgb/set", "on,,,40,0-128-64,150.0-100.0", 2, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -490,7 +492,9 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
                     "{{ white_value|d }},"
                     "{{ red|d }}-"
                     "{{ green|d }}-"
-                    "{{ blue|d }}",
+                    "{{ blue|d }},"
+                    "{{ hue }}-"
+                    "{{ sat }}",
                     "command_off_template": "off",
                     "state_template": '{{ value.split(",")[0] }}',
                     "brightness_template": '{{ value.split(",")[1] }}',
@@ -524,7 +528,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
 
     await common.async_turn_on(hass, "light.test")
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,--", 0, False
+        "test_light_rgb/set", "on,,,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -533,7 +537,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     # Set color_temp
     await common.async_turn_on(hass, "light.test", color_temp=70)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,70,,--", 0, False
+        "test_light_rgb/set", "on,,70,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -543,7 +547,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     # Set full brightness
     await common.async_turn_on(hass, "light.test", brightness=255)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,255,,,--", 0, False
+        "test_light_rgb/set", "on,255,,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -555,7 +559,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
         hass, "light.test", rgb_color=[255, 128, 0], white_value=80
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,80,255-128-0", 0, False
+        "test_light_rgb/set", "on,,,80,255-128-0,30.118-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -566,14 +570,14 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     # Full brightness - normalization of RGB values sent over MQTT
     await common.async_turn_on(hass, "light.test", rgb_color=[128, 64, 0])
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,,255-127-0", 0, False
+        "test_light_rgb/set", "on,,,,255-127-0,30.0-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
 
     # Set half brightness
     await common.async_turn_on(hass, "light.test", brightness=128)
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,128,,,--", 0, False
+        "test_light_rgb/set", "on,128,,,--,-", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
 
@@ -582,7 +586,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
         hass, "light.test", rgb_color=[0, 255, 128], white_value=40
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-255-128", 0, False
+        "test_light_rgb/set", "on,,,40,0-255-128,150.118-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
@@ -592,7 +596,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
         hass, "light.test", rgb_color=[0, 32, 16], white_value=40
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "test_light_rgb/set", "on,,,40,0-255-127", 0, False
+        "test_light_rgb/set", "on,,,40,0-255-127,150.0-100.0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
color change instruction for zigbee devices can only be processed as Hue/Saturation or color x,y

[https://tasmota.github.io/docs/Zigbee/#:~:text=0x0009-,Hue,-0..254%3A%20change](https://tasmota.github.io/docs/Zigbee/#:~:text=0x0009-,Hue,-0..254%3A%20change)

this enhancements adds two more informations alongside the actual rgb values for the template schema

https://www.home-assistant.io/integrations/light.mqtt/#:~:text=strip)%20and%20transitions.-,Template%20schema,-The%20mqtt%20light

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
* This PR fixes or closes issue: fixes #
* This PR is related to issue:
[https://github.com/home-assistant/home-assistant.io/pull/21062](https://github.com/home-assistant/home-assistant.io/pull/21062)
* Link to documentation pull request:


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum



<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
