### PR TITLE
Proxmox entity updates (Sensors, Switches, Buttons)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -714,7 +714,7 @@ homeassistant/components/prometheus/* @knyar
 tests/components/prometheus/* @knyar
 homeassistant/components/prosegur/* @dgomes
 tests/components/prosegur/* @dgomes
-homeassistant/components/proxmoxve/* @k4ds3 @jhollowe @Corbeno
+homeassistant/components/proxmoxve/* @k4ds3 @jhollowe @Corbeno @MkVenture
 homeassistant/components/ps4/* @ktnrg45
 tests/components/ps4/* @ktnrg45
 homeassistant/components/push/* @dgomes

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -49,7 +49,7 @@ from .const import (
     Node_Type,
 )
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH, Platform.BUTTON]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -42,11 +42,12 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    PARSE_DATA,
     PROXMOX_CLIENTS,
     Node_Type,
 )
 
-PLATFORMS = [Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -242,13 +243,15 @@ def create_coordinator_container_vm(
 
 
 def parse_api_container_vm(status):
-    """Get the container or vm api data and return it formatted in a dictionary.
+    """
+    Parse api data calculate additional fields and return it formatted in a dictionary.
 
     It is implemented in this way to allow for more data to be added for sensors
     in the future.
     """
+    data = {v: status[v] for v in PARSE_DATA}
 
-    return {"status": status["status"], "name": status["name"]}
+    return data
 
 
 def call_api_get_status(proxmox, node_name, vm_id, vm_type):

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -43,6 +43,7 @@ from .const import (
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     PARSE_DATA,
+    PROXMOX_CALCULATED_SENSOR_TYPES,
     PROXMOX_CLIENTS,
     Node_Type,
 )
@@ -250,6 +251,11 @@ def parse_api_container_vm(status):
     in the future.
     """
     data = {v: status[v] for v in PARSE_DATA}
+    data_calc = {
+        sensor.key: sensor.calculation(data)
+        for sensor in PROXMOX_CALCULATED_SENSOR_TYPES
+    }
+    data.update(data_calc)
 
     return data
 

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -1,9 +1,22 @@
 """Binary sensor to read Proxmox VE data."""
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import COORDINATORS, DOMAIN, PROXMOX_CLIENTS, ProxmoxEntity
+from . import ProxmoxEntity, compile_device_info
+from .const import (
+    CONF_CONTAINERS,
+    CONF_NODE,
+    CONF_NODES,
+    CONF_VMS,
+    COORDINATORS,
+    DOMAIN,
+    PROXMOX_BINARYSENSOR_TYPES,
+    PROXMOX_CLIENTS,
+)
+from .model import ProxmoxBinarySensorDescription
 
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
@@ -14,16 +27,16 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     sensors = []
 
     for host_config in discovery_info["config"][DOMAIN]:
-        host_name = host_config["host"]
+        host_name = host_config[CONF_HOST]
         host_name_coordinators = hass.data[DOMAIN][COORDINATORS][host_name]
 
         if hass.data[PROXMOX_CLIENTS][host_name] is None:
             continue
 
-        for node_config in host_config["nodes"]:
-            node_name = node_config["node"]
+        for node_config in host_config[CONF_NODES]:
+            node_name = node_config[CONF_NODE]
 
-            for vm_id in node_config["vms"]:
+            for vm_id in node_config[CONF_VMS]:
                 coordinator = host_name_coordinators[node_name][vm_id]
 
                 # unfound vm case
@@ -31,37 +44,58 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
                     continue
 
                 vm_name = coordinator_data["name"]
-                vm_sensor = create_binary_sensor(
-                    coordinator, host_name, node_name, vm_id, vm_name
-                )
-                sensors.append(vm_sensor)
+                device_info = compile_device_info(host_name, node_name, vm_id, vm_name)
+                for description in PROXMOX_BINARYSENSOR_TYPES:
+                    sensors.append(
+                        create_binary_sensor(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=vm_id,
+                            name=vm_name,
+                        )
+                    )
 
-            for container_id in node_config["containers"]:
-                coordinator = host_name_coordinators[node_name][container_id]
+            for ct_id in node_config[CONF_CONTAINERS]:
+                coordinator = host_name_coordinators[node_name][ct_id]
 
                 # unfound container case
                 if (coordinator_data := coordinator.data) is None:
                     continue
 
-                container_name = coordinator_data["name"]
-                container_sensor = create_binary_sensor(
-                    coordinator, host_name, node_name, container_id, container_name
-                )
-                sensors.append(container_sensor)
+                ct_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, ct_id, ct_name)
+                for description in PROXMOX_BINARYSENSOR_TYPES:
+                    sensors.append(
+                        create_binary_sensor(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=ct_id,
+                            name=ct_name,
+                        )
+                    )
 
     add_entities(sensors)
 
 
-def create_binary_sensor(coordinator, host_name, node_name, vm_id, name):
+def create_binary_sensor(
+    coordinator: DataUpdateCoordinator,
+    device_info: DeviceInfo,
+    description: ProxmoxBinarySensorDescription,
+    node_name: str,
+    mid: str,
+    name: str,
+):
     """Create a binary sensor based on the given data."""
     return ProxmoxBinarySensor(
         coordinator=coordinator,
-        unique_id=f"proxmox_{node_name}_{vm_id}_running",
+        device_info=device_info,
+        description=description,
+        unique_id=f"proxmox_{node_name}_{mid}_running",  # Legacy uid kept for non-breaking change
         name=f"{node_name}_{name}_running",
-        icon="",
-        host_name=host_name,
-        node_name=node_name,
-        vm_id=vm_id,
     )
 
 
@@ -71,17 +105,19 @@ class ProxmoxBinarySensor(ProxmoxEntity, BinarySensorEntity):
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
-        unique_id,
-        name,
-        icon,
-        host_name,
-        node_name,
-        vm_id,
+        device_info: DeviceInfo,
+        description: ProxmoxBinarySensorDescription,
+        name: str,
+        unique_id: str,
     ):
         """Create the binary sensor for vms or containers."""
         super().__init__(
-            coordinator, unique_id, name, icon, host_name, node_name, vm_id
+            coordinator=coordinator,
+            device_info=device_info,
+            name=name,
+            unique_id=unique_id,
         )
+        self.entity_description = description
 
     @property
     def is_on(self):

--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -1,0 +1,159 @@
+"""Button to set Proxmox VE data."""
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import ProxmoxClient, ProxmoxEntity, call_api_post_status, compile_device_info
+from .const import (
+    CONF_CONTAINERS,
+    CONF_NODE,
+    CONF_NODES,
+    CONF_VMS,
+    COORDINATORS,
+    DOMAIN,
+    PROXMOX_BUTTON_TYPES,
+    PROXMOX_CLIENTS,
+    Node_Type,
+)
+from .model import ProxmoxButtonDescription
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up button."""
+    if discovery_info is None:
+        return
+
+    buttons = []
+
+    for host_config in discovery_info["config"][DOMAIN]:
+        host_name = host_config[CONF_HOST]
+        host_name_coordinators = hass.data[DOMAIN][COORDINATORS][host_name]
+
+        if hass.data[PROXMOX_CLIENTS][host_name] is None:
+            continue
+
+        proxmox_client = hass.data[PROXMOX_CLIENTS][host_name]
+
+        for node_config in host_config[CONF_NODES]:
+            node_name = node_config[CONF_NODE]
+
+            for vm_id in node_config[CONF_VMS]:
+                coordinator = host_name_coordinators[node_name][vm_id]
+
+                # unfound vm case
+                if (coordinator_data := coordinator.data) is None:
+                    continue
+
+                vm_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, vm_id, vm_name)
+
+                for description in PROXMOX_BUTTON_TYPES:
+                    buttons.append(
+                        create_button(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=vm_id,
+                            name=vm_name,
+                            proxmox_client=proxmox_client,
+                            machine_type=Node_Type.TYPE_VM,
+                        )
+                    )
+
+            for ct_id in node_config[CONF_CONTAINERS]:
+                coordinator = host_name_coordinators[node_name][ct_id]
+
+                # unfound container case
+                if (coordinator_data := coordinator.data) is None:
+                    continue
+
+                ct_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, ct_id, ct_name)
+                for description in PROXMOX_BUTTON_TYPES:
+                    buttons.append(
+                        create_button(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=ct_id,
+                            name=ct_name,
+                            proxmox_client=proxmox_client,
+                            machine_type=Node_Type.TYPE_CONTAINER,
+                        )
+                    )
+
+    add_entities(buttons)
+
+
+def create_button(
+    coordinator: DataUpdateCoordinator,
+    device_info: DeviceInfo,
+    description: ProxmoxButtonDescription,
+    node_name: str,
+    mid: str,
+    name: str,
+    proxmox_client: ProxmoxClient,
+    machine_type: Node_Type,
+):
+    """Create a button based on the given data."""
+    return ProxmoxButton(
+        coordinator=coordinator,
+        device_info=device_info,
+        description=description,
+        unique_id=f"proxmox_{node_name}_{mid}_{description.key}",
+        name=f"{node_name}_{name}_{description.key}",
+        proxmox_client=proxmox_client,
+        node_name=node_name,
+        vm_id=mid,
+        machine_type=machine_type,
+    )
+
+
+class ProxmoxButton(ProxmoxEntity, ButtonEntity):
+    """A button for reading/writing Proxmox VE status."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        device_info: DeviceInfo,
+        description: ProxmoxButtonDescription,
+        name: str,
+        unique_id: str,
+        proxmox_client: ProxmoxClient,
+        node_name: str,
+        vm_id: str,
+        machine_type: Node_Type,
+    ):
+        """Create the button for vms or containers."""
+        super().__init__(
+            coordinator=coordinator,
+            device_info=device_info,
+            name=name,
+            unique_id=unique_id,
+        )
+        self.entity_description = description
+
+        def _button_press():
+            """Post start command & tell HA state is on."""
+            call_api_post_status(
+                proxmox_client.get_api_client(),
+                node_name,
+                vm_id,
+                machine_type,
+                description.key,
+            )
+
+        self._button_press_funct = _button_press
+
+    @property
+    def available(self):
+        """Return sensor availability."""
+        return super().available and self.coordinator.data is not None
+
+    def press(self) -> None:
+        """Press the button."""
+        self._button_press_funct()

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -1,0 +1,38 @@
+"""Constants for Proxmox integration."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Final
+
+from .model import ProxmoxBinarySensorDescription
+
+
+class Node_Type(Enum):
+    """Defines Node Types as VM or Containers."""
+
+    TYPE_VM = 0
+    TYPE_CONTAINER = 1
+
+
+DOMAIN = "proxmoxve"
+PROXMOX_CLIENTS = "proxmox_clients"
+COORDINATORS = "coordinators"
+
+CONF_REALM = "realm"
+CONF_NODE = "node"
+CONF_NODES = "nodes"
+CONF_VMS = "vms"
+CONF_CONTAINERS = "containers"
+
+DEFAULT_PORT = 8006
+DEFAULT_REALM = "pam"
+DEFAULT_VERIFY_SSL = True
+DEFAULT_SCAN_INTERVAL = 60
+
+
+PROXMOX_BINARYSENSOR_TYPES: Final[tuple[ProxmoxBinarySensorDescription, ...]] = (
+    ProxmoxBinarySensorDescription(
+        key="status",
+        icon="mdi:server",
+    ),
+)

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -13,7 +13,11 @@ from homeassistant.const import (
     PERCENTAGE,
 )
 
-from .model import ProxmoxBinarySensorDescription, ProxmoxSensorDescription
+from .model import (
+    ProxmoxBinarySensorDescription,
+    ProxmoxSensorDescription,
+    ProxmoxSwitchDescription,
+)
 
 
 class Node_Type(Enum):
@@ -37,6 +41,23 @@ DEFAULT_PORT = 8006
 DEFAULT_REALM = "pam"
 DEFAULT_VERIFY_SSL = True
 DEFAULT_SCAN_INTERVAL = 60
+
+
+COMMAND_REBOOT = "reboot"
+COMMAND_RESUME = "resume"
+COMMAND_SHUTDOWN = "shutdown"
+COMMAND_START = "start"
+COMMAND_STOP = "stop"
+COMMAND_SUSPEND = "suspend"  # API notes 'This is experimental.'  https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/status/suspend
+
+VM_COMMANDS = (
+    COMMAND_REBOOT,
+    COMMAND_RESUME,
+    COMMAND_SHUTDOWN,
+    COMMAND_START,
+    COMMAND_STOP,
+    COMMAND_SUSPEND,
+)
 
 
 PROXMOX_BINARYSENSOR_TYPES: Final[tuple[ProxmoxBinarySensorDescription, ...]] = (
@@ -155,6 +176,22 @@ PROXMOX_CALCULATED_SENSOR_TYPES: Final[tuple[ProxmoxSensorDescription, ...]] = (
         conversion=lambda x: round(x * 100, 1),
         calculation=lambda x: 1 - x["mem"] / x["maxmem"],
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+)
+
+
+PROXMOX_SWITCH_TYPES: Final[tuple[ProxmoxSwitchDescription, ...]] = (
+    ProxmoxSwitchDescription(
+        key="Switch",
+        icon="mdi:server",
+        start_command=COMMAND_START,
+        stop_command=COMMAND_SHUTDOWN,
+    ),
+    ProxmoxSwitchDescription(
+        key="Switch_Stop",
+        icon="mdi:server",
+        start_command=COMMAND_START,
+        stop_command=COMMAND_STOP,
     ),
 )
 

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -6,7 +6,12 @@ from enum import Enum
 from typing import Final
 
 from homeassistant.components.sensor import SensorStateClass
-from homeassistant.const import ATTR_TIME
+from homeassistant.const import (
+    ATTR_TIME,
+    DATA_GIGABYTES,
+    DATA_RATE_MEGABYTES_PER_SECOND,
+    PERCENTAGE,
+)
 
 from .model import ProxmoxBinarySensorDescription, ProxmoxSensorDescription
 
@@ -41,6 +46,7 @@ PROXMOX_BINARYSENSOR_TYPES: Final[tuple[ProxmoxBinarySensorDescription, ...]] = 
     ),
 )
 
+
 PROXMOX_SENSOR_TYPES: Final[tuple[ProxmoxSensorDescription, ...]] = (
     ProxmoxSensorDescription(
         key="uptime",
@@ -50,10 +56,109 @@ PROXMOX_SENSOR_TYPES: Final[tuple[ProxmoxSensorDescription, ...]] = (
         conversion=lambda x: timedelta(seconds=x),
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    ProxmoxSensorDescription(
+        key="disk",
+        icon="mdi:harddisk",
+        native_unit_of_measurement=DATA_GIGABYTES,
+        conversion=lambda x: round(x / 1073741824, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ProxmoxSensorDescription(
+        key="maxdisk",
+        icon="mdi:harddisk-plus",
+        native_unit_of_measurement=DATA_GIGABYTES,
+        conversion=lambda x: round(x / 1073741824, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxSensorDescription(
+        key="diskread",
+        icon="mdi:harddisk",
+        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
+        conversion=lambda x: round(x / 1048576, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxSensorDescription(
+        key="diskwrite",
+        icon="mdi:harddisk",
+        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
+        conversion=lambda x: round(x / 1048576, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxSensorDescription(
+        key="cpus",
+        icon="mdi:cpu-64-bit",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxSensorDescription(
+        key="cpu",
+        icon="mdi:cpu-64-bit",
+        unit_metric=PERCENTAGE,
+        unit_imperial=PERCENTAGE,
+        native_unit_of_measurement=PERCENTAGE,
+        conversion=lambda x: round(x * 100, 1),
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ProxmoxSensorDescription(
+        key="mem",
+        icon="mdi:memory",
+        native_unit_of_measurement=DATA_GIGABYTES,
+        conversion=lambda x: round(x / 1073741824, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ProxmoxSensorDescription(
+        key="maxmem",
+        icon="mdi:memory",
+        native_unit_of_measurement=DATA_GIGABYTES,
+        conversion=lambda x: round(x / 1073741824, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxSensorDescription(
+        key="netin",
+        icon="mdi:mdi:download-network-outline",
+        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
+        conversion=lambda x: round(x / 1048576, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxSensorDescription(
+        key="netout",
+        icon="mdi:upload-network-outline",
+        native_unit_of_measurement=DATA_RATE_MEGABYTES_PER_SECOND,
+        conversion=lambda x: round(x / 1048576, 2),
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
 )
 
+PROXMOX_CALCULATED_SENSOR_TYPES: Final[tuple[ProxmoxSensorDescription, ...]] = (
+    ProxmoxSensorDescription(
+        key="disk_pct_free",
+        icon="mdi:harddisk",
+        unit_metric=PERCENTAGE,
+        unit_imperial=PERCENTAGE,
+        native_unit_of_measurement=PERCENTAGE,
+        conversion=lambda x: round(x * 100, 1),
+        calculation=lambda x: 1 - x["disk"] / x["maxdisk"],
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ProxmoxSensorDescription(
+        key="mem_pct_free",
+        icon="mdi:memory",
+        unit_metric=PERCENTAGE,
+        unit_imperial=PERCENTAGE,
+        native_unit_of_measurement=PERCENTAGE,
+        conversion=lambda x: round(x * 100, 1),
+        calculation=lambda x: 1 - x["mem"] / x["maxmem"],
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+)
 
 PARSE_DATA = [
     sensor.key for sensor in PROXMOX_SENSOR_TYPES + PROXMOX_BINARYSENSOR_TYPES
 ] + ["name"]
-PROXMOX_SENSOR_TYPES_ALL = PROXMOX_SENSOR_TYPES
+PROXMOX_SENSOR_TYPES_ALL = PROXMOX_SENSOR_TYPES + PROXMOX_CALCULATED_SENSOR_TYPES

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
 
 from .model import (
     ProxmoxBinarySensorDescription,
+    ProxmoxButtonDescription,
     ProxmoxSensorDescription,
     ProxmoxSwitchDescription,
 )
@@ -192,6 +193,35 @@ PROXMOX_SWITCH_TYPES: Final[tuple[ProxmoxSwitchDescription, ...]] = (
         icon="mdi:server",
         start_command=COMMAND_START,
         stop_command=COMMAND_STOP,
+    ),
+)
+
+PROXMOX_BUTTON_TYPES: Final[tuple[ProxmoxButtonDescription, ...]] = (
+    ProxmoxButtonDescription(
+        key=COMMAND_REBOOT,
+        icon="mdi:restart",
+    ),
+    ProxmoxButtonDescription(
+        key=COMMAND_START,
+        icon="mdi:server",
+    ),
+    ProxmoxButtonDescription(
+        key=COMMAND_SHUTDOWN,
+        icon="mdi:server-off",
+    ),
+    ProxmoxButtonDescription(
+        key=COMMAND_STOP,
+        icon="mdi:stop",
+    ),
+    ProxmoxButtonDescription(
+        key=COMMAND_RESUME,
+        icon="mdi:play",
+        entity_registry_enabled_default=False,
+    ),
+    ProxmoxButtonDescription(
+        key=COMMAND_SUSPEND,
+        icon="mdi:pause",
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -1,10 +1,14 @@
 """Constants for Proxmox integration."""
 from __future__ import annotations
 
+from datetime import timedelta
 from enum import Enum
 from typing import Final
 
-from .model import ProxmoxBinarySensorDescription
+from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import ATTR_TIME
+
+from .model import ProxmoxBinarySensorDescription, ProxmoxSensorDescription
 
 
 class Node_Type(Enum):
@@ -36,3 +40,20 @@ PROXMOX_BINARYSENSOR_TYPES: Final[tuple[ProxmoxBinarySensorDescription, ...]] = 
         icon="mdi:server",
     ),
 )
+
+PROXMOX_SENSOR_TYPES: Final[tuple[ProxmoxSensorDescription, ...]] = (
+    ProxmoxSensorDescription(
+        key="uptime",
+        icon="mdi:database-clock-outline",
+        unit_metric=ATTR_TIME,
+        unit_imperial=ATTR_TIME,
+        conversion=lambda x: timedelta(seconds=x),
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+)
+
+
+PARSE_DATA = [
+    sensor.key for sensor in PROXMOX_SENSOR_TYPES + PROXMOX_BINARYSENSOR_TYPES
+] + ["name"]
+PROXMOX_SENSOR_TYPES_ALL = PROXMOX_SENSOR_TYPES

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -2,7 +2,7 @@
   "domain": "proxmoxve",
   "name": "Proxmox VE",
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
-  "codeowners": ["@k4ds3", "@jhollowe", "@Corbeno"],
+  "codeowners": ["@k4ds3", "@jhollowe", "@Corbeno", "@MkVenture"],
   "requirements": ["proxmoxer==1.1.1"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/proxmoxve/model.py
+++ b/homeassistant/components/proxmoxve/model.py
@@ -1,0 +1,14 @@
+"""Type definitions for Proxmox integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+
+
+@dataclass
+class ProxmoxBinarySensorDescription(BinarySensorEntityDescription):
+    """Class describing Proxmox binarysensor entities."""
+
+    unit_metric: str | None = None
+    unit_imperial: str | None = None

--- a/homeassistant/components/proxmoxve/model.py
+++ b/homeassistant/components/proxmoxve/model.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from homeassistant.components.button import ButtonEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
 
@@ -35,3 +36,12 @@ class ProxmoxSwitchDescription(SwitchEntityDescription):
     unit_imperial: str | None = None
     start_command: str | None = None
     stop_command: str | None = None
+
+
+@dataclass
+class ProxmoxButtonDescription(ButtonEntityDescription):
+    """Class describing Proxmox switch entities."""
+
+    unit_metric: str | None = None
+    unit_imperial: str | None = None
+    button_command: str | None = None

--- a/homeassistant/components/proxmoxve/model.py
+++ b/homeassistant/components/proxmoxve/model.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.components.switch import SwitchEntityDescription
 
 
 @dataclass
@@ -24,3 +25,13 @@ class ProxmoxSensorDescription(SensorEntityDescription):
     unit_imperial: str | None = None
     conversion: Callable | None = None  # conversion factor to be applied to units
     calculation: Callable | None = None  # calculation
+
+
+@dataclass
+class ProxmoxSwitchDescription(SwitchEntityDescription):
+    """Class describing Proxmox switch entities."""
+
+    unit_metric: str | None = None
+    unit_imperial: str | None = None
+    start_command: str | None = None
+    stop_command: str | None = None

--- a/homeassistant/components/proxmoxve/model.py
+++ b/homeassistant/components/proxmoxve/model.py
@@ -1,9 +1,11 @@
 """Type definitions for Proxmox integration."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from homeassistant.components.sensor import SensorEntityDescription
 
 
 @dataclass
@@ -12,3 +14,13 @@ class ProxmoxBinarySensorDescription(BinarySensorEntityDescription):
 
     unit_metric: str | None = None
     unit_imperial: str | None = None
+
+
+@dataclass
+class ProxmoxSensorDescription(SensorEntityDescription):
+    """Class describing Proxmox sensor entities."""
+
+    unit_metric: str | None = None
+    unit_imperial: str | None = None
+    conversion: Callable | None = None  # conversion factor to be applied to units
+    calculation: Callable | None = None  # calculation

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -1,0 +1,144 @@
+"""Sensor to read Proxmox VE data."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import ProxmoxEntity, compile_device_info
+from .const import (
+    CONF_CONTAINERS,
+    CONF_NODE,
+    CONF_NODES,
+    CONF_VMS,
+    COORDINATORS,
+    DOMAIN,
+    PROXMOX_CLIENTS,
+    PROXMOX_SENSOR_TYPES_ALL,
+)
+from .model import ProxmoxSensorDescription
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up sensors."""
+    if discovery_info is None:
+        return
+
+    sensors = []
+
+    for host_config in discovery_info["config"][DOMAIN]:
+        host_name = host_config[CONF_HOST]
+        host_name_coordinators = hass.data[DOMAIN][COORDINATORS][host_name]
+
+        if hass.data[PROXMOX_CLIENTS][host_name] is None:
+            continue
+
+        for node_config in host_config[CONF_NODES]:
+            node_name = node_config[CONF_NODE]
+
+            for vm_id in node_config[CONF_VMS]:
+                coordinator = host_name_coordinators[node_name][vm_id]
+
+                # unfound vm case
+                if (coordinator_data := coordinator.data) is None:
+                    continue
+
+                vm_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, vm_id, vm_name)
+
+                for description in PROXMOX_SENSOR_TYPES_ALL:
+                    sensors.append(
+                        create_sensor(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=vm_id,
+                            name=vm_name,
+                        )
+                    )
+
+            for ct_id in node_config[CONF_CONTAINERS]:
+                coordinator = host_name_coordinators[node_name][ct_id]
+
+                # unfound container case
+                if (coordinator_data := coordinator.data) is None:
+                    continue
+
+                ct_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, ct_id, ct_name)
+                for description in PROXMOX_SENSOR_TYPES_ALL:
+                    sensors.append(
+                        create_sensor(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=ct_id,
+                            name=ct_name,
+                        )
+                    )
+
+    add_entities(sensors)
+
+
+def create_sensor(
+    coordinator: DataUpdateCoordinator,
+    device_info: DeviceInfo,
+    description: ProxmoxSensorDescription,
+    node_name: str,
+    mid: str,
+    name: str,
+):
+    """Create a sensor based on the given data."""
+    return ProxmoxSensor(
+        coordinator=coordinator,
+        device_info=device_info,
+        description=description,
+        unique_id=f"proxmox_{node_name}_{mid}_{description.key}",
+        name=f"{node_name}_{name}_{description.key}",
+    )
+
+
+class ProxmoxSensor(ProxmoxEntity, SensorEntity):
+    """A sensor for reading Proxmox VE data."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        device_info: DeviceInfo,
+        description: ProxmoxSensorDescription,
+        name: str,
+        unique_id: str,
+    ):
+        """Create the sensor for vms or containers."""
+        super().__init__(
+            coordinator=coordinator,
+            device_info=device_info,
+            name=name,
+            unique_id=unique_id,
+        )
+        self.entity_description = description
+
+    @property
+    def native_value(self):
+        """Return the units of the sensor."""
+        if (data := self.coordinator.data) is None:
+            return None
+
+        if self.entity_description.key not in data:
+            return None
+
+        native_value = data[self.entity_description.key]
+
+        if self.entity_description.conversion is not None:
+            return self.entity_description.conversion(native_value)
+
+        return native_value
+
+    @property
+    def available(self):
+        """Return sensor availability."""
+
+        return super().available and self.coordinator.data is not None

--- a/homeassistant/components/proxmoxve/switch.py
+++ b/homeassistant/components/proxmoxve/switch.py
@@ -1,0 +1,202 @@
+"""Switch to set Proxmox VE data."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import ProxmoxClient, ProxmoxEntity, call_api_post_status, compile_device_info
+from .const import (
+    COMMAND_SHUTDOWN,
+    COMMAND_START,
+    CONF_CONTAINERS,
+    CONF_NODE,
+    CONF_NODES,
+    CONF_VMS,
+    COORDINATORS,
+    DOMAIN,
+    PROXMOX_CLIENTS,
+    PROXMOX_SWITCH_TYPES,
+    Node_Type,
+)
+from .model import ProxmoxSwitchDescription
+
+
+async def async_setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up switch."""
+    if discovery_info is None:
+        return
+
+    switches = []
+
+    for host_config in discovery_info["config"][DOMAIN]:
+        host_name = host_config[CONF_HOST]
+        host_name_coordinators = hass.data[DOMAIN][COORDINATORS][host_name]
+
+        if hass.data[PROXMOX_CLIENTS][host_name] is None:
+            continue
+
+        proxmox_client = hass.data[PROXMOX_CLIENTS][host_name]
+
+        for node_config in host_config[CONF_NODES]:
+            node_name = node_config[CONF_NODE]
+
+            for vm_id in node_config[CONF_VMS]:
+                coordinator = host_name_coordinators[node_name][vm_id]
+
+                # unfound vm case
+                if (coordinator_data := coordinator.data) is None:
+                    continue
+
+                vm_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, vm_id, vm_name)
+
+                for description in PROXMOX_SWITCH_TYPES:
+                    switches.append(
+                        create_switch(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=vm_id,
+                            name=vm_name,
+                            proxmox_client=proxmox_client,
+                            machine_type=Node_Type.TYPE_VM,
+                        )
+                    )
+
+            for ct_id in node_config[CONF_CONTAINERS]:
+                coordinator = host_name_coordinators[node_name][ct_id]
+
+                # unfound container case
+                if (coordinator_data := coordinator.data) is None:
+                    continue
+
+                ct_name = coordinator_data["name"]
+                device_info = compile_device_info(host_name, node_name, ct_id, ct_name)
+                for description in PROXMOX_SWITCH_TYPES:
+                    switches.append(
+                        create_switch(
+                            coordinator=coordinator,
+                            device_info=device_info,
+                            description=description,
+                            node_name=node_name,
+                            mid=ct_id,
+                            name=ct_name,
+                            proxmox_client=proxmox_client,
+                            machine_type=Node_Type.TYPE_CONTAINER,
+                        )
+                    )
+
+    add_entities(switches)
+
+
+def create_switch(
+    coordinator: DataUpdateCoordinator,
+    device_info: DeviceInfo,
+    description: ProxmoxSwitchDescription,
+    node_name: str,
+    mid: str,
+    name: str,
+    proxmox_client: ProxmoxClient,
+    machine_type: Node_Type,
+):
+    """Create a switch based on the given data."""
+    return ProxmoxBinarySwitch(
+        coordinator=coordinator,
+        device_info=device_info,
+        description=description,
+        unique_id=f"proxmox_{node_name}_{mid}_{description.key}",
+        name=f"{node_name}_{name}_{description.key}",
+        proxmox_client=proxmox_client,
+        node_name=node_name,
+        vm_id=mid,
+        machine_type=machine_type,
+    )
+
+
+class ProxmoxBinarySwitch(ProxmoxEntity, SwitchEntity):
+    """A switch for reading/writing Proxmox VE status."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        device_info: DeviceInfo,
+        description: ProxmoxSwitchDescription,
+        name: str,
+        unique_id: str,
+        proxmox_client: ProxmoxClient,
+        node_name: str,
+        vm_id: str,
+        machine_type: Node_Type,
+    ):
+        """Create the switch for vms or containers."""
+        super().__init__(
+            coordinator=coordinator,
+            device_info=device_info,
+            name=name,
+            unique_id=unique_id,
+        )
+        self.entity_description = description
+
+        def _turn_on_funct():
+            """Post start command & tell HA state is on."""
+            result = call_api_post_status(
+                proxmox_client.get_api_client(),
+                node_name,
+                vm_id,
+                machine_type,
+                description.start_command,
+            )
+            if result is not None and COMMAND_START in result:
+                # received success acknoledgement from API, set state optimistically to on
+                self._attr_is_on = True
+                self.async_write_ha_state()
+                # TODO - QOL improvement - depending on polling overlap, there is still a possibility for the switch
+                # to bounce if the server isn't fully on before the next polling cycle. Ideally need
+                # to skip the next polling cycle if there is one scheduled in the next ~10 seconds
+
+        def _turn_off_funct():
+            """Post shutdown command & tell HA state is off."""
+            result = call_api_post_status(
+                proxmox_client.get_api_client(),
+                node_name,
+                vm_id,
+                machine_type,
+                description.stop_command,
+            )
+            if result is not None and COMMAND_SHUTDOWN in result:
+                # received success acknoledgement from API, set state optimistically to off
+                self._attr_is_on = False
+                self.async_write_ha_state()
+                # TODO - QOL improvement - depending on polling overlap, there is still a possibility for the switch
+                # to bounce if the server isn't fully off before the next polling cycle. Ideally need
+                # to skip the next polling cycle if there is one scheduled in the next ~10 seconds
+
+        self._turn_on_funct = _turn_on_funct
+        self._turn_off_funct = _turn_off_funct
+
+    @property
+    def is_on(self):
+        """Return the switch."""
+        if (data := self.coordinator.data) is None:
+            return None
+
+        return data["status"] == "running"
+
+    @property
+    def available(self):
+        """Return sensor availability."""
+        return super().available and self.coordinator.data is not None
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        self._turn_on_funct()
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        self._turn_off_funct()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
  Add functionality to the proxmoxve component:
  - refactored to include .const and .model to scalability
  - add switches to turn containers / vms on and off
  - add buttons to trigger status commands (shut down, start, stop, restart)
  - add sensors to retrieve various attributes, such as free memory, cpu usage, uptime, etc. 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Reviewed a couple other PRs that are out there and pending. These features aren't included in either of them. Some refactoring of this code will be required to align with them if/as they are finalized. 
- Some minor doc updates will be required - update to include polling time. Some permissions notes for binary switches / buttons. Can make updates once this gets closer to release... updates will change dramatically based on the config flow in PR #49292
- I only have one Proxmox node. This should be fine for multiple, but need someone to validate. 
- Might be necessary for the config to be able to include / exclude some entities. ie some folks might not want HA to have an entity to turn on / off certain vms, and might not want to resolve it in their proxmox permissions. Thoughts?
[ ] I don't love the solution implemented on switches.py ln 159 & 176. It works, but the UI potentially swapping back and forth an extra time isnt ideal. Played around with this for a while and couldn't reliably get it to work 100%. 
- First contribution to HA Core / first time using github seriously. Appreciate the help learning the process. PS - Might need some help / a good pointer for new tests needed?


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x?] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.
- https://github.com/home-assistant/core/pull/49292
- https://github.com/home-assistant/core/pull/58529
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
