### PR TITLE
Add support for philips js screen state

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -827,6 +827,7 @@ omit =
     homeassistant/components/philips_js/light.py
     homeassistant/components/philips_js/media_player.py
     homeassistant/components/philips_js/remote.py
+    homeassistant/components/philips_js/switch.py
     homeassistant/components/pi_hole/sensor.py
     homeassistant/components/pi4ioe5v9xxxx/binary_sensor.py
     homeassistant/components/pi4ioe5v9xxxx/switch.py

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from haphilipsjs import ConnectionFailure, PhilipsTV
+from haphilipsjs.typing import SystemType
 
 from homeassistant.components.automation import AutomationActionType
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +30,7 @@ from homeassistant.core import (
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import CONF_ALLOW_NOTIFY, DOMAIN
+from .const import CONF_ALLOW_NOTIFY, CONF_SYSTEM, DOMAIN
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.LIGHT, Platform.REMOTE]
 
@@ -131,6 +132,20 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 hass, LOGGER, cooldown=2.0, immediate=False
             ),
         )
+
+    @property
+    def system(self) -> SystemType:
+        """Return the system descriptor."""
+        if self.api.system:
+            return self.api.system
+        return self.config_entry.data[CONF_SYSTEM]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the system descriptor."""
+        assert self.config_entry
+        assert self.config_entry.unique_id
+        return self.config_entry.unique_id
 
     @property
     def _notify_wanted(self):

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -32,7 +32,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_ALLOW_NOTIFY, CONF_SYSTEM, DOMAIN
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.LIGHT, Platform.REMOTE]
+PLATFORMS = [
+    Platform.MEDIA_PLAYER,
+    Platform.LIGHT,
+    Platform.REMOTE,
+    Platform.SWITCH,
+]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import timedelta
 import logging
 from typing import Any
@@ -18,7 +18,14 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE, Context, HassJob, HomeAssistant, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Context,
+    Event,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -71,7 +78,7 @@ class PluggableAction:
     def __init__(self, update: Callable[[], None]) -> None:
         """Initialize."""
         self._update = update
-        self._actions: dict[Any, AutomationActionType] = {}
+        self._actions: dict[Any, tuple[HassJob, dict[str, Any]]] = {}
 
     def __bool__(self):
         """Return if we have something attached."""
@@ -102,7 +109,7 @@ class PluggableAction:
 class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Coordinator to update data."""
 
-    def __init__(self, hass, api: PhilipsTV, options: dict) -> None:
+    def __init__(self, hass, api: PhilipsTV, options: Mapping) -> None:
         """Set up the coordinator."""
         self.api = api
         self.options = options
@@ -170,7 +177,7 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
             self._async_notify_stop()
 
     @callback
-    def _async_stop_refresh(self, event: asyncio.Event) -> None:
+    def _async_stop_refresh(self, event: Event) -> None:
         super()._async_stop_refresh(event)
         self._async_notify_stop()
 

--- a/homeassistant/components/philips_js/remote.py
+++ b/homeassistant/components/philips_js/remote.py
@@ -1,8 +1,6 @@
 """Remote control support for Apple TV."""
 import asyncio
 
-from haphilipsjs.typing import SystemType
-
 from homeassistant.components.remote import (
     ATTR_DELAY_SECS,
     ATTR_NUM_REPEATS,
@@ -13,9 +11,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LOGGER, PhilipsTVDataUpdateCoordinator
-from .const import CONF_SYSTEM, DOMAIN
+from .const import DOMAIN
 
 
 async def async_setup_entry(
@@ -25,65 +24,38 @@ async def async_setup_entry(
 ) -> None:
     """Set up the configuration entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities(
-        [
-            PhilipsTVRemote(
-                coordinator,
-                config_entry.data[CONF_SYSTEM],
-                config_entry.unique_id,
-            )
-        ]
-    )
+    async_add_entities([PhilipsTVRemote(coordinator)])
 
 
-class PhilipsTVRemote(RemoteEntity):
+class PhilipsTVRemote(CoordinatorEntity, RemoteEntity):
     """Device that sends commands."""
+
+    _coordinator: PhilipsTVDataUpdateCoordinator
 
     def __init__(
         self,
         coordinator: PhilipsTVDataUpdateCoordinator,
-        system: SystemType,
-        unique_id: str,
     ) -> None:
         """Initialize the Philips TV."""
+        super().__init__(coordinator)
         self._tv = coordinator.api
-        self._coordinator = coordinator
-        self._system = system
-        self._unique_id = unique_id
-
-    @property
-    def name(self):
-        """Return the device name."""
-        return self._system["name"]
+        self._attr_name = f"{coordinator.system['name']} Remote"
+        self._attr_unique_id = coordinator.unique_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, coordinator.unique_id),
+            },
+            manufacturer="Philips",
+            model=coordinator.system.get("model"),
+            name=coordinator.system["name"],
+            sw_version=coordinator.system.get("softwareversion"),
+        )
 
     @property
     def is_on(self):
         """Return true if device is on."""
         return bool(
             self._tv.on and (self._tv.powerstate == "On" or self._tv.powerstate is None)
-        )
-
-    @property
-    def should_poll(self):
-        """No polling needed for Apple TV."""
-        return False
-
-    @property
-    def unique_id(self):
-        """Return unique identifier if known."""
-        return self._unique_id
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a device description for device registry."""
-        return DeviceInfo(
-            identifiers={
-                (DOMAIN, self._unique_id),
-            },
-            manufacturer="Philips",
-            model=self._system.get("model"),
-            name=self._system["name"],
-            sw_version=self._system.get("softwareversion"),
         )
 
     async def async_turn_on(self, **kwargs):

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -1,0 +1,72 @@
+"""Philips TV menu switches."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import config_entries
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import PhilipsTVDataUpdateCoordinator
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up the configuration entry."""
+    coordinator: PhilipsTVDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
+    async_add_entities([PhilipsTVScreenSwitch(coordinator)])
+
+
+class PhilipsTVScreenSwitch(CoordinatorEntity, SwitchEntity):
+    """A Philips TV screen state switch."""
+
+    coordinator: PhilipsTVDataUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: PhilipsTVDataUpdateCoordinator,
+    ) -> None:
+        """Initialize entity."""
+
+        super().__init__(coordinator)
+
+        self._attr_name = f"{coordinator.system['name']} Screen State"
+        self._attr_icon = "mdi:television-shimmer"
+        self._attr_unique_id = f"{coordinator.unique_id}_screenstate"
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, coordinator.unique_id),
+            }
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return true if entity is available."""
+        if not super().available:
+            return False
+        if not self.coordinator.api.on:
+            return False
+        return self.coordinator.api.powerstate == "On"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self.coordinator.api.screenstate == "On"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.coordinator.api.setScreenState("On")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.coordinator.api.setScreenState("Off")

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -41,7 +41,9 @@ def mock_tv():
 @fixture
 async def mock_config_entry(hass):
     """Get standard player."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, title=MOCK_NAME)
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, title=MOCK_NAME, unique_id="ABCDEFGHIJKLF"
+    )
     config_entry.add_to_hass(hass)
     return config_entry
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Adding support for turn on and off a philips tv screen while still being turned on
* Upgrade to self._attr use for entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
