### PR TITLE
Add link flags for grpc armv7 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,6 +42,10 @@ jobs:
             echo "GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true"
             echo "GRPC_PYTHON_BUILD_WITH_CYTHON=true"
             echo "GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY=true"
+            # GRPC on armv7 needs -lexecinfo (issue #56669) since home assistant installs
+            # execinfo-dev when building wheels. The setup.py does not have an option for
+            # adding a single LDFLAG so copy all relevant linux flags here (as of 1.43.0)
+            echo "GRPC_PYTHON_LDFLAGS="-lpthread -Wl,-wrap,memcpy -static-libgcc -lexecinfo"
           ) > .env_file
 
       - name: Upload env_file

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
             # GRPC on armv7 needs -lexecinfo (issue #56669) since home assistant installs
             # execinfo-dev when building wheels. The setup.py does not have an option for
             # adding a single LDFLAG so copy all relevant linux flags here (as of 1.43.0)
-            echo "GRPC_PYTHON_LDFLAGS="-lpthread -Wl,-wrap,memcpy -static-libgcc -lexecinfo"
+            echo "GRPC_PYTHON_LDFLAGS=\"-lpthread -Wl,-wrap,memcpy -static-libgcc -lexecinfo\""
           ) > .env_file
 
       - name: Upload env_file


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `-lexecinfo` to the list of GRPC LDFLAGS, which allows the home assistant wheel builder to create wheels for armv7 grpc builds.

This is needed because:
- Home assistant installs `libexecinfo-dev` in the builder
- abseil-cpp seems to conditionally pick this up [src](https://github.com/abseil/abseil-cpp/blob/f2dbd918d8d08529800eb72f23bd2829f92104a4/absl/debugging/internal/stacktrace_config.h#L55)
- musl does not include `backtrace` as part of the system library, however it can come from `-lexecinfo

This allows building a grpc 1.43.0 wheel on armv7 alpine 3.14 with python 3.9

GRPC currently does not have a way to add a single LDFLAG, so the existing LDFLAGS are copied until an option for that is added, which I can explore.

I would like to discuss how we can best test this and upgrade grpc.  My concern: when the wheels are not in place it will build from source which can take a really long time and will be killed by the supervisor. So ,I *think* we need to build all the wheels first before bumping up to 1.43.0. Would like to discuss any other testing that would be helpful for me to do.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #56669 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
