### PR TITLE
Fix missing device name with legacy flux_led discovery

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -120,7 +120,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not discovery_cached:
         # Only update the entry once we have verified the unique id
         # is either missing or we have verified it matches
-        async_update_entry_from_discovery(hass, entry, discovery)
+        async_update_entry_from_discovery(hass, entry, discovery, device.model_num)
 
     coordinator = FluxLedUpdateCoordinator(hass, device, entry)
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -29,6 +29,7 @@ from .const import (
 )
 from .coordinator import FluxLedUpdateCoordinator
 from .discovery import (
+    async_build_cached_discovery,
     async_clear_discovery_cache,
     async_discover_device,
     async_discover_devices,
@@ -81,11 +82,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Flux LED/MagicLight from a config entry."""
     host = entry.data[CONF_HOST]
-    directed_discovery = None
+    discovery_cached = True
     if discovery := async_get_discovery(hass, host):
-        directed_discovery = False
+        discovery_cached = False
+    else:
+        discovery = async_build_cached_discovery(entry)
     device: AIOWifiLedBulb = async_wifi_bulb_for_host(host, discovery=discovery)
     signal = SIGNAL_STATE_UPDATED.format(device.ipaddr)
+    device.discovery = discovery
 
     @callback
     def _async_state_changed(*_: Any) -> None:
@@ -100,23 +104,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from ex
 
     # UDP probe after successful connect only
-    if not discovery and (discovery := await async_discover_device(hass, host)):
-        directed_discovery = True
+    if discovery_cached:
+        if directed_discovery := await async_discover_device(hass, host):
+            device.discovery = discovery = directed_discovery
+            discovery_cached = False
 
-    if discovery:
-        if entry.unique_id:
-            assert discovery[ATTR_ID] is not None
-            mac = dr.format_mac(cast(str, discovery[ATTR_ID]))
-            if mac != entry.unique_id:
-                # The device is offline and another flux_led device is now using the ip address
-                raise ConfigEntryNotReady(
-                    f"Unexpected device found at {host}; Expected {entry.unique_id}, found {mac}"
-                )
-        if directed_discovery:
-            # Only update the entry once we have verified the unique id
-            # is either missing or we have verified it matches
-            async_update_entry_from_discovery(hass, entry, discovery)
-        device.discovery = discovery
+    if entry.unique_id and discovery.get(ATTR_ID):
+        mac = dr.format_mac(cast(str, discovery[ATTR_ID]))
+        if mac != entry.unique_id:
+            # The device is offline and another flux_led device is now using the ip address
+            raise ConfigEntryNotReady(
+                f"Unexpected device found at {host}; Expected {entry.unique_id}, found {mac}"
+            )
+
+    if not discovery_cached:
+        # Only update the entry once we have verified the unique id
+        # is either missing or we have verified it matches
+        async_update_entry_from_discovery(hass, entry, discovery)
 
     coordinator = FluxLedUpdateCoordinator(hass, device, entry)
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -43,13 +43,9 @@ from .discovery import (
     async_populate_data_from_discovery,
     async_update_entry_from_discovery,
 )
+from .util import format_as_flux_mac
 
 CONF_DEVICE: Final = "device"
-
-
-def format_as_flux_mac(mac: str) -> str:
-    """Convert a device registry formatted mac to flux mac."""
-    return mac.replace(":", "").upper()
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -99,7 +99,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(mac)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.unique_id == mac or entry.data[CONF_HOST] == host:
-                if async_update_entry_from_discovery(self.hass, entry, device):
+                if async_update_entry_from_discovery(self.hass, entry, device, None):
                     self.hass.async_create_task(
                         self.hass.config_entries.async_reload(entry.entry_id)
                     )

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 import contextlib
 from typing import Any, Final, cast
 
-from flux_led.const import ATTR_ID, ATTR_IPADDR, ATTR_MODEL, ATTR_MODEL_DESCRIPTION
+from flux_led.const import (
+    ATTR_ID,
+    ATTR_IPADDR,
+    ATTR_MODEL,
+    ATTR_MODEL_DESCRIPTION,
+    ATTR_MODEL_INFO,
+    ATTR_VERSION_NUM,
+)
 from flux_led.scanner import FluxLEDDiscovery
 import voluptuous as vol
 
@@ -239,16 +246,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await bulb.async_setup(lambda: None)
         finally:
             await bulb.async_stop()
-        mac_address = discovery[ATTR_ID] if discovery else None
-        model = discovery[ATTR_MODEL] if discovery else None
         return FluxLEDDiscovery(
             ipaddr=host,
-            model=model,
-            id=mac_address,
+            model=discovery[ATTR_MODEL] if discovery else None,
+            id=discovery[ATTR_ID] if discovery else None,
             model_num=bulb.model_num,
-            version_num=None,  # This is the minor version number
+            version_num=discovery[ATTR_VERSION_NUM] if discovery else None,
             firmware_date=None,
-            model_info=None,
+            model_info=discovery[ATTR_MODEL_INFO] if discovery else None,
             model_description=bulb.model_data.description,
             remote_access_enabled=None,
             remote_access_host=None,

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -50,6 +50,7 @@ STARTUP_SCAN_TIMEOUT: Final = 5
 DISCOVER_SCAN_TIMEOUT: Final = 10
 
 CONF_MODEL: Final = "model"
+CONF_MODEL_NUM: Final = "model_num"
 CONF_MODEL_INFO: Final = "model_info"
 CONF_MODEL_DESCRIPTION: Final = "model_description"
 CONF_MINOR_VERSION: Final = "minor_version"

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -50,6 +50,8 @@ STARTUP_SCAN_TIMEOUT: Final = 5
 DISCOVER_SCAN_TIMEOUT: Final = 10
 
 CONF_MODEL: Final = "model"
+CONF_MODEL_INFO: Final = "model_info"
+CONF_MODEL_DESCRIPTION: Final = "model_description"
 CONF_MINOR_VERSION: Final = "minor_version"
 CONF_REMOTE_ACCESS_ENABLED: Final = "remote_access_enabled"
 CONF_REMOTE_ACCESS_HOST: Final = "remote_access_host"

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_MODEL,
     CONF_MODEL_DESCRIPTION,
     CONF_MODEL_INFO,
+    CONF_MODEL_NUM,
     CONF_REMOTE_ACCESS_ENABLED,
     CONF_REMOTE_ACCESS_HOST,
     CONF_REMOTE_ACCESS_PORT,
@@ -65,7 +66,7 @@ def async_build_cached_discovery(entry: ConfigEntry) -> FluxLEDDiscovery:
         ipaddr=data[CONF_HOST],
         model=data.get(CONF_MODEL),
         id=format_as_flux_mac(entry.unique_id),
-        model_num=None,
+        model_num=data.get(CONF_MODEL_NUM),
         version_num=data.get(CONF_MINOR_VERSION),
         firmware_date=None,
         model_info=data.get(CONF_MODEL_INFO),
@@ -105,7 +106,10 @@ def async_populate_data_from_discovery(
 
 @callback
 def async_update_entry_from_discovery(
-    hass: HomeAssistant, entry: config_entries.ConfigEntry, device: FluxLEDDiscovery
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    device: FluxLEDDiscovery,
+    model_num: int | None,
 ) -> bool:
     """Update a config entry from a flux_led discovery."""
     data_updates: dict[str, Any] = {}
@@ -115,6 +119,8 @@ def async_update_entry_from_discovery(
     if not entry.unique_id:
         updates["unique_id"] = dr.format_mac(mac_address)
     async_populate_data_from_discovery(entry.data, data_updates, device)
+    if model_num and entry.data.get(CONF_MODEL_NUM) != model_num:
+        data_updates[CONF_MODEL_NUM] = model_num
     if not entry.data.get(CONF_NAME) or is_ip_address(entry.data[CONF_NAME]):
         updates["title"] = data_updates[CONF_NAME] = async_name_from_discovery(device)
     if data_updates:

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -13,6 +13,7 @@ from flux_led.const import (
     ATTR_MODEL,
     ATTR_MODEL_DESCRIPTION,
     ATTR_MODEL_INFO,
+    ATTR_MODEL_NUM,
     ATTR_REMOTE_ACCESS_ENABLED,
     ATTR_REMOTE_ACCESS_HOST,
     ATTR_REMOTE_ACCESS_PORT,
@@ -53,6 +54,7 @@ CONF_TO_DISCOVERY: Final = {
     CONF_REMOTE_ACCESS_PORT: ATTR_REMOTE_ACCESS_PORT,
     CONF_MINOR_VERSION: ATTR_VERSION_NUM,
     CONF_MODEL: ATTR_MODEL,
+    CONF_MODEL_NUM: ATTR_MODEL_NUM,
     CONF_MODEL_INFO: ATTR_MODEL_INFO,
     CONF_MODEL_DESCRIPTION: ATTR_MODEL_DESCRIPTION,
 }
@@ -99,6 +101,7 @@ def async_populate_data_from_discovery(
     for conf_key, discovery_key in CONF_TO_DISCOVERY.items():
         if (
             device.get(discovery_key) is not None
+            and conf_key not in data_updates
             and current_data.get(conf_key) != device[discovery_key]  # type: ignore[misc]
         ):
             data_updates[conf_key] = device[discovery_key]  # type: ignore[misc]
@@ -118,9 +121,9 @@ def async_update_entry_from_discovery(
     updates: dict[str, Any] = {}
     if not entry.unique_id:
         updates["unique_id"] = dr.format_mac(mac_address)
-    async_populate_data_from_discovery(entry.data, data_updates, device)
     if model_num and entry.data.get(CONF_MODEL_NUM) != model_num:
         data_updates[CONF_MODEL_NUM] = model_num
+    async_populate_data_from_discovery(entry.data, data_updates, device)
     if not entry.data.get(CONF_NAME) or is_ip_address(entry.data[CONF_NAME]):
         updates["title"] = data_updates[CONF_NAME] = async_name_from_discovery(device)
     if data_updates:

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -12,6 +12,7 @@ from flux_led.const import (
     ATTR_IPADDR,
     ATTR_MODEL,
     ATTR_MODEL_DESCRIPTION,
+    ATTR_MODEL_INFO,
     ATTR_REMOTE_ACCESS_ENABLED,
     ATTR_REMOTE_ACCESS_HOST,
     ATTR_REMOTE_ACCESS_PORT,
@@ -30,6 +31,8 @@ from homeassistant.util.network import is_ip_address
 from .const import (
     CONF_MINOR_VERSION,
     CONF_MODEL,
+    CONF_MODEL_DESCRIPTION,
+    CONF_MODEL_INFO,
     CONF_REMOTE_ACCESS_ENABLED,
     CONF_REMOTE_ACCESS_HOST,
     CONF_REMOTE_ACCESS_PORT,
@@ -49,6 +52,8 @@ CONF_TO_DISCOVERY: Final = {
     CONF_REMOTE_ACCESS_PORT: ATTR_REMOTE_ACCESS_PORT,
     CONF_MINOR_VERSION: ATTR_VERSION_NUM,
     CONF_MODEL: ATTR_MODEL,
+    CONF_MODEL_INFO: ATTR_MODEL_INFO,
+    CONF_MODEL_DESCRIPTION: ATTR_MODEL_DESCRIPTION,
 }
 
 
@@ -63,8 +68,8 @@ def async_build_cached_discovery(entry: ConfigEntry) -> FluxLEDDiscovery:
         model_num=None,
         version_num=data.get(CONF_MINOR_VERSION),
         firmware_date=None,
-        model_info=None,
-        model_description=None,
+        model_info=data.get(CONF_MODEL_INFO),
+        model_description=data.get(CONF_MODEL_DESCRIPTION),
         remote_access_enabled=data.get(CONF_REMOTE_ACCESS_ENABLED),
         remote_access_host=data.get(CONF_REMOTE_ACCESS_HOST),
         remote_access_port=data.get(CONF_REMOTE_ACCESS_PORT),

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -101,7 +101,8 @@ def async_populate_data_from_discovery(
     for conf_key, discovery_key in CONF_TO_DISCOVERY.items():
         if (
             device.get(discovery_key) is not None
-            and conf_key not in data_updates
+            and conf_key
+            not in data_updates  # Prefer the model num from TCP instead of UDP
             and current_data.get(conf_key) != device[discovery_key]  # type: ignore[misc]
         ):
             data_updates[conf_key] = device[discovery_key]  # type: ignore[misc]

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -21,6 +21,7 @@ from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant import config_entries
 from homeassistant.components import network
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -36,6 +37,7 @@ from .const import (
     DOMAIN,
     FLUX_LED_DISCOVERY,
 )
+from .util import format_as_flux_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +50,25 @@ CONF_TO_DISCOVERY: Final = {
     CONF_MINOR_VERSION: ATTR_VERSION_NUM,
     CONF_MODEL: ATTR_MODEL,
 }
+
+
+@callback
+def async_build_cached_discovery(entry: ConfigEntry) -> FluxLEDDiscovery:
+    """When discovery is unavailable, load it from the config entry."""
+    data = entry.data
+    return FluxLEDDiscovery(
+        ipaddr=data[CONF_HOST],
+        model=data.get(CONF_MODEL),
+        id=format_as_flux_mac(entry.unique_id),
+        model_num=None,
+        version_num=data.get(CONF_MINOR_VERSION),
+        firmware_date=None,
+        model_info=None,
+        model_description=None,
+        remote_access_enabled=data.get(CONF_REMOTE_ACCESS_ENABLED),
+        remote_access_host=data.get(CONF_REMOTE_ACCESS_HOST),
+        remote_access_port=data.get(CONF_REMOTE_ACCESS_PORT),
+    )
 
 
 @callback

--- a/homeassistant/components/flux_led/entity.py
+++ b/homeassistant/components/flux_led/entity.py
@@ -24,7 +24,7 @@ def _async_device_info(
     version_num = device.version_num
     if minor_version := entry.data.get(CONF_MINOR_VERSION):
         sw_version = version_num + int(hex(minor_version)[2:]) / 100
-        sw_version_str = f"{sw_version:0.3f}"
+        sw_version_str = f"{sw_version:0.2f}"
     else:
         sw_version_str = str(device.version_num)
     return DeviceInfo(

--- a/homeassistant/components/flux_led/util.py
+++ b/homeassistant/components/flux_led/util.py
@@ -18,6 +18,11 @@ def _hass_color_modes(device: AIOWifiLedBulb) -> set[str]:
     return {_flux_color_mode_to_hass(mode, color_modes) for mode in color_modes}
 
 
+def format_as_flux_mac(mac: str | None) -> str | None:
+    """Convert a device registry formatted mac to flux mac."""
+    return None if mac is None else mac.replace(":", "").upper()
+
+
 def _flux_color_mode_to_hass(
     flux_color_mode: str | None, flux_color_modes: set[str]
 ) -> str:

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -27,8 +27,8 @@ MODEL_NUM_HEX = "0x35"
 MODEL = "AZ120444"
 MODEL_DESCRIPTION = "Bulb RGBCW"
 MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
-FLUX_MAC_ADDRESS = "aabbccddeeff"
-SHORT_MAC_ADDRESS = "ddeeff"
+FLUX_MAC_ADDRESS = "AABBCCDDEEFF"
+SHORT_MAC_ADDRESS = "DDEEFF"
 
 DEFAULT_ENTRY_TITLE = f"{MODEL_DESCRIPTION} {SHORT_MAC_ADDRESS}"
 
@@ -79,6 +79,16 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.async_set_effect = AsyncMock()
     bulb.async_set_white_temp = AsyncMock()
     bulb.async_set_brightness = AsyncMock()
+    bulb.pixels_per_segment = 300
+    bulb.segments = 2
+    bulb.music_pixels_per_segment = 150
+    bulb.music_segments = 4
+    bulb.operating_mode = "RGB&W"
+    bulb.operating_modes = ["RGB&W", "RGB/W"]
+    bulb.wirings = ["RGBW", "GRBW", "BGRW"]
+    bulb.wiring = "BGRW"
+    bulb.ic_types = ["WS2812B", "UCS1618"]
+    bulb.ic_type = "WS2812B"
     bulb.async_stop = AsyncMock()
     bulb.async_update = AsyncMock()
     bulb.async_turn_off = AsyncMock()

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -24,6 +24,7 @@ MODULE = "homeassistant.components.flux_led"
 MODULE_CONFIG_FLOW = "homeassistant.components.flux_led.config_flow"
 IP_ADDRESS = "127.0.0.1"
 MODEL_NUM_HEX = "0x35"
+MODEL_NUM = 0x35
 MODEL = "AZ120444"
 MODEL_DESCRIPTION = "Bulb RGBCW"
 MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
@@ -52,7 +53,7 @@ FLUX_DISCOVERY = FluxLEDDiscovery(
     ipaddr=IP_ADDRESS,
     model=MODEL,
     id=FLUX_MAC_ADDRESS,
-    model_num=0x25,
+    model_num=MODEL_NUM,
     version_num=0x04,
     firmware_date=datetime.date(2021, 5, 5),
     model_info=MODEL,
@@ -111,8 +112,8 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.color_temp = 2700
     bulb.getWhiteTemperature = MagicMock(return_value=(2700, 128))
     bulb.brightness = 128
-    bulb.model_num = 0x35
-    bulb.model_data = MODEL_MAP[0x35]
+    bulb.model_num = MODEL_NUM
+    bulb.model_data = MODEL_MAP[MODEL_NUM]
     bulb.effect = None
     bulb.speed = 50
     bulb.model = "Bulb RGBCW (0x35)"

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -115,6 +115,79 @@ async def test_discovery(hass: HomeAssistant):
     assert result2["reason"] == "no_devices_found"
 
 
+async def test_discovery_legacy(hass: HomeAssistant):
+    """Test setting up discovery with a legacy device."""
+    with _patch_discovery(device=FLUX_DISCOVERY_PARTIAL), _patch_wifibulb():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert not result["errors"]
+
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+        assert result2["type"] == "form"
+        assert result2["step_id"] == "pick_device"
+        assert not result2["errors"]
+
+        # test we can try again
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert not result["errors"]
+
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+        assert result2["type"] == "form"
+        assert result2["step_id"] == "pick_device"
+        assert not result2["errors"]
+
+    with _patch_discovery(), _patch_wifibulb(), patch(
+        f"{MODULE}.async_setup", return_value=True
+    ) as mock_setup, patch(
+        f"{MODULE}.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_DEVICE: MAC_ADDRESS},
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == "create_entry"
+    assert result3["title"] == DEFAULT_ENTRY_TITLE
+    assert result3["data"] == {
+        CONF_MINOR_VERSION: 4,
+        CONF_HOST: IP_ADDRESS,
+        CONF_NAME: DEFAULT_ENTRY_TITLE,
+        CONF_MODEL: MODEL,
+        CONF_REMOTE_ACCESS_ENABLED: True,
+        CONF_REMOTE_ACCESS_HOST: "the.cloud",
+        CONF_REMOTE_ACCESS_PORT: 8816,
+        CONF_MINOR_VERSION: 0x04,
+    }
+    mock_setup.assert_called_once()
+    mock_setup_entry.assert_called_once()
+
+    # ignore configured devices
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    with _patch_discovery(), _patch_wifibulb():
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "no_devices_found"
+
+
 async def test_discovery_with_existing_device_present(hass: HomeAssistant):
     """Test setting up discovery."""
     config_entry = MockConfigEntry(

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.flux_led.const import (
     CONF_MODEL,
     CONF_MODEL_DESCRIPTION,
     CONF_MODEL_INFO,
+    CONF_MODEL_NUM,
     CONF_REMOTE_ACCESS_ENABLED,
     CONF_REMOTE_ACCESS_HOST,
     CONF_REMOTE_ACCESS_PORT,
@@ -35,6 +36,7 @@ from . import (
     MAC_ADDRESS,
     MODEL,
     MODEL_DESCRIPTION,
+    MODEL_NUM,
     MODULE,
     _patch_discovery,
     _patch_wifibulb,
@@ -94,6 +96,7 @@ async def test_discovery(hass: HomeAssistant):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_INFO: MODEL,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
@@ -169,6 +172,7 @@ async def test_discovery_legacy(hass: HomeAssistant):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_INFO: MODEL,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
@@ -251,6 +255,7 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
             CONF_HOST: IP_ADDRESS,
             CONF_NAME: DEFAULT_ENTRY_TITLE,
             CONF_MODEL: MODEL,
+            CONF_MODEL_NUM: MODEL_NUM,
             CONF_MODEL_INFO: MODEL,
             CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
             CONF_REMOTE_ACCESS_ENABLED: True,
@@ -327,6 +332,7 @@ async def test_manual_working_discovery(hass: HomeAssistant):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_INFO: MODEL,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
@@ -369,6 +375,7 @@ async def test_manual_no_discovery_data(hass: HomeAssistant):
     assert result["type"] == "create_entry"
     assert result["data"] == {
         CONF_HOST: IP_ADDRESS,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_NAME: IP_ADDRESS,
     }
@@ -440,6 +447,7 @@ async def test_discovered_by_discovery(hass):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_INFO: MODEL,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
@@ -477,6 +485,7 @@ async def test_discovered_by_dhcp_udp_responds(hass):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_INFO: MODEL,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
@@ -511,6 +520,7 @@ async def test_discovered_by_dhcp_no_udp_response(hass):
     assert result2["type"] == "create_entry"
     assert result2["data"] == {
         CONF_HOST: IP_ADDRESS,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
     }
@@ -541,6 +551,7 @@ async def test_discovered_by_dhcp_partial_udp_response_fallback_tcp(hass):
     assert result2["type"] == "create_entry"
     assert result2["data"] == {
         CONF_HOST: IP_ADDRESS,
+        CONF_MODEL_NUM: MODEL_NUM,
         CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
     }

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -13,6 +13,8 @@ from homeassistant.components.flux_led.const import (
     CONF_CUSTOM_EFFECT_TRANSITION,
     CONF_MINOR_VERSION,
     CONF_MODEL,
+    CONF_MODEL_DESCRIPTION,
+    CONF_MODEL_INFO,
     CONF_REMOTE_ACCESS_ENABLED,
     CONF_REMOTE_ACCESS_HOST,
     CONF_REMOTE_ACCESS_PORT,
@@ -32,6 +34,7 @@ from . import (
     IP_ADDRESS,
     MAC_ADDRESS,
     MODEL,
+    MODEL_DESCRIPTION,
     MODULE,
     _patch_discovery,
     _patch_wifibulb,
@@ -91,6 +94,8 @@ async def test_discovery(hass: HomeAssistant):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_INFO: MODEL,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
         CONF_REMOTE_ACCESS_HOST: "the.cloud",
         CONF_REMOTE_ACCESS_PORT: 8816,
@@ -164,6 +169,8 @@ async def test_discovery_legacy(hass: HomeAssistant):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_INFO: MODEL,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
         CONF_REMOTE_ACCESS_HOST: "the.cloud",
         CONF_REMOTE_ACCESS_PORT: 8816,
@@ -244,6 +251,8 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
             CONF_HOST: IP_ADDRESS,
             CONF_NAME: DEFAULT_ENTRY_TITLE,
             CONF_MODEL: MODEL,
+            CONF_MODEL_INFO: MODEL,
+            CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
             CONF_REMOTE_ACCESS_ENABLED: True,
             CONF_REMOTE_ACCESS_HOST: "the.cloud",
             CONF_REMOTE_ACCESS_PORT: 8816,
@@ -318,6 +327,8 @@ async def test_manual_working_discovery(hass: HomeAssistant):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_INFO: MODEL,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
         CONF_REMOTE_ACCESS_HOST: "the.cloud",
         CONF_REMOTE_ACCESS_PORT: 8816,
@@ -356,7 +367,11 @@ async def test_manual_no_discovery_data(hass: HomeAssistant):
         await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_HOST: IP_ADDRESS, CONF_NAME: IP_ADDRESS}
+    assert result["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
+        CONF_NAME: IP_ADDRESS,
+    }
 
 
 async def test_discovered_by_discovery_and_dhcp(hass):
@@ -425,6 +440,8 @@ async def test_discovered_by_discovery(hass):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_INFO: MODEL,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
         CONF_REMOTE_ACCESS_HOST: "the.cloud",
         CONF_REMOTE_ACCESS_PORT: 8816,
@@ -460,6 +477,8 @@ async def test_discovered_by_dhcp_udp_responds(hass):
         CONF_HOST: IP_ADDRESS,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
         CONF_MODEL: MODEL,
+        CONF_MODEL_INFO: MODEL,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_REMOTE_ACCESS_ENABLED: True,
         CONF_REMOTE_ACCESS_HOST: "the.cloud",
         CONF_REMOTE_ACCESS_PORT: 8816,
@@ -492,6 +511,7 @@ async def test_discovered_by_dhcp_no_udp_response(hass):
     assert result2["type"] == "create_entry"
     assert result2["data"] == {
         CONF_HOST: IP_ADDRESS,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
     }
     assert mock_async_setup.called
@@ -521,6 +541,7 @@ async def test_discovered_by_dhcp_partial_udp_response_fallback_tcp(hass):
     assert result2["type"] == "create_entry"
     assert result2["data"] == {
         CONF_HOST: IP_ADDRESS,
+        CONF_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
         CONF_NAME: DEFAULT_ENTRY_TITLE,
     }
     assert mock_async_setup.called


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix missing device name with legacy flux_led discovery

The partial discovery would not be completed for legacy devices 0x1,0x2,0x3

Some of these older devices would take a while to connect if we don't provide discovery data lib since it has to try the newer protocols first.

The device would still work but be named as the mac address which made it a bit confusing in the UI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
