### PR TITLE
Drop aemet isoformat() from timestamps

### DIFF
--- a/homeassistant/components/aemet/const.py
+++ b/homeassistant/components/aemet/const.py
@@ -1,6 +1,10 @@
 """Constant values for the AEMET OpenData component."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntityDescription,
@@ -35,6 +39,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     Platform,
 )
+from homeassistant.util import dt as dt_util
 
 ATTRIBUTION = "Powered by AEMET OpenData"
 CONF_STATION_UPDATES = "station_updates"
@@ -200,44 +205,53 @@ FORECAST_MODE_ATTR_API = {
     FORECAST_MODE_HOURLY: ATTR_API_FORECAST_HOURLY,
 }
 
-FORECAST_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
+
+@dataclass
+class ForecastSensorEntityDescription(SensorEntityDescription):
+    """Class describing Aemet forecast sensor entities."""
+
+    value: Callable = date
+
+
+FORECAST_SENSOR_TYPES: tuple[ForecastSensorEntityDescription, ...] = (
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_CONDITION,
         name="Condition",
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_PRECIPITATION,
         name="Precipitation",
         native_unit_of_measurement=PRECIPITATION_MILLIMETERS_PER_HOUR,
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_PRECIPITATION_PROBABILITY,
         name="Precipitation probability",
         native_unit_of_measurement=PERCENTAGE,
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_TEMP,
         name="Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_TEMP_LOW,
         name="Temperature Low",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_TIME,
         name="Time",
         device_class=SensorDeviceClass.TIMESTAMP,
+        value=lambda value: dt_util.parse_datetime(value),
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_WIND_BEARING,
         name="Wind bearing",
         native_unit_of_measurement=DEGREE,
     ),
-    SensorEntityDescription(
+    ForecastSensorEntityDescription(
         key=ATTR_FORECAST_WIND_SPEED,
         name="Wind speed",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,

--- a/homeassistant/components/aemet/const.py
+++ b/homeassistant/components/aemet/const.py
@@ -1,10 +1,6 @@
 """Constant values for the AEMET OpenData component."""
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass
-from datetime import date
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntityDescription,
@@ -39,7 +35,6 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     Platform,
 )
-from homeassistant.util import dt as dt_util
 
 ATTRIBUTION = "Powered by AEMET OpenData"
 CONF_STATION_UPDATES = "station_updates"
@@ -205,53 +200,44 @@ FORECAST_MODE_ATTR_API = {
     FORECAST_MODE_HOURLY: ATTR_API_FORECAST_HOURLY,
 }
 
-
-@dataclass
-class ForecastSensorEntityDescription(SensorEntityDescription):
-    """Class describing Aemet forecast sensor entities."""
-
-    value: Callable = date
-
-
-FORECAST_SENSOR_TYPES: tuple[ForecastSensorEntityDescription, ...] = (
-    ForecastSensorEntityDescription(
+FORECAST_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
         key=ATTR_FORECAST_CONDITION,
         name="Condition",
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_PRECIPITATION,
         name="Precipitation",
         native_unit_of_measurement=PRECIPITATION_MILLIMETERS_PER_HOUR,
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_PRECIPITATION_PROBABILITY,
         name="Precipitation probability",
         native_unit_of_measurement=PERCENTAGE,
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_TEMP,
         name="Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_TEMP_LOW,
         name="Temperature Low",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_TIME,
         name="Time",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value=lambda value: dt_util.parse_datetime(value),
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_WIND_BEARING,
         name="Wind bearing",
         native_unit_of_measurement=DEGREE,
     ),
-    ForecastSensorEntityDescription(
+    SensorEntityDescription(
         key=ATTR_FORECAST_WIND_SPEED,
         name="Wind speed",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,

--- a/homeassistant/components/aemet/sensor.py
+++ b/homeassistant/components/aemet/sensor.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
 
 from .const import (
-    ATTR_FORECAST_TIME,
     ATTRIBUTION,
     DOMAIN,
     ENTRY_NAME,
@@ -132,6 +130,4 @@ class AemetForecastSensor(AbstractAemetSensor):
         )
         if forecasts:
             forecast = forecasts[0].get(self.entity_description.key)
-            if self.entity_description.key == ATTR_FORECAST_TIME:
-                forecast = dt_util.parse_datetime(forecast)
         return forecast

--- a/homeassistant/components/aemet/sensor.py
+++ b/homeassistant/components/aemet/sensor.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import (
+    ATTR_FORECAST_TIME,
     ATTRIBUTION,
     DOMAIN,
     ENTRY_NAME,
@@ -130,4 +132,6 @@ class AemetForecastSensor(AbstractAemetSensor):
         )
         if forecasts:
             forecast = forecasts[0].get(self.entity_description.key)
+            if self.entity_description.key == ATTR_FORECAST_TIME:
+                forecast = dt_util.parse_datetime(forecast)
         return forecast

--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -286,7 +286,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         temperature_feeling = None
         town_id = None
         town_name = None
-        town_timestamp = dt_util.as_utc(elaborated).isoformat()
+        town_timestamp = dt_util.as_utc(elaborated)
         wind_bearing = None
         wind_max_speed = None
         wind_speed = None
@@ -312,7 +312,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
         # Overwrite weather values with closest station data (if present)
         if station_data:
-            station_timestamp = dt_util.as_utc(station_dt).isoformat()
+            station_timestamp = dt_util.as_utc(station_dt)
             if (now_utc - station_dt) <= STATION_MAX_DELTA:
                 if AEMET_ATTR_STATION_HUMIDITY in station_data:
                     humidity = format_float(station_data[AEMET_ATTR_STATION_HUMIDITY])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix AEMET timestamp sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue) https://github.com/home-assistant/core/issues/62514
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/62514
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
