### PR TITLE
Don't attempt to set invalid fan percentage and preset_mode

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -347,13 +347,14 @@ class FanEntity(ToggleEntity):
             data[ATTR_OSCILLATING] = self.oscillating
 
         if supported_features & FanEntityFeature.SET_SPEED:
-            data[ATTR_PERCENTAGE] = self.percentage
+            if self.percentage is not None:
+                data[ATTR_PERCENTAGE] = self.percentage
             data[ATTR_PERCENTAGE_STEP] = self.percentage_step
 
         if (
             supported_features & FanEntityFeature.PRESET_MODE
             or supported_features & FanEntityFeature.SET_SPEED
-        ):
+        ) and self.preset_mode is not None:
             data[ATTR_PRESET_MODE] = self.preset_mode
 
         return data

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -222,7 +222,7 @@ async def test_fans(hass, aioclient_mock, mock_deconz_websocket):
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert not hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE]
+    assert ATTR_PERCENTAGE not in hass.states.get("fan.ceiling_fan").attributes
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -162,7 +162,7 @@ async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
     )
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -175,7 +175,7 @@ async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
 
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
 
 @pytest.mark.parametrize("fan_entity_id", FANS_WITH_PRESET_MODES)
@@ -191,7 +191,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     )
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
-    assert state.attributes[fan.ATTR_PERCENTAGE] is None
+    assert fan.ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[fan.ATTR_PRESET_MODE] == PRESET_MODE_AUTO
     assert state.attributes[fan.ATTR_PRESET_MODES] == [
         PRESET_MODE_AUTO,
@@ -209,7 +209,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_PERCENTAGE] == 100
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
     await hass.services.async_call(
         fan.DOMAIN,
@@ -219,7 +219,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     )
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
-    assert state.attributes[fan.ATTR_PERCENTAGE] is None
+    assert fan.ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[fan.ATTR_PRESET_MODE] == PRESET_MODE_SMART
 
     await hass.services.async_call(
@@ -228,7 +228,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
     assert state.attributes[fan.ATTR_PERCENTAGE] == 0
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -242,7 +242,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
     assert state.attributes[fan.ATTR_PERCENTAGE] == 0
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
@@ -313,7 +313,7 @@ async def test_set_preset_mode(hass, fan_entity_id):
     )
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
-    assert state.attributes[fan.ATTR_PERCENTAGE] is None
+    assert fan.ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[fan.ATTR_PRESET_MODE] == PRESET_MODE_AUTO
 
 

--- a/tests/components/fan/test_reproduce_state.py
+++ b/tests/components/fan/test_reproduce_state.py
@@ -1,4 +1,16 @@
 """Test reproduce state for Fan."""
+
+import pytest
+
+from homeassistant.components.fan import (
+    ATTR_DIRECTION,
+    ATTR_OSCILLATING,
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    ATTR_PRESET_MODES,
+    DIRECTION_FORWARD,
+    DIRECTION_REVERSE,
+)
 from homeassistant.core import State
 from homeassistant.helpers.state import async_reproduce_state
 
@@ -88,3 +100,389 @@ async def test_reproducing_states(hass, caplog):
     assert len(turn_off_calls) == 1
     assert turn_off_calls[0].domain == "fan"
     assert turn_off_calls[0].data == {"entity_id": "fan.entity_on"}
+
+
+MODERN_FAN_ENTITY = "fan.modern_fan"
+MODERN_FAN_OFF_PERCENTAGE10_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PERCENTAGE: 10,
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_OFF_PERCENTAGE15_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PERCENTAGE: 15,
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_ON_INVALID_STATE = {
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_OFF_PPRESET_MODE_AUTO_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PRESET_MODE: "Auto",
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PRESET_MODE: "Eco",
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_ON_PERCENTAGE10_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PERCENTAGE: 10,
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_ON_PERCENTAGE15_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PERCENTAGE: 15,
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_ON_PRESET_MODE_AUTO_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PRESET_MODE: "Auto",
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_ON_PRESET_MODE_ECO_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_FORWARD,
+    ATTR_PRESET_MODE: "Eco",
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+MODERN_FAN_PRESET_MODE_AUTO_REVERSE_STATE = {
+    ATTR_OSCILLATING: True,
+    ATTR_DIRECTION: DIRECTION_REVERSE,
+    ATTR_PRESET_MODE: "Auto",
+    ATTR_PRESET_MODES: ["Auto", "Eco"],
+}
+
+
+@pytest.mark.parametrize(
+    "start_state",
+    [
+        MODERN_FAN_OFF_PERCENTAGE10_STATE,
+        MODERN_FAN_OFF_PERCENTAGE15_STATE,
+        MODERN_FAN_OFF_PPRESET_MODE_AUTO_STATE,
+        MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
+    ],
+)
+async def test_modern_turn_on_invalid(hass, start_state):
+    """Test modern fan state reproduction, turning on with invalid state."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    # Turn on with an invalid config (speed, percentage, preset_modes all None)
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_INVALID_STATE)]
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "fan"
+    assert turn_on_calls[0].data == {"entity_id": MODERN_FAN_ENTITY}
+
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 0
+
+
+@pytest.mark.parametrize(
+    "start_state",
+    [
+        MODERN_FAN_OFF_PERCENTAGE10_STATE,
+        MODERN_FAN_OFF_PPRESET_MODE_AUTO_STATE,
+        MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
+    ],
+)
+async def test_modern_turn_on_percentage_from_different_speed(hass, start_state):
+    """Test modern fan state reproduction, turning on with a different percentage of the state."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PERCENTAGE15_STATE)]
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "fan"
+    assert turn_on_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PERCENTAGE: 15,
+    }
+
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert set_percentage_mode[0].domain == "fan"
+    assert set_percentage_mode[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PERCENTAGE: 15,
+    }
+    assert len(set_preset_mode) == 0
+
+
+async def test_modern_turn_on_percentage_from_same_speed(hass):
+    """Test modern fan state reproduction, turning on with the same percentage as in the state."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "off", MODERN_FAN_OFF_PERCENTAGE15_STATE)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PERCENTAGE15_STATE)]
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "fan"
+    assert turn_on_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PERCENTAGE: 15,
+    }
+
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 0
+
+
+@pytest.mark.parametrize(
+    "start_state",
+    [
+        MODERN_FAN_OFF_PERCENTAGE10_STATE,
+        MODERN_FAN_OFF_PERCENTAGE15_STATE,
+        MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
+    ],
+)
+async def test_modern_turn_on_preset_mode_from_different_speed(hass, start_state):
+    """Test modern fan state reproduction, turning on with a different preset mode from the state."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)]
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "fan"
+    assert turn_on_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PRESET_MODE: "Auto",
+    }
+
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 1
+    assert set_preset_mode[0].domain == "fan"
+    assert set_preset_mode[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PRESET_MODE: "Auto",
+    }
+
+
+async def test_modern_turn_on_preset_mode_from_same_speed(hass):
+    """Test modern fan state reproduction, turning on with the same preset mode as in the state."""
+    hass.states.async_set(
+        MODERN_FAN_ENTITY, "off", MODERN_FAN_OFF_PPRESET_MODE_AUTO_STATE
+    )
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)]
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "fan"
+    assert turn_on_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PRESET_MODE: "Auto",
+    }
+
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 0
+
+
+@pytest.mark.parametrize(
+    "start_state",
+    [
+        MODERN_FAN_OFF_PERCENTAGE10_STATE,
+        MODERN_FAN_OFF_PERCENTAGE15_STATE,
+        MODERN_FAN_OFF_PPRESET_MODE_ECO_STATE,
+    ],
+)
+async def test_modern_turn_on_preset_mode_reverse(hass, start_state):
+    """Test modern fan state reproduction, turning on with preset mode "Auto" and reverse direction."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "off", start_state)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_PRESET_MODE_AUTO_REVERSE_STATE)]
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "fan"
+    assert turn_on_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PRESET_MODE: "Auto",
+    }
+    assert len(set_direction_calls) == 1
+    assert set_direction_calls[0].domain == "fan"
+    assert set_direction_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_DIRECTION: DIRECTION_REVERSE,
+    }
+
+    assert len(turn_off_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 1
+    assert set_preset_mode[0].domain == "fan"
+    assert set_preset_mode[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PRESET_MODE: "Auto",
+    }
+
+
+@pytest.mark.parametrize(
+    "start_state",
+    [
+        MODERN_FAN_ON_PERCENTAGE10_STATE,
+        MODERN_FAN_ON_PERCENTAGE15_STATE,
+        MODERN_FAN_ON_PRESET_MODE_ECO_STATE,
+    ],
+)
+async def test_modern_to_preset(hass, start_state):
+    """Test modern fan state reproduction, switching to preset mode "Auto"."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "on", start_state)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)]
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 1
+    assert set_preset_mode[0].domain == "fan"
+    assert set_preset_mode[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PRESET_MODE: "Auto",
+    }
+
+
+@pytest.mark.parametrize(
+    "start_state",
+    [
+        MODERN_FAN_ON_PERCENTAGE10_STATE,
+        MODERN_FAN_ON_PRESET_MODE_AUTO_STATE,
+        MODERN_FAN_ON_PRESET_MODE_ECO_STATE,
+    ],
+)
+async def test_modern_to_percentage(hass, start_state):
+    """Test modern fan state reproduction, switching to 15% speed."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "on", start_state)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PERCENTAGE15_STATE)]
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 0
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 1
+    assert set_percentage_mode[0].domain == "fan"
+    assert set_percentage_mode[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_PERCENTAGE: 15,
+    }
+    assert len(set_preset_mode) == 0
+
+
+async def test_modern_direction(hass):
+    """Test modern fan state reproduction, switching only direction state."""
+    hass.states.async_set(MODERN_FAN_ENTITY, "on", MODERN_FAN_ON_PRESET_MODE_AUTO_STATE)
+
+    turn_on_calls = async_mock_service(hass, "fan", "turn_on")
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+    set_direction_calls = async_mock_service(hass, "fan", "set_direction")
+    oscillate_calls = async_mock_service(hass, "fan", "oscillate")
+    set_percentage_mode = async_mock_service(hass, "fan", "set_percentage")
+    set_preset_mode = async_mock_service(hass, "fan", "set_preset_mode")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State(MODERN_FAN_ENTITY, "on", MODERN_FAN_PRESET_MODE_AUTO_REVERSE_STATE)]
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+    assert len(set_direction_calls) == 1
+    assert set_direction_calls[0].domain == "fan"
+    assert set_direction_calls[0].data == {
+        "entity_id": MODERN_FAN_ENTITY,
+        ATTR_DIRECTION: DIRECTION_REVERSE,
+    }
+    assert len(oscillate_calls) == 0
+    assert len(set_percentage_mode) == 0
+    assert len(set_preset_mode) == 0

--- a/tests/components/tasmota/test_fan.py
+++ b/tests/components/tasmota/test_fan.py
@@ -53,7 +53,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
-    assert state.attributes["percentage"] is None
+    assert "percentage" not in state.attributes
     assert state.attributes["supported_features"] == fan.SUPPORT_SET_SPEED
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -450,8 +450,12 @@ async def test_fan_init(
     entity_id = await find_entity_id(Platform.FAN, zha_device, hass)
     assert entity_id is not None
     assert hass.states.get(entity_id).state == expected_state
-    assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == expected_percentage
-    assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
+    entity_attrs = hass.states.get(entity_id).attributes
+    if expected_percentage is not None:
+        assert entity_attrs[ATTR_PERCENTAGE] == expected_percentage
+    else:
+        assert ATTR_PERCENTAGE not in entity_attrs
+    assert ATTR_PRESET_MODE not in entity_attrs
 
 
 async def test_fan_update_entity(
@@ -469,7 +473,7 @@ async def test_fan_update_entity(
     assert entity_id is not None
     assert hass.states.get(entity_id).state == STATE_OFF
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 0
-    assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
+    assert ATTR_PRESET_MODE not in hass.states.get(entity_id).attributes
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
     assert cluster.read_attributes.await_count == 2
 
@@ -488,6 +492,6 @@ async def test_fan_update_entity(
     )
     assert hass.states.get(entity_id).state == STATE_ON
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 33
-    assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
+    assert ATTR_PRESET_MODE not in hass.states.get(entity_id).attributes
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
     assert cluster.read_attributes.await_count == 4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When loading state from a saved scene, the `percentage` and `preset_mode`,
may be set to `None`, but calling the service to set them to `None` would result
in an error (#62792.)

Instead handle these two attributes differently:

 - when turning the entity 'on' from 'off' state, call the full form of `turn_on`
   service;
 - if the fan is already on, only call the service for the attribute
   that is not `None`.

This also introduces tests to make sure that the transitions are
behaving as expected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #62792
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
