### PR TITLE
Add light entity to Overkiz integration 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -807,6 +807,7 @@ omit =
     homeassistant/components/overkiz/coordinator.py
     homeassistant/components/overkiz/entity.py
     homeassistant/components/overkiz/executor.py
+    homeassistant/components/overkiz/light.py
     homeassistant/components/overkiz/lock.py
     homeassistant/components/overkiz/number.py
     homeassistant/components/overkiz/sensor.py

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -19,6 +19,7 @@ UPDATE_INTERVAL_ALL_ASSUMED_STATE: Final = timedelta(minutes=60)
 
 PLATFORMS: list[Platform] = [
     Platform.BUTTON,
+    Platform.LIGHT,
     Platform.LOCK,
     Platform.NUMBER,
     Platform.SENSOR,
@@ -32,4 +33,5 @@ IGNORED_OVERKIZ_DEVICES: list[UIClass | UIWidget] = [
 # Used to map the Somfy widget and ui_class to the Home Assistant platform
 OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIClass.DOOR_LOCK: Platform.LOCK,
+    UIClass.LIGHT: Platform.LIGHT,
 }

--- a/homeassistant/components/overkiz/light.py
+++ b/homeassistant/components/overkiz/light.py
@@ -11,14 +11,14 @@ from homeassistant.components.light import (
     COLOR_MODE_RGB,
     LightEntity,
 )
-from homeassistant.components.overkiz import HomeAssistantOverkizData
-from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import HomeAssistantOverkizData
 from .const import DOMAIN
+from .coordinator import OverkizDataUpdateCoordinator
 from .entity import OverkizEntity
 
 

--- a/homeassistant/components/overkiz/light.py
+++ b/homeassistant/components/overkiz/light.py
@@ -1,0 +1,108 @@
+"""Support for Overkiz lights."""
+from __future__ import annotations
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_ONOFF,
+    COLOR_MODE_RGB,
+    LightEntity,
+)
+from homeassistant.components.overkiz import HomeAssistantOverkizData
+from homeassistant.components.overkiz.coordinator import OverkizDataUpdateCoordinator
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import OverkizEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up the Overkiz lights from a config entry."""
+    data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[OverkizLight] = [
+        OverkizLight(device.device_url, data.coordinator)
+        for device in data.platforms[Platform.LIGHT]
+    ]
+
+    async_add_entities(entities)
+
+
+class OverkizLight(OverkizEntity, LightEntity):
+    """Representation of an Overkiz Light."""
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Initialize a device."""
+        super().__init__(device_url, coordinator)
+
+        self._attr_supported_color_modes: set[str] = set()
+
+        if self.executor.has_command(OverkizCommand.SET_RGB):
+            self._attr_supported_color_modes.add(COLOR_MODE_RGB)
+        if self.executor.has_command(OverkizCommand.SET_INTENSITY):
+            self._attr_supported_color_modes.add(COLOR_MODE_BRIGHTNESS)
+        if not self.supported_color_modes:
+            self._attr_supported_color_modes = {COLOR_MODE_ONOFF}
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        return (
+            self.executor.select_state(OverkizState.CORE_ON_OFF)
+            == OverkizCommandParam.ON
+        )
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the rgb color value [int, int, int] (0-255)."""
+        red = self.executor.select_state(OverkizState.CORE_RED_COLOR_INTENSITY)
+        green = self.executor.select_state(OverkizState.CORE_GREEN_COLOR_INTENSITY)
+        blue = self.executor.select_state(OverkizState.CORE_BLUE_COLOR_INTENSITY)
+
+        if red is None or green is None or blue is None:
+            return None
+
+        return (int(red), int(green), int(blue))
+
+    @property
+    def brightness(self) -> int | None:
+        """Return the brightness of this light (0-255)."""
+        if brightness := self.executor.select_state(OverkizState.CORE_LIGHT_INTENSITY):
+            return round(int(brightness) * 255 / 100)
+
+        return None
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the light on."""
+        rgb_color = kwargs.get(ATTR_RGB_COLOR)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        if rgb_color is not None:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_RGB,
+                *[round(float(c)) for c in kwargs[ATTR_RGB_COLOR]],
+            )
+
+        if brightness is not None:
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_INTENSITY, round(float(brightness) / 255 * 100)
+            )
+
+        else:
+            await self.executor.async_execute_command(OverkizCommand.ON)
+
+    async def async_turn_off(self, **_) -> None:
+        """Turn the light off."""
+        await self.executor.async_execute_command(OverkizCommand.OFF)


### PR DESCRIPTION
## Proposed change
Adds light entity to Overkiz integration. Supports on/off lights, lights with brightness capabilities and lights with RGB mode.

<img width="678" alt="Screen Shot 2021-12-27 at 10 43 37" src="https://user-images.githubusercontent.com/1424596/147459165-a4c432b5-4794-4ce3-9de1-b25bc900a4c7.png">


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20880

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
