### PR TITLE
Fix unique_id of nuki config entry

### DIFF
--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -53,6 +53,11 @@ async def async_setup_entry(hass, entry):
 
     hass.data.setdefault(DOMAIN, {})
 
+    # Migration of entry id
+    if type(entry.unique_id) == int:
+        new_id = hex(entry.unique_id).split("x")[-1].upper()
+        hass.config_entries.async_update_entry(entry, unique_id=new_id, title=new_id)
+
     try:
         bridge = await hass.async_add_executor_job(
             NukiBridge,

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -54,7 +54,7 @@ async def async_setup_entry(hass, entry):
 
     hass.data.setdefault(DOMAIN, {})
 
-    # Migration of entry id
+    # Migration of entry unique_id
     if isinstance(entry.unique_id, int):
         new_id = parse_id(entry.unique_id)
         params = {"unique_id": new_id}

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -57,12 +57,10 @@ async def async_setup_entry(hass, entry):
     # Migration of entry id
     if isinstance(entry.unique_id, int):
         new_id = parse_id(entry.unique_id)
+        params = {"unique_id": new_id}
         if entry.title == entry.unique_id:
-            hass.config_entries.async_update_entry(
-                entry, unique_id=new_id, title=new_id
-            )
-        else:
-            hass.config_entries.async_update_entry(entry, unique_id=new_id)
+            params["title"] = new_id
+        hass.config_entries.async_update_entry(entry, **params)
 
     try:
         bridge = await hass.async_add_executor_job(

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -56,7 +56,12 @@ async def async_setup_entry(hass, entry):
     # Migration of entry id
     if isinstance(entry.unique_id, int):
         new_id = hex(entry.unique_id).split("x")[-1].upper()
-        hass.config_entries.async_update_entry(entry, unique_id=new_id, title=new_id)
+        if entry.title == entry.unique_id:
+            hass.config_entries.async_update_entry(
+                entry, unique_id=new_id, title=new_id
+            )
+        else:
+            hass.config_entries.async_update_entry(entry, unique_id=new_id)
 
     try:
         bridge = await hass.async_add_executor_job(

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -54,7 +54,7 @@ async def async_setup_entry(hass, entry):
     hass.data.setdefault(DOMAIN, {})
 
     # Migration of entry id
-    if type(entry.unique_id) == int:
+    if isinstance(entry.unique_id, int):
         new_id = hex(entry.unique_id).split("x")[-1].upper()
         hass.config_entries.async_update_entry(entry, unique_id=new_id, title=new_id)
 

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     DOMAIN,
     ERROR_STATES,
 )
+from .helpers import parse_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ async def async_setup_entry(hass, entry):
 
     # Migration of entry id
     if isinstance(entry.unique_id, int):
-        new_id = hex(entry.unique_id).split("x")[-1].upper()
+        new_id = parse_id(entry.unique_id)
         if entry.title == entry.unique_id:
             hass.config_entries.async_update_entry(
                 entry, unique_id=new_id, title=new_id

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -69,7 +69,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Prepare configuration for a DHCP discovered Nuki bridge."""
-        await self.async_set_unique_id(int(discovery_info.hostname[12:], 16))
+        await self.async_set_unique_id(discovery_info.hostname[12:].upper())
 
         self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -110,7 +110,9 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
 
         if not errors:
-            existing_entry = await self.async_set_unique_id(info["ids"]["hardwareId"])
+            existing_entry = await self.async_set_unique_id(
+                hex(info["ids"]["hardwareId"]).split("x")[-1].upper()
+            )
             if existing_entry:
                 self.hass.config_entries.async_update_entry(existing_entry, data=conf)
                 self.hass.async_create_task(
@@ -139,11 +141,10 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                await self.async_set_unique_id(info["ids"]["hardwareId"])
+                bridgeId = hex(info["ids"]["hardwareId"]).split("x")[-1].upper()
+                await self.async_set_unique_id(bridgeId)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=info["ids"]["hardwareId"], data=user_input
-                )
+                return self.async_create_entry(title=bridgeId, data=user_input)
 
         data_schema = self.discovery_schema or USER_SCHEMA
         return self.async_show_form(

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
+from .helpers import parse_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -158,8 +159,3 @@ class CannotConnect(exceptions.HomeAssistantError):
 
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
-
-
-def parse_id(hardware_id):
-    """Parse Nuki ID."""
-    return hex(hardware_id).split("x")[-1].upper()

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -59,6 +59,10 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.discovery_schema = {}
         self._data = {}
 
+    def parse_id(self, id):
+        """Parse Nuki ID."""
+        return hex(id).split("x")[-1].upper()
+
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
         return await self.async_step_validate(user_input)
@@ -111,7 +115,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not errors:
             existing_entry = await self.async_set_unique_id(
-                hex(info["ids"]["hardwareId"]).split("x")[-1].upper()
+                self.parse_id(info["ids"]["hardwareId"])
             )
             if existing_entry:
                 self.hass.config_entries.async_update_entry(existing_entry, data=conf)
@@ -141,10 +145,10 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                bridgeId = hex(info["ids"]["hardwareId"]).split("x")[-1].upper()
-                await self.async_set_unique_id(bridgeId)
+                bridge_id = self.parse_id(info["ids"]["hardwareId"])
+                await self.async_set_unique_id(bridge_id)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=bridgeId, data=user_input)
+                return self.async_create_entry(title=bridge_id, data=user_input)
 
         data_schema = self.discovery_schema or USER_SCHEMA
         return self.async_show_form(

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -59,10 +59,6 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.discovery_schema = {}
         self._data = {}
 
-    def parse_id(self, id):
-        """Parse Nuki ID."""
-        return hex(id).split("x")[-1].upper()
-
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
         return await self.async_step_validate(user_input)
@@ -115,7 +111,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not errors:
             existing_entry = await self.async_set_unique_id(
-                self.parse_id(info["ids"]["hardwareId"])
+                parse_id(info["ids"]["hardwareId"])
             )
             if existing_entry:
                 self.hass.config_entries.async_update_entry(existing_entry, data=conf)
@@ -145,7 +141,7 @@ class NukiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                bridge_id = self.parse_id(info["ids"]["hardwareId"])
+                bridge_id = parse_id(info["ids"]["hardwareId"])
                 await self.async_set_unique_id(bridge_id)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=bridge_id, data=user_input)
@@ -162,3 +158,8 @@ class CannotConnect(exceptions.HomeAssistantError):
 
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+def parse_id(hardware_id):
+    """Parse Nuki ID."""
+    return hex(hardware_id).split("x")[-1].upper()

--- a/homeassistant/components/nuki/helpers.py
+++ b/homeassistant/components/nuki/helpers.py
@@ -1,0 +1,6 @@
+"""nuki integration helpers."""
+
+
+def parse_id(hardware_id):
+    """Parse Nuki ID."""
+    return hex(hardware_id).split("x")[-1].upper()

--- a/tests/components/nuki/mock.py
+++ b/tests/components/nuki/mock.py
@@ -7,6 +7,7 @@ HOST = "1.1.1.1"
 MAC = "01:23:45:67:89:ab"
 
 HW_ID = 123456789
+ID_HEX = "75BCD15"
 
 MOCK_INFO = {"ids": {"hardwareId": HW_ID}}
 
@@ -16,7 +17,7 @@ async def setup_nuki_integration(hass):
 
     entry = MockConfigEntry(
         domain="nuki",
-        unique_id=HW_ID,
+        unique_id=ID_HEX,
         data={"host": HOST, "port": 8080, "token": "test-token"},
     )
     entry.add_to_hass(hass)

--- a/tests/components/nuki/test_config_flow.py
+++ b/tests/components/nuki/test_config_flow.py
@@ -39,7 +39,7 @@ async def test_form(hass):
         await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == 123456789
+    assert result2["title"] == "75BCD15"
     assert result2["data"] == {
         "host": "1.1.1.1",
         "port": 8080,
@@ -169,7 +169,7 @@ async def test_dhcp_flow(hass):
         )
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result2["title"] == 123456789
+        assert result2["title"] == "75BCD15"
         assert result2["data"] == {
             "host": "1.1.1.1",
             "port": 8080,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changed the naming of the nuki components, since the old naming was an integer which resulted in a buggy integrations card. Also changed it to HEX as it then represents the same ID printed on the Nuki Bridge.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #58352
- This PR is related to issues: #60618 #61111

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
