### PR TITLE
Add unique id to DHCP step in Config Flow for Overkiz 

### DIFF
--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -94,6 +94,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         _LOGGER.debug("DHCP discovery detected gateway %s", obfuscate_id(gateway_id))
 
+        await self.async_set_unique_id(gateway_id)
+
         if self._gateway_already_configured(gateway_id):
             _LOGGER.debug("Gateway %s is already configured", obfuscate_id(gateway_id))
             return self.async_abort(reason="already_configured")

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -19,7 +19,6 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_HUB, DEFAULT_HUB, DOMAIN
 
@@ -95,18 +94,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("DHCP discovery detected gateway %s", obfuscate_id(gateway_id))
 
         await self.async_set_unique_id(gateway_id)
-
-        if self._gateway_already_configured(gateway_id):
-            _LOGGER.debug("Gateway %s is already configured", obfuscate_id(gateway_id))
-            return self.async_abort(reason="already_configured")
+        self._abort_if_unique_id_configured()
 
         return await self.async_step_user()
-
-    def _gateway_already_configured(self, gateway_id: str) -> bool:
-        """See if we already have a gateway matching the id."""
-        device_registry = dr.async_get(self.hass)
-        return bool(
-            device_registry.async_get_device(
-                identifiers={(DOMAIN, gateway_id)}, connections=set()
-            )
-        )

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.components import dhcp
 from homeassistant.components.overkiz.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry, mock_device_registry
+from tests.common import MockConfigEntry
 
 TEST_EMAIL = "test@testdomain.com"
 TEST_EMAIL2 = "test@testdomain.nl"
@@ -120,7 +120,7 @@ async def test_allow_multiple_unique_entries(hass: HomeAssistant) -> None:
     """Test config flow allows Config Flow unique entries."""
     MockConfigEntry(
         domain=DOMAIN,
-        unique_id="test2@testdomain.com",
+        unique_id=TEST_GATEWAY_ID2,
         data={"username": "test2@testdomain.com", "password": TEST_PASSWORD},
     ).add_to_hass(hass)
 
@@ -166,16 +166,10 @@ async def test_dhcp_flow_already_configured(hass: HomeAssistant) -> None:
     """Test that DHCP doesn't setup already configured gateways."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=TEST_EMAIL,
+        unique_id=TEST_GATEWAY_ID,
         data={"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
     )
     config_entry.add_to_hass(hass)
-
-    device_registry = mock_device_registry(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        identifiers={(DOMAIN, "1234-5678-9123")},
-    )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,


### PR DESCRIPTION
## Proposed change
Adds the gateway id as unique id to the Config Flow, so that it can be ignored for the DHCP step in the Config Flow. 

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #62798
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
