### PR TITLE
Fix keyerror when no previous Picnic orders exist

### DIFF
--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -60,11 +60,11 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         """Fetch the data from the Picnic API and return a flat dict with only needed sensor data."""
         # Fetch from the API and pre-process the data
         cart = self.picnic_api_client.get_cart()
-        last_order = self._get_last_order()
 
-        if not cart or not last_order:
+        if not cart:
             raise UpdateFailed("API response doesn't contain expected data.")
 
+        last_order = self._get_last_order()
         slot_data = self._get_slot_data(cart)
 
         return {
@@ -102,11 +102,12 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         """Get data of the last order from the list of deliveries."""
         # Get the deliveries
         deliveries = self.picnic_api_client.get_deliveries(summary=True)
-        if not deliveries:
-            return {}
 
-        # Determine the last order
-        last_order = copy.deepcopy(deliveries[0])
+        # Determine the last order and return an empty dict if there is none
+        try:
+            last_order = copy.deepcopy(deliveries[0])
+        except KeyError:
+            return {}
 
         #  Get the position details if the order is not delivered yet
         delivery_position = {}

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -387,6 +387,21 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
+    async def test_sensors_malformed_delivery_data(self):
+        """Test sensor states when the delivery api returns not a list."""
+        # Setup platform with default responses
+        await self._setup_platform(use_default_responses=True)
+
+        # Change mock responses to empty data and refresh the coordinator
+        self.picnic_mock().get_deliveries.return_value = {"error": "message"}
+        await self._coordinator.async_refresh()
+
+        # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
+        assert self._coordinator.last_update_success is True
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+
     async def test_sensors_malformed_response(self):
         """Test coordinator update fails when API yields ValueError."""
         # Setup platform with default responses

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -398,9 +398,9 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
 
         # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
         assert self._coordinator.last_update_success is True
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
 
     async def test_sensors_malformed_response(self):
         """Test coordinator update fails when API yields ValueError."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle non-list responses of the orders-API. Until now a list or `None` was expected, but the response can also be something else.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59641
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
