### PR TITLE
Set a suggested_area on nest devices based on the Google Home room name

### DIFF
--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -35,6 +35,7 @@ class NestDeviceInfo:
             manufacturer=self.device_brand,
             model=self.device_model,
             name=self.device_name,
+            suggested_area=self.suggested_area,
         )
 
     @property
@@ -44,12 +45,9 @@ class NestDeviceInfo:
             trait: InfoTrait = self._device.traits[InfoTrait.NAME]
             if trait.custom_name:
                 return str(trait.custom_name)
-        # Build a name from the room/structure.  Note: This room/structure name
-        # is not associated with a home assistant Area.
-        if parent_relations := self._device.parent_relations:
-            items = sorted(parent_relations.items())
-            names = [name for id, name in items]
-            return " ".join(names)
+        # Build a name from the room/structure if not set explicitly
+        if area := self.suggested_area:
+            return area
         return self.device_model
 
     @property
@@ -59,3 +57,12 @@ class NestDeviceInfo:
         # devices, instead relying on traits, but we can infer a generic model
         # name based on the type
         return DEVICE_TYPE_MAP.get(self._device.type)
+
+    @property
+    def suggested_area(self) -> str | None:
+        """Return device suggested area based on the Google Home room."""
+        if parent_relations := self._device.parent_relations:
+            items = sorted(parent_relations.items())
+            names = [name for id, name in items]
+            return " ".join(names)
+        return None

--- a/tests/components/nest/test_device_info.py
+++ b/tests/components/nest/test_device_info.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_NAME,
+    ATTR_SUGGESTED_AREA,
 )
 
 
@@ -35,6 +36,7 @@ def test_device_custom_name():
         ATTR_NAME: "My Doorbell",
         ATTR_MANUFACTURER: "Google Nest",
         ATTR_MODEL: "Doorbell",
+        ATTR_SUGGESTED_AREA: None,
     }
 
 
@@ -60,6 +62,7 @@ def test_device_name_room():
         ATTR_NAME: "Some Room",
         ATTR_MANUFACTURER: "Google Nest",
         ATTR_MODEL: "Doorbell",
+        ATTR_SUGGESTED_AREA: "Some Room",
     }
 
 
@@ -79,6 +82,7 @@ def test_device_no_name():
         ATTR_NAME: "Doorbell",
         ATTR_MANUFACTURER: "Google Nest",
         ATTR_MODEL: "Doorbell",
+        ATTR_SUGGESTED_AREA: None,
     }
 
 
@@ -106,4 +110,36 @@ def test_device_invalid_type():
         ATTR_NAME: "My Doorbell",
         ATTR_MANUFACTURER: "Google Nest",
         ATTR_MODEL: None,
+        ATTR_SUGGESTED_AREA: None,
+    }
+
+
+def test_suggested_area():
+    """Test the suggested area with different device name and room name."""
+    device = Device.MakeDevice(
+        {
+            "name": "some-device-id",
+            "type": "sdm.devices.types.DOORBELL",
+            "traits": {
+                "sdm.devices.traits.Info": {
+                    "customName": "My Doorbell",
+                },
+            },
+            "parentRelations": [
+                {"parent": "some-structure-id", "displayName": "Some Room"}
+            ],
+        },
+        auth=None,
+    )
+
+    device_info = NestDeviceInfo(device)
+    assert device_info.device_name == "My Doorbell"
+    assert device_info.device_model == "Doorbell"
+    assert device_info.device_brand == "Google Nest"
+    assert device_info.device_info == {
+        ATTR_IDENTIFIERS: {("nest", "some-device-id")},
+        ATTR_NAME: "My Doorbell",
+        ATTR_MANUFACTURER: "Google Nest",
+        ATTR_MODEL: "Doorbell",
+        ATTR_SUGGESTED_AREA: "Some Room",
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set a suggested_area on nest devices based on the Google Home room name

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
