### PR TITLE
Improve device registry id and connection typing

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -178,7 +178,7 @@ def async_host_input_received(
         logical_address.is_group,
     )
     identifiers = {(DOMAIN, generate_unique_id(config_entry.entry_id, address))}
-    device = device_registry.async_get_device(identifiers, set())
+    device = device_registry.async_get_device(identifiers)
     if device is None:
         return
 

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -104,7 +104,5 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """See if we already have a gateway matching the id."""
         device_registry = dr.async_get(self.hass)
         return bool(
-            device_registry.async_get_device(
-                identifiers={(DOMAIN, gateway_id)}, connections=set()
-            )
+            device_registry.async_get_device(identifiers={(DOMAIN, gateway_id)})
         )

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -153,7 +153,6 @@ async def async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
     device_entry = None
     if entry.unique_id is not None:
         device_entry = dev_reg.async_get_device(
-            identifiers=set(),
             connections={
                 (
                     device_registry.CONNECTION_NETWORK_MAC,

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -151,7 +151,9 @@ async def _remove_device(
     device_registry: DeviceRegistry,
 ) -> None:
     """Remove device from device registry."""
-    device = device_registry.async_get_device(set(), {(CONNECTION_NETWORK_MAC, mac)})
+    device = device_registry.async_get_device(
+        connections={(CONNECTION_NETWORK_MAC, mac)}
+    )
 
     if device is None:
         return

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -204,7 +204,7 @@ class LegacyZWaveMigration:
         entity_entry = ent_reg.async_get(entity_id)
         assert entity_entry
         device_identifier = get_device_id(node.client, node)
-        device_entry = dev_reg.async_get_device({device_identifier}, set())
+        device_entry = dev_reg.async_get_device({device_identifier})
         assert device_entry
 
         # Normalize unit of measurement.

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -25,7 +25,11 @@ async def test_list_devices(hass, client, registry):
     """Test list entries."""
     registry.async_get_or_create(
         config_entry_id="1234",
-        connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
+        connections={
+            helpers_dr.DeviceEntryConnection(
+                helpers_dr.DeviceEntryConnectionType.MAC, "12:34:56:AB:CD:EF"
+            ),
+        },
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
@@ -47,7 +51,9 @@ async def test_list_devices(hass, client, registry):
     assert msg["result"] == [
         {
             "config_entries": ["1234"],
-            "connections": [["ethernet", "12:34:56:78:90:AB:CD:EF"]],
+            "connections": [
+                [helpers_dr.DeviceEntryConnectionType.MAC.value, "12:34:56:AB:CD:EF"],
+            ],
             "identifiers": [["bridgeid", "0123"]],
             "manufacturer": "manufacturer",
             "model": "model",
@@ -84,7 +90,11 @@ async def test_update_device(hass, client, registry):
     """Test update entry."""
     device = registry.async_get_or_create(
         config_entry_id="1234",
-        connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
+        connections={
+            helpers_dr.DeviceEntryConnection(
+                helpers_dr.DeviceEntryConnectionType.MAC, "12:34:56:AB:CD:EF"
+            ),
+        },
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -836,7 +836,7 @@ async def test_no_unnecessary_changes(registry):
     """Make sure we do not consider devices changes."""
     entry = registry.async_get_or_create(
         config_entry_id="1234",
-        connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "456"), ("bla", "123")},
     )
     with patch(


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves device registry identifiers and connections typing by making them NamedTuples and using an enum for the connection type.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
