### PR TITLE
Add scene entity to Overkiz integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -810,6 +810,7 @@ omit =
     homeassistant/components/overkiz/light.py
     homeassistant/components/overkiz/lock.py
     homeassistant/components/overkiz/number.py
+    homeassistant/components/overkiz/scene.py
     homeassistant/components/overkiz/sensor.py
     homeassistant/components/ovo_energy/__init__.py
     homeassistant/components/ovo_energy/const.py

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -1,6 +1,7 @@
 """The Overkiz (by Somfy) integration."""
 from __future__ import annotations
 
+import asyncio
 from collections import defaultdict
 from dataclasses import dataclass
 import logging
@@ -13,10 +14,10 @@ from pyoverkiz.exceptions import (
     MaintenanceException,
     TooManyRequestsException,
 )
-from pyoverkiz.models import Device
+from pyoverkiz.models import Device, Scenario
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -40,7 +41,7 @@ class HomeAssistantOverkizData:
     """Overkiz data stored in the Home Assistant data object."""
 
     coordinator: OverkizDataUpdateCoordinator
-    platforms: dict[str, Device]
+    platforms: dict[Platform, Device | Scenario]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -57,7 +58,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await client.login()
-        setup = await client.get_setup()
+
+        tasks = [
+            client.get_setup(),
+            client.get_scenarios(),
+        ]
+        setup, scenarios = await asyncio.gather(*tasks)
     except BadCredentialsException:
         _LOGGER.error("Invalid authentication")
         return False
@@ -91,14 +97,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         coordinator.update_interval = UPDATE_INTERVAL_ALL_ASSUMED_STATE
 
-    platforms: dict[str, Device] = defaultdict(list)
+    platforms: dict[Platform, Device | Scenario] = defaultdict(list)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantOverkizData(
         coordinator=coordinator,
         platforms=platforms,
     )
 
-    # Map Overkiz device to Home Assistant platform
+    # Map Overkiz entities to Home Assistant platform
+    platforms[Platform.SCENE] = scenarios
+
     for device in coordinator.data.values():
         _LOGGER.debug(
             "The following device has been retrieved. Report an issue if not supported correctly (%s)",

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -59,11 +59,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await client.login()
 
-        tasks = [
-            client.get_setup(),
-            client.get_scenarios(),
-        ]
-        setup, scenarios = await asyncio.gather(*tasks)
+        setup, scenarios = await asyncio.gather(
+            *[
+                client.get_setup(),
+                client.get_scenarios(),
+            ]
+        )
     except BadCredentialsException:
         _LOGGER.error("Invalid authentication")
         return False

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -22,6 +22,7 @@ PLATFORMS: list[Platform] = [
     Platform.LIGHT,
     Platform.LOCK,
     Platform.NUMBER,
+    Platform.SCENE,
     Platform.SENSOR,
 ]
 

--- a/homeassistant/components/overkiz/scene.py
+++ b/homeassistant/components/overkiz/scene.py
@@ -1,0 +1,45 @@
+"""Support for Overkiz scenes."""
+from __future__ import annotations
+
+from typing import Any
+
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.models import Scenario
+
+from homeassistant.components.scene import Scene
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HomeAssistantOverkizData
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up the Overkiz scenes from a config entry."""
+    data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        OverkizScene(scene, data.coordinator.client)
+        for scene in data.platforms[Platform.SCENE]
+    )
+
+
+class OverkizScene(Scene):
+    """Representation of an Overkiz Scene."""
+
+    def __init__(self, scenario: Scenario, client: OverkizClient) -> None:
+        """Initialize the scene."""
+        self.scenario = scenario
+        self.client = client
+        self._attr_name = self.scenario.label
+        self._attr_unique_id = self.scenario.oid
+
+    async def async_activate(self, **kwargs: Any) -> None:
+        """Activate the scene."""
+        await self.client.execute_scenario(self.scenario.oid)


### PR DESCRIPTION
## Proposed change
Maps the scenarios from Overkiz to scene entities in Home Assistant. 


<img width="337" alt="Screen Shot 2021-12-27 at 22 06 37" src="https://user-images.githubusercontent.com/1424596/147507299-b49cfb0e-634b-4971-94b6-e41f228cf08a.png">

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20890

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
