### PR TITLE
Set the nest configuration title to a user friendly name

### DIFF
--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -26,16 +26,16 @@ and config flow.
 from __future__ import annotations
 
 import asyncio
-from collections import OrderedDict
+from collections import Iterable, OrderedDict
 from enum import Enum
 import logging
 import os
-from typing import Any, Iterable
+from typing import Any
 
 import async_timeout
 from google_nest_sdm.exceptions import (
-    AuthException,
     ApiException,
+    AuthException,
     ConfigurationException,
     SubscriberException,
 )

--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -30,14 +30,16 @@ from collections import OrderedDict
 from enum import Enum
 import logging
 import os
-from typing import Any
+from typing import Any, Iterable
 
 import async_timeout
 from google_nest_sdm.exceptions import (
     AuthException,
+    ApiException,
     ConfigurationException,
     SubscriberException,
 )
+from google_nest_sdm.structure import InfoTrait, Structure
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -128,6 +130,17 @@ class UnexpectedStateError(HomeAssistantError):
     """Raised when the config flow is invoked in a 'should not happen' case."""
 
 
+def generate_config_title(structures: Iterable[Structure]) -> str | None:
+    """Pick a user friendly config title based on the Google Home name(s)."""
+    names: list[str] = []
+    for structure in structures:
+        if (trait := structure.traits.get(InfoTrait.NAME)) and trait.custom_name:
+            names.append(trait.custom_name)
+    if not names:
+        return None
+    return ", ".join(names)
+
+
 class NestFlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
 ):
@@ -141,6 +154,8 @@ class NestFlowHandler(
         super().__init__()
         self._reauth = False
         self._data: dict[str, Any] = {DATA_SDM: {}}
+        # Possible name to use for config entry based on the Google Home name
+        self._structure_config_title: str | None = None
 
     @property
     def config_mode(self) -> ConfigMode:
@@ -298,8 +313,18 @@ class NestFlowHandler(
             except SubscriberException as err:
                 _LOGGER.error("Error creating subscription: %s", err)
                 errors[CONF_CLOUD_PROJECT_ID] = "subscriber_error"
-
             if not errors:
+
+                try:
+                    device_manager = await subscriber.async_get_device_manager()
+                except ApiException as err:
+                    # Generating a user friendly home name is best effort
+                    _LOGGER.debug("Error fetching structures: %s", err)
+                else:
+                    self._structure_config_title = generate_config_title(
+                        device_manager.structures.values()
+                    )
+
                 self._data.update(
                     {
                         CONF_SUBSCRIBER_ID: subscriber_id,
@@ -339,7 +364,10 @@ class NestFlowHandler(
                 )
                 await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reauth_successful")
-        return await super().async_oauth_create_entry(self._data)
+        title = self.flow_impl.name
+        if self._structure_config_title:
+            title = self._structure_config_title
+        return self.async_create_entry(title=title, data=self._data)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -26,7 +26,8 @@ and config flow.
 from __future__ import annotations
 
 import asyncio
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from enum import Enum
 import logging
 import os


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set the config entry title name to be the name of the Google Home or
Nest Home that was authorized.

Tests cover these various scenarios:
- No Homes returned from API (fallback to existing behavior)
- Multiple Homes returned from API (uses all of them as the title)
- An error while fetching the list of structures (just continue anyway)
- Homes returned from API are invalid (skipped, as if not returned)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
