### PR TITLE
Add select entity to Overkiz integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -816,6 +816,7 @@ omit =
     homeassistant/components/overkiz/lock.py
     homeassistant/components/overkiz/number.py
     homeassistant/components/overkiz/scene.py
+    homeassistant/components/overkiz/select.py
     homeassistant/components/overkiz/sensor.py
     homeassistant/components/ovo_energy/__init__.py
     homeassistant/components/ovo_energy/const.py

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -1,6 +1,8 @@
 """Parent class for every Overkiz device."""
 from __future__ import annotations
 
+from enum import Enum, unique
+
 from pyoverkiz.enums import OverkizAttribute, OverkizState
 from pyoverkiz.models import Device
 
@@ -95,3 +97,12 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self.entity_description = description
         self._attr_name = f"{super().name} {self.entity_description.name}"
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
+
+
+# Used by translations of state and select sensors
+@unique
+class OverkizDeviceClass(str, Enum):
+    """Device class for Overkiz specific devices."""
+
+    OPEN_CLOSED_PEDESTRIAN = "overkiz__open_closed_pedestrian"
+    MEMORIZED_SIMPLE_VOLUME = "overkiz__memorized_simple_volume"

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -1,11 +1,12 @@
 """Parent class for every Overkiz device."""
 from __future__ import annotations
 
-from enum import Enum, unique
+from enum import unique
 
 from pyoverkiz.enums import OverkizAttribute, OverkizState
 from pyoverkiz.models import Device
 
+from homeassistant.backports.enum import StrEnum
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -101,7 +102,7 @@ class OverkizDescriptiveEntity(OverkizEntity):
 
 # Used by translations of state and select sensors
 @unique
-class OverkizDeviceClass(str, Enum):
+class OverkizDeviceClass(StrEnum):
     """Device class for Overkiz specific devices."""
 
     OPEN_CLOSED_PEDESTRIAN = "overkiz__open_closed_pedestrian"

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
     """Set up the Overkiz select from a config entry."""
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
     entities: list[OverkizSelect] = []

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
-from .entity import OverkizDescriptiveEntity
+from .entity import OverkizDescriptiveEntity, OverkizDeviceClass
 
 
 @dataclass
@@ -48,8 +48,10 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
                 OverkizCommandParam.CLOSED: OverkizCommand.CLOSE,
                 OverkizCommandParam.OPEN: OverkizCommand.OPEN,
                 OverkizCommandParam.PEDESTRIAN: OverkizCommand.SET_PEDESTRIAN_POSITION,
-            }[OverkizCommandParam(option)]
+            }[OverkizCommandParam(option)],
+            None,
         ),
+        device_class=OverkizDeviceClass.OPEN_CLOSED_PEDESTRIAN,
     ),
     OverkizSelectDescription(
         key=OverkizState.IO_MEMORIZED_SIMPLE_VOLUME,
@@ -60,6 +62,7 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
             OverkizCommand.SET_MEMORIZED_SIMPLE_VOLUME, option
         ),
         entity_category=EntityCategory.CONFIG,
+        device_class=OverkizDeviceClass.MEMORIZED_SIMPLE_VOLUME,
     ),
 ]
 

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -23,9 +22,7 @@ class OverkizSelectDescriptionMixin:
     """Define an entity description mixin for select entities."""
 
     options: list[str | OverkizCommandParam]
-    select_option: Callable[
-        [str, Callable[[str | OverkizCommand, None | Any], Awaitable]], Awaitable
-    ]
+    select_option: Callable[[str, Callable[..., Awaitable[None]]], Awaitable[None]]
 
 
 @dataclass

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -1,0 +1,119 @@
+"""Support for Overkiz select."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HomeAssistantOverkizData
+from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
+from .entity import OverkizDescriptiveEntity
+
+
+@dataclass
+class OverkizSelectDescriptionMixin:
+    """Define an entity description mixin for select entities."""
+
+    options: list[str]
+    select_option: Callable[[str, Callable], None]
+
+
+@dataclass
+class OverkizSelectDescription(SelectEntityDescription, OverkizSelectDescriptionMixin):
+    """Class to describe an Overkiz select entity."""
+
+
+SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
+    OverkizSelectDescription(
+        key=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
+        name="Position",
+        icon="mdi:content-save-cog",
+        options=[
+            OverkizCommandParam.OPEN,
+            OverkizCommandParam.PEDESTRIAN,
+            OverkizCommandParam.CLOSED,
+        ],
+        select_option=lambda option, execute_command: execute_command(
+            {
+                OverkizCommandParam.CLOSED: OverkizCommand.CLOSE,
+                OverkizCommandParam.OPEN: OverkizCommand.OPEN,
+                OverkizCommandParam.PEDESTRIAN: OverkizCommand.SET_PEDESTRIAN_POSITION,
+            }[option]
+        ),
+    ),
+    OverkizSelectDescription(
+        key=OverkizState.IO_MEMORIZED_SIMPLE_VOLUME,
+        name="Memorized Simple Volume",
+        icon="mdi:volume-high",
+        options=[OverkizCommandParam.STANDARD, OverkizCommandParam.HIGHEST],
+        select_option=lambda option, execute_command: execute_command(
+            OverkizCommand.SET_MEMORIZED_SIMPLE_VOLUME, option
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up the Overkiz select from a config entry."""
+    data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
+    entities: list[OverkizSelect] = []
+
+    key_supported_states = {
+        description.key: description for description in SELECT_DESCRIPTIONS
+    }
+
+    for device in data.coordinator.data.values():
+        if (
+            device.widget in IGNORED_OVERKIZ_DEVICES
+            or device.ui_class in IGNORED_OVERKIZ_DEVICES
+        ):
+            continue
+
+        for state in device.definition.states:
+            if description := key_supported_states.get(state.qualified_name):
+                entities.append(
+                    OverkizSelect(
+                        device.device_url,
+                        data.coordinator,
+                        description,
+                    )
+                )
+
+    async_add_entities(entities)
+
+
+class OverkizSelect(OverkizDescriptiveEntity, SelectEntity):
+    """Representation of an Overkiz Select entity."""
+
+    entity_description: OverkizSelectDescription
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        if state := self.device.states.get(self.entity_description.key):
+            return state.value
+
+        return None
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return self.entity_description.options
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.entity_description.select_option(
+            option, self.executor.async_execute_command
+        )

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -30,6 +30,27 @@ class OverkizSelectDescription(SelectEntityDescription, OverkizSelectDescription
     """Class to describe an Overkiz select entity."""
 
 
+def _select_option_open_closed_pedestrian(
+    option: str, execute_command: Callable[..., Awaitable[None]]
+) -> Awaitable[None]:
+    """Change the selected option for Open/Closed/Pedestrian."""
+    return execute_command(
+        {
+            OverkizCommandParam.CLOSED: OverkizCommand.CLOSE,
+            OverkizCommandParam.OPEN: OverkizCommand.OPEN,
+            OverkizCommandParam.PEDESTRIAN: OverkizCommand.SET_PEDESTRIAN_POSITION,
+        }[OverkizCommandParam(option)],
+        None,
+    )
+
+
+def _select_option_memorized_simple_volume(
+    option: str, execute_command: Callable[..., Awaitable[None]]
+) -> Awaitable[None]:
+    """Change the selected option for Memorized Simple Volume."""
+    return execute_command(OverkizCommand.SET_MEMORIZED_SIMPLE_VOLUME, option)
+
+
 SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
     OverkizSelectDescription(
         key=OverkizState.CORE_OPEN_CLOSED_PEDESTRIAN,
@@ -40,14 +61,7 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
             OverkizCommandParam.PEDESTRIAN,
             OverkizCommandParam.CLOSED,
         ],
-        select_option=lambda option, execute_command: execute_command(
-            {
-                OverkizCommandParam.CLOSED: OverkizCommand.CLOSE,
-                OverkizCommandParam.OPEN: OverkizCommand.OPEN,
-                OverkizCommandParam.PEDESTRIAN: OverkizCommand.SET_PEDESTRIAN_POSITION,
-            }[OverkizCommandParam(option)],
-            None,
-        ),
+        select_option=_select_option_open_closed_pedestrian,
         device_class=OverkizDeviceClass.OPEN_CLOSED_PEDESTRIAN,
     ),
     OverkizSelectDescription(
@@ -55,9 +69,7 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
         name="Memorized Simple Volume",
         icon="mdi:volume-high",
         options=[OverkizCommandParam.STANDARD, OverkizCommandParam.HIGHEST],
-        select_option=lambda option, execute_command: execute_command(
-            OverkizCommand.SET_MEMORIZED_SIMPLE_VOLUME, option
-        ),
+        select_option=_select_option_memorized_simple_volume,
         entity_category=EntityCategory.CONFIG,
         device_class=OverkizDeviceClass.MEMORIZED_SIMPLE_VOLUME,
     ),

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -1,9 +1,8 @@
 """Support for Overkiz select."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Awaitable
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Awaitable
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -22,7 +23,7 @@ class OverkizSelectDescriptionMixin:
     """Define an entity description mixin for select entities."""
 
     options: list[str]
-    select_option: Callable[[str, Callable], None]
+    select_option: Callable[[str, Callable], Awaitable]
 
 
 @dataclass

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -21,8 +22,10 @@ from .entity import OverkizDescriptiveEntity
 class OverkizSelectDescriptionMixin:
     """Define an entity description mixin for select entities."""
 
-    options: list[str]
-    select_option: Callable[[str, Callable], Awaitable]
+    options: list[str | OverkizCommandParam]
+    select_option: Callable[
+        [str, Callable[[str | OverkizCommand, None | Any], Awaitable]], Awaitable
+    ]
 
 
 @dataclass
@@ -45,7 +48,7 @@ SELECT_DESCRIPTIONS: list[OverkizSelectDescription] = [
                 OverkizCommandParam.CLOSED: OverkizCommand.CLOSE,
                 OverkizCommandParam.OPEN: OverkizCommand.OPEN,
                 OverkizCommandParam.PEDESTRIAN: OverkizCommand.SET_PEDESTRIAN_POSITION,
-            }[option]
+            }[OverkizCommandParam(option)]
         ),
     ),
     OverkizSelectDescription(
@@ -103,7 +106,7 @@ class OverkizSelect(OverkizDescriptiveEntity, SelectEntity):
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         if state := self.device.states.get(self.entity_description.key):
-            return state.value
+            return str(state.value)
 
         return None
 

--- a/homeassistant/components/overkiz/strings.select.json
+++ b/homeassistant/components/overkiz/strings.select.json
@@ -1,0 +1,13 @@
+{
+    "state": {
+        "overkiz__open_closed_pedestrian": {
+            "open": "Open",
+            "pedestrian": "Pedestrian",
+            "closed": "Closed"
+        },
+        "overkiz__memorized_simple_volume": {
+            "highest": "Highest",
+            "standard": "Standard"
+        }
+    }
+}

--- a/homeassistant/components/overkiz/translations/select.en.json
+++ b/homeassistant/components/overkiz/translations/select.en.json
@@ -1,0 +1,13 @@
+{
+    "state": {
+        "overkiz__memorized_simple_volume": {
+            "highest": "Highest",
+            "standard": "Standard"
+        },
+        "overkiz__open_closed_pedestrian": {
+            "closed": "Closed",
+            "open": "Open",
+            "pedestrian": "Pedestrian"
+        }
+    }
+}


### PR DESCRIPTION
## Proposed change
Add select entity to Overkiz integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20907

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
