### PR TITLE
Update pvo to 0.2.0

### DIFF
--- a/homeassistant/components/pvoutput/manifest.json
+++ b/homeassistant/components/pvoutput/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/pvoutput",
   "config_flow": true,
   "codeowners": ["@fabaff", "@frenck"],
-  "requirements": ["pvo==0.1.0"],
+  "requirements": ["pvo==0.2.0"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/pvoutput/sensor.py
+++ b/homeassistant/components/pvoutput/sensor.py
@@ -89,11 +89,11 @@ SENSORS: tuple[PVOutputSensorEntityDescription, ...] = (
         value_fn=lambda status: status.energy_generation,
     ),
     PVOutputSensorEntityDescription(
-        key="normalized_ouput",
+        key="normalized_output",
         name="Efficiency",
         native_unit_of_measurement=f"{ENERGY_KILO_WATT_HOUR}/{POWER_KILO_WATT}",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda status: status.normalized_ouput,
+        value_fn=lambda status: status.normalized_output,
     ),
     PVOutputSensorEntityDescription(
         key="power_consumption",
@@ -209,7 +209,7 @@ class PVOutputSensorEntity(CoordinatorEntity, SensorEntity):
             ATTR_POWER_GENERATION: self.coordinator.data.power_generation,
             ATTR_ENERGY_CONSUMPTION: self.coordinator.data.energy_consumption,
             ATTR_POWER_CONSUMPTION: self.coordinator.data.power_consumption,
-            ATTR_EFFICIENCY: self.coordinator.data.normalized_ouput,
+            ATTR_EFFICIENCY: self.coordinator.data.normalized_output,
             ATTR_TEMPERATURE: self.coordinator.data.temperature,
             ATTR_VOLTAGE: self.coordinator.data.voltage,
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1292,7 +1292,7 @@ pushbullet.py==0.11.0
 pushover_complete==1.1.1
 
 # homeassistant.components.pvoutput
-pvo==0.1.0
+pvo==0.2.0
 
 # homeassistant.components.rpi_gpio_pwm
 pwmled==1.6.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -790,7 +790,7 @@ pure-python-adb[async]==0.3.0.dev0
 pushbullet.py==0.11.0
 
 # homeassistant.components.pvoutput
-pvo==0.1.0
+pvo==0.2.0
 
 # homeassistant.components.canary
 py-canary==0.5.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates `pvo` to 0.2.0

Release notes: https://github.com/frenck/python-pvoutput/releases/tag/v0.2.0

Fixes a typo in the model, which has been adjusted in Home Assistant in this PR as well. This will change the unique ID of an entity, however, this has not yet been released to the public yet.

Additionally, this bump allows for fetching system information, so the device concept can be implemented in a follow-up PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
     Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
