### PR TITLE
Implement an rtsp to webrtc registry in camera

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -695,10 +695,8 @@ class Camera(Entity):
         if DATA_RTSP_TO_WEB_RTC not in self.hass.data:
             return False
         stream_source = await self.stream_source()
-        if not stream_source:
-            return False
         for prefix in RTSP_PREFIXES:
-            if stream_source.startswith(prefix):
+            if stream_source and stream_source.startswith(prefix):
                 return True
         return False
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -315,11 +315,15 @@ def async_register_rtsp_to_web_rtc_provider(
 
 async def _async_refresh_providers(hass: HomeAssistant) -> None:
     """Check all cameras for any state changes for registered providers."""
-    component: EntityComponent = hass.data[DOMAIN]
-    for entity in component.entities:
-        camera = cast(Camera, entity)
+
+    async def _refresh(camera: Camera) -> None:
         if await camera.async_refresh_providers():
             camera.async_write_ha_state()
+
+    component: EntityComponent = hass.data[DOMAIN]
+    await asyncio.gather(
+        *(_refresh(cast(Camera, camera)) for camera in component.entities)
+    )
 
 
 def _async_get_rtsp_to_web_rtc_providers(

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import collections
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -61,6 +61,7 @@ from .const import (
     CONF_DURATION,
     CONF_LOOKBACK,
     DATA_CAMERA_PREFS,
+    DATA_RTSP_TO_WEB_RTC,
     DOMAIN,
     SERVICE_RECORD,
     STREAM_TYPE_HLS,
@@ -92,6 +93,8 @@ STATE_IDLE: Final = "idle"
 # Bitfield of features supported by the camera entity
 SUPPORT_ON_OFF: Final = 1
 SUPPORT_STREAM: Final = 2
+
+RTSP_PREFIXES = {"rtsp://", "rtsps://"}
 
 DEFAULT_CONTENT_TYPE: Final = "image/jpeg"
 ENTITY_IMAGE_URL: Final = "/api/camera_proxy/{0}?token={1}"
@@ -284,6 +287,49 @@ def _get_camera_from_entity_id(hass: HomeAssistant, entity_id: str) -> Camera:
     return cast(Camera, camera)
 
 
+def async_register_rtsp_to_web_rtc_provider(
+    hass: HomeAssistant,
+    domain: str,
+    provider: Callable[[str, str], Awaitable[str | None]],
+) -> Callable[[], None]:
+    """Register an RTSP to WebRTC provider.
+
+    Integrations may register a Callable that accepts a `stream_source` and
+    SDP `offer` as an input, and the output is the SDP `answer`. An implementation
+    may return None if the source or offer is not eligible or throw HomeAssistantError
+    on failure. The first provider to satisfy the offer will be used.
+    """
+
+    def remove_provider() -> None:
+        if domain in hass.data[DATA_RTSP_TO_WEB_RTC]:
+            del hass.data[DATA_RTSP_TO_WEB_RTC]
+        hass.async_create_task(_async_refresh_providers(hass))
+
+    hass.data.setdefault(DATA_RTSP_TO_WEB_RTC, {})
+    hass.data[DATA_RTSP_TO_WEB_RTC][domain] = provider
+    hass.async_create_task(_async_refresh_providers(hass))
+    return remove_provider
+
+
+async def _async_refresh_providers(hass: HomeAssistant) -> None:
+    """Check all cameras for any state changes for registered providers."""
+    component: EntityComponent = hass.data[DOMAIN]
+    for entity in component.entities:
+        camera = cast(Camera, entity)
+        if await camera.async_refresh_providers():
+            camera.async_write_ha_state()
+
+
+def _async_get_rtsp_to_web_rtc_providers(
+    hass: HomeAssistant,
+) -> Iterable[Callable[[str, str], Awaitable[str | None]]]:
+    """Return registered RTSP to WebRTC providers."""
+    providers: dict[str, Callable[[str, str], Awaitable[str | None]]] = hass.data.get(
+        DATA_RTSP_TO_WEB_RTC, {}
+    )
+    return providers.values()
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the camera component."""
     component = hass.data[DOMAIN] = EntityComponent(
@@ -391,6 +437,7 @@ class Camera(Entity):
         self._warned_old_signature = False
         self.async_update_token()
         self._create_stream_lock: asyncio.Lock | None = None
+        self._rtsp_to_webrtc = False
 
     @property
     def entity_picture(self) -> str:
@@ -446,6 +493,8 @@ class Camera(Entity):
             return self._attr_frontend_stream_type
         if not self.supported_features & SUPPORT_STREAM:
             return None
+        if self._rtsp_to_webrtc:
+            return STREAM_TYPE_WEB_RTC
         return STREAM_TYPE_HLS
 
     @property
@@ -487,8 +536,17 @@ class Camera(Entity):
         """Handle the WebRTC offer and return an answer.
 
         This is used by cameras with SUPPORT_STREAM and STREAM_TYPE_WEB_RTC.
+
+        Integrations can override with a native WebRTC implementation.
         """
-        raise NotImplementedError()
+        stream_source = await self.stream_source()
+        if not stream_source:
+            return None
+        for provider in _async_get_rtsp_to_web_rtc_providers(self.hass):
+            answer_sdp = await provider(stream_source, offer_sdp)
+            if answer_sdp:
+                return answer_sdp
+        raise HomeAssistantError("WebRTC offer was not accepted by any providers")
 
     def camera_image(
         self, width: int | None = None, height: int | None = None
@@ -613,6 +671,36 @@ class Camera(Entity):
         self.access_tokens.append(
             hashlib.sha256(_RND.getrandbits(256).to_bytes(32, "little")).hexdigest()
         )
+
+    async def async_internal_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_internal_added_to_hass()
+
+    async def async_refresh_providers(self) -> bool:
+        """Determine if any of the registered providers are suitable for this entity.
+
+        This affects state attributes, so it should be invoked any time the registered
+        providers or inputs to the state attributes change.
+
+        Returns True if any state was updated (and needs to be written)
+        """
+        old_state = self._rtsp_to_webrtc
+        self._rtsp_to_webrtc = await self._async_use_rtsp_to_webrtc()
+        return old_state != self._rtsp_to_webrtc
+
+    async def _async_use_rtsp_to_webrtc(self) -> bool:
+        """Determine if a WebRTC provider can be used for the camera."""
+        if not self.supported_features & SUPPORT_STREAM:
+            return False
+        if DATA_RTSP_TO_WEB_RTC not in self.hass.data:
+            return False
+        stream_source = await self.stream_source()
+        if not stream_source:
+            return False
+        for prefix in RTSP_PREFIXES:
+            if stream_source.startswith(prefix):
+                return True
+        return False
 
 
 class CameraView(HomeAssistantView):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -704,10 +704,8 @@ class Camera(Entity):
             return False
         stream_source = await self.stream_source()
         return any(
-            [
-                stream_source and stream_source.startswith(prefix)
-                for prefix in RTSP_PREFIXES
-            ]
+            stream_source and stream_source.startswith(prefix)
+            for prefix in RTSP_PREFIXES
         )
 
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -703,10 +703,12 @@ class Camera(Entity):
         if DATA_RTSP_TO_WEB_RTC not in self.hass.data:
             return False
         stream_source = await self.stream_source()
-        for prefix in RTSP_PREFIXES:
-            if stream_source and stream_source.startswith(prefix):
-                return True
-        return False
+        return any(
+            [
+                stream_source and stream_source.startswith(prefix)
+                for prefix in RTSP_PREFIXES
+            ]
+        )
 
 
 class CameraView(HomeAssistantView):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -299,6 +299,8 @@ def async_register_rtsp_to_web_rtc_provider(
     may return None if the source or offer is not eligible or throw HomeAssistantError
     on failure. The first provider to satisfy the offer will be used.
     """
+    if DOMAIN not in hass.data:
+        raise ValueError("Unexpected state, camera not loaded")
 
     def remove_provider() -> None:
         if domain in hass.data[DATA_RTSP_TO_WEB_RTC]:
@@ -675,6 +677,8 @@ class Camera(Entity):
     async def async_internal_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_internal_added_to_hass()
+        # Note: State is always updated by entity on return
+        await self.async_refresh_providers()
 
     async def async_refresh_providers(self) -> bool:
         """Determine if any of the registered providers are suitable for this entity.

--- a/homeassistant/components/camera/const.py
+++ b/homeassistant/components/camera/const.py
@@ -4,6 +4,7 @@ from typing import Final
 DOMAIN: Final = "camera"
 
 DATA_CAMERA_PREFS: Final = "camera_prefs"
+DATA_RTSP_TO_WEB_RTC: Final = "rtsp_to_web_rtc"
 
 PREF_PRELOAD_STREAM: Final = "preload_stream"
 

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -109,7 +109,10 @@ async def mock_hls_stream_source_fixture():
     with patch(
         "homeassistant.components.camera.Camera.stream_source",
         return_value=HLS_STREAM_SOURCE,
-    ) as mock_hls_stream_source:
+    ) as mock_hls_stream_source, patch(
+        "homeassistant.components.camera.Camera.supported_features",
+        return_value=camera.SUPPORT_STREAM,
+    ):
         yield mock_hls_stream_source
 
 

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -28,6 +28,11 @@ from .common import EMPTY_8_6_JPEG, mock_turbo_jpeg
 
 from tests.components.camera import common
 
+STREAM_SOURCE = "rtsp://127.0.0.1/stream"
+HLS_STREAM_SOURCE = "http://127.0.0.1/example.m3u"
+WEBRTC_OFFER = "v=0\r\n"
+WEBRTC_ANSWER = "a=sendonly"
+
 
 @pytest.fixture(name="mock_camera")
 async def mock_camera_fixture(hass):
@@ -57,7 +62,7 @@ async def mock_camera_web_rtc_fixture(hass):
         new_callable=PropertyMock(return_value=STREAM_TYPE_WEB_RTC),
     ), patch(
         "homeassistant.components.camera.Camera.async_handle_web_rtc_offer",
-        return_value="a=sendonly",
+        return_value=WEBRTC_ANSWER,
     ):
         yield
 
@@ -83,6 +88,47 @@ async def image_mock_url_fixture(hass):
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
     )
     await hass.async_block_till_done()
+
+
+@pytest.fixture(name="mock_stream_source")
+async def mock_stream_source_fixture():
+    """Fixture to create an RTSP stream source."""
+    with patch(
+        "homeassistant.components.camera.Camera.stream_source",
+        return_value=STREAM_SOURCE,
+    ) as mock_stream_source, patch(
+        "homeassistant.components.camera.Camera.supported_features",
+        return_value=camera.SUPPORT_STREAM,
+    ):
+        yield mock_stream_source
+
+
+@pytest.fixture(name="mock_hls_stream_source")
+async def mock_hls_stream_source_fixture():
+    """Fixture to create an HLS stream source."""
+    with patch(
+        "homeassistant.components.camera.Camera.stream_source",
+        return_value=HLS_STREAM_SOURCE,
+    ) as mock_hls_stream_source:
+        yield mock_hls_stream_source
+
+
+async def provide_web_rtc_answer(stream_source: str, offer: str) -> str:
+    """Simulate an rtsp to webrtc provider."""
+    assert stream_source == STREAM_SOURCE
+    assert offer == WEBRTC_OFFER
+    return WEBRTC_ANSWER
+
+
+@pytest.fixture(name="mock_rtsp_to_web_rtc")
+async def mock_rtsp_to_web_rtc_fixture(hass):
+    """Fixture that registers a mock rtsp to web_rtc provider."""
+    mock_provider = Mock(side_effect=provide_web_rtc_answer)
+    unsub = camera.async_register_rtsp_to_web_rtc_provider(
+        hass, "mock_domain", mock_provider
+    )
+    yield mock_provider
+    unsub()
 
 
 async def test_get_image_from_camera(hass, image_mock_url):
@@ -189,17 +235,13 @@ async def test_get_image_from_camera_not_jpeg(hass, image_mock_url):
     assert image.content == b"png"
 
 
-async def test_get_stream_source_from_camera(hass, mock_camera):
+async def test_get_stream_source_from_camera(hass, mock_camera, mock_stream_source):
     """Fetch stream source from camera entity."""
 
-    with patch(
-        "homeassistant.components.camera.Camera.stream_source",
-        return_value="rtsp://127.0.0.1/stream",
-    ) as mock_camera_stream_source:
-        stream_source = await camera.async_get_stream_source(hass, "camera.demo_camera")
+    stream_source = await camera.async_get_stream_source(hass, "camera.demo_camera")
 
-    assert mock_camera_stream_source.called
-    assert stream_source == "rtsp://127.0.0.1/stream"
+    assert mock_stream_source.called
+    assert stream_source == STREAM_SOURCE
 
 
 async def test_get_image_without_exists_camera(hass, image_mock_url):
@@ -503,7 +545,7 @@ async def test_websocket_web_rtc_offer(
             "id": 9,
             "type": "camera/web_rtc_offer",
             "entity_id": "camera.demo_camera",
-            "offer": "v=0\r\n",
+            "offer": WEBRTC_OFFER,
         }
     )
     response = await client.receive_json()
@@ -511,7 +553,7 @@ async def test_websocket_web_rtc_offer(
     assert response["id"] == 9
     assert response["type"] == TYPE_RESULT
     assert response["success"]
-    assert response["result"]["answer"] == "a=sendonly"
+    assert response["result"]["answer"] == WEBRTC_ANSWER
 
 
 async def test_websocket_web_rtc_offer_invalid_entity(
@@ -526,7 +568,7 @@ async def test_websocket_web_rtc_offer_invalid_entity(
             "id": 9,
             "type": "camera/web_rtc_offer",
             "entity_id": "camera.does_not_exist",
-            "offer": "v=0\r\n",
+            "offer": WEBRTC_OFFER,
         }
     )
     response = await client.receive_json()
@@ -575,7 +617,7 @@ async def test_websocket_web_rtc_offer_failure(
                 "id": 9,
                 "type": "camera/web_rtc_offer",
                 "entity_id": "camera.demo_camera",
-                "offer": "v=0\r\n",
+                "offer": WEBRTC_OFFER,
             }
         )
         response = await client.receive_json()
@@ -604,7 +646,7 @@ async def test_websocket_web_rtc_offer_timeout(
                 "id": 9,
                 "type": "camera/web_rtc_offer",
                 "entity_id": "camera.demo_camera",
-                "offer": "v=0\r\n",
+                "offer": WEBRTC_OFFER,
             }
         )
         response = await client.receive_json()
@@ -628,7 +670,7 @@ async def test_websocket_web_rtc_offer_invalid_stream_type(
             "id": 9,
             "type": "camera/web_rtc_offer",
             "entity_id": "camera.demo_camera",
-            "offer": "v=0\r\n",
+            "offer": WEBRTC_OFFER,
         }
     )
     response = await client.receive_json()
@@ -690,3 +732,145 @@ async def test_stream_unavailable(hass, hass_ws_client, mock_camera, mock_stream
     demo_camera = hass.states.get("camera.demo_camera")
     assert demo_camera is not None
     assert demo_camera.state == camera.STATE_STREAMING
+
+
+async def test_rtsp_to_web_rtc_offer(
+    hass,
+    hass_ws_client,
+    mock_camera,
+    mock_stream_source,
+    mock_rtsp_to_web_rtc,
+):
+    """Test creating a web_rtc offer from an rstp provider."""
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 9,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+            "offer": WEBRTC_OFFER,
+        }
+    )
+    response = await client.receive_json()
+
+    assert response.get("id") == 9
+    assert response.get("type") == TYPE_RESULT
+    assert response.get("success")
+    assert "result" in response
+    assert response["result"] == {"answer": WEBRTC_ANSWER}
+
+    assert mock_rtsp_to_web_rtc.called
+
+
+async def test_unsupported_rtsp_to_web_rtc_stream_type(
+    hass,
+    hass_ws_client,
+    mock_camera,
+    mock_hls_stream_source,  # Not an RTSP stream source
+    mock_rtsp_to_web_rtc,
+):
+    """Test rtsp-to-webrtc is not registered for non-RTSP streams."""
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 10,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+            "offer": WEBRTC_OFFER,
+        }
+    )
+    response = await client.receive_json()
+
+    assert response.get("id") == 10
+    assert response.get("type") == TYPE_RESULT
+    assert "success" in response
+    assert not response["success"]
+
+
+async def test_rtsp_to_web_rtc_provider_unregistered(
+    hass,
+    hass_ws_client,
+    mock_camera,
+    mock_stream_source,
+):
+    """Test creating a web_rtc offer from an rstp provider."""
+    mock_provider = Mock(side_effect=provide_web_rtc_answer)
+    unsub = camera.async_register_rtsp_to_web_rtc_provider(
+        hass, "mock_domain", mock_provider
+    )
+
+    client = await hass_ws_client(hass)
+
+    # Registered provider can handle the WebRTC offer
+    await client.send_json(
+        {
+            "id": 11,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+            "offer": WEBRTC_OFFER,
+        }
+    )
+    response = await client.receive_json()
+    assert response["id"] == 11
+    assert response["type"] == TYPE_RESULT
+    assert response["success"]
+    assert response["result"]["answer"] == WEBRTC_ANSWER
+
+    assert mock_provider.called
+    mock_provider.reset_mock()
+
+    # Unregister provider, then verify the WebRTC offer cannot be handled
+    unsub()
+    await client.send_json(
+        {
+            "id": 12,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+            "offer": WEBRTC_OFFER,
+        }
+    )
+    response = await client.receive_json()
+    assert response.get("id") == 12
+    assert response.get("type") == TYPE_RESULT
+    assert "success" in response
+    assert not response["success"]
+
+    assert not mock_provider.called
+
+
+async def test_rtsp_to_web_rtc_offer_not_accepted(
+    hass,
+    hass_ws_client,
+    mock_camera,
+    mock_stream_source,
+):
+    """Test a provider that can't satisfy the rtsp to webrtc offer."""
+
+    async def provide_none(stream_source: str, offer: str) -> str:
+        """Simulate a provider that can't accept the offer."""
+        return None
+
+    mock_provider = Mock(side_effect=provide_none)
+    unsub = camera.async_register_rtsp_to_web_rtc_provider(
+        hass, "mock_domain", mock_provider
+    )
+    client = await hass_ws_client(hass)
+
+    # Registered provider can handle the WebRTC offer
+    await client.send_json(
+        {
+            "id": 11,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+            "offer": WEBRTC_OFFER,
+        }
+    )
+    response = await client.receive_json()
+    assert response["id"] == 11
+    assert response.get("type") == TYPE_RESULT
+    assert "success" in response
+    assert not response["success"]
+
+    assert mock_provider.called
+
+    unsub()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow integrations to register a provider that can convert an RTSP stream and WebRTC offer to a WebRTC answer. This is
planned to be used by the RTSPtoWebRTC server integration as an initial pass, but could
support other server implementations as well.

This implementation was proposed in https://github.com/home-assistant/architecture/discussions/658

An example integration implementation can be https://github.com/home-assistant/core/pull/59660 though it was not yet modified to use this interface.

Some integrations that support streams were updated to call `async_added_to_hass` in `Camera` to ensure the provider registry is checked on startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1171

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
