### PR TITLE
Skip empty test directories in gen_requirements_all

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -147,11 +147,11 @@ def has_tests(module: str):
 
     # Dev environments might have stale directories around
     # from removed tests. Check for that.
-    content = [f.name for f in path.glob("*")]
-
     # Directories need to contain more than `__pycache__`
     # to exist in Git and so be seen by CI.
-    return content != ["__pycache__"]
+    content = [f.name for f in path.glob("*") if f.name != "__pycache__"]
+
+    return len(content) > 0
 
 
 def explore_module(package, explore_children):

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -136,22 +136,12 @@ def has_tests(module: str):
     """Test if a module has tests.
 
     Module format: homeassistant.components.hue
-    Test if exists: tests/components/hue
+    Test if exists: tests/components/hue/__init__.py
     """
-    path = Path(module.replace(".", "/").replace("homeassistant", "tests"))
-    if not path.exists():
-        return False
-
-    if not path.is_dir():
-        return True
-
-    # Dev environments might have stale directories around
-    # from removed tests. Check for that.
-    # Directories need to contain more than `__pycache__`
-    # to exist in Git and so be seen by CI.
-    content = [f.name for f in path.glob("*") if f.name != "__pycache__"]
-
-    return len(content) > 0
+    path = (
+        Path(module.replace(".", "/").replace("homeassistant", "tests")) / "__init__.py"
+    )
+    return path.exists()
 
 
 def explore_module(package, explore_children):

--- a/tests/components/amberelectric/__init__.py
+++ b/tests/components/amberelectric/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the amberelectric integration."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If there is an empty directory `tests/components/foo`, then the dependencies for integration `foo` will be erroneously added to `requirements_test_all.txt` by `script.gen_requirements_all`. To reproduce:

```bash
$ mkdir tests/components/splunk
$ python3 -m script.gen_requirements_all
[...]
$ git diff requirements_test_all.txt
diff --git a/requirements_test_all.txt b/requirements_test_all.txt
index 212d323539..a7b7351a46 100644
--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -503,6 +503,9 @@ hangups==0.4.16
 # homeassistant.components.cloud
 hass-nabucasa==0.50.0
 
+# homeassistant.components.splunk
+hass_splunk==0.1.1
+
 # homeassistant.components.tasmota
 hatasmota==0.3.1
 ```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
