### PR TITLE
Reload nest integration when new devices are added

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -1,9 +1,9 @@
 """Support for Nest devices."""
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 import logging
-from typing import Awaitable, Callable
 
 from aiohttp import web
 from google_nest_sdm.event import EventMessage

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from http import HTTPStatus
 import logging
+from typing import Awaitable, Callable
 
 from aiohttp import web
 from google_nest_sdm.event import EventMessage
@@ -178,12 +179,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 class SignalUpdateCallback:
     """An EventCallback invoked when new events arrive from subscriber."""
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(
+        self, hass: HomeAssistant, config_reload_cb: Callable[[], Awaitable[None]]
+    ) -> None:
         """Initialize EventCallback."""
         self._hass = hass
+        self._config_reload_cb = config_reload_cb
 
     async def async_handle_event(self, event_message: EventMessage) -> None:
         """Process an incoming EventMessage."""
+        if event_message.relation_update:
+            # A device was added/removed or a home was added/removed. Reload the integration
+            # in order to detect any changes.
+            _LOGGER.info("Devices or homes have changed; Reloading")
+            self._hass.async_create_task(self._config_reload_cb())
+            return
         if not event_message.resource_update_name:
             return
         device_id = event_message.resource_update_name
@@ -221,7 +231,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Use disk backed event media store
     subscriber.cache_policy.store = await async_get_media_event_store(hass, subscriber)
 
-    callback = SignalUpdateCallback(hass)
+    async def async_config_reload() -> None:
+        await hass.config_entries.async_reload(entry.entry_id)
+
+    callback = SignalUpdateCallback(hass, async_config_reload)
     subscriber.set_update_callback(callback.async_handle_event)
     try:
         await subscriber.start_async()

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -502,6 +502,7 @@ async def test_structure_update_event(hass):
     ):
         await subscriber.async_receive_event(message)
         await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     # No home assistant events published
     assert not events

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -502,7 +502,6 @@ async def test_structure_update_event(hass):
     ):
         await subscriber.async_receive_event(message)
         await hass.async_block_till_done()
-        await hass.async_block_till_done()
 
     # No home assistant events published
     assert not events


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Listen for relation events to be published, and when a relation changes (a new device is added, etc) then reload the
integration to discover new devices automatically. This previously required a home assistant restart.

See https://developers.google.com/nest/device-access/api/events#relation-events for more details on relation events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #62275
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
