### PR TITLE
Gracefully handle unknown HVAC mode in Tuya

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -306,7 +306,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         if DPCode.MODE in self.device.function:
             data_type = EnumTypeData.from_json(self.device.function[DPCode.MODE].values)
             for tuya_mode in data_type.range:
-                if tuya_mode in TUYA_HVAC_TO_HA.values():
+                if tuya_mode not in TUYA_HVAC_TO_HA:
                     LOGGER.warning(
                         "Unknown HVAC mode '%s' for device %s; assuming it as off",
                         tuya_mode,

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -225,6 +225,16 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
                 if tuya_mode in data_type.range:
                     self._hvac_to_tuya[ha_mode] = tuya_mode
                     self._attr_hvac_modes.append(ha_mode)
+
+            # Log unknown modes
+            for tuya_mode in data_type.range:
+                if tuya_mode in TUYA_HVAC_TO_HA.values():
+                    LOGGER.warning(
+                        "Unknown HVAC mode '%s' for device %s; assuming it as off",
+                        tuya_mode,
+                        device.name,
+                    )
+
         elif DPCode.SWITCH in device.function:
             self._attr_hvac_modes = [
                 HVAC_MODE_OFF,
@@ -436,14 +446,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
                 return self.entity_description.switch_only_hvac_mode
             return HVAC_MODE_OFF
 
-        if (mode := self.device.status.get(DPCode.MODE)) is not None:
-            if mode not in TUYA_HVAC_TO_HA:
-                LOGGER.warning(
-                    "Unknown HVAC mode '%s' for device %s, assuming off",
-                    mode,
-                    self.name,
-                )
-                return HVAC_MODE_OFF
+        if (
+            mode := self.device.status.get(DPCode.MODE)
+        ) is not None and mode in TUYA_HVAC_TO_HA:
             return TUYA_HVAC_TO_HA[mode]
 
         return HVAC_MODE_OFF

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantTuyaData
 from .base import EnumTypeData, IntegerTypeData, TuyaEntity
-from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode
+from .const import DOMAIN, LOGGER, TUYA_DISCOVERY_NEW, DPCode
 
 TUYA_HVAC_TO_HA = {
     "auto": HVAC_MODE_HEAT_COOL,
@@ -436,8 +436,16 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
                 return self.entity_description.switch_only_hvac_mode
             return HVAC_MODE_OFF
 
-        if self.device.status.get(DPCode.MODE) is not None:
-            return TUYA_HVAC_TO_HA[self.device.status[DPCode.MODE]]
+        if (mode := self.device.status.get(DPCode.MODE)) is not None:
+            if mode not in TUYA_HVAC_TO_HA:
+                LOGGER.warning(
+                    "Unknown HVAC mode '%s' for device %s, assuming off",
+                    mode,
+                    self.name,
+                )
+                return HVAC_MODE_OFF
+            return TUYA_HVAC_TO_HA[mode]
+
         return HVAC_MODE_OFF
 
     @property

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
+import logging
 
 from tuya_iot import TuyaCloudOpenAPIEndpoint
 
@@ -39,6 +40,7 @@ from homeassistant.const import (
 )
 
 DOMAIN = "tuya"
+LOGGER = logging.getLogger(__package__)
 
 CONF_AUTH_TYPE = "auth_type"
 CONF_PROJECT_TYPE = "tuya_project_type"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds gracefully handling of missing/unexpected Tuya HVAC modes.

If an unknown mode is received, we'll log a proper warning and assume the HVAC mode is off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #62839 #62392 #59529 #59517
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
