### PR TITLE
[Airly] Add color attribute to CAQI sensor

### DIFF
--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     ATTR_API_ADVICE,
     ATTR_API_CAQI,
+    ATTR_API_CAQI_COLOR,
     ATTR_API_CAQI_DESCRIPTION,
     ATTR_API_CAQI_LEVEL,
     CONF_USE_NEAREST,
@@ -200,6 +201,7 @@ class AirlyDataUpdateCoordinator(DataUpdateCoordinator):
             data[f"{standard['pollutant']}_PERCENT"] = standard["percent"]
         data[ATTR_API_CAQI] = index["value"]
         data[ATTR_API_CAQI_LEVEL] = index["level"].lower().replace("_", " ")
+        data[ATTR_API_CAQI_COLOR] = index["color"]
         data[ATTR_API_CAQI_DESCRIPTION] = index["description"]
         data[ATTR_API_ADVICE] = index["advice"]
         return data

--- a/homeassistant/components/airly/const.py
+++ b/homeassistant/components/airly/const.py
@@ -5,6 +5,7 @@ from typing import Final
 
 ATTR_API_ADVICE: Final = "ADVICE"
 ATTR_API_CAQI: Final = "CAQI"
+ATTR_API_CAQI_COLOR: Final = "COLOR"
 ATTR_API_CAQI_DESCRIPTION: Final = "DESCRIPTION"
 ATTR_API_CAQI_LEVEL: Final = "LEVEL"
 ATTR_API_HUMIDITY: Final = "HUMIDITY"
@@ -15,6 +16,7 @@ ATTR_API_PRESSURE: Final = "PRESSURE"
 ATTR_API_TEMPERATURE: Final = "TEMPERATURE"
 
 ATTR_ADVICE: Final = "advice"
+ATTR_COLOR: Final = "color"
 ATTR_DESCRIPTION: Final = "description"
 ATTR_LEVEL: Final = "level"
 ATTR_LIMIT: Final = "limit"

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -32,6 +32,7 @@ from .const import (
     ATTR_ADVICE,
     ATTR_API_ADVICE,
     ATTR_API_CAQI,
+    ATTR_API_CAQI_COLOR,
     ATTR_API_CAQI_DESCRIPTION,
     ATTR_API_CAQI_LEVEL,
     ATTR_API_HUMIDITY,
@@ -40,6 +41,7 @@ from .const import (
     ATTR_API_PM25,
     ATTR_API_PRESSURE,
     ATTR_API_TEMPERATURE,
+    ATTR_COLOR,
     ATTR_DESCRIPTION,
     ATTR_LEVEL,
     ATTR_LIMIT,
@@ -176,6 +178,7 @@ class AirlySensor(CoordinatorEntity, SensorEntity):
         if self.entity_description.key == ATTR_API_CAQI:
             self._attrs[ATTR_LEVEL] = self.coordinator.data[ATTR_API_CAQI_LEVEL]
             self._attrs[ATTR_ADVICE] = self.coordinator.data[ATTR_API_ADVICE]
+            self._attrs[ATTR_COLOR] = self.coordinator.data[ATTR_API_CAQI_COLOR]
             self._attrs[ATTR_DESCRIPTION] = self.coordinator.data[
                 ATTR_API_CAQI_DESCRIPTION
             ]


### PR DESCRIPTION
Signed-off-by: Michal Zylowski <michal@zylowski.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Airly API offers field 'color' that is really useful for preparing dashboard in home assistant. Field is already available in airly library, so it is only missing in HA integration. That commit add that field to HA as attribute to CAQI sensor.
![image](https://user-images.githubusercontent.com/13780868/147657496-b33bc690-1b81-4368-859a-8a8be462414c.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: -
- This PR is related to issue: -
- Link to documentation pull request: -

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
