### PR TITLE
Normalize Hue colortemp if value outside of bounds

### DIFF
--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -31,7 +31,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from ..bridge import HueBridge
 from ..const import CONF_ALLOW_HUE_GROUPS, DOMAIN
 from .entity import HueBaseEntity
-from .helpers import normalize_hue_brightness, normalize_hue_transition
+from .helpers import (
+    normalize_hue_brightness,
+    normalize_hue_colortemp,
+    normalize_hue_transition,
+)
 
 ALLOWED_ERRORS = [
     "device (groupedLight) has communication issues, command (on) may not have effect",
@@ -151,7 +155,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         """Turn the light on."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
         xy_color = kwargs.get(ATTR_XY_COLOR)
-        color_temp = kwargs.get(ATTR_COLOR_TEMP)
+        color_temp = normalize_hue_colortemp(kwargs.get(ATTR_COLOR_TEMP))
         brightness = normalize_hue_brightness(kwargs.get(ATTR_BRIGHTNESS))
         flash = kwargs.get(ATTR_FLASH)
 

--- a/homeassistant/components/hue/v2/helpers.py
+++ b/homeassistant/components/hue/v2/helpers.py
@@ -1,7 +1,8 @@
 """Helper functions for Philips Hue v2."""
+from __future__ import annotations
 
 
-def normalize_hue_brightness(brightness):
+def normalize_hue_brightness(brightness: float | None) -> float | None:
     """Return calculated brightness values."""
     if brightness is not None:
         # Hue uses a range of [0, 100] to control brightness.
@@ -10,10 +11,21 @@ def normalize_hue_brightness(brightness):
     return brightness
 
 
-def normalize_hue_transition(transition):
+def normalize_hue_transition(transition: float | None) -> float | None:
     """Return rounded transition values."""
     if transition is not None:
         # hue transition duration is in milliseconds and round them to 100ms
         transition = int(round(transition, 1) * 1000)
 
     return transition
+
+
+def normalize_hue_colortemp(colortemp: int | None) -> int | None:
+    """Return color temperature within Hue's ranges."""
+    if colortemp is not None:
+        # Hue only accepts a range between 153..500
+        if colortemp > 500:
+            colortemp = 500
+        if colortemp < 153:
+            colortemp = 153
+    return colortemp

--- a/homeassistant/components/hue/v2/helpers.py
+++ b/homeassistant/components/hue/v2/helpers.py
@@ -24,8 +24,6 @@ def normalize_hue_colortemp(colortemp: int | None) -> int | None:
     """Return color temperature within Hue's ranges."""
     if colortemp is not None:
         # Hue only accepts a range between 153..500
-        if colortemp > 500:
-            colortemp = 500
-        if colortemp < 153:
-            colortemp = 153
+        colortemp = min(colortemp, 500)
+        colortemp = max(colortemp, 153)
     return colortemp

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -30,7 +30,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from ..bridge import HueBridge
 from ..const import DOMAIN
 from .entity import HueBaseEntity
-from .helpers import normalize_hue_brightness, normalize_hue_transition
+from .helpers import (
+    normalize_hue_brightness,
+    normalize_hue_colortemp,
+    normalize_hue_transition,
+)
 
 ALLOWED_ERRORS = [
     "device (light) has communication issues, command (on) may not have effect",
@@ -158,7 +162,7 @@ class HueLight(HueBaseEntity, LightEntity):
         """Turn the device on."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
         xy_color = kwargs.get(ATTR_XY_COLOR)
-        color_temp = kwargs.get(ATTR_COLOR_TEMP)
+        color_temp = normalize_hue_colortemp(kwargs.get(ATTR_COLOR_TEMP))
         brightness = normalize_hue_brightness(kwargs.get(ATTR_BRIGHTNESS))
         flash = kwargs.get(ATTR_FLASH)
 

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -140,6 +140,25 @@ async def test_light_turn_on_service(hass, mock_bridge_v2, v2_resources_test_dat
     )
     assert len(mock_bridge_v2.mock_requests) == 4
     assert mock_bridge_v2.mock_requests[3]["json"]["identify"]["action"] == "identify"
+    
+    # test again with sending a colortemperature which is out of range
+    # which should be normalized to the upper/lower bounds Hue can handle
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": test_light_id, "color_temp": 50},
+        blocking=True,
+    )
+    assert len(mock_bridge_v2.mock_requests) == 5
+    assert mock_bridge_v2.mock_requests[4]["json"]["color_temperature"]["mirek"] == 153
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": test_light_id, "color_temp": 550},
+        blocking=True,
+    )
+    assert len(mock_bridge_v2.mock_requests) == 6
+    assert mock_bridge_v2.mock_requests[5]["json"]["color_temperature"]["mirek"] == 500
 
 
 async def test_light_turn_off_service(hass, mock_bridge_v2, v2_resources_test_data):

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -140,7 +140,7 @@ async def test_light_turn_on_service(hass, mock_bridge_v2, v2_resources_test_dat
     )
     assert len(mock_bridge_v2.mock_requests) == 4
     assert mock_bridge_v2.mock_requests[3]["json"]["identify"]["action"] == "identify"
-    
+
     # test again with sending a colortemperature which is out of range
     # which should be normalized to the upper/lower bounds Hue can handle
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change

Normalize color temperature to the upper/lower bounds Hue can handle.
The new API is a bit more fanatic with checking if the values are within the Hue range.

BTW: Why are these bounds not checked by the HA service call, is there a reason for that ?

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #62842
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
