### PR TITLE
Add UniFi Protect button

### DIFF
--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -1,0 +1,58 @@
+"""Support for Ubiquiti's UniFi Protect NVR."""
+from __future__ import annotations
+
+import logging
+
+from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DEVICES_THAT_ADOPT, DOMAIN
+from .data import ProtectData
+from .entity import ProtectDeviceEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Discover devices on a UniFi Protect NVR."""
+    data: ProtectData = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        [
+            ProtectButton(
+                data,
+                device,
+            )
+            for device in data.get_by_types(DEVICES_THAT_ADOPT)
+        ]
+    )
+
+
+class ProtectButton(ProtectDeviceEntity, ButtonEntity):
+    """A Ubiquiti UniFi Protect Reboot button."""
+
+    def __init__(
+        self,
+        data: ProtectData,
+        device: ProtectAdoptableDeviceModel,
+    ) -> None:
+        """Initialize an UniFi camera."""
+        super().__init__(data, device)
+        self._attr_name = f"{self.device.name} Reboot Device"
+        self._attr_entity_registry_enabled_default = False
+        self._attr_device_class = ButtonDeviceClass.RESTART
+
+    @callback
+    async def async_press(self) -> None:
+        """Press the button."""
+
+        _LOGGER.debug("Rebooting %s with id %s", self.device.model, self.device.id)
+        await self.device.reboot()

--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -7,7 +7,7 @@ from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DEVICES_THAT_ADOPT, DOMAIN
@@ -50,7 +50,6 @@ class ProtectButton(ProtectDeviceEntity, ButtonEntity):
         self._attr_entity_registry_enabled_default = False
         self._attr_device_class = ButtonDeviceClass.RESTART
 
-    @callback
     async def async_press(self) -> None:
         """Press the button."""
 

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -41,4 +41,4 @@ DEVICES_FOR_SUBSCRIBE = DEVICES_WITH_ENTITIES | {ModelType.EVENT}
 MIN_REQUIRED_PROTECT_V = Version("1.20.0")
 OUTDATED_LOG_MESSAGE = "You are running v%s of UniFi Protect. Minimum required version is v%s. Please upgrade UniFi Protect and then retry"
 
-PLATFORMS = [Platform.CAMERA, Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.BUTTON, Platform.CAMERA, Platform.MEDIA_PLAYER]

--- a/tests/components/unifiprotect/test_button.py
+++ b/tests/components/unifiprotect/test_button.py
@@ -1,0 +1,73 @@
+"""Test the UniFi Protect button platform."""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pyunifiprotect.data import Camera
+
+from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import MockEntityFixture, enable_entity
+
+
+@pytest.fixture(name="camera")
+async def camera_fixture(
+    hass: HomeAssistant, mock_entry: MockEntityFixture, mock_camera: Camera
+):
+    """Fixture for a single camera with only the button platform active, no extra setup."""
+
+    camera_obj = mock_camera.copy(deep=True)
+    camera_obj._api = mock_entry.api
+    camera_obj.channels[0]._api = mock_entry.api
+    camera_obj.channels[1]._api = mock_entry.api
+    camera_obj.channels[2]._api = mock_entry.api
+    camera_obj.name = "Test Camera"
+
+    mock_entry.api.bootstrap.cameras = {
+        camera_obj.id: camera_obj,
+    }
+
+    with patch("homeassistant.components.unifiprotect.PLATFORMS", [Platform.BUTTON]):
+        await hass.config_entries.async_setup(mock_entry.entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+
+    assert len(hass.states.async_all()) == 0
+    assert len(entity_registry.entities) == 1
+
+    yield (camera_obj, "button.test_camera_reboot_device")
+
+
+async def test_button(
+    hass: HomeAssistant,
+    mock_entry: MockEntityFixture,
+    camera: tuple[Camera, str],
+):
+    """Test button entity."""
+
+    mock_entry.api.reboot_device = AsyncMock()
+
+    unique_id = f"{camera[0].id}"
+    entity_id = camera[1]
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert entity.disabled
+    assert entity.unique_id == unique_id
+
+    await enable_entity(hass, mock_entry.entry.entry_id, entity_id)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+
+    await hass.services.async_call(
+        "button", "press", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    mock_entry.api.reboot_device.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Third PR for migrating HACS integration for UniFi Protect. Adds the `button` platform and has feedback from @MartinHjelmare on the `media_player` platform

Previous PRs:

* Initial + `camera`: https://github.com/home-assistant/core/pull/62697 (follow up: https://github.com/home-assistant/core/pull/62806)
* `media_player`: https://github.com/home-assistant/core/pull/62895

Following the advice of @bdraco, these PRs will be broken up into smaller PRs to make them easier to review and merge:

* Initial - config flow, data service + camera platform
* One per entity platform
* One for remaining services

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TBA (waiting for first docs PR to be merged first)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
