### PR TITLE
Detect unsupported system in CPU Speed integration

### DIFF
--- a/homeassistant/components/cpuspeed/__init__.py
+++ b/homeassistant/components/cpuspeed/__init__.py
@@ -1,12 +1,21 @@
 """The CPU Speed integration."""
+from cpuinfo import cpuinfo
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import PLATFORMS
+from .const import LOGGER, PLATFORMS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
+    if not await hass.async_add_executor_job(cpuinfo.get_cpu_info):
+        LOGGER.error(
+            "Unable to get CPU information, the CPU Speed integration "
+            "is not compatible with your system"
+        )
+        return False
+
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/cpuspeed/config_flow.py
+++ b/homeassistant/components/cpuspeed/config_flow.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from cpuinfo import cpuinfo
+
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
@@ -26,6 +28,9 @@ class CPUSpeedFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is None:
             return self.async_show_form(step_id="user")
+
+        if not await self.hass.async_add_executor_job(cpuinfo.get_cpu_info):
+            return self.async_abort(reason="not_compatible")
 
         return self.async_create_entry(
             title=self._imported_name or "CPU Speed",

--- a/homeassistant/components/cpuspeed/strings.json
+++ b/homeassistant/components/cpuspeed/strings.json
@@ -8,7 +8,8 @@
       }
     },
     "abort": {
-      "alread_configured": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "alread_configured": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "not_compatible": "Unable to get CPU information, this integration is not compatible with your system"
     }
   }
 }

--- a/homeassistant/components/cpuspeed/translations/en.json
+++ b/homeassistant/components/cpuspeed/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "alread_configured": "Already configured. Only a single configuration possible."
+            "alread_configured": "Already configured. Only a single configuration possible.",
+            "not_compatible": "Unable to get CPU information, this integration is not compatible with your system"
         },
         "step": {
             "user": {

--- a/tests/components/cpuspeed/conftest.py
+++ b/tests/components/cpuspeed/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -20,6 +20,20 @@ def mock_config_entry() -> MockConfigEntry:
         data={},
         unique_id=DOMAIN,
     )
+
+
+@pytest.fixture
+def mock_cpuinfo_config_flow() -> Generator[MagicMock, None, None]:
+    """Return a mocked get_cpu_info.
+
+    It is only used to check thruthy or falsy values, so it is mocked
+    to return True.
+    """
+    with patch(
+        "homeassistant.components.cpuspeed.config_flow.cpuinfo.get_cpu_info",
+        return_value=True,
+    ) as cpuinfo_mock:
+        yield cpuinfo_mock
 
 
 @pytest.fixture

--- a/tests/components/cpuspeed/test_config_flow.py
+++ b/tests/components/cpuspeed/test_config_flow.py
@@ -88,7 +88,6 @@ async def test_not_compatible(
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test we abort the configuration flow when incompatible."""
-    """Test the full user configuration flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )

--- a/tests/components/cpuspeed/test_config_flow.py
+++ b/tests/components/cpuspeed/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for the CPU Speed config flow."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.cpuspeed.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
@@ -17,6 +17,7 @@ from tests.common import MockConfigEntry
 
 async def test_full_user_flow(
     hass: HomeAssistant,
+    mock_cpuinfo_config_flow: MagicMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test the full user configuration flow."""
@@ -38,10 +39,12 @@ async def test_full_user_flow(
     assert result2.get("data") == {}
 
     assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_cpuinfo_config_flow.mock_calls) == 1
 
 
 async def test_already_configured(
     hass: HomeAssistant,
+    mock_cpuinfo_config_flow: MagicMock,
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -56,10 +59,12 @@ async def test_already_configured(
     assert result.get("reason") == "already_configured"
 
     assert len(mock_setup_entry.mock_calls) == 0
+    assert len(mock_cpuinfo_config_flow.mock_calls) == 0
 
 
 async def test_import_flow(
     hass: HomeAssistant,
+    mock_cpuinfo_config_flow: MagicMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
     """Test the import configuration flow."""
@@ -74,3 +79,32 @@ async def test_import_flow(
     assert result.get("data") == {}
 
     assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_cpuinfo_config_flow.mock_calls) == 1
+
+
+async def test_not_compatible(
+    hass: HomeAssistant,
+    mock_cpuinfo_config_flow: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we abort the configuration flow when incompatible."""
+    """Test the full user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    mock_cpuinfo_config_flow.return_value = {}
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result2.get("type") == RESULT_TYPE_ABORT
+    assert result2.get("reason") == "not_compatible"
+
+    assert len(mock_setup_entry.mock_calls) == 0
+    assert len(mock_cpuinfo_config_flow.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Detect incompatible CPU/Systems in the CPU Speed integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
