### PR TITLE
Update legacy nest config flow tests to use modern best practices

### DIFF
--- a/tests/components/nest/test_config_flow_legacy.py
+++ b/tests/components/nest/test_config_flow_legacy.py
@@ -1,193 +1,223 @@
 """Tests for the Nest config flow."""
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 
-from homeassistant import data_entry_flow
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.nest import DOMAIN, config_flow
 from homeassistant.setup import async_setup_component
 
-from tests.common import mock_coro
+from tests.common import MockConfigEntry, mock_coro
+
+CONFIG = {DOMAIN: {"client_id": "bla", "client_secret": "bla"}}
 
 
 async def test_abort_if_no_implementation_registered(hass):
     """Test we abort if no implementation is registered."""
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
-
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "missing_configuration"
 
 
 async def test_abort_if_single_instance_allowed(hass):
     """Test we abort if Nest is already setup."""
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
+    existing_entry = MockConfigEntry(domain=DOMAIN, data={})
+    existing_entry.add_to_hass(hass)
 
-    with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
-        result = await flow.async_step_init()
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
 
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_full_flow_implementation(hass):
-    """Test registering an implementation and finishing flow works."""
-    gen_authorize_url = AsyncMock(return_value="https://example.com")
-    convert_code = AsyncMock(return_value={"access_token": "yoo"})
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, convert_code
-    )
+async def test_full_flow_implementation_with_multiple(hass):
+    """Test the flow with multiple auth implementations registered."""
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+    # Register an additional implementation to select from during the flow
     config_flow.register_flow_implementation(
         hass, "test-other", "Test Other", None, None
     )
 
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
-    result = await flow.async_step_init({"flow_impl": "test"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"flow_impl": "nest"},
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
-    assert result["description_placeholders"] == {"url": "https://example.com"}
-
-    result = await flow.async_step_link({"code": "123ABC"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["data"]["tokens"] == {"access_token": "yoo"}
-    assert result["data"]["impl_domain"] == "test"
-    assert result["title"] == "Nest (via Test)"
-
-
-async def test_not_pick_implementation_if_only_one(hass):
-    """Test we allow picking implementation if we have two."""
-    gen_authorize_url = AsyncMock(return_value="https://example.com")
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, None
+    assert (
+        result["description_placeholders"]
+        .get("url")
+        .startswith("https://home.nest.com/login/oauth2?client_id=bla")
     )
 
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
+    def mock_login(auth):
+        assert auth.pin == "123ABC"
+        auth.auth_callback({"access_token": "yoo"})
+
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.NestAuth.login", new=mock_login
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123ABC"}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["data"]["tokens"] == {"access_token": "yoo"}
+        assert result["data"]["impl_domain"] == "nest"
+        assert result["title"] == "Nest (via configuration.yaml)"
+
+
+async def test_flow_end_to_end(hass):
+    """Test the flow end to end with a single auth implementation."""
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
 
 
 async def test_abort_if_timeout_generating_auth_url(hass):
     """Test we abort if generating authorize url fails."""
-    gen_authorize_url = Mock(side_effect=asyncio.TimeoutError)
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, None
-    )
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.generate_auth_url",
+        side_effect=asyncio.TimeoutError,
+    ):
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
+        await hass.async_block_till_done()
 
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "authorize_url_timeout"
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "authorize_url_timeout"
 
 
 async def test_abort_if_exception_generating_auth_url(hass):
     """Test we abort if generating authorize url blows up."""
-    gen_authorize_url = Mock(side_effect=ValueError)
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, None
-    )
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.generate_auth_url",
+        side_effect=ValueError,
+    ):
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
+        await hass.async_block_till_done()
 
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "unknown_authorize_url_generation"
 
 
 async def test_verify_code_timeout(hass):
     """Test verify code timing out."""
-    gen_authorize_url = AsyncMock(return_value="https://example.com")
-    convert_code = Mock(side_effect=asyncio.TimeoutError)
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, convert_code
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
 
-    result = await flow.async_step_link({"code": "123ABC"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
-    assert result["errors"] == {"code": "timeout"}
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.NestAuth.login",
+        side_effect=asyncio.TimeoutError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123ABC"}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "link"
+        assert result["errors"] == {"code": "timeout"}
 
 
 async def test_verify_code_invalid(hass):
     """Test verify code invalid."""
-    gen_authorize_url = AsyncMock(return_value="https://example.com")
-    convert_code = Mock(side_effect=config_flow.CodeInvalid)
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, convert_code
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
 
-    result = await flow.async_step_link({"code": "123ABC"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
-    assert result["errors"] == {"code": "invalid_pin"}
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.NestAuth.login",
+        side_effect=config_flow.CodeInvalid,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123ABC"}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "link"
+        assert result["errors"] == {"code": "invalid_pin"}
 
 
 async def test_verify_code_unknown_error(hass):
     """Test verify code unknown error."""
-    gen_authorize_url = AsyncMock(return_value="https://example.com")
-    convert_code = Mock(side_effect=config_flow.NestAuthError)
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, convert_code
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
 
-    result = await flow.async_step_link({"code": "123ABC"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
-    assert result["errors"] == {"code": "unknown"}
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.NestAuth.login",
+        side_effect=config_flow.NestAuthError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123ABC"}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "link"
+        assert result["errors"] == {"code": "unknown"}
 
 
 async def test_verify_code_exception(hass):
     """Test verify code blows up."""
-    gen_authorize_url = AsyncMock(return_value="https://example.com")
-    convert_code = Mock(side_effect=ValueError)
-    config_flow.register_flow_implementation(
-        hass, "test", "Test", gen_authorize_url, convert_code
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-
-    flow = config_flow.NestFlowHandler()
-    flow.hass = hass
-    result = await flow.async_step_init()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"
 
-    result = await flow.async_step_link({"code": "123ABC"})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "link"
-    assert result["errors"] == {"code": "internal_error"}
+    with patch(
+        "homeassistant.components.nest.legacy.local_auth.NestAuth.login",
+        side_effect=ValueError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"code": "123ABC"}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "link"
+        assert result["errors"] == {"code": "internal_error"}
 
 
 async def test_step_import(hass):
     """Test that we trigger import when configuring with client."""
     with patch("os.path.isfile", return_value=False):
-        assert await async_setup_component(
-            hass, DOMAIN, {DOMAIN: {"client_id": "bla", "client_secret": "bla"}}
-        )
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
         await hass.async_block_till_done()
 
     flow = hass.config_entries.flow.async_progress()[0]
@@ -205,9 +235,7 @@ async def test_step_import_with_token_cache(hass):
     ), patch(
         "homeassistant.components.nest.async_setup_entry", return_value=mock_coro(True)
     ):
-        assert await async_setup_component(
-            hass, DOMAIN, {DOMAIN: {"client_id": "bla", "client_secret": "bla"}}
-        )
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
         await hass.async_block_till_done()
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]

--- a/tests/components/nest/test_config_flow_legacy.py
+++ b/tests/components/nest/test_config_flow_legacy.py
@@ -35,8 +35,8 @@ async def test_abort_if_single_instance_allowed(hass):
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_full_flow_implementation_with_multiple(hass):
-    """Test the flow with multiple auth implementations registered."""
+async def test_full_flow_implementation(hass):
+    """Test registering an implementation and finishing flow works."""
     assert await async_setup_component(hass, DOMAIN, CONFIG)
     await hass.async_block_till_done()
     # Register an additional implementation to select from during the flow
@@ -78,8 +78,8 @@ async def test_full_flow_implementation_with_multiple(hass):
         assert result["title"] == "Nest (via configuration.yaml)"
 
 
-async def test_flow_end_to_end(hass):
-    """Test the flow end to end with a single auth implementation."""
+async def test_not_pick_implementation_if_only_one(hass):
+    """Test we pick the default implementation when registered."""
     assert await async_setup_component(hass, DOMAIN, CONFIG)
     await hass.async_block_till_done()
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update legacy nest integration config flow tests to test the config flow actually through the integration APIs rather
than interacting with the config flow object directly. This is a pre-factoring pulled out of a larger config flow revamp
where we want to exercise the actual production code for initializing configuration, config flows, and authentication
implementations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
