### PR TITLE
Fix local_file partial tests

### DIFF
--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -14,7 +14,10 @@ async def test_loading_file(hass, hass_client):
 
     with mock.patch("os.path.isfile", mock.Mock(return_value=True)), mock.patch(
         "os.access", mock.Mock(return_value=True)
-    ), mock.patch("mimetypes.guess_type", mock.Mock(return_value=(None, None))):
+    ), mock.patch(
+        "homeassistant.components.local_file.camera.mimetypes.guess_type",
+        mock.Mock(return_value=(None, None)),
+    ):
         await async_setup_component(
             hass,
             "camera",
@@ -138,7 +141,10 @@ async def test_update_file_path(hass):
 
     with mock.patch("os.path.isfile", mock.Mock(return_value=True)), mock.patch(
         "os.access", mock.Mock(return_value=True)
-    ), mock.patch("mimetypes.guess_type", mock.Mock(return_value=(None, None))):
+    ), mock.patch(
+        "homeassistant.components.local_file.camera.mimetypes.guess_type",
+        mock.Mock(return_value=(None, None)),
+    ):
 
         camera_1 = {"platform": "local_file", "file_path": "mock/path.jpg"}
         camera_2 = {

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -14,7 +14,7 @@ async def test_loading_file(hass, hass_client):
 
     with mock.patch("os.path.isfile", mock.Mock(return_value=True)), mock.patch(
         "os.access", mock.Mock(return_value=True)
-    ):
+    ), mock.patch("mimetypes.guess_type", mock.Mock(return_value=(None, None))):
         await async_setup_component(
             hass,
             "camera",
@@ -138,7 +138,7 @@ async def test_update_file_path(hass):
 
     with mock.patch("os.path.isfile", mock.Mock(return_value=True)), mock.patch(
         "os.access", mock.Mock(return_value=True)
-    ):
+    ), mock.patch("mimetypes.guess_type", mock.Mock(return_value=(None, None))):
 
         camera_1 = {"platform": "local_file", "file_path": "mock/path.jpg"}
         camera_2 = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I am not sure why `mimetypes.guess_type` needs to be patched in 3.9, but if it not patched it causes error in the tests:
```
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity_platform.py", line 249, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/workspaces/home-assistant-core/homeassistant/components/local_file/camera.py", line 39, in setup_platform
    camera = LocalFile(config[CONF_NAME], file_path)
  File "/workspaces/home-assistant-core/homeassistant/components/local_file/camera.py", line 74, in __init__
    content, _ = mimetypes.guess_type(file_path)
  File "/usr/local/lib/python3.9/mimetypes.py", line 291, in guess_type
    init()
  File "/usr/local/lib/python3.9/mimetypes.py", line 364, in init
    db.read(file)
  File "/usr/local/lib/python3.9/mimetypes.py", line 205, in read
    with open(filename, encoding='utf-8') as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/etc/httpd/mime.types'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63021
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
