### PR TITLE
Hue allow per-device availability override

### DIFF
--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "hue"
 
 CONF_API_VERSION = "api_version"
+CONF_IGNORE_AVAILABILITY = "ignore_availability"
 
 CONF_SUBTYPE = "subtype"
 

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -70,7 +70,8 @@
         "data": {
           "allow_hue_groups": "Allow Hue groups",
           "allow_hue_scenes": "Allow Hue scenes",
-          "allow_unreachable": "Allow unreachable bulbs to report their state correctly"
+          "allow_unreachable": "Allow unreachable bulbs to report their state correctly",
+          "ignore_availability": "Ignore connectivity status for the given devices"
         }
       }
     }

--- a/homeassistant/components/hue/translations/en.json
+++ b/homeassistant/components/hue/translations/en.json
@@ -69,7 +69,8 @@
                 "data": {
                     "allow_hue_groups": "Allow Hue groups",
                     "allow_hue_scenes": "Allow Hue scenes",
-                    "allow_unreachable": "Allow unreachable bulbs to report their state correctly"
+                    "allow_unreachable": "Allow unreachable bulbs to report their state correctly",
+                    "ignore_availability": "Ignore connectivity status for the given devices"
                 }
             }
         }

--- a/homeassistant/components/hue/translations/nl.json
+++ b/homeassistant/components/hue/translations/nl.json
@@ -69,7 +69,8 @@
                 "data": {
                     "allow_hue_groups": "Sta Hue-groepen toe",
                     "allow_hue_scenes": "Sta Hue sc\u00e8nes toe",
-                    "allow_unreachable": "Onbereikbare lampen toestaan hun status correct te melden"
+                    "allow_unreachable": "Onbereikbare lampen toestaan hun status correct te melden",
+                    "ignore_availability": "Negeer beschikbaarheid status voor deze apparaten"
                 }
             }
         }

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 
 from ..bridge import HueBridge
-from ..const import DOMAIN
+from ..const import CONF_IGNORE_AVAILABILITY, DOMAIN
 
 RESOURCE_TYPE_NAMES = {
     # a simple mapping of hue resource type to Hass name
@@ -71,7 +71,7 @@ class HueBaseEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        self._check_availability_workaround()
+        self._check_availability()
         # Add value_changed callbacks.
         self.async_on_remove(
             self.controller.subscribe(
@@ -103,16 +103,16 @@ class HueBaseEntity(Entity):
     @property
     def available(self) -> bool:
         """Return entity availability."""
+        # entities without a device attached should be always available
         if self.device is None:
-            # entities without a device attached should be always available
             return True
+        # the zigbee connectivity sensor itself should be always available
         if self.resource.type == ResourceTypes.ZIGBEE_CONNECTIVITY:
-            # the zigbee connectivity sensor itself should be always available
             return True
         if self._ignore_availability:
             return True
+        # all device-attached entities get availability from the zigbee connectivity
         if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
-            # all device-attached entities get availability from the zigbee connectivity
             return zigbee.status == ConnectivityServiceStatus.CONNECTED
         return True
 
@@ -132,30 +132,41 @@ class HueBaseEntity(Entity):
             ent_reg.async_remove(self.entity_id)
         else:
             self.logger.debug("Received status update for %s", self.entity_id)
-            self._check_availability_workaround()
+            self._check_availability()
             self.on_update()
             self.async_write_ha_state()
 
     @callback
-    def _check_availability_workaround(self):
+    def _check_availability(self):
         """Check availability of the device."""
-        if self.resource.type != ResourceTypes.LIGHT:
-            return
+        # return if we already processed this entity
         if self._ignore_availability is not None:
-            # already processed
             return
+        # only do the availability check for entities connected to a device
+        if self.device is None:
+            return
+        # ignore availability if user added device to ignore list
+        if self.device.id in self.bridge.config_entry.options.get(
+            CONF_IGNORE_AVAILABILITY, []
+        ):
+            self._ignore_availability = True
+            self.logger.info(
+                "Device %s is configured to ignore availability status. ",
+                self.name,
+            )
+            return
+        # certified products (normally) report their state correctly
+        # no need for workaround/reporting
         if self.device.product_data.certified:
-            # certified products report their state correctly
             self._ignore_availability = False
             return
         # some (3th party) Hue lights report their connection status incorrectly
         # causing the zigbee availability to report as disconnected while in fact
-        # it can be controlled. Although this is in fact something the device manufacturer
-        # should fix, we work around it here. If the light is reported unavailable
+        # it can be controlled. If the light is reported unavailable
         # by the zigbee connectivity but the state changes its considered as a
         # malfunctioning device and we report it.
-        # while the user should actually fix this issue instead of ignoring it, we
-        # ignore the availability for this light from this point.
+        # While the user should actually fix this issue, we allow to
+        # ignore the availability for this light/device from the config options.
         cur_state = self.resource.on.on
         if self._last_state is None:
             self._last_state = cur_state
@@ -168,9 +179,9 @@ class HueBaseEntity(Entity):
                 # the device state changed from on->off or off->on
                 # while it was reported as not connected!
                 self.logger.warning(
-                    "Light %s changed state while reported as disconnected. "
-                    "This might be an indicator that routing is not working for this device. "
-                    "Home Assistant will ignore availability for this light from now on. "
+                    "Device %s changed state while reported as disconnected. "
+                    "This might be an indicator that routing is not working for this device "
+                    "or the device is having connectivity issues. "
                     "Device details: %s - %s (%s) fw: %s",
                     self.name,
                     self.device.product_data.manufacturer_name,
@@ -180,6 +191,4 @@ class HueBaseEntity(Entity):
                 )
                 # do we want to store this in some persistent storage?
                 self._ignore_availability = True
-            else:
-                self._ignore_availability = False
         self._last_state = cur_state

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -181,7 +181,7 @@ class HueBaseEntity(Entity):
                 self.logger.warning(
                     "Device %s changed state while reported as disconnected. "
                     "This might be an indicator that routing is not working for this device "
-                    "or the device is having connectivity issues. "
+                    "or the device is having connectivity issues. You can disable availability reporting for this device in the Hue options."
                     "Device details: %s - %s (%s) fw: %s",
                     self.name,
                     self.device.product_data.manufacturer_name,

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -181,7 +181,8 @@ class HueBaseEntity(Entity):
                 self.logger.warning(
                     "Device %s changed state while reported as disconnected. "
                     "This might be an indicator that routing is not working for this device "
-                    "or the device is having connectivity issues. You can disable availability reporting for this device in the Hue options."
+                    "or the device is having connectivity issues. "
+                    "You can disable availability reporting for this device in the Hue options. "
                     "Device details: %s - %s (%s) fw: %s",
                     self.name,
                     self.device.product_data.manufacturer_name,

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -80,7 +80,7 @@ class HueBaseEntity(Entity):
                 (EventType.RESOURCE_UPDATED, EventType.RESOURCE_DELETED),
             )
         )
-        # also subscribe to device update event to catch devicer changes (e.g. name)
+        # also subscribe to device update event to catch device changes (e.g. name)
         if self.device is None:
             return
         self.async_on_remove(
@@ -92,10 +92,12 @@ class HueBaseEntity(Entity):
         )
         # subscribe to zigbee_connectivity to catch availability changes
         if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
-            self.bridge.api.sensors.zigbee_connectivity.subscribe(
-                self._handle_event,
-                zigbee.id,
-                EventType.RESOURCE_UPDATED,
+            self.async_on_remove(
+                self.bridge.api.sensors.zigbee_connectivity.subscribe(
+                    self._handle_event,
+                    zigbee.id,
+                    EventType.RESOURCE_UPDATED,
+                )
             )
 
     @property

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -103,7 +103,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
         # Entities for Hue groups are disabled by default
         # unless they were enabled in old version (legacy option)
-        self._attr_entity_registry_enabled_default = bridge.config_entry.data.get(
+        self._attr_entity_registry_enabled_default = bridge.config_entry.options.get(
             CONF_ALLOW_HUE_GROUPS, False
         )
 


### PR DESCRIPTION
## Proposed change

Add options flow to Hue (V2) integration which allows the user to specify devices for which they want to completely ignore the availability status. For example for misbehaving (non routing) 3rd party bulbs or just lights in a remote location having some connectivity issues.

I kept the logging in the code so users have some sort of clue about misbehaving devices and/or connectivity issues.

This will fix all the reported availability issues as the user has now all control how to treat unavailable devices.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #62807 fixes #62717 fixes #62659
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
