### PR TITLE
Fix KNX Expose for strings longer than 14 bytes

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -252,12 +252,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if CONF_KNX_EXPOSE in config:
         for expose_config in config[CONF_KNX_EXPOSE]:
-            try:
-                knx_module.exposures.append(
-                    create_knx_exposure(hass, knx_module.xknx, expose_config)
-                )
-            except XKNXException:
-                _LOGGER.exception("Error during setup of expose sensor.")
+            knx_module.exposures.append(
+                create_knx_exposure(hass, knx_module.xknx, expose_config)
+            )
 
     hass.config_entries.async_setup_platforms(
         entry,

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -252,9 +252,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if CONF_KNX_EXPOSE in config:
         for expose_config in config[CONF_KNX_EXPOSE]:
-            knx_module.exposures.append(
-                create_knx_exposure(hass, knx_module.xknx, expose_config)
-            )
+            try:
+                knx_module.exposures.append(
+                    create_knx_exposure(hass, knx_module.xknx, expose_config)
+                )
+            except XKNXException:
+                _LOGGER.exception("Error during setup of expose sensor.")
 
     hass.config_entries.async_setup_platforms(
         entry,

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -108,7 +108,7 @@ class KNXExposeSensor:
         try:
             self.device.sensor_value.value = state_value
         except ConversionError:
-            _LOGGER.exception("Error during sending of expose sensor value.")
+            _LOGGER.exception("Error during sending of expose sensor value")
 
     @callback
     def shutdown(self) -> None:
@@ -162,7 +162,7 @@ class KNXExposeSensor:
         try:
             await self.device.set(value)
         except ConversionError:
-            _LOGGER.exception("Error during sending of expose sensor value.")
+            _LOGGER.exception("Error during sending of expose sensor value")
 
 
 class KNXExposeTime:

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @callback
 def create_knx_exposure(
-        hass: HomeAssistant, xknx: XKNX, config: ConfigType
+    hass: HomeAssistant, xknx: XKNX, config: ConfigType
 ) -> KNXExposeSensor | KNXExposeTime:
     """Create exposures from config."""
     address = config[KNX_ADDRESS]
@@ -39,8 +39,8 @@ def create_knx_exposure(
 
     exposure: KNXExposeSensor | KNXExposeTime
     if (
-            isinstance(expose_type, str)
-            and expose_type.lower() in ExposeSchema.EXPOSE_TIME_TYPES
+        isinstance(expose_type, str)
+        and expose_type.lower() in ExposeSchema.EXPOSE_TIME_TYPES
     ):
         exposure = KNXExposeTime(xknx, expose_type, address)
     else:
@@ -61,14 +61,14 @@ class KNXExposeSensor:
     """Object to Expose Home Assistant entity to KNX bus."""
 
     def __init__(
-            self,
-            hass: HomeAssistant,
-            xknx: XKNX,
-            expose_type: int | str,
-            entity_id: str,
-            attribute: str | None,
-            default: StateType,
-            address: str,
+        self,
+        hass: HomeAssistant,
+        xknx: XKNX,
+        expose_type: int | str,
+        entity_id: str,
+        attribute: str | None,
+        default: StateType,
+        address: str,
     ) -> None:
         """Initialize of Expose class."""
         self.hass = hass
@@ -139,8 +139,11 @@ class KNXExposeSensor:
             and issubclass(self.device.sensor_value.dpt_class, DPTNumeric)
         ):
             return float(value)
-        if (value is not None
-                and issubclass(self.device.sensor_value.dpt_class, DPTString)):
+        if (
+            value is not None
+            and isinstance(self.device.sensor_value, RemoteValueSensor)
+            and issubclass(self.device.sensor_value.dpt_class, DPTString)
+        ):
             # DPT 16.000 only allows up to 14 Bytes
             return str(value)[:14]
         return value

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 from xknx import XKNX
 from xknx.devices import DateTime, ExposeSensor
-from xknx.dpt import DPTNumeric
+from xknx.dpt import DPTNumeric, DPTString
 from xknx.remote_value import RemoteValueSensor
 
 from homeassistant.const import (
@@ -25,7 +25,7 @@ from .schema import ExposeSchema
 
 @callback
 def create_knx_exposure(
-    hass: HomeAssistant, xknx: XKNX, config: ConfigType
+        hass: HomeAssistant, xknx: XKNX, config: ConfigType
 ) -> KNXExposeSensor | KNXExposeTime:
     """Create exposures from config."""
     address = config[KNX_ADDRESS]
@@ -35,8 +35,8 @@ def create_knx_exposure(
 
     exposure: KNXExposeSensor | KNXExposeTime
     if (
-        isinstance(expose_type, str)
-        and expose_type.lower() in ExposeSchema.EXPOSE_TIME_TYPES
+            isinstance(expose_type, str)
+            and expose_type.lower() in ExposeSchema.EXPOSE_TIME_TYPES
     ):
         exposure = KNXExposeTime(xknx, expose_type, address)
     else:
@@ -57,14 +57,14 @@ class KNXExposeSensor:
     """Object to Expose Home Assistant entity to KNX bus."""
 
     def __init__(
-        self,
-        hass: HomeAssistant,
-        xknx: XKNX,
-        expose_type: int | str,
-        entity_id: str,
-        attribute: str | None,
-        default: StateType,
-        address: str,
+            self,
+            hass: HomeAssistant,
+            xknx: XKNX,
+            expose_type: int | str,
+            entity_id: str,
+            attribute: str | None,
+            default: StateType,
+            address: str,
     ) -> None:
         """Initialize of Expose class."""
         self.hass = hass
@@ -132,6 +132,10 @@ class KNXExposeSensor:
             and issubclass(self.device.sensor_value.dpt_class, DPTNumeric)
         ):
             return float(value)
+        if (value is not None
+                and issubclass(self.device.sensor_value.dpt_class, DPTString)):
+            # DPT 16.000 only allows up to 14 Bytes
+            return str(value)[:14]
         return value
 
     async def _async_entity_changed(self, event: Event) -> None:

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -130,6 +130,7 @@ async def test_expose_attribute_with_default(hass: HomeAssistant, knx: KNXTestKi
 
 async def test_expose_string(hass: HomeAssistant, knx: KNXTestKit):
     """Test an expose to send string values of up to 14 bytes only."""
+
     entity_id = "fake.entity"
     attribute = "fake_attribute"
     await knx.setup_integration(
@@ -174,6 +175,7 @@ async def test_expose_with_date(localtime, hass: HomeAssistant, knx: KNXTestKit)
             }
         }
     )
+    assert not hass.states.async_all()
 
     await knx.assert_write("1/1/8", (0x7A, 0x1, 0x7, 0xE9, 0xD, 0xE, 0x20, 0x80))
 

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -139,14 +139,17 @@ async def test_expose_string(hass: HomeAssistant, knx: KNXTestKit):
                 KNX_ADDRESS: "1/1/8",
                 CONF_ENTITY_ID: entity_id,
                 CONF_ATTRIBUTE: attribute,
+                ExposeSchema.CONF_KNX_EXPOSE_DEFAULT: "Test",
             }
         },
     )
     assert not hass.states.async_all()
 
-    # Before init no response shall be sent
+    # Before init default value shall be sent as response
     await knx.receive_read("1/1/8")
-    await knx.assert_telegram_count(0)
+    await knx.assert_response(
+        "1/1/8", (84, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    )
 
     # Change attribute; keep state
     hass.states.async_set(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
KNX Expose should not try to send too long strings. The underlying data type allows a maximum of 14 bytes which for ASCII, is 14 characters.

This PR cuts the remaining characters if the string is too long and avoids an exception in the library. Users shouldn't have to deal with this error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/62826
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
