### PR TITLE
Add new service for generating QR code for guest wifi credentials

### DIFF
--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -19,6 +19,8 @@ DATA_FRITZ = "fritz_data"
 DSL_CONNECTION: Literal["dsl"] = "dsl"
 
 DEFAULT_DEVICE_NAME = "Unknown device"
+DEFAULT_GUEST_WIFI_ENCRYPTION = "WPA/WPA2"
+DEFAULT_GUEST_WIFI_QR_FILENAME = "fritz_guest_wifi_qr.svg"
 DEFAULT_HOST = "192.168.178.1"
 DEFAULT_PORT = 49000
 DEFAULT_USERNAME = ""
@@ -31,6 +33,7 @@ FRITZ_SERVICES = "fritz_services"
 SERVICE_REBOOT = "reboot"
 SERVICE_RECONNECT = "reconnect"
 SERVICE_CLEANUP = "cleanup"
+SERVICE_GEN_GUEST_WIFI_QR = "generate_guest_wifi_qr"
 
 SWITCH_TYPE_DEFLECTION = "CallDeflection"
 SWITCH_TYPE_PORTFORWARD = "PortForward"

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/fritz",
   "requirements": [
     "fritzconnection==1.7.2",
+    "PyQRCode==1.2.1",
     "xmltodict==0.12.0"
   ],
   "dependencies": ["network"],

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -10,6 +10,7 @@ from .const import (
     DOMAIN,
     FRITZ_SERVICES,
     SERVICE_CLEANUP,
+    SERVICE_GEN_GUEST_WIFI_QR,
     SERVICE_REBOOT,
     SERVICE_RECONNECT,
 )
@@ -17,7 +18,12 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-SERVICE_LIST = [SERVICE_CLEANUP, SERVICE_REBOOT, SERVICE_RECONNECT]
+SERVICE_LIST = [
+    SERVICE_CLEANUP,
+    SERVICE_REBOOT,
+    SERVICE_RECONNECT,
+    SERVICE_GEN_GUEST_WIFI_QR,
+]
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:

--- a/homeassistant/components/fritz/services.yaml
+++ b/homeassistant/components/fritz/services.yaml
@@ -35,3 +35,23 @@ cleanup:
           integration: fritz
           entity:
             device_class: connectivity
+
+generate_guest_wifi_qr:
+  name: Generate QR code for guest wifi
+  description: Generates a QR code for the guest wifi. The QR code will be located in /config/www.
+  fields:
+    device_id:
+      name: Fritz!Box Device
+      description: Select the Fritz!Box to check
+      required: true
+      selector:
+        device:
+          integration: fritz
+          entity:
+            device_class: connectivity
+    filename:
+      name: Filename
+      description: Name of the qr code file. Filename must be specified with SVG ending.
+      required: false
+      selector:
+        text:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,6 +39,7 @@ PyMata==2.20
 PyNaCl==1.4.0
 
 # homeassistant.auth.mfa_modules.totp
+# homeassistant.components.fritz
 # homeassistant.components.homekit
 PyQRCode==1.2.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -20,6 +20,7 @@ PyFlick==0.0.2
 PyNaCl==1.4.0
 
 # homeassistant.auth.mfa_modules.totp
+# homeassistant.components.fritz
 # homeassistant.components.homekit
 PyQRCode==1.2.1
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new service to the `fritz` integration to generate a QR code for the guest wifi credentials. The generated QR code will be saved in the `www` root dir. The QR code will be saved as SVG file. After calling the service its possible to show the code in the frontend by using the `camera` component (to prevent browser caching):

```
camera:
  - platform: generic
    name: Fritz Guest QR
    still_image_url: http://127.0.0.1:8123/local/fritz_guest_wifi_qr.svg
    content_type: image/svg+xml
```

## Type of changes
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
