### PR TITLE
Add additional service to set advanced Hue scene options

### DIFF
--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -59,13 +59,13 @@ async def async_setup_entry(
         {
             vol.Optional(ATTR_DYNAMIC): vol.Coerce(bool),
             vol.Optional(ATTR_SPEED): vol.All(
-                vol.Coerce(int), vol.Clamp(min=0, max=100)
+                vol.Coerce(int), vol.Range(min=0, max=100)
             ),
             vol.Optional(ATTR_TRANSITION): vol.All(
-                vol.Coerce(float), vol.Clamp(min=0, max=300)
+                vol.Coerce(float), vol.Range(min=0, max=600)
             ),
             vol.Optional(ATTR_BRIGHTNESS): vol.All(
-                vol.Coerce(int), vol.Clamp(min=0, max=255)
+                vol.Coerce(int), vol.Range(min=0, max=255)
             ),
         },
         "async_activate",

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -5,25 +5,29 @@ from typing import Any
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
-from aiohue.v2.controllers.scenes import ScenesController
-from aiohue.v2.models.scene import Scene as HueScene
+from aiohue.v2.controllers.scenes import Scene as HueScene, ScenesController
+import voluptuous as vol
 
-from homeassistant.components.light import ATTR_TRANSITION
-from homeassistant.components.scene import Scene as SceneEntity
+from homeassistant.components.scene import ATTR_TRANSITION, Scene as SceneEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import entity_platform
 
 from .bridge import HueBridge
 from .const import DOMAIN
 from .v2.entity import HueBaseEntity
 from .v2.helpers import normalize_hue_transition
 
+SERVICE_ACTIVATE_SCENE = "activate_scene"
+ATTR_DYNAMIC = "dynamic"
+ATTR_SPEED = "speed"
+ATTR_BRIGHTNESS = "brightness"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: entity_platform.AddEntitiesCallback,
 ) -> None:
     """Set up scene platform from Hue group scenes."""
     bridge: HueBridge = hass.data[DOMAIN][config_entry.entry_id]
@@ -46,6 +50,19 @@ async def async_setup_entry(
     # register listener for new items only
     config_entry.async_on_unload(
         api.scenes.subscribe(async_add_entity, event_filter=EventType.RESOURCE_ADDED)
+    )
+
+    # add platform service to turn_on/activate scene with advanced options
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_ACTIVATE_SCENE,
+        {
+            vol.Optional(ATTR_DYNAMIC): vol.Coerce(int),
+            vol.Optional(ATTR_SPEED): vol.Coerce(int),
+            vol.Optional(ATTR_TRANSITION): vol.Coerce(int),
+            vol.Optional(ATTR_BRIGHTNESS): vol.Coerce(int),
+        },
+        "async_activate",
     )
 
 
@@ -97,13 +114,26 @@ class HueSceneEntity(HueBaseEntity, SceneEntity):
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate Hue scene."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
-        dynamic = kwargs.get("dynamic", self.is_dynamic)
+        # the options below are advanced only
+        # as we're not allowed to override the default scene turn_on service
+        # we've implemented a `activate_scene` entity service
+        dynamic = kwargs.get(ATTR_DYNAMIC, False)
+        speed = kwargs.get(ATTR_SPEED)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        if speed is not None:
+            await self.bridge.async_request_call(
+                self.controller.update,
+                self.resource.id,
+                HueScene(self.resource.id, speed=speed / 100),
+            )
 
         await self.bridge.async_request_call(
             self.controller.recall,
             self.resource.id,
             dynamic=dynamic,
             duration=transition,
+            brightness=brightness,
         )
 
     @property

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -30,6 +30,7 @@ activate_scene:
   target:
     entity:
       domain: scene
+      integration: hue
   fields:
     transition:
       name: Transition
@@ -60,4 +61,4 @@ activate_scene:
       selector:
         number:
           min: 0
-          max: 100
+          max: 255

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -1,5 +1,6 @@
 # Describes the format for available hue services
 
+# legacy hue_activate_scene to activate a scene
 hue_activate_scene:
   name: Activate scene
   description: Activate a hue scene stored in the hue hub.
@@ -21,3 +22,42 @@ hue_activate_scene:
       description: Enable dynamic mode of the scene (V2 bridges and supported scenes only).
       selector:
         boolean:
+
+# entity service to activate a Hue scene (V2)
+activate_scene:
+  name: Activate Hue Scene
+  description: Activate a Hue scene with more control over the options.
+  target:
+    entity:
+      domain: scene
+  fields:
+    transition:
+      name: Transition
+      description: Transition duration it takes to bring devices to the state
+        defined in the scene.
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: seconds
+    dynamic:
+      name: Dynamic
+      description: Enable dynamic mode of the scene.
+      selector:
+        boolean:
+    speed:
+      name: Speed
+      description: Speed of dynamic palette for this scene
+      advanced: true
+      selector:
+        number:
+          min: 0
+          max: 100
+    brightness:
+      name: Brightness
+      description: Set brightness for the scene.
+      advanced: true
+      selector:
+        number:
+          min: 0
+          max: 100

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -7,6 +7,7 @@ from typing import Any
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.groups import GroupedLight, Room, Zone
+from aiohue.v2.models.feature import DynamicsFeatureStatus
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -105,7 +106,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         self._attr_entity_registry_enabled_default = bridge.config_entry.data.get(
             CONF_ALLOW_HUE_GROUPS, False
         )
-
+        self._dynamic_mode_active = False
         self._update_values()
 
     async def async_added_to_hass(self) -> None:
@@ -148,6 +149,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             "hue_scenes": scenes,
             "hue_type": self.group.type.value,
             "lights": lights,
+            "dynamics": self._dynamic_mode_active,
         }
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -261,6 +263,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         total_brightness = 0
         all_lights = self.controller.get_lights(self.resource.id)
         lights_in_colortemp_mode = 0
+        lights_in_dynamic_mode = 0
         # loop through all lights to find capabilities
         for light in all_lights:
             if color_temp := light.color_temperature:
@@ -278,6 +281,12 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             if dimming := light.dimming:
                 lights_with_dimming_support += 1
                 total_brightness += dimming.brightness
+            if (
+                light.dynamics
+                and light.dynamics.status == DynamicsFeatureStatus.DYNAMIC_PALETTE
+            ):
+                lights_in_dynamic_mode += 1
+
         # this is a bit hacky because light groups may contain lights
         # of different capabilities. We set a colormode as supported
         # if any of the lights support it
@@ -296,6 +305,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             )
         else:
             supported_color_modes.add(COLOR_MODE_ONOFF)
+        self._dynamic_mode_active = lights_in_dynamic_mode > 0
         self._attr_supported_color_modes = supported_color_modes
         # pick a winner for the current colormode
         if lights_in_colortemp_mode == lights_with_color_temp_support:

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -87,6 +87,43 @@ async def test_scene_turn_on_service(hass, mock_bridge_v2, v2_resources_test_dat
     }
 
 
+async def test_scene_advanced_turn_on_service(
+    hass, mock_bridge_v2, v2_resources_test_data
+):
+    """Test calling the advanced turn on service on a scene."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+
+    await setup_platform(hass, mock_bridge_v2, "scene")
+
+    test_entity_id = "scene.test_room_regular_test_scene"
+
+    # call the hue.activate_scene service
+    await hass.services.async_call(
+        "hue",
+        "activate_scene",
+        {"entity_id": test_entity_id},
+        blocking=True,
+    )
+
+    # PUT request should have been sent to device with correct params
+    assert len(mock_bridge_v2.mock_requests) == 1
+    assert mock_bridge_v2.mock_requests[0]["method"] == "put"
+    assert mock_bridge_v2.mock_requests[0]["json"]["recall"] == {"action": "active"}
+
+    # test again with sending speed and dynamic
+    await hass.services.async_call(
+        "hue",
+        "activate_scene",
+        {"entity_id": test_entity_id, "speed": 80, "dynamic": True},
+        blocking=True,
+    )
+    assert len(mock_bridge_v2.mock_requests) == 3
+    assert mock_bridge_v2.mock_requests[1]["json"]["speed"] == 0.8
+    assert mock_bridge_v2.mock_requests[2]["json"]["recall"] == {
+        "action": "dynamic_palette",
+    }
+
+
 async def test_scene_updates(hass, mock_bridge_v2, v2_resources_test_data):
     """Test scene events from bridge."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)


### PR DESCRIPTION
## Proposed change

Hue accepts a few parameters when activating a scene, such as the brightness, speed and most important, if it needs to run in dynamic mode or not. Our current default is to enable dynamic mode when activating a scene but Hue recently changed something that even normal scenes can be run as dynamic. 

Because we can't override the default scene.turn_on parameters, I've implemented a second "activate_scene" entity service which accepts those additional params. Left the params in the default turn_on method to be future proof when we are allowed to send additional (integration specific) parameters to a turn_on service.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #61554
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
