### PR TITLE
Add full test coverage to CPU Speed

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -179,8 +179,6 @@ omit =
     homeassistant/components/coolmaster/climate.py
     homeassistant/components/coolmaster/const.py
     homeassistant/components/cppm_tracker/device_tracker.py
-    homeassistant/components/cpuspeed/__init__.py
-    homeassistant/components/cpuspeed/sensor.py
     homeassistant/components/crownstone/__init__.py
     homeassistant/components/crownstone/const.py
     homeassistant/components/crownstone/listeners.py

--- a/homeassistant/components/cpuspeed/sensor.py
+++ b/homeassistant/components/cpuspeed/sensor.py
@@ -74,12 +74,12 @@ class CPUSpeedSensor(SensorEntity):
         """Get the latest data and updates the state."""
         info = cpuinfo.get_cpu_info()
 
-        if info is not None and HZ_ACTUAL in info:
+        if info and HZ_ACTUAL in info:
             self._attr_native_value = round(float(info[HZ_ACTUAL][0]) / 10 ** 9, 2)
         else:
             self._attr_native_value = None
 
-        if info is not None:
+        if info:
             self._attr_extra_state_attributes = {
                 ATTR_ARCH: info["arch_string_raw"],
                 ATTR_BRAND: info["brand_raw"],

--- a/tests/components/cpuspeed/conftest.py
+++ b/tests/components/cpuspeed/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant.components.cpuspeed.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -43,3 +44,33 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.cpuspeed.async_setup_entry", return_value=True
     ) as mock_setup:
         yield mock_setup
+
+
+@pytest.fixture
+def mock_cpuinfo() -> Generator[MagicMock, None, None]:
+    """Return a mocked get_cpu_info."""
+    info = {
+        "hz_actual": (3200000001, 0),
+        "arch_string_raw": "aargh",
+        "brand_raw": "Intel Ryzen 7",
+        "hz_advertised": (3600000001, 0),
+    }
+
+    with patch(
+        "homeassistant.components.cpuspeed.cpuinfo.get_cpu_info",
+        return_value=info,
+    ) as cpuinfo_mock:
+        yield cpuinfo_mock
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_cpuinfo: MagicMock
+) -> MockConfigEntry:
+    """Set up the CPU Speed integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/cpuspeed/test_init.py
+++ b/tests/components/cpuspeed/test_init.py
@@ -1,0 +1,64 @@
+"""Tests for the CPU Speed integration."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.cpuspeed.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_cpuinfo: MagicMock,
+) -> None:
+    """Test the CPU Speed configuration entry loading/unloading."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert len(mock_cpuinfo.mock_calls) == 2
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.data.get(DOMAIN)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_config_entry_not_compatible(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_cpuinfo: MagicMock,
+) -> None:
+    """Test the CPU Speed configuration entry loading/unloading."""
+    mock_config_entry.add_to_hass(hass)
+    mock_cpuinfo.return_value = {}
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert len(mock_cpuinfo.mock_calls) == 1
+
+
+async def test_import_config(
+    hass: HomeAssistant,
+    mock_cpuinfo: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the CPU Speed being set up from config via import."""
+    assert await async_setup_component(
+        hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: {"platform": DOMAIN}}
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert len(mock_cpuinfo.mock_calls) == 3
+    assert "the CPU Speed platform in YAML is deprecated" in caplog.text

--- a/tests/components/cpuspeed/test_init.py
+++ b/tests/components/cpuspeed/test_init.py
@@ -36,6 +36,7 @@ async def test_config_entry_not_compatible(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_cpuinfo: MagicMock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the CPU Speed configuration entry loading on an unsupported system."""
     mock_config_entry.add_to_hass(hass)
@@ -46,6 +47,7 @@ async def test_config_entry_not_compatible(
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert len(mock_cpuinfo.mock_calls) == 1
+    assert "is not compatible with your system" in caplog.text
 
 
 async def test_import_config(

--- a/tests/components/cpuspeed/test_init.py
+++ b/tests/components/cpuspeed/test_init.py
@@ -37,7 +37,7 @@ async def test_config_entry_not_compatible(
     mock_config_entry: MockConfigEntry,
     mock_cpuinfo: MagicMock,
 ) -> None:
-    """Test the CPU Speed configuration entry loading/unloading."""
+    """Test the CPU Speed configuration entry loading on an unsupported system."""
     mock_config_entry.add_to_hass(hass)
     mock_cpuinfo.return_value = {}
 

--- a/tests/components/cpuspeed/test_sensor.py
+++ b/tests/components/cpuspeed/test_sensor.py
@@ -1,0 +1,63 @@
+"""Tests for the sensor provided by the CPU Speed integration."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.cpuspeed.sensor import ATTR_ARCH, ATTR_BRAND, ATTR_HZ
+from homeassistant.components.homeassistant import (
+    DOMAIN as HOME_ASSISTANT_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensor(
+    hass: HomeAssistant,
+    mock_cpuinfo: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the CPU Speed sensor."""
+    await async_setup_component(hass, "homeassistant", {})
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get("sensor.cpu_speed")
+    assert entry
+    assert entry.unique_id == entry.config_entry_id
+    assert entry.entity_category is None
+
+    state = hass.states.get("sensor.cpu_speed")
+    assert state
+    assert state.state == "3.2"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "CPU Speed"
+    assert state.attributes.get(ATTR_ICON) == "mdi:pulse"
+    assert ATTR_DEVICE_CLASS not in state.attributes
+
+    assert state.attributes.get(ATTR_ARCH) == "aargh"
+    assert state.attributes.get(ATTR_BRAND) == "Intel Ryzen 7"
+    assert state.attributes.get(ATTR_HZ) == 3.6
+
+    mock_cpuinfo.return_value = {}
+    await hass.services.async_call(
+        HOME_ASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: "sensor.cpu_speed"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.cpu_speed")
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ARCH) == "aargh"
+    assert state.attributes.get(ATTR_BRAND) == "Intel Ryzen 7"
+    assert state.attributes.get(ATTR_HZ) == 3.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Brings up test coverage to 100% for the CPU Speed integration.
Fixes one possible bug found when info returns an empty dict.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
