### PR TITLE
Simplify nest reauth config flow

### DIFF
--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -80,9 +80,7 @@ class OAuthFixture:
         assert result["type"] == "form"
         assert result["step_id"] == "pick_implementation"
 
-        return await self.hass.config_entries.flow.async_configure(
-            result["flow_id"], {"implementation": auth_domain}
-        )
+        return await self.async_configure(result, {"implementation": auth_domain})
 
     async def async_oauth_web_flow(self, result: dict) -> None:
         """Invoke the oauth flow for Web Auth with fake responses."""
@@ -169,9 +167,7 @@ class OAuthFixture:
         with patch(
             "homeassistant.components.nest.async_setup_entry", return_value=True
         ) as mock_setup:
-            await self.hass.config_entries.flow.async_configure(
-                result["flow_id"], user_input
-            )
+            await self.async_configure(result, user_input)
             assert len(mock_setup.mock_calls) == 1
             await self.hass.async_block_till_done()
         return self.get_config_entry()
@@ -542,7 +538,7 @@ async def test_pubsub_subscriber_config_entry_reauth(hass, oauth, subscriber):
         hass,
         {
             "auth_implementation": APP_AUTH_DOMAIN,
-            "subscription_id": SUBSCRIBER_ID,
+            "subscriber_id": SUBSCRIBER_ID,
             "cloud_project_id": CLOUD_PROJECT_ID,
             "token": {
                 "access_token": "some-revoked-token",
@@ -552,22 +548,9 @@ async def test_pubsub_subscriber_config_entry_reauth(hass, oauth, subscriber):
     )
     result = await oauth.async_reauth(old_entry.data)
     await oauth.async_oauth_app_flow(result)
-    result = await oauth.async_configure(result, {"code": "1234"})
 
-    # Configure Pub/Sub
-    await oauth.async_pubsub_flow(result, cloud_project_id=CLOUD_PROJECT_ID)
-
-    # Verify existing tokens are replaced
-    with patch(
-        "homeassistant.components.nest.api.GoogleNestSubscriber",
-        return_value=subscriber,
-    ):
-        entry = await oauth.async_finish_setup(
-            result, {"cloud_project_id": "other-cloud-project-id"}
-        )
-        await hass.async_block_till_done()
-
-    entry = oauth.get_config_entry()
+    # Entering an updated access token refreshs the config entry.
+    entry = await oauth.async_finish_setup(result, {"code": "1234"})
     entry.data["token"].pop("expires_at")
     assert entry.unique_id == DOMAIN
     assert entry.data["token"] == {
@@ -577,7 +560,5 @@ async def test_pubsub_subscriber_config_entry_reauth(hass, oauth, subscriber):
         "expires_in": 60,
     }
     assert entry.data["auth_implementation"] == APP_AUTH_DOMAIN
-    assert (
-        "projects/other-cloud-project-id/subscriptions" in entry.data["subscriber_id"]
-    )
-    assert entry.data["cloud_project_id"] == "other-cloud-project-id"
+    assert entry.data["subscriber_id"] == SUBSCRIBER_ID
+    assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify nest reauth config flow by skipping review of the pub/sub subscriber
when performing re-auth. We can simply preserve the existing configuration
rather than having the user walk through the steps again, given all we
really need to do is refresh auth tokens.

This is a pre-factoring step pulled out of another larger nest config flow revamp. I think when originally adding this I was worried users may need a way to go back and fix the subscriber if there is a mistake, but it seems to be working very well and this is not necessarily. It makes future config flow features complex to reason about, so removing this.

Also fixes a bug in the test where the existing config entry had an incorrect field name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
