### PR TITLE
Add configuration flow to Whois

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1268,6 +1268,7 @@ omit =
     homeassistant/components/waze_travel_time/helpers.py
     homeassistant/components/waze_travel_time/sensor.py
     homeassistant/components/webostv/*
+    homeassistant/components/whois/__init__.py
     homeassistant/components/whois/sensor.py
     homeassistant/components/wiffi/*
     homeassistant/components/wirelesstag/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1035,6 +1035,7 @@ tests/components/wemo/* @esev
 homeassistant/components/whirlpool/* @abmantis
 tests/components/whirlpool/* @abmantis
 homeassistant/components/whois/* @frenck
+tests/components/whois/* @frenck
 homeassistant/components/wiffi/* @mampfes
 tests/components/wiffi/* @mampfes
 homeassistant/components/wilight/* @leofig-rj

--- a/homeassistant/components/whois/__init__.py
+++ b/homeassistant/components/whois/__init__.py
@@ -1,1 +1,16 @@
-"""The whois component."""
+"""The Whois integration."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import PLATFORMS
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up from a config entry."""
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/whois/config_flow.py
+++ b/homeassistant/components/whois/config_flow.py
@@ -1,0 +1,52 @@
+"""Config flow to configure the Whois integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_DOMAIN, CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+
+class WhoisFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Config flow for Whois."""
+
+    VERSION = 1
+
+    imported_name: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_DOMAIN].lower())
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=self.imported_name or str(user_input[CONF_DOMAIN]),
+                data={
+                    CONF_DOMAIN: user_input[CONF_DOMAIN].lower(),
+                },
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DOMAIN): str,
+                }
+            ),
+        )
+
+    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+        """Handle a flow initialized by importing a config."""
+        self.imported_name = config[CONF_NAME]
+        return await self.async_step_user(
+            user_input={
+                CONF_DOMAIN: config[CONF_DOMAIN],
+            }
+        )

--- a/homeassistant/components/whois/config_flow.py
+++ b/homeassistant/components/whois/config_flow.py
@@ -27,7 +27,7 @@ class WhoisFlowHandler(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_DOMAIN].lower())
             self._abort_if_unique_id_configured()
             return self.async_create_entry(
-                title=self.imported_name or str(user_input[CONF_DOMAIN]),
+                title=self.imported_name or user_input[CONF_DOMAIN],
                 data={
                     CONF_DOMAIN: user_input[CONF_DOMAIN].lower(),
                 },

--- a/homeassistant/components/whois/const.py
+++ b/homeassistant/components/whois/const.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import logging
 from typing import Final
 
+from homeassistant.const import Platform
+
 DOMAIN: Final = "whois"
+PLATFORMS = [Platform.SENSOR]
 
 LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/whois/manifest.json
+++ b/homeassistant/components/whois/manifest.json
@@ -3,6 +3,7 @@
   "name": "Whois",
   "documentation": "https://www.home-assistant.io/integrations/whois",
   "requirements": ["python-whois==0.7.3"],
+  "config_flow": true,
   "codeowners": ["@frenck"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -24,7 +24,7 @@ from .const import (
     LOGGER,
 )
 
-SCANTERVAL = timedelta(hours=24)
+SCAN_INTERVAL = timedelta(hours=24)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 import whois
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_DOMAIN, CONF_NAME, TIME_DAYS
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -19,6 +20,7 @@ from .const import (
     ATTR_REGISTRAR,
     ATTR_UPDATED,
     DEFAULT_NAME,
+    DOMAIN,
     LOGGER,
 )
 
@@ -39,20 +41,39 @@ def setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the WHOIS sensor."""
-    domain = config[CONF_DOMAIN]
-    name = config[CONF_NAME]
+    LOGGER.warning(
+        "Configuration of the Whois platform in YAML is deprecated and will be "
+        "removed in Home Assistant 2022.4; Your existing configuration "
+        "has been imported into the UI automatically and can be safely removed "
+        "from your configuration.yaml file"
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_NAME: config[CONF_NAME]},
+        )
+    )
 
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the platform from config_entry."""
+    domain = entry.data[CONF_DOMAIN]
     try:
-        if "expiration_date" in whois.whois(domain):
-            add_entities([WhoisSensor(name, domain)], True)
-        else:
-            LOGGER.error(
-                "WHOIS lookup for %s didn't contain an expiration date", domain
-            )
-            return
+        info = await hass.async_add_executor_job(whois.whois, domain)
     except whois.BaseException as ex:  # pylint: disable=broad-except
         LOGGER.error("Exception %s occurred during WHOIS lookup for %s", ex, domain)
         return
+
+    if "expiration_date" not in info:
+        LOGGER.error("WHOIS lookup for %s didn't contain an expiration date", domain)
+        return
+
+    async_add_entities([WhoisSensor(domain)], True)
 
 
 class WhoisSensor(SensorEntity):
@@ -61,11 +82,11 @@ class WhoisSensor(SensorEntity):
     _attr_icon = "mdi:calendar-clock"
     _attr_native_unit_of_measurement = TIME_DAYS
 
-    def __init__(self, name: str, domain: str) -> None:
+    def __init__(self, domain: str) -> None:
         """Initialize the sensor."""
+        self._attr_name = domain
         self.whois = whois.whois
         self._domain = domain
-        self._attr_name = name
 
     def _empty_value_and_attributes(self) -> None:
         """Empty the state and attributes on an error."""

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -51,7 +51,7 @@ def setup_platform(
         hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_IMPORT},
-            data={CONF_NAME: config[CONF_NAME]},
+            data={CONF_DOMAIN: config[CONF_DOMAIN], CONF_NAME: config[CONF_NAME]},
         )
     )
 

--- a/homeassistant/components/whois/strings.json
+++ b/homeassistant/components/whois/strings.json
@@ -6,6 +6,9 @@
           "domain": "Domain name"
         }
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }
   }
 }

--- a/homeassistant/components/whois/strings.json
+++ b/homeassistant/components/whois/strings.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "domain": "Domain name"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/whois/translations/en.json
+++ b/homeassistant/components/whois/translations/en.json
@@ -1,5 +1,8 @@
 {
     "config": {
+        "abort": {
+            "already_configured": "Service is already configured"
+        },
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/whois/translations/en.json
+++ b/homeassistant/components/whois/translations/en.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "data": {
+                    "domain": "Domain name"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -347,6 +347,7 @@ FLOWS = [
     "waze_travel_time",
     "wemo",
     "whirlpool",
+    "whois",
     "wiffi",
     "wilight",
     "withings",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1193,6 +1193,9 @@ python-tado==0.12.0
 # homeassistant.components.twitch
 python-twitch-client==0.6.0
 
+# homeassistant.components.whois
+python-whois==0.7.3
+
 # homeassistant.components.awair
 python_awair==0.2.1
 

--- a/tests/components/whois/__init__.py
+++ b/tests/components/whois/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Whois integration."""

--- a/tests/components/whois/conftest.py
+++ b/tests/components/whois/conftest.py
@@ -1,0 +1,34 @@
+"""Fixtures for Whois integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.whois.const import DOMAIN
+from homeassistant.const import CONF_DOMAIN
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="Home Assistant",
+        domain=DOMAIN,
+        data={
+            CONF_DOMAIN: "Home-Assistant.io",
+        },
+        unique_id="home-assistant.io",
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.whois.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -1,0 +1,80 @@
+"""Tests for the Whois config flow."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.components.whois.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_DOMAIN, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_user_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the full user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_DOMAIN: "Example.com"},
+    )
+
+    assert result2.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result2.get("title") == "Example.com"
+    assert result2.get("data") == {CONF_DOMAIN: "example.com"}
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test we abort if already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_DOMAIN: "HOME-Assistant.io"},
+    )
+
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "already_configured"
+
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
+async def test_import_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the import configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_DOMAIN: "Example.com", CONF_NAME: "My Example Domain"},
+    )
+
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result.get("title") == "My Example Domain"
+    assert result.get("data") == {
+        CONF_DOMAIN: "example.com",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Whois integration migrated to configuration via the UI. Configuring Whois via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR implements the bare minimum configuration flow for the Whois integration, including import.

This PR is part of a bunch of PRs that I have ready for this integration. Others include:

- Replacing the current library with a more modern (existing) one (that actually provides error checking and such)
- Extend config flow/integration setup to take into account that a domain name can be free for registration (and thus does not have an expiration date)
- Add entity descriptions
- Add more entities
- Some more deprecations (attributes and such)
- Add full test coverage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20942

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
