### PR TITLE
Fix MQTT cover not using tilt_command_template

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -582,10 +582,20 @@ class MqttCover(MqttEntity, CoverEntity):
 
     async def async_open_cover_tilt(self, **kwargs):
         """Tilt the cover open."""
+        tilt_open_position = self._config[CONF_TILT_OPEN_POSITION]
+        variables = {
+            "tilt_position": tilt_open_position,
+            "entity_id": self.entity_id,
+            "position_open": self._config.get(CONF_POSITION_OPEN),
+            "position_closed": self._config.get(CONF_POSITION_CLOSED),
+            "tilt_min": self._config.get(CONF_TILT_MIN),
+            "tilt_max": self._config.get(CONF_TILT_MAX),
+        }
+        tilt_payload = self._set_tilt_template(tilt_open_position, variables=variables)
         await mqtt.async_publish(
             self.hass,
             self._config.get(CONF_TILT_COMMAND_TOPIC),
-            self._config[CONF_TILT_OPEN_POSITION],
+            tilt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )
@@ -597,10 +607,22 @@ class MqttCover(MqttEntity, CoverEntity):
 
     async def async_close_cover_tilt(self, **kwargs):
         """Tilt the cover closed."""
+        tilt_closed_position = self._config[CONF_TILT_CLOSED_POSITION]
+        variables = {
+            "tilt_position": tilt_closed_position,
+            "entity_id": self.entity_id,
+            "position_open": self._config.get(CONF_POSITION_OPEN),
+            "position_closed": self._config.get(CONF_POSITION_CLOSED),
+            "tilt_min": self._config.get(CONF_TILT_MIN),
+            "tilt_max": self._config.get(CONF_TILT_MAX),
+        }
+        tilt_payload = self._set_tilt_template(
+            tilt_closed_position, variables=variables
+        )
         await mqtt.async_publish(
             self.hass,
             self._config.get(CONF_TILT_COMMAND_TOPIC),
-            self._config[CONF_TILT_CLOSED_POSITION],
+            tilt_payload,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN],
         )

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -933,12 +933,11 @@ async def test_set_tilt_templated_and_attributes(hass, mqtt_mock):
                 "position_closed": 0,
                 "set_position_topic": "set-position-topic",
                 "set_position_template": "{{position-1}}",
-                "tilt_command_template": '\
-                {% if state_attr(entity_id, "friendly_name") != "test" %}\
-                  {{ 5 }}\
-                {% else %}\
-                  {{ 23 }}\
-                {% endif %}',
+                "tilt_command_template": "{"
+                '"enitity_id": "{{ entity_id }}",'
+                '"value": {{ value }},'
+                '"tilt_position": {{ tilt_position }}'
+                "}",
                 "payload_open": "OPEN",
                 "payload_close": "CLOSE",
                 "payload_stop": "STOP",
@@ -950,12 +949,57 @@ async def test_set_tilt_templated_and_attributes(hass, mqtt_mock):
     await hass.services.async_call(
         cover.DOMAIN,
         SERVICE_SET_COVER_TILT_POSITION,
-        {ATTR_ENTITY_ID: "cover.test", ATTR_TILT_POSITION: 99},
+        {ATTR_ENTITY_ID: "cover.test", ATTR_TILT_POSITION: 45},
         blocking=True,
     )
 
     mqtt_mock.async_publish.assert_called_once_with(
-        "tilt-command-topic", "23", 0, False
+        "tilt-command-topic",
+        '{"enitity_id": "cover.test","value": 45,"tilt_position": 45}',
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    await hass.services.async_call(
+        cover.DOMAIN,
+        SERVICE_OPEN_COVER_TILT,
+        {ATTR_ENTITY_ID: "cover.test"},
+        blocking=True,
+    )
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic",
+        '{"enitity_id": "cover.test","value": 100,"tilt_position": 100}',
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    await hass.services.async_call(
+        cover.DOMAIN,
+        SERVICE_CLOSE_COVER_TILT,
+        {ATTR_ENTITY_ID: "cover.test"},
+        blocking=True,
+    )
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic",
+        '{"enitity_id": "cover.test","value": 0,"tilt_position": 0}',
+        0,
+        False,
+    )
+    mqtt_mock.async_publish.reset_mock()
+
+    await hass.services.async_call(
+        cover.DOMAIN,
+        SERVICE_TOGGLE_COVER_TILT,
+        {ATTR_ENTITY_ID: "cover.test"},
+        blocking=True,
+    )
+    mqtt_mock.async_publish.assert_called_once_with(
+        "tilt-command-topic",
+        '{"enitity_id": "cover.test","value": 100,"tilt_position": 100}',
+        0,
+        False,
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The tilt_command_template of the `cover` platform only apples `tilt_command_template` when setting the tilt position when `SERVICE_SET_COVER_TILT_POSITION` is called.
It is needed the `tilt_command_template`  is also applied when when `SERVICE_OPEN_COVER_TILT` and `SERVICE_CLOSE_COVER_TILT` is called. This PR fixes that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63024
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
