### PR TITLE
Add new buttons for Shelly Gas

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -70,7 +70,7 @@ BUTTONS: Final = [
     ShellyButtonDescription(
         key="mute",
         name="Mute",
-        icon="mdi:volume-variant-off",
+        icon="mdi:volume-mute",
         entity_category=EntityCategory.CONFIG,
         press_action=lambda wrapper: wrapper.device.trigger_shelly_gas_mute(),
         supported=lambda wrapper: wrapper.device.model in SHELLY_GAS_MODELS,

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -115,7 +115,7 @@ async def async_setup_entry(
 
 
 class ShellyButton(ButtonEntity):
-    """Defines a Shelly OTA update base button."""
+    """Defines a Shelly base button."""
 
     entity_description: ShellyButtonDescription
 
@@ -124,7 +124,7 @@ class ShellyButton(ButtonEntity):
         wrapper: RpcDeviceWrapper | BlockDeviceWrapper,
         description: ShellyButtonDescription,
     ) -> None:
-        """Initialize Shelly OTA update button."""
+        """Initialize Shelly button."""
         self.entity_description = description
         self.wrapper = wrapper
 
@@ -140,5 +140,5 @@ class ShellyButton(ButtonEntity):
         )
 
     async def async_press(self) -> None:
-        """Triggers the OTA update service."""
+        """Triggers the Shelly button press service."""
         await self.entity_description.press_action(self.wrapper)

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -99,19 +99,19 @@ async def async_setup_entry(
         ].get(BLOCK):
             wrapper = cast(BlockDeviceWrapper, block_wrapper)
 
-    if wrapper is None:
-        return
+    if wrapper is not None:
+        entities = []
 
-    entities = []
-    for button in BUTTONS:
-        if (
-            button.key in ("self_test", "mute", "unmute")
-            and wrapper.device.model != "SHGS-1"
-        ):
-            continue
-        entities.append(ShellyButton(wrapper, button))
+        for button in BUTTONS:
+            if (
+                button.key in ("self_test", "mute", "unmute")
+                and wrapper.device.model != "SHGS-1"
+            ):
+                continue
 
-    async_add_entities(entities)
+            entities.append(ShellyButton(wrapper, button))
+
+        async_add_entities(entities)
 
 
 class ShellyButton(ButtonEntity):

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -57,6 +57,27 @@ BUTTONS: Final = [
         entity_category=EntityCategory.CONFIG,
         press_action=lambda wrapper: wrapper.device.trigger_reboot(),
     ),
+    ShellyButtonDescription(
+        key="self_test",
+        name="Self Test",
+        icon="mdi:progress-wrench",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        press_action=lambda wrapper: wrapper.device.trigger_shelly_gas_self_test(),
+    ),
+    ShellyButtonDescription(
+        key="mute",
+        name="Mute",
+        icon="mdi:volume-variant-off",
+        entity_category=EntityCategory.CONFIG,
+        press_action=lambda wrapper: wrapper.device.trigger_shelly_gas_mute(),
+    ),
+    ShellyButtonDescription(
+        key="unmute",
+        name="Unmute",
+        icon="mdi:volume-high",
+        entity_category=EntityCategory.CONFIG,
+        press_action=lambda wrapper: wrapper.device.trigger_shelly_gas_unmute(),
+    ),
 ]
 
 
@@ -78,8 +99,19 @@ async def async_setup_entry(
         ].get(BLOCK):
             wrapper = cast(BlockDeviceWrapper, block_wrapper)
 
-    if wrapper is not None:
-        async_add_entities([ShellyButton(wrapper, button) for button in BUTTONS])
+    if wrapper is None:
+        return
+
+    entities = []
+    for button in BUTTONS:
+        if (
+            button.key in ("self_test", "mute", "unmute")
+            and wrapper.device.model != "SHGS-1"
+        ):
+            continue
+        entities.append(ShellyButton(wrapper, button))
+
+    async_add_entities(entities)
 
 
 class ShellyButton(ButtonEntity):

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -161,3 +161,5 @@ MAX_RPC_KEY_INSTANCES = 4
 
 # Time to wait before reloading entry upon device config change
 ENTRY_RELOAD_COOLDOWN = 60
+
+SHELLY_GAS_MODELS = ["SHGS-1"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds button entities for Shelly Gas:
- self test
- mute
- unmute

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
