### PR TITLE
Enable strict typing for Overkiz integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -101,6 +101,7 @@ homeassistant.components.number.*
 homeassistant.components.onewire.*
 homeassistant.components.open_meteo.*
 homeassistant.components.openuv.*
+homeassistant.components.overkiz.*
 homeassistant.components.persistent_notification.*
 homeassistant.components.pi_hole.*
 homeassistant.components.proximity.*

--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -145,6 +145,6 @@ class OverkizBinarySensor(OverkizDescriptiveEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
         if state := self.device.states.get(self.entity_description.key):
-            return self.entity_description.value_fn(str(state.value))
+            return self.entity_description.value_fn(state.value)
 
         return None

--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommandParam, OverkizState
 
@@ -40,28 +41,28 @@ BINARY_SENSOR_DESCRIPTIONS: list[OverkizBinarySensorDescription] = [
         key=OverkizState.CORE_RAIN,
         name="Rain",
         icon="mdi:weather-rainy",
-        value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.DETECTED),
     ),
     # SmokeSensor/SmokeSensor
     OverkizBinarySensorDescription(
         key=OverkizState.CORE_SMOKE,
         name="Smoke",
         device_class=BinarySensorDeviceClass.SMOKE,
-        value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.DETECTED),
     ),
     # WaterSensor/WaterDetectionSensor
     OverkizBinarySensorDescription(
         key=OverkizState.CORE_WATER_DETECTION,
         name="Water",
         icon="mdi:water",
-        value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.DETECTED),
     ),
     # AirSensor/AirFlowSensor
     OverkizBinarySensorDescription(
         key=OverkizState.CORE_GAS_DETECTION,
         name="Gas",
         device_class=BinarySensorDeviceClass.GAS,
-        value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.DETECTED),
     ),
     # OccupancySensor/OccupancySensor
     # OccupancySensor/MotionSensor
@@ -69,35 +70,35 @@ BINARY_SENSOR_DESCRIPTIONS: list[OverkizBinarySensorDescription] = [
         key=OverkizState.CORE_OCCUPANCY,
         name="Occupancy",
         device_class=BinarySensorDeviceClass.OCCUPANCY,
-        value_fn=lambda state: state == OverkizCommandParam.PERSON_INSIDE,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.PERSON_INSIDE),
     ),
     # ContactSensor/WindowWithTiltSensor
     OverkizBinarySensorDescription(
         key=OverkizState.CORE_VIBRATION,
         name="Vibration",
         device_class=BinarySensorDeviceClass.VIBRATION,
-        value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.DETECTED),
     ),
     # ContactSensor/ContactSensor
     OverkizBinarySensorDescription(
         key=OverkizState.CORE_CONTACT,
         name="Contact",
         device_class=BinarySensorDeviceClass.DOOR,
-        value_fn=lambda state: state == OverkizCommandParam.OPEN,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.OPEN),
     ),
     # Siren/SirenStatus
     OverkizBinarySensorDescription(
         key=OverkizState.CORE_ASSEMBLY,
         name="Assembly",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        value_fn=lambda state: state == OverkizCommandParam.OPEN,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.OPEN),
     ),
     # Unknown
     OverkizBinarySensorDescription(
         key=OverkizState.IO_VIBRATION_DETECTED,
         name="Vibration",
         device_class=BinarySensorDeviceClass.VIBRATION,
-        value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+        value_fn=lambda state: state == cast(str, OverkizCommandParam.DETECTED),
     ),
 ]
 
@@ -144,6 +145,6 @@ class OverkizBinarySensor(OverkizDescriptiveEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
         if state := self.device.states.get(self.entity_description.key):
-            return self.entity_description.value_fn(state.value)
+            return self.entity_description.value_fn(str(state.value))
 
         return None

--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -106,7 +106,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
     """Set up the Overkiz binary sensors from a config entry."""
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
     entities: list[OverkizBinarySensor] = []

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -171,7 +171,11 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
             return cast(None, state.value)
 
         cast_to_python = DATA_TYPE_TO_PYTHON[data_type]
-        return cast_to_python(state.value)
+        value = cast_to_python(state.value)
+
+        assert isinstance(value, (str, float, int, bool))
+
+        return value
 
     def places_to_area(self, place: Place) -> dict[str, str]:
         """Convert places with sub_places to a flat dictionary."""

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import timedelta
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import ServerDisconnectedError
 from pyoverkiz.client import OverkizClient
@@ -168,7 +168,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
         data_type = DataType(state.type)
 
         if data_type == DataType.NONE:
-            return state.value
+            return cast(None, state.value)
 
         cast_to_python = DATA_TYPE_TO_PYTHON[data_type]
         return cast_to_python(state.value)

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from pyoverkiz.models import Command, Device
@@ -41,7 +41,7 @@ class OverkizExecutor:
         """Select first existing active state in a list of states."""
         for state in states:
             if current_state := self.device.states[state]:
-                return current_state.value
+                return cast(str, current_state.value)
 
         return None
 
@@ -53,7 +53,7 @@ class OverkizExecutor:
         """Select first existing active state in a list of states."""
         for attribute in attributes:
             if current_attribute := self.device.attributes[attribute]:
-                return current_attribute.value
+                return cast(str, current_attribute.value)
 
         return None
 

--- a/homeassistant/components/overkiz/light.py
+++ b/homeassistant/components/overkiz/light.py
@@ -1,7 +1,7 @@
 """Support for Overkiz lights."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -59,9 +59,8 @@ class OverkizLight(OverkizEntity, LightEntity):
     @property
     def is_on(self) -> bool:
         """Return true if light is on."""
-        return (
-            self.executor.select_state(OverkizState.CORE_ON_OFF)
-            == OverkizCommandParam.ON
+        return self.executor.select_state(OverkizState.CORE_ON_OFF) == cast(
+            str, OverkizCommandParam.ON
         )
 
     @property

--- a/homeassistant/components/overkiz/lock.py
+++ b/homeassistant/components/overkiz/lock.py
@@ -1,7 +1,7 @@
 """Support for Overkiz locks."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -44,7 +44,6 @@ class OverkizLock(OverkizEntity, LockEntity):
     @property
     def is_locked(self) -> bool | None:
         """Return a boolean for the state of the lock."""
-        return (
-            self.executor.select_state(OverkizState.CORE_LOCKED_UNLOCKED)
-            == OverkizCommandParam.LOCKED
+        return self.executor.select_state(OverkizState.CORE_LOCKED_UNLOCKED) == cast(
+            str, OverkizCommandParam.LOCKED
         )

--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizState
 
@@ -92,7 +93,7 @@ class OverkizNumber(OverkizDescriptiveEntity, NumberEntity):
     def value(self) -> float | None:
         """Return the entity value to represent the entity state."""
         if state := self.device.states.get(self.entity_description.key):
-            return state.value
+            return cast(float, state.value)
 
         return None
 

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -419,11 +419,11 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
         self._attr_name = "HomeKit Setup Code"
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         """Return the value of the sensor."""
-        return cast(
-            str, self.device.attributes.get(OverkizAttribute.HOMEKIT_SETUP_CODE).value
-        )
+        if state := self.device.attributes.get(OverkizAttribute.HOMEKIT_SETUP_CODE):
+            return cast(str, state.value)
+        return None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast
 
 from pyoverkiz.enums import OverkizAttribute, OverkizState, UIWidget
 
@@ -401,7 +402,7 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
         if self.entity_description.native_value:
             return self.entity_description.native_value(state.value)
 
-        return state.value
+        return cast(str, state.value)
 
 
 class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
@@ -420,7 +421,9 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the value of the sensor."""
-        return self.device.attributes.get(OverkizAttribute.HOMEKIT_SETUP_CODE).value
+        return cast(
+            str, self.device.attributes.get(OverkizAttribute.HOMEKIT_SETUP_CODE).value
+        )
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1122,6 +1122,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.overkiz.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.persistent_notification.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Enable strict typing for Overkiz integration.

There are still 18 errors remaining, however all of them look related. It seems related to our `States` model implementation in pyoverkiz. https://github.com/iMicknl/python-overkiz-api/blob/ddc4f267df150e1453942196d3f0276c47205add/pyoverkiz/models.py#L279-L307

It looks related to `    def __init__(self, states: list[dict[str, Any]] | None = None) -> None:`. 

As discussed with @bdraco, a draft PR so that other people can easier have a look, to see if they have an idea where this error is coming from.

```
homeassistant/components/overkiz/coordinator.py:171: error: Returning Any from function declared to return "Union[Dict[Any, Any], List[Any], float, int, bool, str, None]"  [no-any-return]
homeassistant/components/overkiz/coordinator.py:174: error: Returning Any from function declared to return "Union[Dict[Any, Any], List[Any], float, int, bool, str, None]"  [no-any-return]
homeassistant/components/overkiz/executor.py:44: error: Returning Any from function declared to return "Optional[str]"  [no-any-return]
homeassistant/components/overkiz/executor.py:56: error: Returning Any from function declared to return "Optional[str]"  [no-any-return]
homeassistant/components/overkiz/sensor.py:404: error: Returning Any from function declared to return "Union[None, str, int, float]"  [no-any-return]
homeassistant/components/overkiz/sensor.py:423: error: Returning Any from function declared to return "str"  [no-any-return]
homeassistant/components/overkiz/number.py:95: error: Returning Any from function declared to return "Optional[float]"  [no-any-return]
homeassistant/components/overkiz/lock.py:47: error: Returning Any from function declared to return "Optional[bool]"  [no-any-return]
homeassistant/components/overkiz/light.py:62: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:43: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:50: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:57: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:64: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:72: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:79: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:86: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:93: error: Returning Any from function declared to return "bool"  [no-any-return]
homeassistant/components/overkiz/binary_sensor.py:100: error: Returning Any from function declared to return "bool"  [no-any-return]
Found 18 errors in 7 files (checked 13 source files)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
