### PR TITLE
Add fritz camera entity to display guest wifi qr code

### DIFF
--- a/homeassistant/components/fritz/camera.py
+++ b/homeassistant/components/fritz/camera.py
@@ -1,0 +1,126 @@
+"""FRITZ camera integration.
+
+Currently only used to display QR codes.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import io
+import logging
+
+import pyqrcode
+
+from homeassistant.components.camera import Camera
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util, slugify
+
+from .common import FritzBoxBaseEntity, FritzBoxTools
+from .const import (
+    DEFAULT_GUEST_WIFI_ENCRYPTION,
+    DEFAULT_GUEST_WIFI_QR_REFRESH_SEC,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Add a weather entity from a config_entry."""
+    _LOGGER.debug("Setting up FRITZ!Box camera entities")
+    fritzbox_tools: FritzBoxTools = hass.data[DOMAIN][entry.entry_id]
+
+    entities = await hass.async_add_executor_job(
+        _setup_guest_wifi_qr, fritzbox_tools, entry.title
+    )
+
+    async_add_entities(entities, True)
+
+
+def _setup_guest_wifi_qr(
+    fritzbox_tools: FritzBoxTools, device_friendly_name: str
+) -> list[FritzGuestWifiQRCamera]:
+    """Set up guest wifi entity to display the qr code."""
+    _LOGGER.debug("Setting up qr code camera entity")
+    ssid = fritzbox_tools.fritz_guest_wifi.ssid
+    return [
+        FritzGuestWifiQRCamera(
+            fritzbox_tools,
+            device_friendly_name,
+            ssid,
+        )
+    ]
+
+
+class FritzGuestWifiQRCamera(FritzBoxBaseEntity, Camera):
+    """Implementation of the FritzBox guest wifi QR code camera entity."""
+
+    QR_CODE = "QR code"
+
+    def __init__(
+        self,
+        fritzbox_tools: FritzBoxTools,
+        device_friendly_name: str,
+        ssid: str,
+    ) -> None:
+        """Initialize the camera."""
+        Camera.__init__(self)
+
+        self._attr_name = f"{device_friendly_name} {ssid} {self.QR_CODE}"
+        self._attr_unique_id = (
+            f"{fritzbox_tools.unique_id}-{slugify(ssid)}-{slugify(self.QR_CODE)}"
+        )
+        self._attr_icon = "mdi:qrcode-scan"
+        super().__init__(fritzbox_tools, device_friendly_name)
+
+        self.content_type = "image/svg+xml"
+        self._ssid: str = ssid
+        self._last_qr: bytes | None = None
+        self._refresh_at: datetime | None = None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the attributes."""
+        attrs: dict[str, str] = {}
+        attrs["ssid"] = self._ssid or STATE_UNKNOWN
+        attrs["refresh_after_seconds"] = str(DEFAULT_GUEST_WIFI_QR_REFRESH_SEC)
+        return attrs
+
+    def _needs_refresh(self) -> bool:
+        """Check if a refresh of the qr code is necessary."""
+        if not (self._refresh_at and self._last_qr):
+            return True
+
+        return dt_util.utcnow() > self._refresh_at
+
+    def _generate_guest_wifi_qr(self) -> bytes:
+        """Generate a QR code for the guest wifi."""
+        _LOGGER.debug("start generating guest wifi qr code")
+
+        wifi = f"WIFI:S:{self._ssid};T:{DEFAULT_GUEST_WIFI_ENCRYPTION};P:{self._fritzbox_tools.fritz_guest_wifi.get_password()};;"
+        _LOGGER.debug("wifi string: %s", wifi)
+        buffer = io.BytesIO()
+        img = pyqrcode.create(wifi)
+        _LOGGER.debug("qr code created")
+        img.svg(buffer, scale=1, module_color="#000", background="#FFF")
+        return buffer.getvalue()
+
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
+        """Return bytes of camera image."""
+        if self._needs_refresh():
+            _LOGGER.debug("refresh qr code")
+            self._last_qr = await self.hass.async_add_executor_job(
+                self._generate_guest_wifi_qr
+            )
+            now = dt_util.utcnow()
+            self._refresh_at = now + timedelta(
+                seconds=DEFAULT_GUEST_WIFI_QR_REFRESH_SEC
+            )
+
+        return self._last_qr

--- a/homeassistant/components/fritz/camera.py
+++ b/homeassistant/components/fritz/camera.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Add a weather entity from a config_entry."""
+    """Add a entities from a config_entry."""
     _LOGGER.debug("Setting up FRITZ!Box camera entities")
     fritzbox_tools: FritzBoxTools = hass.data[DOMAIN][entry.entry_id]
 

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -17,6 +17,7 @@ from fritzconnection.core.exceptions import (
 )
 from fritzconnection.lib.fritzhosts import FritzHosts
 from fritzconnection.lib.fritzstatus import FritzStatus
+from fritzconnection.lib.fritzwlan import FritzGuestWLAN
 
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.device_tracker.const import (
@@ -140,6 +141,7 @@ class FritzBoxTools(update_coordinator.DataUpdateCoordinator):
         self._options: MappingProxyType[str, Any] | None = None
         self._unique_id: str | None = None
         self.connection: FritzConnection = None
+        self.fritz_guest_wifi: FritzGuestWLAN = None
         self.fritz_hosts: FritzHosts = None
         self.fritz_status: FritzStatus = None
         self.hass = hass
@@ -175,6 +177,7 @@ class FritzBoxTools(update_coordinator.DataUpdateCoordinator):
             _LOGGER.error("Unable to establish a connection with %s", self.host)
             return
 
+        self.fritz_guest_wifi = FritzGuestWLAN(fc=self.connection)
         self.fritz_status = FritzStatus(fc=self.connection)
         info = self.connection.call_action("DeviceInfo:1", "GetInfo")
         if not self._unique_id:

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -9,6 +9,7 @@ DOMAIN = "fritz"
 PLATFORMS = [
     Platform.BUTTON,
     Platform.BINARY_SENSOR,
+    Platform.CAMERA,
     Platform.DEVICE_TRACKER,
     Platform.SENSOR,
     Platform.SWITCH,
@@ -19,6 +20,8 @@ DATA_FRITZ = "fritz_data"
 DSL_CONNECTION: Literal["dsl"] = "dsl"
 
 DEFAULT_DEVICE_NAME = "Unknown device"
+DEFAULT_GUEST_WIFI_ENCRYPTION = "WPA/WPA2"
+DEFAULT_GUEST_WIFI_QR_REFRESH_SEC = 60
 DEFAULT_HOST = "192.168.178.1"
 DEFAULT_PORT = 49000
 DEFAULT_USERNAME = ""

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/fritz",
   "requirements": [
     "fritzconnection==1.8.0",
+    "PyQRCode==1.2.1",
     "xmltodict==0.12.0"
   ],
   "dependencies": ["network"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,6 +39,7 @@ PyMata==2.20
 PyNaCl==1.4.0
 
 # homeassistant.auth.mfa_modules.totp
+# homeassistant.components.fritz
 # homeassistant.components.homekit
 PyQRCode==1.2.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -20,6 +20,7 @@ PyFlick==0.0.2
 PyNaCl==1.4.0
 
 # homeassistant.auth.mfa_modules.totp
+# homeassistant.components.fritz
 # homeassistant.components.homekit
 PyQRCode==1.2.1
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
According to the suggestion from @davet2001 in the original pull request (https://github.com/home-assistant/core/pull/63033), I implemented a `camera` entity for the `fritz` integration which displays the QR code of the guest wifi network. Currently the QR code refreshes every 60 seconds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
