### PR TITLE
Fix upnp device not being reinitialized after device changes location

### DIFF
--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -16,7 +16,7 @@ from homeassistant.components.ssdp import SsdpChange
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-import homeassistant.util.dt as dt_util
+from homeassistant.util.dt import utcnow
 
 from .const import (
     BYTES_RECEIVED,
@@ -154,7 +154,7 @@ class Device:
         )
 
         return {
-            TIMESTAMP: dt_util.utcnow(),
+            TIMESTAMP: utcnow(),
             BYTES_RECEIVED: values[0],
             BYTES_SENT: values[1],
             PACKETS_RECEIVED: values[2],

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -31,6 +31,17 @@ from .const import (
 )
 
 
+async def async_create_upnp_device(
+    hass: HomeAssistant, ssdp_location: str
+) -> UpnpDevice:
+    """Create UPnP device."""
+    session = async_get_clientsession(hass)
+    requester = AiohttpSessionRequester(session, with_sleep=True, timeout=20)
+
+    factory = UpnpFactory(requester, disable_state_variable_validation=True)
+    return await factory.async_create_device(ssdp_location)
+
+
 class Device:
     """Home Assistant representation of a UPnP/IGD device."""
 
@@ -41,24 +52,11 @@ class Device:
         self.coordinator: DataUpdateCoordinator = None
 
     @classmethod
-    async def async_create_upnp_device(
-        cls, hass: HomeAssistant, ssdp_location: str
-    ) -> UpnpDevice:
-        """Create UPnP device."""
-        # Build async_upnp_client requester.
-        session = async_get_clientsession(hass)
-        requester = AiohttpSessionRequester(session, True, 20)
-
-        # Create async_upnp_client device.
-        factory = UpnpFactory(requester, disable_state_variable_validation=True)
-        return await factory.async_create_device(ssdp_location)
-
-    @classmethod
     async def async_create_device(
         cls, hass: HomeAssistant, ssdp_location: str
     ) -> Device:
         """Create UPnP/IGD device."""
-        upnp_device = await Device.async_create_upnp_device(hass, ssdp_location)
+        upnp_device = await async_create_upnp_device(hass, ssdp_location)
 
         # Create profile wrapper.
         igd_device = IgdDevice(upnp_device, None)

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -83,7 +83,7 @@ class Device:
         if location == device.device_url:
             return
 
-        new_upnp_device = await Device.async_create_upnp_device(self.hass, location)
+        new_upnp_device = await async_create_upnp_device(self.hass, location)
         device.reinit(new_upnp_device)
 
     @property

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -67,7 +67,7 @@ class Device:
         # Register SSDP callback for updates.
         usn = f"{upnp_device.udn}::{upnp_device.device_type}"
         await ssdp.async_register_callback(
-            hass, device.async_ssdp_callback, {ssdp.ATTR_SSDP_USN: usn}
+            hass, device.async_ssdp_callback, {"usn": usn}
         )
 
         return device
@@ -76,7 +76,8 @@ class Device:
         self, headers: Mapping[str, Any], change: SsdpChange
     ) -> None:
         """SSDP callback, update if needed."""
-        if change != SsdpChange.UPDATE or ssdp.ATTR_SSDP_LOCATION not in headers:
+        _LOGGER.debug("SSDP Callback, change: %s, headers: %s", change, headers)
+        if ssdp.ATTR_SSDP_LOCATION not in headers:
             return
 
         location = headers[ssdp.ATTR_SSDP_LOCATION]
@@ -84,7 +85,7 @@ class Device:
         if location == device.device_url:
             return
 
-        new_upnp_device = Device.async_create_upnp_device(self.hass, location)
+        new_upnp_device = await Device.async_create_upnp_device(self.hass, location)
         device.reinit(new_upnp_device)
 
     @property

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -2,10 +2,10 @@
 from typing import Optional, Sequence
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
+
 from async_upnp_client.client import UpnpDevice
 from async_upnp_client.event_handler import UpnpEventHandler
 from async_upnp_client.profiles.igd import StatusInfo
-
 import pytest
 
 from homeassistant.components import ssdp
@@ -110,7 +110,7 @@ class MockIgdDevice:
         self._timestamp = dt.utcnow()
         self.traffic_times_polled = 0
         self.status_times_polled = 0
-        
+
         self.traffic_data = {
             BYTES_RECEIVED: 0,
             BYTES_SENT: 0,
@@ -184,19 +184,25 @@ class MockIgdDevice:
         :param services List of service names to try to get action from, defaults to [WANIPC,WANPPP]
         """
         self.status_times_polled += 1
-        return StatusInfo(self.status_data[WAN_STATUS], "", self.status_data[ROUTER_UPTIME])
+        return StatusInfo(
+            self.status_data[WAN_STATUS], "", self.status_data[ROUTER_UPTIME]
+        )
 
 
 @pytest.fixture(autouse=True)
 def mock_upnp_device():
     """Mock homeassistant.components.upnp.Device."""
-    async def mock_async_create_upnp_device(hass: HomeAssistant, location: str) -> UpnpDevice:
+
+    async def mock_async_create_upnp_device(
+        hass: HomeAssistant, location: str
+    ) -> UpnpDevice:
         """Create UPnP device."""
         return MockUpnpDevice(location)
 
     with patch(
-        "homeassistant.components.upnp.device.async_create_upnp_device", side_effect=mock_async_create_upnp_device
-    ) as mock_async_create_upnp_device, patch (
+        "homeassistant.components.upnp.device.async_create_upnp_device",
+        side_effect=mock_async_create_upnp_device,
+    ) as mock_async_create_upnp_device, patch(
         "homeassistant.components.upnp.device.IgdDevice", new=MockIgdDevice
     ) as mock_igd_device:
         yield mock_async_create_upnp_device, mock_igd_device

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -1,7 +1,10 @@
 """Configuration for SSDP tests."""
-from typing import Any, Mapping
+from typing import Optional, Sequence
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
+from async_upnp_client.client import UpnpDevice
+from async_upnp_client.event_handler import UpnpEventHandler
+from async_upnp_client.profiles.igd import StatusInfo
 
 import pytest
 
@@ -16,7 +19,6 @@ from homeassistant.components.upnp.const import (
     PACKETS_SENT,
     ROUTER_IP,
     ROUTER_UPTIME,
-    TIMESTAMP,
     WAN_STATUS,
 )
 from homeassistant.core import HomeAssistant
@@ -29,17 +31,20 @@ TEST_ST = "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
 TEST_USN = f"{TEST_UDN}::{TEST_ST}"
 TEST_LOCATION = "http://192.168.1.1/desc.xml"
 TEST_HOSTNAME = urlparse(TEST_LOCATION).hostname
-TEST_FRIENDLY_NAME = "friendly name"
+TEST_FRIENDLY_NAME = "mock-name"
 TEST_DISCOVERY = ssdp.SsdpServiceInfo(
     ssdp_usn=TEST_USN,
     ssdp_st=TEST_ST,
     ssdp_location=TEST_LOCATION,
     upnp={
-        ssdp.ATTR_UPNP_UDN: TEST_UDN,
-        "usn": TEST_USN,
-        "location": TEST_LOCATION,
         "_udn": TEST_UDN,
-        "friendlyName": TEST_FRIENDLY_NAME,
+        "location": TEST_LOCATION,
+        "usn": TEST_USN,
+        ssdp.ATTR_UPNP_DEVICE_TYPE: TEST_ST,
+        ssdp.ATTR_UPNP_FRIENDLY_NAME: TEST_FRIENDLY_NAME,
+        ssdp.ATTR_UPNP_MANUFACTURER: "mock-manufacturer",
+        ssdp.ATTR_UPNP_MODEL_NAME: "mock-model-name",
+        ssdp.ATTR_UPNP_UDN: TEST_UDN,
     },
     ssdp_headers={
         "_host": TEST_HOSTNAME,
@@ -47,52 +52,37 @@ TEST_DISCOVERY = ssdp.SsdpServiceInfo(
 )
 
 
-class MockDevice:
-    """Mock device for Device."""
+class MockUpnpDevice:
+    """Mock async_upnp_client UpnpDevice."""
 
-    def __init__(self, hass: HomeAssistant, udn: str) -> None:
-        """Initialize mock device."""
-        self.hass = hass
-        self._udn = udn
-        self.traffic_times_polled = 0
-        self.status_times_polled = 0
-        self._timestamp = dt.utcnow()
-
-    @classmethod
-    async def async_create_device(cls, hass, ssdp_location) -> "MockDevice":
-        """Return self."""
-        return cls(hass, TEST_UDN)
-
-    async def async_ssdp_callback(
-        self, headers: Mapping[str, Any], change: ssdp.SsdpChange
-    ) -> None:
-        """SSDP callback, update if needed."""
-        pass
-
-    @property
-    def udn(self) -> str:
-        """Get the UDN."""
-        return self._udn
+    def __init__(self, location: str) -> None:
+        """Initialize."""
+        self.device_url = location
 
     @property
     def manufacturer(self) -> str:
         """Get manufacturer."""
-        return "mock-manufacturer"
+        return TEST_DISCOVERY.upnp[ssdp.ATTR_UPNP_MANUFACTURER]
 
     @property
     def name(self) -> str:
         """Get name."""
-        return "mock-name"
+        return TEST_DISCOVERY.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME]
 
     @property
     def model_name(self) -> str:
         """Get the model name."""
-        return "mock-model-name"
+        return TEST_DISCOVERY.upnp[ssdp.ATTR_UPNP_MODEL_NAME]
 
     @property
     def device_type(self) -> str:
         """Get the device type."""
-        return "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+        return TEST_DISCOVERY.upnp[ssdp.ATTR_UPNP_DEVICE_TYPE]
+
+    @property
+    def udn(self) -> str:
+        """Get the UDN."""
+        return TEST_DISCOVERY.upnp[ssdp.ATTR_UPNP_UDN]
 
     @property
     def usn(self) -> str:
@@ -104,39 +94,112 @@ class MockDevice:
         """Get the unique id."""
         return self.usn
 
-    @property
-    def hostname(self) -> str:
-        """Get the hostname."""
-        return "mock-hostname"
+    def reinit(self, new_upnp_device: UpnpDevice) -> None:
+        """Reinitialize."""
+        self.device_url = new_upnp_device.device_url
 
-    async def async_get_traffic_data(self) -> Mapping[str, Any]:
-        """Get traffic data."""
-        self.traffic_times_polled += 1
-        return {
-            TIMESTAMP: self._timestamp,
+
+class MockIgdDevice:
+    """Mock async_upnp_client IgdDevice."""
+
+    def __init__(self, device: MockUpnpDevice, event_handler: UpnpEventHandler) -> None:
+        """Initialize mock device."""
+        self.device = device
+        self.profile_device = device
+
+        self._timestamp = dt.utcnow()
+        self.traffic_times_polled = 0
+        self.status_times_polled = 0
+        
+        self.traffic_data = {
             BYTES_RECEIVED: 0,
             BYTES_SENT: 0,
             PACKETS_RECEIVED: 0,
             PACKETS_SENT: 0,
         }
-
-    async def async_get_status(self) -> Mapping[str, Any]:
-        """Get connection status, uptime, and external IP."""
-        self.status_times_polled += 1
-        return {
+        self.status_data = {
             WAN_STATUS: "Connected",
             ROUTER_UPTIME: 10,
             ROUTER_IP: "8.9.10.11",
         }
 
+    @property
+    def name(self) -> str:
+        """Get the name of the device."""
+        return self.profile_device.name
+
+    @property
+    def manufacturer(self) -> str:
+        """Get the manufacturer of this device."""
+        return self.profile_device.manufacturer
+
+    @property
+    def model_name(self) -> str:
+        """Get the model name of this device."""
+        return self.profile_device.model_name
+
+    @property
+    def udn(self) -> str:
+        """Get the UDN of the device."""
+        return self.profile_device.udn
+
+    @property
+    def device_type(self) -> str:
+        """Get the device type of this device."""
+        return self.profile_device.device_type
+
+    async def async_get_total_bytes_received(self) -> Optional[int]:
+        """Get total bytes received."""
+        self.traffic_times_polled += 1
+        return self.traffic_data[BYTES_RECEIVED]
+
+    async def async_get_total_bytes_sent(self) -> Optional[int]:
+        """Get total bytes sent."""
+        return self.traffic_data[BYTES_SENT]
+
+    async def async_get_total_packets_received(self) -> Optional[int]:
+        """Get total packets received."""
+        return self.traffic_data[PACKETS_RECEIVED]
+
+    async def async_get_total_packets_sent(self) -> Optional[int]:
+        """Get total packets sent."""
+        return self.traffic_data[PACKETS_SENT]
+
+    async def async_get_external_ip_address(
+        self, services: Optional[Sequence[str]] = None
+    ) -> Optional[str]:
+        """
+        Get the external IP address.
+
+        :param services List of service names to try to get action from, defaults to [WANIPC,WANPPP]
+        """
+        return self.status_data[ROUTER_IP]
+
+    async def async_get_status_info(
+        self, services: Optional[Sequence[str]] = None
+    ) -> Optional[StatusInfo]:
+        """
+        Get status info.
+
+        :param services List of service names to try to get action from, defaults to [WANIPC,WANPPP]
+        """
+        self.status_times_polled += 1
+        return StatusInfo(self.status_data[WAN_STATUS], "", self.status_data[ROUTER_UPTIME])
+
 
 @pytest.fixture(autouse=True)
 def mock_upnp_device():
     """Mock homeassistant.components.upnp.Device."""
+    async def mock_async_create_upnp_device(hass: HomeAssistant, location: str) -> UpnpDevice:
+        """Create UPnP device."""
+        return MockUpnpDevice(location)
+
     with patch(
-        "homeassistant.components.upnp.Device", new=MockDevice
-    ) as mock_async_create_device:
-        yield mock_async_create_device
+        "homeassistant.components.upnp.device.async_create_upnp_device", side_effect=mock_async_create_upnp_device
+    ) as mock_async_create_upnp_device, patch (
+        "homeassistant.components.upnp.device.IgdDevice", new=MockIgdDevice
+    ) as mock_igd_device:
+        yield mock_async_create_upnp_device, mock_igd_device
 
 
 @pytest.fixture

--- a/tests/components/upnp/test_binary_sensor.py
+++ b/tests/components/upnp/test_binary_sensor.py
@@ -12,29 +12,27 @@ from homeassistant.components.upnp.const import (
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from .conftest import MockDevice
-
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+from .conftest import MockIgdDevice
 
 
 async def test_upnp_binary_sensors(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ):
     """Test normal sensors."""
-    mock_device: MockDevice = hass.data[DOMAIN][setup_integration.entry_id].device
+    mock_device: MockIgdDevice = hass.data[DOMAIN][setup_integration.entry_id].device._igd_device
 
     # First poll.
     wan_status_state = hass.states.get("binary_sensor.mock_name_wan_status")
     assert wan_status_state.state == "on"
 
     # Second poll.
-    mock_device.async_get_status = AsyncMock(
-        return_value={
-            WAN_STATUS: "Disconnected",
-            ROUTER_UPTIME: 100,
-            ROUTER_IP: "",
-        }
-    )
+    mock_device.status_data = {
+        WAN_STATUS: "Disconnected",
+        ROUTER_UPTIME: 100,
+        ROUTER_IP: "",
+    }
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
     await hass.async_block_till_done()
 

--- a/tests/components/upnp/test_binary_sensor.py
+++ b/tests/components/upnp/test_binary_sensor.py
@@ -1,7 +1,6 @@
 """Tests for UPnP/IGD binary_sensor."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
 
 from homeassistant.components.upnp.const import (
     DOMAIN,
@@ -12,16 +11,18 @@ from homeassistant.components.upnp.const import (
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed
-
 from .conftest import MockIgdDevice
+
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_upnp_binary_sensors(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ):
     """Test normal sensors."""
-    mock_device: MockIgdDevice = hass.data[DOMAIN][setup_integration.entry_id].device._igd_device
+    mock_device: MockIgdDevice = hass.data[DOMAIN][
+        setup_integration.entry_id
+    ].device._igd_device
 
     # First poll.
     wan_status_state = hass.states.get("binary_sensor.mock_name_wan_status")

--- a/tests/components/upnp/test_binary_sensor.py
+++ b/tests/components/upnp/test_binary_sensor.py
@@ -20,15 +20,14 @@ async def test_upnp_binary_sensors(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ):
     """Test normal sensors."""
-    mock_device: MockIgdDevice = hass.data[DOMAIN][
-        setup_integration.entry_id
-    ].device._igd_device
-
     # First poll.
     wan_status_state = hass.states.get("binary_sensor.mock_name_wan_status")
     assert wan_status_state.state == "on"
 
     # Second poll.
+    mock_device: MockIgdDevice = hass.data[DOMAIN][
+        setup_integration.entry_id
+    ].device._igd_device
     mock_device.status_data = {
         WAN_STATUS: "Disconnected",
         ROUTER_UPTIME: 100,

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -199,7 +199,9 @@ async def test_options_flow(hass: HomeAssistant):
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
-    mock_device: MockIgdDevice = hass.data[DOMAIN][config_entry.entry_id].device._igd_device
+    mock_device: MockIgdDevice = hass.data[DOMAIN][
+        config_entry.entry_id
+    ].device._igd_device
 
     # Reset.
     mock_device.traffic_times_polled = 0

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -25,7 +25,7 @@ from .conftest import (
     TEST_ST,
     TEST_UDN,
     TEST_USN,
-    MockDevice,
+    MockIgdDevice,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -199,7 +199,7 @@ async def test_options_flow(hass: HomeAssistant):
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
-    mock_device: MockDevice = hass.data[DOMAIN][config_entry.entry_id].device
+    mock_device: MockIgdDevice = hass.data[DOMAIN][config_entry.entry_id].device._igd_device
 
     # Reset.
     mock_device.traffic_times_polled = 0

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -199,11 +199,11 @@ async def test_options_flow(hass: HomeAssistant):
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
+
+    # Reset.
     mock_device: MockIgdDevice = hass.data[DOMAIN][
         config_entry.entry_id
     ].device._igd_device
-
-    # Reset.
     mock_device.traffic_times_polled = 0
     mock_device.status_times_polled = 0
 

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import pytest
-from homeassistant.components import ssdp
 
+from homeassistant.components import ssdp
 from homeassistant.components.upnp import UpnpDataUpdateCoordinator
 from homeassistant.components.upnp.const import (
     CONFIG_ENTRY_ST,
@@ -34,7 +34,9 @@ async def test_async_setup_entry_default(hass: HomeAssistant):
     assert await hass.config_entries.async_setup(entry.entry_id) is True
 
 
-async def test_reinitialize_device(hass: HomeAssistant, setup_integration: MockConfigEntry):
+async def test_reinitialize_device(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+):
     """Test device is reinitialized when device changes location."""
     config_entry = setup_integration
     coordinator: UpnpDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -32,3 +32,19 @@ async def test_async_setup_entry_default(hass: HomeAssistant):
     # Load config_entry.
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id) is True
+
+
+async def test_reinitialize_device(hass: HomeAssistant, setup_integration: MockConfigEntry):
+    """Test device is reinitialized when device changes location."""
+    config_entry = setup_integration
+    coordinator: UpnpDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    device: Device = coordinator.device
+    assert device._igd_device.device.device_url == TEST_DISCOVERY.ssdp_location
+
+    # Reinit.
+    new_location = "http://192.168.1.1:12345/desc.xml"
+    headers = {
+        ssdp.ATTR_SSDP_LOCATION: new_location,
+    }
+    await device.async_ssdp_callback(headers, ...)
+    assert device._igd_device.device.device_url == new_location

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 import pytest
+from homeassistant.components import ssdp
 
+from homeassistant.components.upnp import UpnpDataUpdateCoordinator
 from homeassistant.components.upnp.const import (
     CONFIG_ENTRY_ST,
     CONFIG_ENTRY_UDN,
     DOMAIN,
 )
+from homeassistant.components.upnp.device import Device
 from homeassistant.core import HomeAssistant
 
-from .conftest import TEST_ST, TEST_UDN
+from .conftest import TEST_DISCOVERY, TEST_ST, TEST_UDN
 
 from tests.common import MockConfigEntry
 
@@ -18,7 +21,6 @@ from tests.common import MockConfigEntry
 @pytest.mark.usefixtures("ssdp_instant_discovery", "mock_get_source_ip")
 async def test_async_setup_entry_default(hass: HomeAssistant):
     """Test async_setup_entry."""
-
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -1,8 +1,8 @@
 """Tests for UPnP/IGD sensor."""
 
 from unittest.mock import patch
-from homeassistant.components.upnp import UpnpDataUpdateCoordinator
 
+from homeassistant.components.upnp import UpnpDataUpdateCoordinator
 from homeassistant.components.upnp.const import (
     BYTES_RECEIVED,
     BYTES_SENT,

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -1,6 +1,5 @@
 """Tests for UPnP/IGD sensor."""
 
-from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.components.upnp.const import (
@@ -54,7 +53,7 @@ async def test_upnp_sensors(hass: HomeAssistant, setup_integration: MockConfigEn
         ROUTER_UPTIME: 100,
         ROUTER_IP: "",
     }
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     b_received_state = hass.states.get("sensor.mock_name_b_received")
@@ -91,14 +90,17 @@ async def test_derived_upnp_sensors(
     assert packets_s_sent_state.state == "unknown"
 
     # Second poll.
-    with patch("homeassistant.core.dt_util.utcnow", return_value=now + UPDATE_INTERVAL):
+    with patch(
+        "homeassistant.components.upnp.device.dt_util.utcnow",
+        return_value=now + UPDATE_INTERVAL,
+    ):
         mock_device.traffic_data = {
             BYTES_RECEIVED: int(10240 * UPDATE_INTERVAL.total_seconds()),
             BYTES_SENT: int(20480 * UPDATE_INTERVAL.total_seconds()),
             PACKETS_RECEIVED: int(30 * UPDATE_INTERVAL.total_seconds()),
             PACKETS_SENT: int(40 * UPDATE_INTERVAL.total_seconds()),
         }
-        async_fire_time_changed(hass, now + timedelta(seconds=31))
+        async_fire_time_changed(hass, now + UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
         kib_s_received_state = hass.states.get("sensor.mock_name_kib_s_received")

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -1,7 +1,7 @@
 """Tests for UPnP/IGD sensor."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from homeassistant.components.upnp.const import (
     BYTES_RECEIVED,
@@ -11,23 +11,22 @@ from homeassistant.components.upnp.const import (
     PACKETS_SENT,
     ROUTER_IP,
     ROUTER_UPTIME,
-    TIMESTAMP,
     UPDATE_INTERVAL,
     WAN_STATUS,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-# from .conftest import MockDevice
+from .conftest import MockIgdDevice
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-
-from .conftest import MockIgdDevice
 
 
 async def test_upnp_sensors(hass: HomeAssistant, setup_integration: MockConfigEntry):
     """Test normal sensors."""
-    mock_device: MockIgdDevice = hass.data[DOMAIN][setup_integration.entry_id].device._igd_device
+    mock_device: MockIgdDevice = hass.data[DOMAIN][
+        setup_integration.entry_id
+    ].device._igd_device
 
     # First poll.
     b_received_state = hass.states.get("sensor.mock_name_b_received")
@@ -76,7 +75,9 @@ async def test_derived_upnp_sensors(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ):
     """Test derived sensors."""
-    mock_device: MockIgdDevice = hass.data[DOMAIN][setup_integration.entry_id].device._igd_device
+    mock_device: MockIgdDevice = hass.data[DOMAIN][
+        setup_integration.entry_id
+    ].device._igd_device
     now = dt_util.utcnow()
 
     # First poll.
@@ -90,7 +91,7 @@ async def test_derived_upnp_sensors(
     assert packets_s_sent_state.state == "unknown"
 
     # Second poll.
-    with patch("homeassistant.core.dt_util.utcnow", return_value=now + UPDATE_INTERVAL) as mock_utcnow:
+    with patch("homeassistant.core.dt_util.utcnow", return_value=now + UPDATE_INTERVAL):
         mock_device.traffic_data = {
             BYTES_RECEIVED: int(10240 * UPDATE_INTERVAL.total_seconds()),
             BYTES_SENT: int(20480 * UPDATE_INTERVAL.total_seconds()),
@@ -102,7 +103,9 @@ async def test_derived_upnp_sensors(
 
         kib_s_received_state = hass.states.get("sensor.mock_name_kib_s_received")
         kib_s_sent_state = hass.states.get("sensor.mock_name_kib_s_sent")
-        packets_s_received_state = hass.states.get("sensor.mock_name_packets_s_received")
+        packets_s_received_state = hass.states.get(
+            "sensor.mock_name_packets_s_received"
+        )
         packets_s_sent_state = hass.states.get("sensor.mock_name_packets_s_sent")
         assert kib_s_received_state.state == "10.0"
         assert kib_s_sent_state.state == "20.0"

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for UPnP/IGD sensor."""
 
 from unittest.mock import patch
+from homeassistant.components.upnp import UpnpDataUpdateCoordinator
 
 from homeassistant.components.upnp.const import (
     BYTES_RECEIVED,
@@ -10,6 +11,7 @@ from homeassistant.components.upnp.const import (
     PACKETS_SENT,
     ROUTER_IP,
     ROUTER_UPTIME,
+    TIMESTAMP,
     UPDATE_INTERVAL,
     WAN_STATUS,
 )
@@ -23,10 +25,6 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_upnp_sensors(hass: HomeAssistant, setup_integration: MockConfigEntry):
     """Test normal sensors."""
-    mock_device: MockIgdDevice = hass.data[DOMAIN][
-        setup_integration.entry_id
-    ].device._igd_device
-
     # First poll.
     b_received_state = hass.states.get("sensor.mock_name_b_received")
     b_sent_state = hass.states.get("sensor.mock_name_b_sent")
@@ -42,6 +40,9 @@ async def test_upnp_sensors(hass: HomeAssistant, setup_integration: MockConfigEn
     assert wan_status_state.state == "Connected"
 
     # Second poll.
+    mock_device: MockIgdDevice = hass.data[DOMAIN][
+        setup_integration.entry_id
+    ].device._igd_device
     mock_device.traffic_data = {
         BYTES_RECEIVED: 10240,
         BYTES_SENT: 20480,
@@ -74,10 +75,7 @@ async def test_derived_upnp_sensors(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ):
     """Test derived sensors."""
-    mock_device: MockIgdDevice = hass.data[DOMAIN][
-        setup_integration.entry_id
-    ].device._igd_device
-    now = dt_util.utcnow()
+    coordinator: UpnpDataUpdateCoordinator = hass.data[DOMAIN][setup_integration.entry_id]
 
     # First poll.
     kib_s_received_state = hass.states.get("sensor.mock_name_kib_s_received")
@@ -90,10 +88,12 @@ async def test_derived_upnp_sensors(
     assert packets_s_sent_state.state == "unknown"
 
     # Second poll.
+    now = coordinator.data[TIMESTAMP]
     with patch(
-        "homeassistant.components.upnp.device.dt_util.utcnow",
+        "homeassistant.components.upnp.device.utcnow",
         return_value=now + UPDATE_INTERVAL,
     ):
+        mock_device: MockIgdDevice = coordinator.device._igd_device
         mock_device.traffic_data = {
             BYTES_RECEIVED: int(10240 * UPDATE_INTERVAL.total_seconds()),
             BYTES_SENT: int(20480 * UPDATE_INTERVAL.total_seconds()),

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -75,7 +75,9 @@ async def test_derived_upnp_sensors(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ):
     """Test derived sensors."""
-    coordinator: UpnpDataUpdateCoordinator = hass.data[DOMAIN][setup_integration.entry_id]
+    coordinator: UpnpDataUpdateCoordinator = hass.data[DOMAIN][
+        setup_integration.entry_id
+    ]
 
     # First poll.
     kib_s_received_state = hass.states.get("sensor.mock_name_kib_s_received")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix the callback registration by using the right `match_dict` for the `ssdp`-callback.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60858
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
