### PR TITLE
Bump mill-local to 0.1.1 and add device info

### DIFF
--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -204,6 +204,19 @@ class LocalMillHeater(CoordinatorEntity, ClimateEntity):
         """Initialize the thermostat."""
         super().__init__(coordinator)
         self._attr_name = coordinator.mill_data_connection.name
+        if coordinator.mill_data_connection.mac_address:
+            self._attr_unique_id = coordinator.mill_data_connection.mac_address
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (DOMAIN, self.coordinator.mill_data_connection.mac_address)
+                },
+                configuration_url=self.coordinator.mill_data_connection.url,
+                manufacturer=MANUFACTURER,
+                model="Generation 3",
+                name=coordinator.mill_data_connection.name,
+                sw_version=coordinator.mill_data_connection.version,
+            )
+
         self._update_attr()
 
     async def async_set_temperature(self, **kwargs):

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -205,11 +206,10 @@ class LocalMillHeater(CoordinatorEntity, ClimateEntity):
         super().__init__(coordinator)
         self._attr_name = coordinator.mill_data_connection.name
         if coordinator.mill_data_connection.mac_address:
-            self._attr_unique_id = coordinator.mill_data_connection.mac_address
+            mac = self.coordinator.mill_data_connection.mac_address
+            self._attr_unique_id = mac
             self._attr_device_info = DeviceInfo(
-                identifiers={
-                    (DOMAIN, self.coordinator.mill_data_connection.mac_address)
-                },
+                connections={(CONNECTION_NETWORK_MAC, mac)},
                 configuration_url=self.coordinator.mill_data_connection.url,
                 manufacturer=MANUFACTURER,
                 model="Generation 3",

--- a/homeassistant/components/mill/manifest.json
+++ b/homeassistant/components/mill/manifest.json
@@ -2,7 +2,7 @@
   "domain": "mill",
   "name": "Mill",
   "documentation": "https://www.home-assistant.io/integrations/mill",
-  "requirements": ["millheater==0.9.0", "mill-local==0.1.0"],
+  "requirements": ["millheater==0.9.0", "mill-local==0.1.1"],
   "codeowners": ["@danielhiversen"],
   "config_flow": true,
   "iot_class": "local_polling"

--- a/homeassistant/components/mill/sensor.py
+++ b/homeassistant/components/mill/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -203,11 +204,10 @@ class LocalMillSensor(CoordinatorEntity, SensorEntity):
             f"{coordinator.mill_data_connection.name} {entity_description.name}"
         )
         if coordinator.mill_data_connection.mac_address:
-            self._attr_unique_id = f"{coordinator.mill_data_connection.mac_address}_{entity_description.key}"
+            mac = self.coordinator.mill_data_connection.mac_address
+            self._attr_unique_id = f"{mac}_{entity_description.key}"
             self._attr_device_info = DeviceInfo(
-                identifiers={
-                    (DOMAIN, self.coordinator.mill_data_connection.mac_address)
-                },
+                connections={(CONNECTION_NETWORK_MAC, mac)},
                 configuration_url=self.coordinator.mill_data_connection.url,
                 manufacturer=MANUFACTURER,
                 model="Generation 3",

--- a/homeassistant/components/mill/sensor.py
+++ b/homeassistant/components/mill/sensor.py
@@ -202,6 +202,18 @@ class LocalMillSensor(CoordinatorEntity, SensorEntity):
         self._attr_name = (
             f"{coordinator.mill_data_connection.name} {entity_description.name}"
         )
+        if coordinator.mill_data_connection.mac_address:
+            self._attr_unique_id = f"{coordinator.mill_data_connection.mac_address}_{entity_description.key}"
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (DOMAIN, self.coordinator.mill_data_connection.mac_address)
+                },
+                configuration_url=self.coordinator.mill_data_connection.url,
+                manufacturer=MANUFACTURER,
+                model="Generation 3",
+                name=coordinator.mill_data_connection.name,
+                sw_version=coordinator.mill_data_connection.version,
+            )
 
     @property
     def native_value(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1019,7 +1019,7 @@ micloud==0.4
 miflora==0.7.0
 
 # homeassistant.components.mill
-mill-local==0.1.0
+mill-local==0.1.1
 
 # homeassistant.components.mill
 millheater==0.9.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -622,7 +622,7 @@ mficlient==0.3.0
 micloud==0.4
 
 # homeassistant.components.mill
-mill-local==0.1.0
+mill-local==0.1.1
 
 # homeassistant.components.mill
 millheater==0.9.0


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mill, add device info
Requires a heater firmware from December 2021 or newer.
https://github.com/Danielhiversen/pyMillLocal/compare/0.1.0...0.1.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
