### PR TITLE
Extend Songpal to provide settings as separate entities

### DIFF
--- a/homeassistant/components/songpal/const.py
+++ b/homeassistant/components/songpal/const.py
@@ -3,3 +3,11 @@ DOMAIN = "songpal"
 SET_SOUND_SETTING = "set_sound_setting"
 
 CONF_ENDPOINT = "endpoint"
+
+ATTR_NEWEST_VERSION = "newest_version"
+
+# Known settings that need to be special handled.
+TITLE_TEXTID_REPEAT_TYPE = "playbackMode-repeatType"
+TITLE_TEXTID_SHUFFLE_TYPE = "playbackMode-shuffleType"
+TITLE_TEXTID_SOUND_MODE = "sound-mode"
+TITLE_TEXTID_VERSION = "other-htversion-TBD"  # sic

--- a/homeassistant/components/songpal/coordinator.py
+++ b/homeassistant/components/songpal/coordinator.py
@@ -1,0 +1,273 @@
+"""Client implementation for Songpal-enable (Sony) media devices."""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from datetime import timedelta
+import logging
+
+import async_timeout
+from songpal import Device, SongpalException
+from songpal.containers import (
+    Input,
+    InterfaceInfo,
+    PlayInfo,
+    Power,
+    Setting,
+    SettingsEntry,
+    SoftwareUpdateInfo,
+    Sysinfo,
+    Volume,
+)
+from songpal.notification import (
+    ChangeNotification,
+    ConnectChange,
+    ContentChange,
+    PowerChange,
+    SettingChange,
+    SoftwareUpdateChange,
+    VolumeChange,
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, TITLE_TEXTID_VERSION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class SongpalState:
+    """Single container of state for the SongpalCoordinator."""
+
+    system_information: Sysinfo
+    interface_info: InterfaceInfo
+    power: Power
+    settings: dict[str, Setting]
+    sw_update_info: SoftwareUpdateInfo
+    volume: Volume
+    inputs: list[Input]
+    playing_content: PlayInfo
+
+    @property
+    def unique_id(self) -> str:
+        """Return an Unique ID for the device.
+
+        If present, use the serialNumber. If not, use the MAC address,
+        either wired or wireless.
+        """
+        return (
+            self.system_information.serialNumber
+            or self.system_information.macAddr
+            or self.system_information.wirelessMacAddr
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the common device information of the Songpal device."""
+        connections = set()
+
+        if self.system_information.macAddr:
+            connections.add((CONNECTION_NETWORK_MAC, self.system_information.macAddr))
+        if self.system_information.wirelessMacAddr:
+            connections.add(
+                (CONNECTION_NETWORK_MAC, self.system_information.wirelessMacAddr)
+            )
+
+        identifiers = set()
+        if self.system_information.serialNumber:
+            identifiers = {(DOMAIN, self.system_information.serialNumber)}
+
+        return DeviceInfo(
+            identifiers=identifiers,
+            connections=connections,
+            manufacturer="Sony Corporation",
+            default_name=self.interface_info.modelName,
+            sw_version=self.system_information.version,
+            model=self.interface_info.modelName,
+        )
+
+
+class SongpalCoordinator(DataUpdateCoordinator[SongpalState]):
+    """Wrapper for the Songpal Device object to be shared among entities."""
+
+    _listener_task: asyncio.Task | None = None
+    settings_definitions: list[SettingsEntry] = []
+
+    def __init__(self, name: str, hass: HomeAssistant, device: Device) -> None:
+        """Create but don't activate the client wrapper."""
+        self.device = device
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=name,
+            update_method=self.async_update_data,
+            # Interval is only used if there was no data pushed by the API in the same time,
+            # or if we lost connection.
+            update_interval=timedelta(seconds=45),
+        )
+
+    async def _handle_notification(self, change: ChangeNotification) -> None:
+        _LOGGER.debug("[%s] received notification: %r", self.name, change)
+        new_data = self.data
+        if isinstance(change, PowerChange):
+            new_data.power = change
+        elif isinstance(change, SettingChange):
+            new_setting = new_data.settings.get(change.titleTextID, None)
+            if new_setting is None:
+                _LOGGER.warning(
+                    "[%s] Received change for unknown setting %s",
+                    self.name,
+                    change.titleTextID,
+                )
+
+            new_setting.currentValue = change.currentValue
+            if change.isAvailable is not None:
+                new_setting.isAvailable = change.isAvailable
+
+            if new_setting.type != change.type:
+                _LOGGER.warning(
+                    "[%s] Setting %s change type from %s to %s, will likely break",
+                    self.name,
+                    change.target,
+                    new_setting.type,
+                    change.type,
+                )
+
+            new_data.settings[change.titleTextID] = new_setting
+        elif isinstance(change, SoftwareUpdateChange):
+            new_data.sw_update_info = change
+        elif isinstance(change, VolumeChange):
+            # The change volume notification does not repeat the min/max/step settings, so only override
+            # the new parameters.
+
+            new_data.volume.volume = change.volume
+            new_data.volume.output = change.output
+            # This is annoying: Volume keeps the mute attribute as string and converts it when requesting
+            # isMuted, while VolumeChange converts it on creation, so we need to re-synthesize the string.
+            new_data.volume.mute = "on" if change.mute else "off"
+        elif isinstance(change, ContentChange):
+            new_data.playing_content = change
+        elif isinstance(change, ConnectChange):
+            # This is only sent when one of the notifications listeners failed, and implies the connection
+            # to the device dropped.
+            _LOGGER.warning("[%s] Disconnected: %r", self.name, change.exception)
+            await self.async_request_refresh()
+        else:
+            _LOGGER.debug("[%s] unknown notification", self.name)
+            return
+
+        self.async_set_updated_data(new_data)
+
+    async def async_request_refresh(self) -> None:
+        """Stop the listeners, and request a refresh."""
+        _LOGGER.debug("[%s] Stopping listeners for refresh", self.name)
+        await self.device.stop_listen_notifications()
+
+        return await super().async_request_refresh()
+
+    async def async_update_data(self) -> SongpalState:
+        """Fetch all the information from the Songpal device."""
+        try:
+            # set timeout to avoid blocking the setup process
+            async with async_timeout.timeout(10):
+                await self.device.get_supported_methods()
+        except (SongpalException, asyncio.TimeoutError) as ex:
+            _LOGGER.warning("[%s] Unable to connect", self.device.endpoint)
+            _LOGGER.debug("Unable to get methods from songpal", exc_info=True)
+            if isinstance(ex, asyncio.TimeoutError):
+                raise ex
+            raise UpdateFailed(str(ex)) from ex
+
+        if not self._listener_task or self._listener_task.done():
+            self._listener_task = self.hass.loop.create_task(
+                self.device.listen_notifications(self._handle_notification)
+            )
+
+        # We only need to fetch the settings definition once, as the only thing that do change are the
+        # current values and their availability.
+        if not self.settings_definitions:
+            settings_tree = await self.device.get_settings()
+            _LOGGER.debug("[%s] Retrieved settings tree: %r", self.name, settings_tree)
+
+            def _append_settings(entry: SettingsEntry) -> None:
+                if entry.is_directory:
+                    # Ignore the initial settings in particular, as they should not be changed!
+                    if entry.usage == "initialSetting":
+                        return
+
+                    for sub_entry in entry.settings or []:
+                        _append_settings(sub_entry)
+                else:
+                    self.settings_definitions.append(entry)
+
+            for entry in settings_tree:
+                # Ignore nullTarget entries or it'll fail to fetch their state.
+                if entry.type == "nullTarget":
+                    continue
+                if entry.titleTextID == TITLE_TEXTID_VERSION:
+                    continue
+                _append_settings(entry)
+
+        all_settings = {}
+        settings_fetchers = [
+            setting.get_value(self.device) for setting in self.settings_definitions
+        ]
+        settings_fetched = asyncio.gather(*settings_fetchers, return_exceptions=True)
+        for result in await settings_fetched:
+            if isinstance(result, Exception):
+                _LOGGER.warning(
+                    "[%s] Exception while fetching settings: %s", self.name, result
+                )
+                continue
+
+            # The titleTextID field seems to be more stable than the target!
+            if result.titleTextID in all_settings:
+                _LOGGER.warning(
+                    "[%s] Duplicate setting retrieved for %s",
+                    self.name,
+                    result.titleTextID,
+                )
+
+            # Some boolean settings are reported as enum for some reason, and sometimes
+            # even change between the two types depending on whether the device is on or off
+            # as is the case on the HT-A7000. Set the correct type here to avoid repeating
+            # ourselves in all the places.
+
+            if result.type == "enumTarget":
+                possible_values = {
+                    candidate.value
+                    for candidate in result.candidate
+                    if candidate.isAvailable
+                }
+                if possible_values == {"on", "off"}:
+                    result.type = "booleanTarget"
+                    # Also look through the settings definition to update it!
+                    for setting in self.settings_definitions:
+                        if setting.titleTextID == result.titleTextID:
+                            setting.type = "booleanTarget"
+
+            all_settings[result.titleTextID] = result
+
+        all_volumes = await self.device.get_volume_information()
+        if len(all_volumes) > 1:
+            raise ConfigEntryNotReady(
+                f"Multiple volume controls found (unsupported): {all_volumes!r}"
+            )
+
+        play_info = await self.device.get_play_info()
+
+        return SongpalState(
+            system_information=await self.device.get_system_info(),
+            interface_info=await self.device.get_interface_information(),
+            power=await self.device.get_power(),
+            settings=all_settings,
+            sw_update_info=await self.device.get_update_info(),
+            volume=all_volumes[0],
+            inputs=await self.device.get_inputs(),
+            playing_content=play_info,
+        )

--- a/homeassistant/components/songpal/entity.py
+++ b/homeassistant/components/songpal/entity.py
@@ -1,0 +1,94 @@
+"""Base entity for Songpal-enabled (Sony) media devices."""
+from __future__ import annotations
+
+import logging
+
+from songpal.containers import SettingCandidate, SettingsEntry
+
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import SongpalCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_SETTINGS_ICONS = {
+    "sound-night": "mdi:power-sleep",
+    "sound-voice": "mdi:account-voice",
+}
+
+
+class SongpalEntity(CoordinatorEntity[SongpalCoordinator]):
+    """Base class for Songpal entities."""
+
+    coordinator: SongpalCoordinator
+
+    _attr_base_name: str | None = None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information for the current Songpal device."""
+        return self.coordinator.data.device_info
+
+    @property
+    def name(self) -> str:
+        """Construct a default name, if given a base name."""
+        if self._attr_base_name:
+            return f"{self.coordinator.name} {self._attr_base_name}"
+
+        return f"{self.coordinator.name}"
+
+
+class SongpalSettingEntity(SongpalEntity):
+    """A Songpal entity that relates directly to a (sound) setting."""
+
+    def __init__(self, coordinator: SongpalCoordinator, setting: SettingsEntry) -> None:
+        """Instantiate a new Songpal entity attached to a setting."""
+        super().__init__(coordinator)
+
+        self._setting = setting
+
+        _LOGGER.debug("Creating a new setting entity for %s", self._setting.titleTextID)
+
+        self._attr_base_name = self._setting.title
+        self._attr_unique_id = (
+            f"{self.coordinator.data.unique_id}-{self._setting.titleTextID}"
+        )
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_icon = _SETTINGS_ICONS.get(self._setting.titleTextID, None)
+
+    @property
+    def candidates(self) -> list[SettingCandidate]:
+        """Return the list of candidates for the settings."""
+        if self._setting.titleTextID not in self.coordinator.data.settings:
+            return []
+
+        return self.coordinator.data.settings[self._setting.titleTextID].candidate
+
+    @property
+    def _current_value(self) -> str | None:
+        return self.coordinator.data.settings[self._setting.titleTextID].currentValue
+
+    @property
+    def available(self) -> bool:
+        """Return whether the setting is available to change."""
+        return (
+            super().available
+            and self._setting.titleTextID in self.coordinator.data.settings
+            and self.coordinator.data.settings[self._setting.titleTextID].isAvailable
+        )
+
+    async def update_setting(self, value_or_candidate: str | SettingCandidate) -> None:
+        """Update the value of the attached setting."""
+        if isinstance(value_or_candidate, SettingCandidate):
+            value = value_or_candidate.value
+        else:
+            value = value_or_candidate
+
+        _LOGGER.debug(
+            "[%s] Setting '%s' to '%s'", self.name, self._setting.titleTextID, value
+        )
+
+        await self.coordinator.device.services[self._setting.apiMapping.service][
+            self._setting.apiMapping.setApi["name"]
+        ]({"settings": [{"target": self._setting.apiMapping.target, "value": value}]})

--- a/homeassistant/components/songpal/number.py
+++ b/homeassistant/components/songpal/number.py
@@ -1,0 +1,75 @@
+"""Select platform for Songpal."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SongpalCoordinator
+from .entity import SongpalSettingEntity
+from .media_player import MEDIA_PLAYER_SETTINGS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up songpal select entities."""
+    coordinator: SongpalCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+
+    for setting in coordinator.settings_definitions:
+        _LOGGER.debug("Looking at setting %r", setting)
+
+        # Ignore settings that are exposed via MediaPlayerEntity.
+        if setting.titleTextID in MEDIA_PLAYER_SETTINGS:
+            continue
+
+        if setting.type in {"integerTarget", "doubleNumberTarget"}:
+            entities.append(SongpalNumberEntity(coordinator, setting))
+
+    async_add_entities(entities)
+
+
+class SongpalNumberEntity(NumberEntity, SongpalSettingEntity):
+    """Base entity for Songpal number settings."""
+
+    @property
+    def value(self) -> float | None:
+        """Return the current value for the setting."""
+        if self._current_value is None:
+            return None
+
+        return float(self._current_value)
+
+    @property
+    def min_value(self) -> float:
+        """Return the minimum value for the setting."""
+        return float(self.candidates[0].min)
+
+    @property
+    def max_value(self) -> float:
+        """Return the maximum value for the setting."""
+        return float(self.candidates[0].max)
+
+    @property
+    def step(self) -> float:
+        """Return the step for each change."""
+        return float(self.candidates[0].step)
+
+    async def async_set_value(self, value: float) -> None:
+        """Change the set value."""
+        if self._setting.type == "integerTarget":
+            normalized_value = str(int(value))
+        else:
+            normalized_value = str(value)
+
+        await self.update_setting(str(normalized_value))

--- a/homeassistant/components/songpal/select.py
+++ b/homeassistant/components/songpal/select.py
@@ -1,0 +1,69 @@
+"""Select platform for Songpal."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SongpalCoordinator
+from .entity import SongpalSettingEntity
+from .media_player import MEDIA_PLAYER_SETTINGS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up songpal select entities."""
+    coordinator: SongpalCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+
+    for setting in coordinator.settings_definitions:
+        _LOGGER.debug("Looking at setting %r", setting)
+
+        # Ignore settings that are exposed via MediaPlayerEntity.
+        if setting.titleTextID in MEDIA_PLAYER_SETTINGS:
+            continue
+
+        if setting.type == "enumTarget":
+            entities.append(SongpalSelectEntity(coordinator, setting))
+
+    async_add_entities(entities)
+
+
+class SongpalSelectEntity(SelectEntity, SongpalSettingEntity):
+    """Base entity for Songpal enum settings."""
+
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options for the setting."""
+        return [
+            candidate.title for candidate in self.candidates if candidate.isAvailable
+        ]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option, or none."""
+        for candidate in self.candidates:
+            if candidate.value == self._current_value:
+                return candidate.title
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        for candidate in self.candidates:
+            if candidate.title == option:
+                await self.update_setting(candidate)
+                break
+        else:
+            _LOGGER.warning(
+                "Unable to select option '%s', no matching title found", option
+            )

--- a/homeassistant/components/songpal/switch.py
+++ b/homeassistant/components/songpal/switch.py
@@ -1,0 +1,54 @@
+"""Switch platform for Songpal."""
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SongpalCoordinator
+from .entity import SongpalSettingEntity
+from .media_player import MEDIA_PLAYER_SETTINGS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up songpal select entities."""
+    coordinator: SongpalCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+
+    for setting in coordinator.settings_definitions:
+        _LOGGER.debug("Looking at setting %r", setting)
+
+        # Ignore settings that are exposed via MediaPlayerEntity.
+        if setting.titleTextID in MEDIA_PLAYER_SETTINGS:
+            continue
+
+        if setting.type == "booleanTarget":
+            entities.append(SongpalSwitchEntity(coordinator, setting))
+
+    async_add_entities(entities)
+
+
+class SongpalSwitchEntity(SwitchEntity, SongpalSettingEntity):
+    """Base entity for Songpal boolean settings."""
+
+    @property
+    def is_on(self) -> bool:
+        """Convert the setting value to a switch state."""
+        return self._current_value == "on"
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the setting on."""
+        await self.update_setting("on")
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the setting off."""
+        await self.update_setting("off")

--- a/homeassistant/components/songpal/update.py
+++ b/homeassistant/components/songpal/update.py
@@ -1,0 +1,72 @@
+"""Update platform for Songpal."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.update import UpdateDeviceClass, UpdateEntity
+from homeassistant.components.update.const import UpdateEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SongpalCoordinator
+from .entity import SongpalEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up songpal media player."""
+    coordinator: SongpalCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = [SognpalUpdateEntity(coordinator)]
+
+    async_add_entities(entities)
+
+
+class SognpalUpdateEntity(UpdateEntity, SongpalEntity):
+    """Software update availability sensor."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    _attr_base_name = "Firmware Update"
+
+    @property
+    def unique_id(self) -> str:
+        """Create a unique identifier for the entity."""
+        return f"{self.coordinator.data.unique_id}-update"
+
+    @property
+    def auto_update(self) -> bool:
+        """Return whether the device is set to auto-update."""
+        return self.coordinator.data.settings["system-autoupdate"].currentValue == "on"
+
+    @property
+    def installed_version(self) -> str:
+        """Return the current version of the firmware."""
+        return self.coordinator.data.system_information.version
+
+    @property
+    def latest_version(self) -> str | None:
+        """Return the current available version of the firmware, if any."""
+        if self.coordinator.data.sw_update_info.isUpdatable:
+            return self.coordinator.data.sw_update_info.swInfo.updatableVersion
+
+        return None
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update.
+
+        No specific version can be provided, and no backup can be taken.
+        """
+
+        assert version is None and not backup
+
+        await self.coordinator.device.activate_system_update()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Note**: at the time of creation this is a very early draft of pull request to just make it available for others to try.

This pull request extends the songpal integration by factoring the client (device, connection) object out of the MediaPlayerEntity, and introduces switch and select platforms so that settings such as night mode, immersive mode, and the volume of surround can be changed from Home Assistant:

![image](https://user-images.githubusercontent.com/74834/147833813-56560173-a517-4ae9-abcd-3b38b8bcff45.png)

![image](https://user-images.githubusercontent.com/74834/147833816-19328771-9402-4090-82d4-aa341ff296ed.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
