### PR TITLE
Start using `ParamSpec` for decorator functions

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -2,17 +2,18 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Awaitable, Sequence
 import contextlib
 from datetime import datetime, timedelta
 import functools
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from async_upnp_client import UpnpService, UpnpStateVariable
 from async_upnp_client.const import NotificationSubType
 from async_upnp_client.exceptions import UpnpError, UpnpResponseError
 from async_upnp_client.profiles.dlna import DmrDevice, PlayMode, TransportState
 from async_upnp_client.utils import async_get_local_ip
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp
@@ -65,27 +66,32 @@ from .data import EventListenAddr, get_domain_data
 
 PARALLEL_UPDATES = 0
 
-Func = TypeVar("Func", bound=Callable[..., Any])
+_T = TypeVar("_T", bound="DlnaDmrEntity")
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
-def catch_request_errors(func: Func) -> Func:
+def catch_request_errors(
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Awaitable[_R | None]]:  # type: ignore[misc]
     """Catch UpnpError errors."""
 
     @functools.wraps(func)
-    async def wrapper(self: "DlnaDmrEntity", *args: Any, **kwargs: Any) -> Any:
+    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
         """Catch UpnpError errors and check availability before and after request."""
         if not self.available:
             _LOGGER.warning(
                 "Device disappeared when trying to call service %s", func.__name__
             )
-            return
+            return None
         try:
-            return await func(self, *args, **kwargs)
+            return await func(self, *args, **kwargs)  # type: ignore[no-any-return]  # mypy can't yet infer 'func'
         except UpnpError as err:
             self.check_available = True
             _LOGGER.error("Error during call %s: %r", func.__name__, err)
+        return None
 
-    return cast(Func, wrapper)
+    return wrapper
 
 
 async def async_setup_entry(

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 import contextlib
 from datetime import datetime, timedelta
 import functools
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from async_upnp_client import UpnpService, UpnpStateVariable
 from async_upnp_client.const import NotificationSubType

--- a/homeassistant/components/evil_genius_labs/util.py
+++ b/homeassistant/components/evil_genius_labs/util.py
@@ -1,4 +1,6 @@
 """Utilities for Evil Genius Labs."""
+from __future__ import annotations
+
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import TypeVar

--- a/homeassistant/components/evil_genius_labs/util.py
+++ b/homeassistant/components/evil_genius_labs/util.py
@@ -1,21 +1,27 @@
 """Utilities for Evil Genius Labs."""
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import Any, TypeVar, cast
+from typing import TypeVar
+
+from typing_extensions import Concatenate, ParamSpec
 
 from . import EvilGeniusEntity
 
-CallableT = TypeVar("CallableT", bound=Callable)
+_T = TypeVar("_T", bound=EvilGeniusEntity)
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
-def update_when_done(func: CallableT) -> CallableT:
+def update_when_done(
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Awaitable[_R]]:  # type: ignore[misc]
     """Decorate function to trigger update when function is done."""
 
     @wraps(func)
-    async def wrapper(self: EvilGeniusEntity, *args: Any, **kwargs: Any) -> Any:
+    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         """Wrap function."""
         result = await func(self, *args, **kwargs)
         await self.coordinator.async_request_refresh()
-        return result
+        return result  # type: ignore[no-any-return]  # mypy can't yet infer 'func'
 
-    return cast(CallableT, wrapper)
+    return wrapper

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -1,8 +1,9 @@
 """Helper methods for common tasks."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from soco.exceptions import SoCoException, SoCoUPnPException
 from typing_extensions import Concatenate, ParamSpec
@@ -22,7 +23,7 @@ UID_POSTFIX = "01400"
 
 _LOGGER = logging.getLogger(__name__)
 
-_T = TypeVar("_T", SonosSpeaker, SonosEntity)
+_T = TypeVar("_T", "SonosSpeaker", "SonosEntity")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
 

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 from soco.exceptions import SoCoException, SoCoUPnPException
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -19,20 +20,26 @@ if TYPE_CHECKING:
 UID_PREFIX = "RINCON_"
 UID_POSTFIX = "01400"
 
-WrapFuncType = TypeVar("WrapFuncType", bound=Callable[..., Any])
-
 _LOGGER = logging.getLogger(__name__)
+
+_T = TypeVar("_T", SonosSpeaker, SonosEntity)
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
 def soco_error(
     errorcodes: list[str] | None = None, raise_on_err: bool = True
-) -> Callable:
+) -> Callable[  # type: ignore[misc]
+    [Callable[Concatenate[_T, _P], _R]], Callable[Concatenate[_T, _P], _R | None]
+]:
     """Filter out specified UPnP errors and raise exceptions for service calls."""
 
-    def decorator(funct: WrapFuncType) -> WrapFuncType:
+    def decorator(
+        funct: Callable[Concatenate[_T, _P], _R]  # type: ignore[misc]
+    ) -> Callable[Concatenate[_T, _P], _R | None]:  # type: ignore[misc]
         """Decorate functions."""
 
-        def wrapper(self: SonosSpeaker | SonosEntity, *args: Any, **kwargs: Any) -> Any:
+        def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R | None:
             """Wrap for all soco UPnP exception."""
             try:
                 result = funct(self, *args, **kwargs)
@@ -65,7 +72,7 @@ def soco_error(
             )
             return result
 
-        return cast(WrapFuncType, wrapper)
+        return wrapper
 
     return decorator
 

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -1,9 +1,11 @@
 """Common code for tplink."""
 from __future__ import annotations
 
-from typing import Any, Callable, TypeVar, cast
+from collections.abc import Awaitable
+from typing import Callable, TypeVar
 
 from kasa import SmartDevice
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
@@ -12,19 +14,20 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 
-WrapFuncType = TypeVar("WrapFuncType", bound=Callable[..., Any])
+_T = TypeVar("_T", bound="CoordinatedTPLinkEntity")
+_P = ParamSpec("_P")
 
 
-def async_refresh_after(func: WrapFuncType) -> WrapFuncType:
+def async_refresh_after(
+    func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Awaitable[None]]:  # type: ignore[misc]
     """Define a wrapper to refresh after."""
 
-    async def _async_wrap(
-        self: CoordinatedTPLinkEntity, *args: Any, **kwargs: Any
-    ) -> None:
+    async def _async_wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
         await func(self, *args, **kwargs)
         await self.coordinator.async_request_refresh_without_children()
 
-    return cast(WrapFuncType, _async_wrap)
+    return _async_wrap
 
 
 class CoordinatedTPLinkEntity(CoordinatorEntity):

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -1,8 +1,8 @@
 """Common code for tplink."""
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from typing import Callable, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
 
 from kasa import SmartDevice
 from typing_extensions import Concatenate, ParamSpec

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -1,9 +1,10 @@
 """Provide functionality to interact with the vlc telnet interface."""
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from functools import wraps
-from typing import Any, Awaitable, Callable, TypeVar
+from typing import Any, TypeVar
 
 from aiovlc.client import Client
 from aiovlc.exceptions import AuthError, CommandError, ConnectError

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from datetime import datetime
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Awaitable, Callable, TypeVar
 
 from aiovlc.client import Client
 from aiovlc.exceptions import AuthError, CommandError, ConnectError
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
@@ -49,7 +50,9 @@ SUPPORT_VLC = (
     | SUPPORT_VOLUME_SET
 )
 
-Func = TypeVar("Func", bound=Callable[..., Any])
+_T = TypeVar("_T", bound="VlcDevice")
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
 async def async_setup_entry(
@@ -64,11 +67,13 @@ async def async_setup_entry(
     async_add_entities([VlcDevice(entry, vlc, name, available)], True)
 
 
-def catch_vlc_errors(func: Func) -> Func:
+def catch_vlc_errors(
+    func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Awaitable[None]]:  # type: ignore[misc]
     """Catch VLC errors."""
 
     @wraps(func)
-    async def wrapper(self: VlcDevice, *args: Any, **kwargs: Any) -> Any:
+    async def wrapper(self: VlcDevice, *args: _P.args, **kwargs: _P.kwargs) -> None:
         """Catch VLC errors and modify availability."""
         try:
             await func(self, *args, **kwargs)
@@ -80,7 +85,7 @@ def catch_vlc_errors(func: Func) -> Func:
                 LOGGER.error("Connection error: %s", err)
                 self._available = False
 
-    return cast(Func, wrapper)
+    return wrapper
 
 
 class VlcDevice(MediaPlayerEntity):

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from typing_extensions import ParamSpec
 

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, TypeVar
+
+from typing_extensions import ParamSpec
 
 from homeassistant.components.hassio import (
     async_create_backup,
@@ -35,7 +38,8 @@ from .const import (
     LOGGER,
 )
 
-F = TypeVar("F", bound=Callable[..., Any])  # pylint: disable=invalid-name
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 DATA_ADDON_MANAGER = f"{DOMAIN}_addon_manager"
 
@@ -47,13 +51,17 @@ def get_addon_manager(hass: HomeAssistant) -> AddonManager:
     return AddonManager(hass)
 
 
-def api_error(error_message: str) -> Callable[[F], F]:
+def api_error(
+    error_message: str,
+) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]:
     """Handle HassioAPIError and raise a specific AddonError."""
 
-    def handle_hassio_api_error(func: F) -> F:
+    def handle_hassio_api_error(
+        func: Callable[_P, Awaitable[_R]]
+    ) -> Callable[_P, Awaitable[_R]]:
         """Handle a HassioAPIError."""
 
-        async def wrapper(*args, **kwargs):  # type: ignore
+        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             """Wrap an add-on manager method."""
             try:
                 return_value = await func(*args, **kwargs)
@@ -62,7 +70,7 @@ def api_error(error_message: str) -> Callable[[F], F]:
 
             return return_value
 
-        return cast(F, wrapper)
+        return wrapper
 
     return handle_hassio_api_error
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -29,7 +29,7 @@ pyyaml==6.0
 requests==2.26.0
 scapy==2.4.5
 sqlalchemy==1.4.27
-typing-extensions>=3.10.0.2;python_version<"3.10"
+typing-extensions>=3.10.0.2,<5.0
 voluptuous-serialize==2.5.0
 voluptuous==0.12.2
 yarl==1.6.3

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -29,6 +29,7 @@ pyyaml==6.0
 requests==2.26.0
 scapy==2.4.5
 sqlalchemy==1.4.27
+typing-extensions>=3.10.0.2;python_version<"3.10"
 voluptuous-serialize==2.5.0
 voluptuous==0.12.2
 yarl==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pip>=8.0.3,<20.3
 python-slugify==4.0.1
 pyyaml==6.0
 requests==2.26.0
+typing-extensions>=3.10.0.2;python_version<"3.10"
 voluptuous==0.12.2
 voluptuous-serialize==2.5.0
 yarl==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pip>=8.0.3,<20.3
 python-slugify==4.0.1
 pyyaml==6.0
 requests==2.26.0
-typing-extensions>=3.10.0.2;python_version<"3.10"
+typing-extensions>=3.10.0.2,<5.0
 voluptuous==0.12.2
 voluptuous-serialize==2.5.0
 yarl==1.6.3

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ REQUIRES = [
     "python-slugify==4.0.1",
     "pyyaml==6.0",
     "requests==2.26.0",
+    'typing-extensions>=3.10.0.2;python_version<"3.10"',
     "voluptuous==0.12.2",
     "voluptuous-serialize==2.5.0",
     "yarl==1.6.3",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ REQUIRES = [
     "python-slugify==4.0.1",
     "pyyaml==6.0",
     "requests==2.26.0",
-    'typing-extensions>=3.10.0.2;python_version<"3.10"',
+    "typing-extensions>=3.10.0.2,<5.0",
     "voluptuous==0.12.2",
     "voluptuous-serialize==2.5.0",
     "yarl==1.6.3",


### PR DESCRIPTION
## Proposed change
The last mypy release 0.930 added experimental support for `ParamSpec`. Though I might as well try and see what is possible. At the moment most decorator functions are annotated something like this
```py
class A: ...

F = TypeVar("F", bound=Callable[..., Any])

def decorator(func: F) -> F:
    def inner(self: A, *args: Any, **kwargs: Any) -> Any:
        return func(self, *args, **kwargs)
    return cast(F, inner)
```

Unfortunately, some require `typing.Concatenate` which is one of the things that isn't supported just yet. That doesn't mean though that changes are useless. Pyright fully supports `ParamSpec` so using it will improve the type hints within VS Code. Additionally, it isn't any worse either. With `Callable[..., Any]` neither the arguments nor the return type are checked. That doesn't change with the incomplete `ParamSpec` support.

Additionally, any functions that don't require `Concatenate` will already work with mypy.

http://mypy-lang.blogspot.com/2021/12/mypy-0930-released.html
https://www.python.org/dev/peps/pep-0612/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
