### PR TITLE
Add set sleepnumber service

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -11,7 +11,13 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-from .const import DOMAIN
+from .const import (
+    ATTR_ENTITY,
+    ATTR_SLEEP_NUMBER,
+    DOMAIN,
+    SERVICE_SET_SLEEP_NUMBER,
+    SLEEP_NUMBER,
+)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
@@ -25,6 +31,14 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_PASSWORD): cv.string,
             }
         )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+SERVICE_SET_SLEEP_NUMBER_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY): cv.entity_ids,
+        vol.Optional(ATTR_SLEEP_NUMBER, default=100): vol.Range(0, 100),
     },
     extra=vol.ALLOW_EXTRA,
 )
@@ -52,6 +66,16 @@ def setup(hass, config):
     hass.data[DOMAIN] = data
     discovery.load_platform(hass, "sensor", DOMAIN, {}, config)
     discovery.load_platform(hass, "binary_sensor", DOMAIN, {}, config)
+
+    def handle_set_sleep_number(call):
+        SleepIQService.set_sleepnumber(call, hass, client)
+
+    hass.services.register(
+        DOMAIN,
+        SERVICE_SET_SLEEP_NUMBER,
+        handle_set_sleep_number,
+        schema=SERVICE_SET_SLEEP_NUMBER_SCHEMA,
+    )
 
     return True
 
@@ -106,3 +130,39 @@ class SleepIQSensor(Entity):
 
         self.bed = self.sleepiq_data.beds[self._bed_id]
         self.side = getattr(self.bed, self._side)
+
+
+class SleepIQService:
+    """SleepIQ Services."""
+
+    @staticmethod
+    def set_sleepnumber(call, hass, client):
+        """Call sleepyq library to set the Sleep Number setting of a side of a bed."""
+        entity_ids = call.data.get("entity_id", {})
+        new_value = call.data.get(SLEEP_NUMBER, 100)
+
+        for entity_id in entity_ids:
+            entity = hass.states.get(entity_id)
+            if entity is not None:
+                bed_id = entity.attributes.get("bed_id")
+                side = entity.attributes.get("side")
+                if bed_id is not None and side is not None:
+                    try:
+                        client.set_sleepnumber(side, new_value, bed_id)
+                    except ValueError:
+                        message = """
+                            SleepIQ failed to set the sleep number, check your username and password"
+                        """
+                        _LOGGER.error(message)
+                else:
+                    _LOGGER.error(
+                        "BedID and/or Side missing from EntityID %s. BedID: %s; Side: %s",
+                        entity_id,
+                        bed_id,
+                        side,
+                    )
+            else:
+                _LOGGER.error("EntityID %s does not exist", entity_id)
+                return False
+
+        return True

--- a/homeassistant/components/sleepiq/const.py
+++ b/homeassistant/components/sleepiq/const.py
@@ -2,10 +2,16 @@
 
 DOMAIN = "sleepiq"
 
+BED_ID = "bed_id"
 IS_IN_BED = "is_in_bed"
 SLEEP_NUMBER = "sleep_number"
 SENSOR_TYPES = {SLEEP_NUMBER: "SleepNumber", IS_IN_BED: "Is In Bed"}
 
 LEFT = "left"
 RIGHT = "right"
+SIDE = "side"
 SIDES = [LEFT, RIGHT]
+
+SERVICE_SET_SLEEP_NUMBER = "set_sleep_number"
+ATTR_ENTITY = "entity_id"
+ATTR_SLEEP_NUMBER = "sleep_number"

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -2,7 +2,7 @@
 from homeassistant.components.sensor import SensorEntity
 
 from . import SleepIQSensor
-from .const import DOMAIN, SENSOR_TYPES, SIDES, SLEEP_NUMBER
+from .const import BED_ID, DOMAIN, SENSOR_TYPES, SIDE, SIDES, SLEEP_NUMBER
 
 ICON = "mdi:bed"
 
@@ -45,6 +45,14 @@ class SleepNumberSensor(SleepIQSensor, SensorEntity):
     def icon(self):
         """Icon to use in the frontend, if any."""
         return ICON
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sleepnumber sensor."""
+        return {
+            BED_ID: self._bed_id,
+            SIDE: self._side,
+        }
 
     def update(self):
         """Get the latest data from SleepIQ and updates the states."""

--- a/homeassistant/components/sleepiq/services.yaml
+++ b/homeassistant/components/sleepiq/services.yaml
@@ -1,0 +1,15 @@
+set_sleep_number:
+  description: Sets the Sleep Number setting of a side of a bed.
+  target:
+    entity:
+      domain: sensor
+  fields:
+    sleep_number:
+      description: The new sleep number setting between 5 and 100 in multiples of 5.  A number not a multiple of 5 will be rounded to the nearest multiple.
+      example: "80"
+      default: "100"
+      selector:
+        number:
+          min: 5
+          max: 100
+          step: 5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a service to the SleepIQ integration that allows automations to set the firmness (or SleepNumber) of a side of a bed.

This is a re-attempt of previous PR:
  - #[44552](https://github.com/home-assistant/core/pull/44552)
  - #[41014](https://github.com/home-assistant/core/pull/41014)

Adding this service as an Entity service to the sensor was considered, but I was unable to figure out how that would work on a sensor which is read-only, vice an entity like a switch.  Happy to re-approach this implementation with some guidance.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Added service to set sleep number within Home Assistant sleepiq component:

- sleepiq.set_sleep_number

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: None
- This PR is related to issue: None
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
