### PR TITLE
Add Picnic last_order_max_order_time sensor

### DIFF
--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -35,6 +35,7 @@ SENSOR_LAST_ORDER_SLOT_END = "last_order_slot_end"
 SENSOR_LAST_ORDER_STATUS = "last_order_status"
 SENSOR_LAST_ORDER_ETA_START = "last_order_eta_start"
 SENSOR_LAST_ORDER_ETA_END = "last_order_eta_end"
+SENSOR_LAST_ORDER_MAX_ORDER_TIME = "last_order_max_order_time"
 SENSOR_LAST_ORDER_DELIVERY_TIME = "last_order_delivery_time"
 SENSOR_LAST_ORDER_TOTAL_PRICE = "last_order_total_price"
 
@@ -147,6 +148,16 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         data_type="last_order_data",
         value_fn=lambda last_order: dt_util.parse_datetime(
             str(last_order.get("eta", {}).get("end"))
+        ),
+    ),
+    PicnicSensorEntityDescription(
+        key=SENSOR_LAST_ORDER_MAX_ORDER_TIME,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock-alert-outline",
+        entity_registry_enabled_default=True,
+        data_type="last_order_data",
+        value_fn=lambda last_order: dt_util.parse_datetime(
+            str(last_order.get("slot", {}).get("cut_off_time"))
         ),
     ),
     PicnicSensorEntityDescription(

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -251,7 +251,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         )
         self._assert_sensor(
             "sensor.picnic_last_order_max_order_time",
-            "2021-02-25T21:00:00.000+00:00",
+            "2021-02-25T21:00:00+00:00",
             cls=SensorDeviceClass.TIMESTAMP,
         )
         self._assert_sensor(
@@ -409,7 +409,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
         self._assert_sensor(
-            "sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE
+            "sensor.picnic_last_order_max_order_time", STATE_UNKNOWN
         )
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
 

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -390,7 +390,9 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         )
         self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE)
+        self._assert_sensor(
+            "sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE
+        )
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
     async def test_sensors_malformed_delivery_data(self):
@@ -406,7 +408,9 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         assert self._coordinator.last_update_success is True
         self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
-        self._assert_sensor("sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE)
+        self._assert_sensor(
+            "sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE
+        )
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
 
     async def test_sensors_malformed_response(self):

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -408,9 +408,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         assert self._coordinator.last_update_success is True
         self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
-        self._assert_sensor(
-            "sensor.picnic_last_order_max_order_time", STATE_UNKNOWN
-        )
+        self._assert_sensor("sensor.picnic_last_order_max_order_time", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
 
     async def test_sensors_malformed_response(self):

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -250,6 +250,11 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
             cls=SensorDeviceClass.TIMESTAMP,
         )
         self._assert_sensor(
+            "sensor.picnic_last_order_max_order_time",
+            "2021-02-25T21:00:00.000+00:00",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
             "sensor.picnic_last_order_delivery_time",
             "2021-02-26T19:54:05+00:00",
             cls=SensorDeviceClass.TIMESTAMP,
@@ -385,6 +390,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         )
         self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
 
     async def test_sensors_malformed_delivery_data(self):
@@ -400,6 +406,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         assert self._coordinator.last_update_success is True
         self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
 
     async def test_sensors_malformed_response(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Whilst the `Picnic` integration already provided a sensor for the cut-off time to add groceries in an open order (in shopping cart), there was no sensor indicating how much time was left to add groceries to an _existing_ order. This PR adds this sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20973

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
