### PR TITLE
Add keyboard_remote integration tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -579,7 +579,6 @@ omit =
     homeassistant/components/keenetic_ndms2/router.py
     homeassistant/components/kef/*
     homeassistant/components/keyboard/*
-    homeassistant/components/keyboard_remote/*
     homeassistant/components/kira/*
     homeassistant/components/kiwi/lock.py
     homeassistant/components/knx/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -522,6 +522,7 @@ homeassistant/components/keenetic_ndms2/* @foxel
 tests/components/keenetic_ndms2/* @foxel
 homeassistant/components/kef/* @basnijholt
 homeassistant/components/keyboard_remote/* @bendavid @lanrat
+tests/components/keyboard_remote/* @bendavid @lanrat
 homeassistant/components/kmtronic/* @dgomes
 tests/components/kmtronic/* @dgomes
 homeassistant/components/knx/* @Julius2342 @farmio @marvin-w

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -10,7 +10,7 @@ from evdev import InputDevice, categorize, ecodes, list_devices
 import voluptuous as vol
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant
+from home`assistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -10,7 +10,7 @@ from evdev import InputDevice, categorize, ecodes, list_devices
 import voluptuous as vol
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
-from home`assistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ extension-pkg-allow-list = [
     "av.stream",
     "ciso8601",
     "cv2",
+    "evdev._ecodes",
 ]
 
 [tool.pylint.BASIC]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -605,7 +605,7 @@ epsonprinter==0.0.9
 eternalegypt==0.0.12
 
 # homeassistant.components.keyboard_remote
-# evdev==1.4.0
+evdev==1.4.0
 
 # homeassistant.components.evohome
 evohome-async==0.3.15

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -167,6 +167,9 @@ aiomusiccast==0.14.3
 # homeassistant.components.nanoleaf
 aionanoleaf==0.2.0
 
+# homeassistant.components.keyboard_remote
+aionotify==0.2.0
+
 # homeassistant.components.notion
 aionotion==3.0.2
 
@@ -420,6 +423,9 @@ ephem==4.1.2
 
 # homeassistant.components.epson
 epson-projector==0.4.2
+
+# homeassistant.components.keyboard_remote
+evdev==1.4.0
 
 # homeassistant.components.faa_delays
 faadelays==0.0.7

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -21,7 +21,6 @@ COMMENT_REQUIREMENTS = (
     "bluepy",
     "decora",
     "decora_wifi",
-    "evdev",
     "face_recognition",
     "homeassistant-pyozw",
     "opencv-python-headless",

--- a/tests/components/keyboard_remote/__init__.py
+++ b/tests/components/keyboard_remote/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Keyboard Remote integration."""

--- a/tests/components/keyboard_remote/conftest.py
+++ b/tests/components/keyboard_remote/conftest.py
@@ -1,0 +1,239 @@
+"""Fixtures for Keyboard Remote integration."""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import patch
+
+import aionotify
+from evdev import InputEvent, ecodes
+import pytest
+
+from homeassistant.components.keyboard_remote import (
+    DOMAIN,
+    KEYBOARD_REMOTE_CONNECTED,
+    KEYBOARD_REMOTE_DISCONNECTED,
+)
+from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+WatcherEvent = collections.namedtuple("Event", ["name", "flags", "cookie", "alias"])
+
+
+class InputDeviceInterface:
+    """Duck typing interface to mock evdev.InputDevice."""
+
+    def create_event(self, path: str, code: int, value: int) -> None:
+        """Create a new event."""
+
+
+class WatcherInterface:
+    """Duck typing interface to mock aionotify.Watcher."""
+
+    def create_event(self, name: str, flags: int) -> None:
+        """Create a new event."""
+
+
+class MockManager:
+    """Manager for mock object needed to test keyboard_remote."""
+
+    def __init__(self):
+        """Initialize MockManager."""
+        self._evdev_devices: list[InputDeviceInterface] = []
+        self._aionotify_watcher: WatcherInterface | None = None
+
+    @property
+    def active(self) -> bool:
+        """Return if manager is is active."""
+        return len(self._evdev_devices) > 0
+
+    def add_evdev_device(self, device: InputDeviceInterface) -> None:
+        """Add a new managed evdev device."""
+        self._evdev_devices.append(device)
+
+    def create_evdev_event(self, path: str, code: int, value: int) -> None:
+        """Create a new evdev event (simulated keyboard action)."""
+        for device in self._evdev_devices:
+            device.create_event(path, code, value)
+
+    def add_aionotify_watcher(self, watcher: WatcherInterface) -> None:
+        """Add a new managed aionotify watcher."""
+        self._aionotify_watcher = watcher
+
+    def create_aionotify_event(self, name: str, flags: int) -> None:
+        """Create a new aionotify event (simulated usb plug/unplug)."""
+        self._aionotify_watcher.create_event(name, flags)
+
+    def __enter__(self):
+        """Enter context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit context manager."""
+        self._evdev_devices.clear()
+
+
+def create_input_device(manager: MockManager, devices: dict[str, dict[str, str]]):
+    """Create a mock evdev.InputDevice."""
+
+    class InputDevice(InputDeviceInterface):
+        """Class for mock evdev.InputDevice."""
+
+        def __init__(self, path):
+            if path not in devices:
+                raise OSError
+            self.path: str = devices[path]["path"]
+            self.name: str = devices[path]["name"]
+            self.event: InputEvent | None = None
+            manager.add_evdev_device(self)
+
+        def create_event(self, path: str, code: int, value: int) -> None:
+            """Create a new event (simulated keyboard action)."""
+            if path == self.path:
+                self.event = InputEvent(1, 2, ecodes.EV_KEY, code, value)
+
+        def async_read_loop(self) -> AsyncGenerator:
+            """Iterate events created in create_event()."""
+            return self._async_read_loop()
+
+        async def _async_read_loop(self) -> AsyncGenerator:
+            while manager.active:
+                if self.event:
+                    yield self.event
+                    self.event = None
+                await asyncio.sleep(0.005)
+
+        @staticmethod
+        def fileno() -> int:
+            """Mock call."""
+            return 0
+
+        def __getattr__(self, name):
+            """Mock unimplemented methods."""
+
+            def func(*args, **kwargs):
+                """Mock call."""
+
+            return func
+
+    return InputDevice
+
+
+def create_watcher(manager: MockManager):
+    """Create a mock aionotify.Watcher."""
+
+    class Watcher(WatcherInterface):
+        """Class for mock aionotify.Watcher."""
+
+        def __init__(self):
+            self.event: aionotify.base.Event | None = None
+            manager.add_aionotify_watcher(self)
+
+        def create_event(self, name: str, flags: int) -> None:
+            """Create a new event (simulated keyboard action)."""
+            self.event = WatcherEvent(name=name, flags=flags, cookie="", alias="")
+
+        async def get_event(self) -> aionotify.base.Event:
+            """Return events as they are generated in create_event()."""
+            while manager.active:
+                if self.event:
+                    event = self.event
+                    self.event = None
+                    return event
+                await asyncio.sleep(0.005)
+            raise asyncio.CancelledError
+
+        async def setup(self, *args, **kwargs) -> None:
+            """Mock call."""
+
+        def __getattr__(self, name):
+            """Mock unimplemented methods."""
+
+            def func(*args, **kwargs):
+                """Mock call."""
+
+            return func
+
+    return Watcher
+
+
+@pytest.fixture
+def mock_manager(request: pytest.FixtureRequest) -> Generator[None, MockManager, None]:
+    """Return a manager for creating evdev device and aionotify watcher events."""
+    devices: dict[str, dict[str, str]] = {}
+    paths: list[str] = []
+
+    if hasattr(request, "param"):
+        devices = {p["path"]: p for p in request.param}
+        paths = [p["path"] for p in request.param]
+
+    def realpath(path) -> str:
+        """Mock os.path.realpath."""
+        for device in devices.values():
+            if "symlink" in device and device["symlink"] == path:
+                return device["path"]
+        return path
+
+    with MockManager() as manager:
+        with patch(
+            "homeassistant.components.keyboard_remote.list_devices", return_value=paths
+        ), patch(
+            "homeassistant.components.keyboard_remote.InputDevice",
+            side_effect=create_input_device(manager, devices),
+        ), patch(
+            "aionotify.Watcher", side_effect=create_watcher(manager)
+        ), patch(
+            "os.path.realpath", side_effect=realpath
+        ):
+            yield manager
+
+
+@pytest.fixture
+async def keyboard_remote(
+    hass: HomeAssistant, request: pytest.FixtureRequest
+) -> Generator[None, None, None]:
+    """Create a pre-configured keyboard_remote integration."""
+
+    config = []
+    if hasattr(request, "param"):
+        config = request.param
+
+    # Setup keyboard_remote integration
+    await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+    await hass.async_block_till_done()
+
+    # Trigger keyboard_remote start
+    listener = create_bus_signal(hass, KEYBOARD_REMOTE_CONNECTED)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    # Can't use hass.async_block_till_done() since keyboard_remote integration uses loop
+    await asyncio.wait_for(listener.wait(), 1)
+
+    yield
+
+    listener = create_bus_signal(hass, KEYBOARD_REMOTE_DISCONNECTED)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+
+def create_bus_signal(
+    hass: HomeAssistant, name: str, data: dict | None = None
+) -> asyncio.Event:
+    """Create signal for hass bus events."""
+
+    if data is not None:
+        data.clear()
+
+    signal = asyncio.Event()
+
+    async def listener(event) -> None:
+        nonlocal data
+        if data is not None:
+            data.update(event.data)
+        signal.set()
+
+    hass.bus.async_listen(name, listener)
+
+    return signal

--- a/tests/components/keyboard_remote/test_keyboard_remote.py
+++ b/tests/components/keyboard_remote/test_keyboard_remote.py
@@ -1,0 +1,332 @@
+"""Tests for Keyboard Remote config entry."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import aionotify
+import pytest
+
+from homeassistant.components.keyboard_remote import (
+    DOMAIN,
+    KEY_VALUE,
+    KEYBOARD_REMOTE_COMMAND_RECEIVED,
+    KEYBOARD_REMOTE_CONNECTED,
+    KEYBOARD_REMOTE_DISCONNECTED,
+)
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import MockManager, create_bus_signal
+
+from tests.common import assert_setup_component
+
+KEY_DOWN = KEY_VALUE["key_down"]
+KEY_UP = KEY_VALUE["key_up"]
+KEY_HOLD = KEY_VALUE["key_hold"]
+
+
+async def test_config_empty(hass: HomeAssistant) -> None:
+    """Test setup ignored with empty config."""
+    config = []
+    with assert_setup_component(0, DOMAIN) as handle_config:
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+    assert not handle_config[DOMAIN]
+
+
+async def test_config_single_device(hass: HomeAssistant) -> None:
+    """Test setup succeeds with single device in config."""
+    config = [{"device_descriptor": "/dev/input/event2", "type": ["key_up"]}]
+    with assert_setup_component(1, DOMAIN) as handle_config:
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+    assert handle_config[DOMAIN]
+
+
+async def test_config_multiple_devices(hass: HomeAssistant) -> None:
+    """Test setup succeeds with multiple devices in config."""
+    config = [
+        {"device_descriptor": "/dev/input/event1", "type": ["key_up"]},
+        {"device_name": "USB Keyboard", "type": ["key_up"]},
+    ]
+    with assert_setup_component(2, DOMAIN) as handle_config:
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+    assert handle_config[DOMAIN]
+
+
+async def test_config_conflicting_params(hass: HomeAssistant) -> None:
+    """Test setup fails with conflicting config params."""
+    config = [
+        {
+            "device_descriptor": "/dev/input/event1",
+            "device_name": "USB Keyboard",
+            "type": ["key_up"],
+        }
+    ]
+    with assert_setup_component(0, DOMAIN) as handle_config:
+        await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+    assert not handle_config[DOMAIN]
+
+
+async def test_config_bad_type(hass: HomeAssistant) -> None:
+    """Test setup fails with bad config type param."""
+    config = [{"device_descriptor": "/dev/input/event1", "type": ["key_bad"]}]
+    with assert_setup_component(0, DOMAIN) as handle_config:
+        await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+    assert not handle_config[DOMAIN]
+
+
+async def test_setup_bad_descriptor(
+    hass: HomeAssistant, mock_manager: MockManager
+) -> None:
+    """Test setup fails with non-existent descriptor."""
+    with patch(
+        "homeassistant.components.keyboard_remote.list_devices",
+        return_value=["/dev/input/notfound"],
+    ):
+        # Setup keyboard_remote
+        config = [{"device_descriptor": "/dev/input/event1", "type": ["key_up"]}]
+        with assert_setup_component(1, DOMAIN) as handle_config:
+            await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        assert handle_config[DOMAIN]
+        await hass.async_block_till_done()
+
+        # Attempt startup
+        listener = create_bus_signal(hass, KEYBOARD_REMOTE_CONNECTED)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+        # Assert didn't start
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(listener.wait(), 0.05)
+
+
+@pytest.mark.parametrize(
+    "mock_manager,keyboard_remote",
+    [
+        (
+            [  # mock_manager config
+                {"path": "/dev/input/event1", "name": "USB Other"},
+                {"path": "/dev/input/event2", "name": "Test USB Keyboard"},
+                {"path": "/dev/input/event3", "name": "Test USB System Control"},
+                {"path": "/dev/input/event4", "name": "Test Named USB Keyboard"},
+                {
+                    "path": "/dev/input/event5",
+                    "name": "Test Symlinked USB Keyboard",
+                    "symlink": "/dev/input/by-id/usb-Symlinked-event-kbd",
+                },
+            ],
+            [  # keyboard_remote config
+                {
+                    "device_descriptor": "/dev/input/event2",
+                    "type": ["key_down", "key_up", "key_hold"],
+                },
+                {"device_descriptor": "/dev/input/event3", "type": ["key_down"]},
+                {"device_name": "Test Named USB Keyboard", "type": ["key_down"]},
+                {
+                    "device_descriptor": "/dev/input/by-id/usb-Symlinked-event-kbd",
+                    "type": ["key_down"],
+                },
+            ],
+        )
+    ],
+    indirect=True,
+)
+async def test_command_basic(
+    hass: HomeAssistant, mock_manager: MockManager, keyboard_remote: None
+) -> None:
+    """Test keyboard commands."""
+    data: dict[str, str] = {}
+    signal = create_bus_signal(hass, KEYBOARD_REMOTE_COMMAND_RECEIVED, data)
+
+    # Test event1 key_down ignored (since event1 not being listened to)
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event1", 32, KEY_DOWN)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(signal.wait(), 0.05)
+
+    # Test event2 key_down received
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_down"
+    assert data["device_descriptor"] == "/dev/input/event2"
+    assert data["device_name"] == "Test USB Keyboard"
+
+    # Test event2 key_hold received
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_HOLD)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_hold"
+    assert data["device_descriptor"] == "/dev/input/event2"
+    assert data["device_name"] == "Test USB Keyboard"
+
+    # Test repeated event2 key_hold received
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_HOLD)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_hold"
+    assert data["device_descriptor"] == "/dev/input/event2"
+    assert data["device_name"] == "Test USB Keyboard"
+
+    # Test event2 key_up received
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_UP)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_up"
+    assert data["device_descriptor"] == "/dev/input/event2"
+    assert data["device_name"] == "Test USB Keyboard"
+
+    # Test event3 key_down received
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event3", 31, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 31
+    assert data["type"] == "key_down"
+    assert data["device_descriptor"] == "/dev/input/event3"
+    assert data["device_name"] == "Test USB System Control"
+
+    # Test event3 key_up ignored (since event3 key_up not being listened to)
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event3", 32, KEY_UP)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(signal.wait(), 0.05)
+
+    # Test named event4 key_down received
+    mock_manager.create_evdev_event("/dev/input/event4", 30, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_down"
+    assert data["device_descriptor"] == "/dev/input/event4"
+    assert data["device_name"] == "Test Named USB Keyboard"
+
+    # Test symlinked event5 key_down works
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event5", 32, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 32
+    assert data["device_descriptor"] == "/dev/input/event5"
+    assert data["device_name"] == "Test Symlinked USB Keyboard"
+
+
+@pytest.mark.parametrize(
+    "mock_manager,keyboard_remote",
+    [
+        (
+            [  # mock_manager config
+                {"path": "/dev/input/event2", "name": "Test USB Keyboard"}
+            ],
+            [  # keyboard_remote config
+                {
+                    "device_descriptor": "/dev/input/event2",
+                    "type": ["key_down", "key_up"],
+                    "emulate_key_hold_repeat": 0.1,
+                    "emulate_key_hold": True,
+                    "emulate_key_hold_delay": 0.01,
+                }
+            ],
+        )
+    ],
+    indirect=True,
+)
+async def test_command_emulated_hold(
+    hass: HomeAssistant, mock_manager: MockManager, keyboard_remote: None
+) -> None:
+    """Test emulated hold keyboard commands."""
+    data: dict[str, str] = {}
+    signal = create_bus_signal(hass, KEYBOARD_REMOTE_COMMAND_RECEIVED, data)
+
+    # Test event2 key_down
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_down"
+    assert data["device_descriptor"] == "/dev/input/event2"
+
+    # Test event2 key_hold automatically generated
+    signal.clear()
+    await asyncio.wait_for(signal.wait(), 0.015)  # wait at least emulate_key_hold_delay
+    assert data["key_code"] == 30
+    assert data["type"] == "key_hold"
+    assert data["device_descriptor"] == "/dev/input/event2"
+
+    # Test event2 key_up
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_UP)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["type"] == "key_up"
+    assert data["device_descriptor"] == "/dev/input/event2"
+
+    # Test event2 key_hold is canceled on teardown
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+
+
+@pytest.mark.parametrize(
+    "mock_manager,keyboard_remote",
+    [
+        (
+            [  # mock_manager config
+                {"path": "/dev/input/event2", "name": "Test USB Keyboard"},
+                {"path": "/dev/input/event3", "name": "Test Other USB Keyboard"},
+            ],
+            [  # keyboard_remote config
+                {"device_descriptor": "/dev/input/event2", "type": ["key_down"]},
+            ],
+        )
+    ],
+    indirect=True,
+)
+async def test_device_monitor(
+    hass: HomeAssistant, mock_manager: MockManager, keyboard_remote: None
+) -> None:
+    """Test device monitoring."""
+    data = {}
+    signal = create_bus_signal(hass, KEYBOARD_REMOTE_COMMAND_RECEIVED, data)
+
+    connect_data = {}
+    connect_signal = create_bus_signal(hass, KEYBOARD_REMOTE_CONNECTED, connect_data)
+
+    disconnect_data = {}
+    disconnect_signal = create_bus_signal(
+        hass, KEYBOARD_REMOTE_DISCONNECTED, disconnect_data
+    )
+
+    # Baseline event2 key_down check
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.1)
+    assert data["key_code"] == 30
+    assert data["device_descriptor"] == "/dev/input/event2"
+
+    # Disconnect /dev/input/event2
+    mock_manager.create_aionotify_event("event2", aionotify.Flags.DELETE)
+    await asyncio.wait_for(disconnect_signal.wait(), 0.2)
+    assert disconnect_data["device_descriptor"] == "/dev/input/event2"
+
+    # Test event2 key_down ignored (since event2 no longer being listened to)
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_DOWN)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(signal.wait(), 0.05)
+
+    # Reconnect /dev/input/event2
+    mock_manager.create_aionotify_event("event2", aionotify.Flags.CREATE)
+    await asyncio.wait_for(connect_signal.wait(), 0.2)
+
+    # Test event2 key_down works again
+    signal.clear()
+    mock_manager.create_evdev_event("/dev/input/event2", 30, KEY_DOWN)
+    await asyncio.wait_for(signal.wait(), 0.2)
+    assert data["key_code"] == 30
+    assert data["device_descriptor"] == "/dev/input/event2"
+
+    # Test events for inputs not in config are ignored
+    connect_signal.clear()
+    mock_manager.create_aionotify_event("event3", aionotify.Flags.CREATE)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(connect_signal.wait(), 0.05)


### PR DESCRIPTION
## Proposed change
Added tests for the keyboard_remote integration. This will establish a working baseline of tests to help guard against future regressions, such as another PR I am working on to add new features to it.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

The tests work by mocking out the two primary external dependencies evdev.InputDevice and aionotify.Watcher. These mocked dependencies (defined in conftest.py) give the tests the ability to generate mock events allowing for full functional testing of the integration.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
