### PR TITLE
Allow mobile app registrations only supporting websocket push

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -551,8 +551,8 @@ homeassistant/components/minecraft_server/* @elmurato
 tests/components/minecraft_server/* @elmurato
 homeassistant/components/minio/* @tkislan
 tests/components/minio/* @tkislan
-homeassistant/components/mobile_app/* @robbiet480
-tests/components/mobile_app/* @robbiet480
+homeassistant/components/mobile_app/* @home-assistant/core
+tests/components/mobile_app/* @home-assistant/core
 homeassistant/components/modbus/* @adamchengtkc @janiversen @vzahradnik
 tests/components/modbus/* @adamchengtkc @janiversen @vzahradnik
 homeassistant/components/modem_callerid/* @tkdrob

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -1,4 +1,8 @@
 """Constants for mobile_app."""
+import voluptuous as vol
+
+from homeassistant.helpers import config_validation as cv
+
 DOMAIN = "mobile_app"
 
 STORAGE_KEY = DOMAIN
@@ -26,6 +30,7 @@ ATTR_MANUFACTURER = "manufacturer"
 ATTR_MODEL = "model"
 ATTR_OS_NAME = "os_name"
 ATTR_OS_VERSION = "os_version"
+ATTR_PUSH_HAS_LOCAL = "push_has_local"
 ATTR_PUSH_TOKEN = "push_token"
 ATTR_PUSH_URL = "push_url"
 ATTR_PUSH_RATE_LIMITS = "rateLimits"
@@ -76,3 +81,12 @@ SIGNAL_SENSOR_UPDATE = f"{DOMAIN}_sensor_update"
 SIGNAL_LOCATION_UPDATE = DOMAIN + "_location_update_{}"
 
 ATTR_CAMERA_ENTITY_ID = "camera_entity_id"
+
+SCHEMA_APP_DATA = vol.Schema(
+    {
+        vol.Inclusive(ATTR_PUSH_TOKEN, "push_cloud"): cv.string,
+        vol.Inclusive(ATTR_PUSH_URL, "push_cloud"): cv.url,
+        vol.Optional(ATTR_PUSH_HAS_LOCAL): cv.boolean,
+    },
+    extra=vol.ALLOW_EXTRA,
+)

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -30,7 +30,7 @@ ATTR_MANUFACTURER = "manufacturer"
 ATTR_MODEL = "model"
 ATTR_OS_NAME = "os_name"
 ATTR_OS_VERSION = "os_version"
-ATTR_PUSH_HAS_LOCAL = "push_has_local"
+ATTR_PUSH_WEBSOCKET_CHANNEL = "push_websocket_channel"
 ATTR_PUSH_TOKEN = "push_token"
 ATTR_PUSH_URL = "push_url"
 ATTR_PUSH_RATE_LIMITS = "rateLimits"
@@ -86,7 +86,9 @@ SCHEMA_APP_DATA = vol.Schema(
     {
         vol.Inclusive(ATTR_PUSH_TOKEN, "push_cloud"): cv.string,
         vol.Inclusive(ATTR_PUSH_URL, "push_cloud"): cv.url,
-        vol.Optional(ATTR_PUSH_HAS_LOCAL): cv.boolean,
+        # Set to True to indicate that this registration will connect via websocket channel
+        # to receive push notifications.
+        vol.Optional(ATTR_PUSH_WEBSOCKET_CHANNEL): cv.boolean,
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_SECRET,
     CONF_USER_ID,
     DOMAIN,
+    SCHEMA_APP_DATA,
 )
 from .helpers import supports_encryption
 
@@ -45,7 +46,7 @@ class RegistrationsView(HomeAssistantView):
     @RequestDataValidator(
         vol.Schema(
             {
-                vol.Optional(ATTR_APP_DATA, default={}): dict,
+                vol.Optional(ATTR_APP_DATA, default={}): SCHEMA_APP_DATA,
                 vol.Required(ATTR_APP_ID): cv.string,
                 vol.Required(ATTR_APP_NAME): cv.string,
                 vol.Required(ATTR_APP_VERSION): cv.string,

--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -6,7 +6,7 @@
   "requirements": ["PyNaCl==1.4.0", "emoji==1.5.0"],
   "dependencies": ["http", "webhook", "person", "tag", "websocket_api"],
   "after_dependencies": ["cloud", "camera", "notify"],
-  "codeowners": ["@robbiet480"],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal",
   "iot_class": "local_push"
 }

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -119,13 +119,16 @@ class MobileAppNotificationService(BaseNotificationService):
         local_push_channels = self.hass.data[DOMAIN][DATA_PUSH_CHANNEL]
 
         for target in targets:
+            registration = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target].data
+
             if target in local_push_channels:
                 local_push_channels[target].async_send_notification(
-                    data, partial(self._async_send_remote_message_target, target)
+                    data,
+                    partial(
+                        self._async_send_remote_message_target, target, registration
+                    ),
                 )
                 continue
-
-            registration = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target].data
 
             # Test if local push only.
             if ATTR_PUSH_URL not in registration[ATTR_APP_DATA]:

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -15,6 +15,7 @@ from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT,
     BaseNotificationService,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.util.dt as dt_util
 
@@ -124,14 +125,19 @@ class MobileAppNotificationService(BaseNotificationService):
                 )
                 continue
 
-            await self._async_send_remote_message_target(target, data)
+            registration = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target].data
 
-    async def _async_send_remote_message_target(self, target, data):
+            # Test if local push only.
+            if ATTR_PUSH_URL not in registration[ATTR_APP_DATA]:
+                raise HomeAssistantError(
+                    "Device not connected to local push notifications"
+                )
+
+            await self._async_send_remote_message_target(target, registration, data)
+
+    async def _async_send_remote_message_target(self, target, registration, data):
         """Send a message to a target."""
-        entry = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target]
-        entry_data = entry.data
-
-        app_data = entry_data[ATTR_APP_DATA]
+        app_data = registration[ATTR_APP_DATA]
         push_token = app_data[ATTR_PUSH_TOKEN]
         push_url = app_data[ATTR_PUSH_URL]
 
@@ -139,12 +145,12 @@ class MobileAppNotificationService(BaseNotificationService):
         target_data[ATTR_PUSH_TOKEN] = push_token
 
         reg_info = {
-            ATTR_APP_ID: entry_data[ATTR_APP_ID],
-            ATTR_APP_VERSION: entry_data[ATTR_APP_VERSION],
+            ATTR_APP_ID: registration[ATTR_APP_ID],
+            ATTR_APP_VERSION: registration[ATTR_APP_VERSION],
             ATTR_WEBHOOK_ID: target,
         }
-        if ATTR_OS_VERSION in entry_data:
-            reg_info[ATTR_OS_VERSION] = entry_data[ATTR_OS_VERSION]
+        if ATTR_OS_VERSION in registration:
+            reg_info[ATTR_OS_VERSION] = registration[ATTR_OS_VERSION]
 
         target_data["registration_info"] = reg_info
 
@@ -160,7 +166,7 @@ class MobileAppNotificationService(BaseNotificationService):
                 HTTPStatus.CREATED,
                 HTTPStatus.ACCEPTED,
             ):
-                log_rate_limits(self.hass, entry_data[ATTR_DEVICE_NAME], result)
+                log_rate_limits(self.hass, registration[ATTR_DEVICE_NAME], result)
                 return
 
             fallback_error = result.get("errorMessage", "Unknown error")
@@ -177,7 +183,7 @@ class MobileAppNotificationService(BaseNotificationService):
             if response.status == HTTPStatus.TOO_MANY_REQUESTS:
                 _LOGGER.warning(message)
                 log_rate_limits(
-                    self.hass, entry_data[ATTR_DEVICE_NAME], result, logging.WARNING
+                    self.hass, registration[ATTR_DEVICE_NAME], result, logging.WARNING
                 )
             else:
                 _LOGGER.error(message)

--- a/homeassistant/components/mobile_app/util.py
+++ b/homeassistant/components/mobile_app/util.py
@@ -7,6 +7,7 @@ from homeassistant.core import callback
 
 from .const import (
     ATTR_APP_DATA,
+    ATTR_PUSH_HAS_LOCAL,
     ATTR_PUSH_TOKEN,
     ATTR_PUSH_URL,
     DATA_CONFIG_ENTRIES,
@@ -37,7 +38,9 @@ def supports_push(hass, webhook_id: str) -> bool:
     """Return if push notifications is supported."""
     config_entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id]
     app_data = config_entry.data[ATTR_APP_DATA]
-    return ATTR_PUSH_TOKEN in app_data and ATTR_PUSH_URL in app_data
+    return (
+        ATTR_PUSH_TOKEN in app_data and ATTR_PUSH_URL in app_data
+    ) or ATTR_PUSH_HAS_LOCAL in app_data
 
 
 @callback

--- a/homeassistant/components/mobile_app/util.py
+++ b/homeassistant/components/mobile_app/util.py
@@ -7,9 +7,9 @@ from homeassistant.core import callback
 
 from .const import (
     ATTR_APP_DATA,
-    ATTR_PUSH_HAS_LOCAL,
     ATTR_PUSH_TOKEN,
     ATTR_PUSH_URL,
+    ATTR_PUSH_WEBSOCKET_CHANNEL,
     DATA_CONFIG_ENTRIES,
     DATA_DEVICES,
     DATA_NOTIFY,
@@ -40,7 +40,7 @@ def supports_push(hass, webhook_id: str) -> bool:
     app_data = config_entry.data[ATTR_APP_DATA]
     return (
         ATTR_PUSH_TOKEN in app_data and ATTR_PUSH_URL in app_data
-    ) or ATTR_PUSH_HAS_LOCAL in app_data
+    ) or ATTR_PUSH_WEBSOCKET_CHANNEL in app_data
 
 
 @callback

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -91,6 +91,7 @@ from .const import (
     ERR_ENCRYPTION_REQUIRED,
     ERR_INVALID_FORMAT,
     ERR_SENSOR_NOT_REGISTERED,
+    SCHEMA_APP_DATA,
     SIGNAL_LOCATION_UPDATE,
     SIGNAL_SENSOR_UPDATE,
 )
@@ -332,7 +333,7 @@ async def webhook_update_location(hass, config_entry, data):
 @WEBHOOK_COMMANDS.register("update_registration")
 @validate_schema(
     {
-        vol.Optional(ATTR_APP_DATA, default={}): dict,
+        vol.Optional(ATTR_APP_DATA): SCHEMA_APP_DATA,
         vol.Required(ATTR_APP_VERSION): cv.string,
         vol.Required(ATTR_DEVICE_NAME): cv.string,
         vol.Required(ATTR_MANUFACTURER): cv.string,

--- a/tests/common.py
+++ b/tests/common.py
@@ -286,7 +286,12 @@ async def async_test_home_assistant(loop, load_registries=True):
     hass.config.media_dirs = {"local": get_test_config_dir("media")}
     hass.config.skip_pip = True
 
-    hass.config_entries = config_entries.ConfigEntries(hass, {})
+    hass.config_entries = config_entries.ConfigEntries(
+        hass,
+        {
+            "_": "Not empty or else some bad checks for hass config in discovery.py breaks"
+        },
+    )
     hass.config_entries._entries = {}
     hass.config_entries._store._async_ensure_stop_listener = lambda: None
 

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.mobile_app.const import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -100,6 +101,38 @@ async def setup_push_receiver(hass, aioclient_mock, hass_admin_user):
 
     assert hass.services.has_service("notify", "mobile_app_test")
     assert hass.services.has_service("notify", "mobile_app_loaded_late")
+
+
+@pytest.fixture
+async def setup_local_push(hass, hass_admin_user):
+    """Set up local push."""
+    local_push_entry = MockConfigEntry(
+        data={
+            "app_data": {"push_has_local": True},
+            "app_id": "io.homeassistant.mobile_app",
+            "app_name": "mobile_app tests",
+            "app_version": "1.0",
+            "device_id": "local-push-device-id",
+            "device_name": "Local Push Name",
+            "manufacturer": "Home Assistant",
+            "model": "mobile_app",
+            "os_name": "Linux",
+            "os_version": "5.0.6",
+            "secret": "123abc2",
+            "supports_encryption": False,
+            "user_id": hass_admin_user.id,
+            "webhook_id": "local-push-webhook-id",
+        },
+        domain=DOMAIN,
+        source="registration",
+        title="local push test entry",
+        version=1,
+    )
+    local_push_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(local_push_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service("notify", "mobile_app_local_push_name")
 
 
 async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
@@ -333,3 +366,39 @@ async def test_notify_ws_not_confirming(
     )
 
     assert len(aioclient_mock.mock_calls) == 3
+
+
+async def test_local_push_only(hass, hass_ws_client, setup_local_push):
+    """Test a local only push registration."""
+    with pytest.raises(HomeAssistantError) as e_info:
+        assert await hass.services.async_call(
+            "notify",
+            "mobile_app_local_push_name",
+            {"message": "Not connected"},
+            blocking=True,
+        )
+
+    assert str(e_info.value) == "Device not connected to local push notifications"
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "mobile_app/push_notification_channel",
+            "webhook_id": "local-push-webhook-id",
+        }
+    )
+
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+
+    assert await hass.services.async_call(
+        "notify",
+        "mobile_app_local_push_name",
+        {"message": "Hello world 1"},
+        blocking=True,
+    )
+
+    msg = await client.receive_json()
+    assert msg == {"id": 5, "type": "event", "event": {"message": "Hello world 1"}}

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -104,16 +104,16 @@ async def setup_push_receiver(hass, aioclient_mock, hass_admin_user):
 
 
 @pytest.fixture
-async def setup_local_push(hass, hass_admin_user):
+async def setup_websocket_channel_only_push(hass, hass_admin_user):
     """Set up local push."""
-    local_push_entry = MockConfigEntry(
+    entry = MockConfigEntry(
         data={
-            "app_data": {"push_has_local": True},
+            "app_data": {"push_websocket_channel": True},
             "app_id": "io.homeassistant.mobile_app",
             "app_name": "mobile_app tests",
             "app_version": "1.0",
-            "device_id": "local-push-device-id",
-            "device_name": "Local Push Name",
+            "device_id": "websocket-push-device-id",
+            "device_name": "Websocket Push Name",
             "manufacturer": "Home Assistant",
             "model": "mobile_app",
             "os_name": "Linux",
@@ -121,18 +121,18 @@ async def setup_local_push(hass, hass_admin_user):
             "secret": "123abc2",
             "supports_encryption": False,
             "user_id": hass_admin_user.id,
-            "webhook_id": "local-push-webhook-id",
+            "webhook_id": "websocket-push-webhook-id",
         },
         domain=DOMAIN,
         source="registration",
-        title="local push test entry",
+        title="websocket push test entry",
         version=1,
     )
-    local_push_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(local_push_entry.entry_id)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.services.has_service("notify", "mobile_app_local_push_name")
+    assert hass.services.has_service("notify", "mobile_app_websocket_push_name")
 
 
 async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
@@ -368,12 +368,12 @@ async def test_notify_ws_not_confirming(
     assert len(aioclient_mock.mock_calls) == 3
 
 
-async def test_local_push_only(hass, hass_ws_client, setup_local_push):
+async def test_local_push_only(hass, hass_ws_client, setup_websocket_channel_only_push):
     """Test a local only push registration."""
     with pytest.raises(HomeAssistantError) as e_info:
         assert await hass.services.async_call(
             "notify",
-            "mobile_app_local_push_name",
+            "mobile_app_websocket_push_name",
             {"message": "Not connected"},
             blocking=True,
         )
@@ -386,7 +386,7 @@ async def test_local_push_only(hass, hass_ws_client, setup_local_push):
         {
             "id": 5,
             "type": "mobile_app/push_notification_channel",
-            "webhook_id": "local-push-webhook-id",
+            "webhook_id": "websocket-push-webhook-id",
         }
     )
 
@@ -395,7 +395,7 @@ async def test_local_push_only(hass, hass_ws_client, setup_local_push):
 
     assert await hass.services.async_call(
         "notify",
-        "mobile_app_local_push_name",
+        "mobile_app_websocket_push_name",
         {"message": "Hello world 1"},
         blocking=True,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mobile app: allow registrations to support websocket push notifications only.

Docs https://github.com/home-assistant/developers.home-assistant/pull/1172


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
