### PR TITLE
Add support for Add-on discovery in rtsp_to_webrtc

### DIFF
--- a/homeassistant/components/rtsp_to_webrtc/config_flow.py
+++ b/homeassistant/components/rtsp_to_webrtc/config_flow.py
@@ -24,7 +24,7 @@ DATA_SCHEMA = vol.Schema({vol.Required(DATA_SERVER_URL): str})
 class RTSPToWebRTCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """RTSPtoWebRTC config flow."""
 
-    _hassio_discovery: dict[str, Any] | None = None
+    _hassio_discovery: dict[str, Any]
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -83,7 +83,6 @@ class RTSPToWebRTCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Confirm Add-on discovery."""
-        assert self._hassio_discovery
         errors = None
         if user_input is not None:
             # Validate server connection once user has confirmed

--- a/homeassistant/components/rtsp_to_webrtc/config_flow.py
+++ b/homeassistant/components/rtsp_to_webrtc/config_flow.py
@@ -9,6 +9,8 @@ import rtsp_to_webrtc
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import HassioServiceInfo
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -21,6 +23,8 @@ DATA_SCHEMA = vol.Schema({vol.Required(DATA_SERVER_URL): str})
 
 class RTSPToWebRTCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """RTSPtoWebRTC config flow."""
+
+    _hassio_discovery: dict[str, Any] | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -41,25 +45,64 @@ class RTSPToWebRTCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors={DATA_SERVER_URL: "invalid_url"},
             )
 
-        errors = {}
-        client = rtsp_to_webrtc.client.Client(async_get_clientsession(self.hass), url)
-        try:
-            await client.heartbeat()
-        except rtsp_to_webrtc.exceptions.ResponseError as err:
-            _LOGGER.error("RTSPtoWebRTC server failure: %s", str(err))
-            errors["base"] = "server_failure"
-        except rtsp_to_webrtc.exceptions.ClientError as err:
-            _LOGGER.error("RTSPtoWebRTC communication failure: %s", str(err))
-            errors["base"] = "server_unreachable"
-        if errors:
+        if error_code := await self._test_connection(url):
             return self.async_show_form(
                 step_id="user",
                 data_schema=DATA_SCHEMA,
-                errors=errors,
+                errors={"base": error_code},
             )
 
         await self.async_set_unique_id(DOMAIN)
         return self.async_create_entry(
             title=url,
+            data={DATA_SERVER_URL: url},
+        )
+
+    async def _test_connection(self, url: str) -> str | None:
+        """Test the connection and return any relevant errors."""
+        client = rtsp_to_webrtc.client.Client(async_get_clientsession(self.hass), url)
+        try:
+            await client.heartbeat()
+        except rtsp_to_webrtc.exceptions.ResponseError as err:
+            _LOGGER.error("RTSPtoWebRTC server failure: %s", str(err))
+            return "server_failure"
+        except rtsp_to_webrtc.exceptions.ClientError as err:
+            _LOGGER.error("RTSPtoWebRTC communication failure: %s", str(err))
+            return "server_unreachable"
+        return None
+
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
+        """Prepare confiugration for the RTSPtoWebRTC server add-on discovery."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        self._hassio_discovery = discovery_info.config
+        return await self.async_step_hassio_confirm()
+
+    async def async_step_hassio_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm Add-on discovery."""
+        assert self._hassio_discovery
+        errors = None
+        if user_input is not None:
+            # Validate server connection once user has confirmed
+            host = self._hassio_discovery[CONF_HOST]
+            port = self._hassio_discovery[CONF_PORT]
+            url = f"http://{host}:{port}"
+            if error_code := await self._test_connection(url):
+                errors = {"base": error_code}
+
+        if user_input is None or errors:
+            # Show initial confirmation or errors from server validation
+            return self.async_show_form(
+                step_id="hassio_confirm",
+                description_placeholders={"addon": self._hassio_discovery["addon"]},
+                data_schema=vol.Schema({}),
+                errors=errors,
+            )
+
+        return self.async_create_entry(
+            title=self._hassio_discovery["addon"],
             data={DATA_SERVER_URL: url},
         )

--- a/homeassistant/components/rtsp_to_webrtc/strings.json
+++ b/homeassistant/components/rtsp_to_webrtc/strings.json
@@ -7,6 +7,10 @@
         "data": {
           "server_url": "RTSPtoWebRTC server URL e.g. https://example.com"
         }
+      },
+      "hassio_confirm": {
+        "title": "RTSPtoWebRTC via Home Assistant add-on",
+        "description": "Do you want to configure Home Assistant to connect to the RTSPtoWebRTC server provided by the add-on: {addon}?"
       }
     },
     "error": {

--- a/tests/components/rtsp_to_webrtc/test_config_flow.py
+++ b/tests/components/rtsp_to_webrtc/test_config_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import rtsp_to_webrtc
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.rtsp_to_webrtc import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -31,6 +32,7 @@ async def test_web_full_flow(hass: HomeAssistant) -> None:
             result["flow_id"], {"server_url": "https://example.com"}
         )
         assert result.get("type") == "create_entry"
+        assert result.get("title") == "https://example.com"
         assert "result" in result
         assert result["result"].data == {"server_url": "https://example.com"}
 
@@ -107,4 +109,107 @@ async def test_server_failure(hass: HomeAssistant) -> None:
         )
         assert result.get("type") == "form"
         assert result.get("step_id") == "user"
+        assert result.get("errors") == {"base": "server_failure"}
+
+
+async def test_hassio_discovery(hass):
+    """Test supervisor add-on discovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=HassioServiceInfo(
+            config={
+                "addon": "RTSPtoWebRTC",
+                "host": "fake-server",
+                "port": 8083,
+            }
+        ),
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "hassio_confirm"
+    assert result.get("description_placeholders") == {"addon": "RTSPtoWebRTC"}
+
+    with patch("rtsp_to_webrtc.client.Client.heartbeat"), patch(
+        "homeassistant.components.rtsp_to_webrtc.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
+
+        assert result.get("type") == "create_entry"
+        assert result.get("title") == "RTSPtoWebRTC"
+        assert "result" in result
+        assert result["result"].data == {"server_url": "http://fake-server:8083"}
+
+        assert len(mock_setup.mock_calls) == 1
+
+
+async def test_hassio_single_config_entry(hass: HomeAssistant) -> None:
+    """Test supervisor add-on discovery only allows a single entry."""
+    old_entry = MockConfigEntry(domain=DOMAIN, data={"example": True})
+    old_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=HassioServiceInfo(
+            config={
+                "addon": "RTSPtoWebRTC",
+                "host": "fake-server",
+                "port": 8083,
+            }
+        ),
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+    assert result.get("type") == "abort"
+    assert result.get("reason") == "single_instance_allowed"
+
+
+async def test_hassio_ignored(hass: HomeAssistant) -> None:
+    """Test ignoring superversor add-on discovery."""
+    old_entry = MockConfigEntry(domain=DOMAIN, source=config_entries.SOURCE_IGNORE)
+    old_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=HassioServiceInfo(
+            config={
+                "addon": "RTSPtoWebRTC",
+                "host": "fake-server",
+                "port": 8083,
+            }
+        ),
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+    assert result.get("type") == "abort"
+    assert result.get("reason") == "single_instance_allowed"
+
+
+async def test_hassio_discovery_server_failure(hass: HomeAssistant) -> None:
+    """Test server failure during supvervisor add-on discovery shows an error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=HassioServiceInfo(
+            config={
+                "addon": "RTSPtoWebRTC",
+                "host": "fake-server",
+                "port": 8083,
+            }
+        ),
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "hassio_confirm"
+    assert not result.get("errors")
+    assert "flow_id" in result
+
+    with patch(
+        "rtsp_to_webrtc.client.Client.heartbeat",
+        side_effect=rtsp_to_webrtc.exceptions.ResponseError(),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result.get("type") == "form"
+        assert result.get("step_id") == "hassio_confirm"
         assert result.get("errors") == {"base": "server_failure"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add supervisor add-on discover support to rtsp_to_webrtc so that the integration can be
configured when an add-on is added.

This was modeled after the existing implementations in Ad Guard and deCONZ.

I have not manually tested this yet as I don't have a working supervisor development environment yet, but will be attempting to get that set up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
