### PR TITLE
Use more narrow exception catching in `nest`

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -8,9 +8,11 @@ import logging
 from aiohttp import web
 from google_nest_sdm.event import EventMessage
 from google_nest_sdm.exceptions import (
+    ApiException,
     AuthException,
     ConfigurationException,
-    GoogleNestException,
+    DecodeException,
+    SubscriberException,
 )
 import voluptuous as vol
 
@@ -245,7 +247,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Configuration error: %s", err)
         subscriber.stop_async()
         return False
-    except GoogleNestException as err:
+    except SubscriberException as err:
         if DATA_NEST_UNAVAILABLE not in hass.data[DOMAIN]:
             _LOGGER.error("Subscriber error: %s", err)
             hass.data[DOMAIN][DATA_NEST_UNAVAILABLE] = True
@@ -254,7 +256,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await subscriber.async_get_device_manager()
-    except GoogleNestException as err:
+    except ApiException as err:
         if DATA_NEST_UNAVAILABLE not in hass.data[DOMAIN]:
             _LOGGER.error("Device manager error: %s", err)
             hass.data[DOMAIN][DATA_NEST_UNAVAILABLE] = True
@@ -296,7 +298,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     _LOGGER.debug("Deleting subscriber '%s'", subscriber.subscriber_id)
     try:
         await subscriber.delete_subscription()
-    except GoogleNestException as err:
+    except (AuthException, SubscriberException) as err:
         _LOGGER.warning(
             "Unable to delete subscription '%s'; Will be automatically cleaned up by cloud console: %s",
             subscriber.subscriber_id,
@@ -337,7 +339,7 @@ class NestEventMediaView(HomeAssistantView):
             )
         try:
             event_media = await nest_device.event_media_manager.get_media(event_id)
-        except GoogleNestException as err:
+        except (DecodeException, ApiException) as err:
             raise HomeAssistantError("Unable to fetch media for event") from err
         if not event_media:
             return self._json_error(

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -11,7 +11,6 @@ from google_nest_sdm.exceptions import (
     ApiException,
     AuthException,
     ConfigurationException,
-    DecodeException,
     SubscriberException,
 )
 import voluptuous as vol
@@ -339,7 +338,7 @@ class NestEventMediaView(HomeAssistantView):
             )
         try:
             event_media = await nest_device.event_media_manager.get_media(event_id)
-        except (DecodeException, ApiException) as err:
+        except ApiException as err:
             raise HomeAssistantError("Unable to fetch media for event") from err
         if not event_media:
             return self._json_error(

--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import FanTrait, TemperatureTrait
-from google_nest_sdm.exceptions import GoogleNestException
+from google_nest_sdm.exceptions import ApiException
 from google_nest_sdm.thermostat_traits import (
     ThermostatEcoTrait,
     ThermostatHeatCoolTrait,
@@ -90,7 +90,7 @@ async def async_setup_sdm_entry(
     subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
     try:
         device_manager = await subscriber.async_get_device_manager()
-    except GoogleNestException as err:
+    except ApiException as err:
         raise PlatformNotReady from err
 
     entities = []

--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -35,7 +35,7 @@ import async_timeout
 from google_nest_sdm.exceptions import (
     AuthException,
     ConfigurationException,
-    GoogleNestException,
+    SubscriberException,
 )
 import voluptuous as vol
 
@@ -285,7 +285,7 @@ class NestFlowHandler(
             except ConfigurationException as err:
                 _LOGGER.error("Configuration error creating subscription: %s", err)
                 errors[CONF_CLOUD_PROJECT_ID] = "bad_project_id"
-            except GoogleNestException as err:
+            except SubscriberException as err:
                 _LOGGER.error("Error creating subscription: %s", err)
                 errors[CONF_CLOUD_PROJECT_ID] = "subscriber_error"
 

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -5,7 +5,7 @@ import logging
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import HumidityTrait, TemperatureTrait
-from google_nest_sdm.exceptions import GoogleNestException
+from google_nest_sdm.exceptions import ApiException
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -40,7 +40,7 @@ async def async_setup_sdm_entry(
     subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
     try:
         device_manager = await subscriber.async_get_device_manager()
-    except GoogleNestException as err:
+    except ApiException as err:
         _LOGGER.warning("Failed to get devices: %s", err)
         raise PlatformNotReady from err
 

--- a/tests/components/nest/test_config_flow_sdm.py
+++ b/tests/components/nest/test_config_flow_sdm.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from google_nest_sdm.exceptions import (
     AuthException,
     ConfigurationException,
-    GoogleNestException,
+    SubscriberException,
 )
 import pytest
 
@@ -473,7 +473,7 @@ async def test_pubsub_subscription_failure(hass, oauth):
     await oauth.async_pubsub_flow(result)
     with patch(
         "homeassistant.components.nest.api.GoogleNestSubscriber.create_subscription",
-        side_effect=GoogleNestException(),
+        side_effect=SubscriberException(),
     ):
         result = await oauth.async_configure(
             result, {"cloud_project_id": CLOUD_PROJECT_ID}

--- a/tests/components/nest/test_init_sdm.py
+++ b/tests/components/nest/test_init_sdm.py
@@ -10,9 +10,10 @@ import logging
 from unittest.mock import patch
 
 from google_nest_sdm.exceptions import (
+    ApiException,
     AuthException,
     ConfigurationException,
-    GoogleNestException,
+    SubscriberException,
 )
 
 from homeassistant.components.nest import DOMAIN
@@ -66,7 +67,7 @@ async def test_setup_susbcriber_failure(hass, caplog):
     """Test configuration error."""
     with patch(
         "homeassistant.components.nest.api.GoogleNestSubscriber.start_async",
-        side_effect=GoogleNestException(),
+        side_effect=SubscriberException(),
     ), caplog.at_level(logging.ERROR, logger="homeassistant.components.nest"):
         result = await async_setup_sdm(hass)
         assert result
@@ -83,7 +84,7 @@ async def test_setup_device_manager_failure(hass, caplog):
         "homeassistant.components.nest.api.GoogleNestSubscriber.start_async"
     ), patch(
         "homeassistant.components.nest.api.GoogleNestSubscriber.async_get_device_manager",
-        side_effect=GoogleNestException(),
+        side_effect=ApiException(),
     ), caplog.at_level(
         logging.ERROR, logger="homeassistant.components.nest"
     ):
@@ -252,7 +253,7 @@ async def test_remove_entry_delete_subscriber_failure(hass, caplog):
 
     with patch(
         "homeassistant.components.nest.api.GoogleNestSubscriber.delete_subscription",
-        side_effect=GoogleNestException(),
+        side_effect=SubscriberException(),
     ):
         assert await hass.config_entries.async_remove(entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Stop using GoogleNestSubscriberException which is the base class for
all exceptions and use more narrow exceptions instead.

This is a pre-factor from discussion in PR #63207

Overview for reviewing:
- ApiException is for talking to the Nest SDM API (not for subscriber calls).
- AuthException is somewhat self explanatory and can be thrown in API call contexts or subscriber context. After PR #63224 this inherits from ApiException, however we don't exercise this in home assistant tests, and it is rare to throw auth exceptions from the API so we can be loose with merge order.
- See [auth.py](https://github.com/allenporter/python-google-nest-sdm/blob/0da6a381d9f688ff9a026847b03e344baf995b70/google_nest_sdm/auth.py#L76) for examples of how exceptions are thrown in the API calls.
- SubscriberException is specific to interacting with the pub/sub subscription APIs
- ConfigurationException is very narrow for catching common configuration errors in the subscriber
- See [google_nest_subscriber.py](https://github.com/allenporter/python-google-nest-sdm/blob/0da6a381d9f688ff9a026847b03e344baf995b70/google_nest_sdm/google_nest_subscriber.py#L356) for an exception of how exceptions are thrown in the subscriber.

The more complex cases typically involve the subscriber in the init or config flow where it is useful to catch multiple exceptions and handle them differently. The integration exception cases are simpler and focused on API errors only.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
