### PR TITLE
Replace whois library in Whois integration

### DIFF
--- a/homeassistant/components/whois/config_flow.py
+++ b/homeassistant/components/whois/config_flow.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
+import whois
+from whois.exceptions import (
+    FailedParsingWhoisOutput,
+    UnknownDateFormat,
+    UnknownTld,
+    WhoisCommandFailed,
+)
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_DOMAIN, CONF_NAME
@@ -23,23 +30,44 @@ class WhoisFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by the user."""
+        errors = {}
+
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_DOMAIN].lower())
+            domain = user_input[CONF_DOMAIN].lower()
+
+            await self.async_set_unique_id(domain)
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(
-                title=self.imported_name or user_input[CONF_DOMAIN],
-                data={
-                    CONF_DOMAIN: user_input[CONF_DOMAIN].lower(),
-                },
-            )
+
+            try:
+                await self.hass.async_add_executor_job(whois.query, domain)
+            except UnknownTld:
+                errors["base"] = "unknown_tld"
+            except WhoisCommandFailed:
+                errors["base"] = "whois_command_failed"
+            except FailedParsingWhoisOutput:
+                errors["base"] = "unexpected_response"
+            except UnknownDateFormat:
+                errors["base"] = "unknown_date_format"
+            else:
+                return self.async_create_entry(
+                    title=self.imported_name or user_input[CONF_DOMAIN],
+                    data={
+                        CONF_DOMAIN: domain,
+                    },
+                )
+        else:
+            user_input = {}
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_DOMAIN): str,
+                    vol.Required(
+                        CONF_DOMAIN, default=user_input.get(CONF_DOMAIN, "")
+                    ): str,
                 }
             ),
+            errors=errors,
         )
 
     async def async_step_import(self, config: dict[str, Any]) -> FlowResult:

--- a/homeassistant/components/whois/manifest.json
+++ b/homeassistant/components/whois/manifest.json
@@ -2,7 +2,7 @@
   "domain": "whois",
   "name": "Whois",
   "documentation": "https://www.home-assistant.io/integrations/whois",
-  "requirements": ["python-whois==0.7.3"],
+  "requirements": ["whois==0.9.13"],
   "config_flow": true,
   "codeowners": ["@frenck"],
   "iot_class": "cloud_polling"

--- a/homeassistant/components/whois/strings.json
+++ b/homeassistant/components/whois/strings.json
@@ -7,6 +7,12 @@
         }
       }
     },
+    "error": {
+      "unexpected_response": "Unexpected response from whois server",
+      "unknown_date_format": "Unknown date format in whois server response",
+      "unknown_tld": "The given TLD is unknown or not available to this integration",
+      "whois_command_failed": "Whois command failed: could not retrieve whois information"
+    },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }

--- a/homeassistant/components/whois/translations/en.json
+++ b/homeassistant/components/whois/translations/en.json
@@ -3,6 +3,12 @@
         "abort": {
             "already_configured": "Service is already configured"
         },
+        "error": {
+            "unexpected_response": "Unexpected response from whois server",
+            "unknown_date_format": "Unknown date format in whois server response",
+            "unknown_tld": "The given TLD is unknown or not available to this integration",
+            "whois_command_failed": "Whois command failed; could not retrieve whois information"
+        },
         "step": {
             "user": {
                 "data": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1968,9 +1968,6 @@ python-twitch-client==0.6.0
 # homeassistant.components.vlc
 python-vlc==1.1.2
 
-# homeassistant.components.whois
-python-whois==0.7.3
-
 # homeassistant.components.awair
 python_awair==0.2.1
 
@@ -2445,6 +2442,9 @@ webexteamssdk==1.1.1
 
 # homeassistant.components.whirlpool
 whirlpool-sixth-sense==0.15.1
+
+# homeassistant.components.whois
+whois==0.9.13
 
 # homeassistant.components.wiffi
 wiffi==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1193,9 +1193,6 @@ python-tado==0.12.0
 # homeassistant.components.twitch
 python-twitch-client==0.6.0
 
-# homeassistant.components.whois
-python-whois==0.7.3
-
 # homeassistant.components.awair
 python_awair==0.2.1
 
@@ -1470,6 +1467,9 @@ watchdog==2.1.6
 
 # homeassistant.components.whirlpool
 whirlpool-sixth-sense==0.15.1
+
+# homeassistant.components.whois
+whois==0.9.13
 
 # homeassistant.components.wiffi
 wiffi==1.1.0

--- a/tests/components/whois/conftest.py
+++ b/tests/components/whois/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -23,6 +23,13 @@ def mock_config_entry() -> MockConfigEntry:
         },
         unique_id="home-assistant.io",
     )
+
+
+@pytest.fixture
+def mock_whois_config_flow() -> Generator[MagicMock, None, None]:
+    """Return a mocked whois."""
+    with patch("homeassistant.components.whois.config_flow.whois.query") as whois_mock:
+        yield whois_mock
 
 
 @pytest.fixture

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -1,6 +1,13 @@
 """Tests for the Whois config flow."""
+from unittest.mock import AsyncMock, MagicMock
 
-from unittest.mock import AsyncMock
+import pytest
+from whois.exceptions import (
+    FailedParsingWhoisOutput,
+    UnknownDateFormat,
+    UnknownTld,
+    WhoisCommandFailed,
+)
 
 from homeassistant.components.whois.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
@@ -18,6 +25,7 @@ from tests.common import MockConfigEntry
 async def test_full_user_flow(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
+    mock_whois_config_flow: MagicMock,
 ) -> None:
     """Test the full user configuration flow."""
     result = await hass.config_entries.flow.async_init(
@@ -40,10 +48,68 @@ async def test_full_user_flow(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    "throw,reason",
+    [
+        (UnknownTld, "unknown_tld"),
+        (FailedParsingWhoisOutput, "unexpected_response"),
+        (UnknownDateFormat, "unknown_date_format"),
+        (WhoisCommandFailed, "whois_command_failed"),
+    ],
+)
+async def test_full_flow_with_error(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_whois_config_flow: MagicMock,
+    throw: Exception,
+    reason: str,
+) -> None:
+    """Test the full user configuration flow with an error.
+
+    This tests tests a full config flow, with an error happening; allowing
+    the user to fix the error and try again.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    mock_whois_config_flow.side_effect = throw
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_DOMAIN: "Example.com"},
+    )
+
+    assert result2.get("type") == RESULT_TYPE_FORM
+    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("errors") == {"base": reason}
+    assert "flow_id" in result2
+
+    assert len(mock_setup_entry.mock_calls) == 0
+    assert len(mock_whois_config_flow.mock_calls) == 1
+
+    mock_whois_config_flow.side_effect = None
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        user_input={CONF_DOMAIN: "Example.com"},
+    )
+
+    assert result3.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result3.get("title") == "Example.com"
+    assert result3.get("data") == {CONF_DOMAIN: "example.com"}
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_whois_config_flow.mock_calls) == 2
+
+
 async def test_already_configured(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    mock_whois_config_flow: MagicMock,
 ) -> None:
     """Test we abort if already configured."""
     mock_config_entry.add_to_hass(hass)
@@ -63,6 +129,7 @@ async def test_already_configured(
 async def test_import_flow(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
+    mock_whois_config_flow: MagicMock,
 ) -> None:
     """Test the import configuration flow."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR replaces the whois client library used by the whois integration.

The previous library functioned well, but lacked error handling and reporting (no matter what you'd throw at it, it would never fail). The replacement library throws exceptions that can be used for data validation and error handling.

Both the previous library and this library are equally popular (and the most popular Whois libraries) on GitHub/PyPi.

One major difference in handling is that we no longer check if there is an expiration date available. This was previously needed to know if the query succeeded or not. With the new library, this is not an issue and would thus give an "unknown" state instead of not loading at all.

As part of the effort to refactor the Whois integration (to get it into the UI and work nicely), this is one of the steps. More PRs are to follow; including adding entity descriptions, data update coordinator, and more test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
