### PR TITLE
Add strict typing to `core.py` (5) - Task

### DIFF
--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -76,7 +76,7 @@ async def async_attach_trigger(
                     job,
                     {
                         "trigger": {
-                            **trigger_data,
+                            **trigger_data,  # type: ignore  # https://github.com/python/mypy/issues/9117
                             **config,
                             "description": f"{DOMAIN} - {entity_id}",
                         }

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -23,10 +23,12 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Generic,
     NamedTuple,
     Optional,
     TypeVar,
     cast,
+    overload,
 )
 from urllib.parse import urlparse
 
@@ -94,6 +96,8 @@ async_timeout_backcompat.enable()
 block_async_io.enable()
 
 T = TypeVar("T")
+_R = TypeVar("_R")
+_R_co = TypeVar("_R_co", covariant=True)  # pylint: disable=invalid-name
 # Internal; not helpers.typing.UNDEFINED due to circular dependency
 _UNDEF: dict[Any, Any] = {}
 # pylint: disable=invalid-name
@@ -174,7 +178,7 @@ class HassJobType(enum.Enum):
     Executor = 3
 
 
-class HassJob:
+class HassJob(Generic[_R_co]):
     """Represent a job to be run later.
 
     We check the callable type in advance
@@ -184,7 +188,7 @@ class HassJob:
 
     __slots__ = ("job_type", "target")
 
-    def __init__(self, target: Callable) -> None:
+    def __init__(self, target: Callable[..., _R_co]) -> None:
         """Create a job object."""
         if asyncio.iscoroutine(target):
             raise ValueError("Coroutine not allowed to be passed to HassJob")
@@ -197,7 +201,7 @@ class HassJob:
         return f"<Job {self.job_type} {self.target}>"
 
 
-def _get_callable_job_type(target: Callable) -> HassJobType:
+def _get_callable_job_type(target: Callable[..., Any]) -> HassJobType:
     """Determine the job type from the callable."""
     # Check for partials to properly determine if coroutine function
     check_target = target
@@ -236,7 +240,8 @@ class HomeAssistant:
     def __init__(self) -> None:
         """Initialize new Home Assistant object."""
         self.loop = asyncio.get_running_loop()
-        self._pending_tasks: list = []
+        # pylint: disable-next=unsubscriptable-object
+        self._pending_tasks: list[asyncio.Future[Any]] = []
         self._track_task = True
         self.bus = EventBus(self)
         self.services = ServiceRegistry(self)
@@ -354,10 +359,33 @@ class HomeAssistant:
             raise ValueError("Don't call add_job with None")
         self.loop.call_soon_threadsafe(self.async_add_job, target, *args)
 
+    @overload
     @callback
     def async_add_job(
-        self, target: Callable[..., Any], *args: Any
-    ) -> asyncio.Future | None:
+        self, target: Callable[..., Awaitable[_R]], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @overload
+    @callback
+    def async_add_job(
+        self, target: Callable[..., Awaitable[_R] | _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @overload
+    @callback
+    def async_add_job(
+        self, target: Coroutine[Any, Any, _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @callback
+    def async_add_job(
+        self,
+        target: Callable[..., Awaitable[_R] | _R] | Coroutine[Any, Any, _R],
+        *args: Any,
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
         """Add a job to be executed by the event loop or by an executor.
 
         If the job is either a coroutine or decorated with @callback, it will be
@@ -374,24 +402,44 @@ class HomeAssistant:
         if asyncio.iscoroutine(target):
             return self.async_create_task(target)
 
+        target = cast(Callable[..., _R], target)
         return self.async_add_hass_job(HassJob(target), *args)
 
+    @overload
     @callback
-    def async_add_hass_job(self, hassjob: HassJob, *args: Any) -> asyncio.Future | None:
+    def async_add_hass_job(
+        self, hassjob: HassJob[Awaitable[_R]], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @overload
+    @callback
+    def async_add_hass_job(
+        self, hassjob: HassJob[Awaitable[_R] | _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @callback
+    def async_add_hass_job(
+        self, hassjob: HassJob[Awaitable[_R] | _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
         """Add a HassJob from within the event loop.
 
         This method must be run in the event loop.
         hassjob: HassJob to call.
         args: parameters for method to call.
         """
+        task: asyncio.Future[_R]  # pylint: disable=unsubscriptable-object
         if hassjob.job_type == HassJobType.Coroutinefunction:
-            task = self.loop.create_task(hassjob.target(*args))
+            task = self.loop.create_task(
+                cast(Callable[..., Awaitable[_R]], hassjob.target)(*args)
+            )
         elif hassjob.job_type == HassJobType.Callback:
             self.loop.call_soon(hassjob.target, *args)
             return None
         else:
-            task = self.loop.run_in_executor(  # type: ignore
-                None, hassjob.target, *args
+            task = self.loop.run_in_executor(
+                None, cast(Callable[..., _R], hassjob.target), *args
             )
 
         # If a task is scheduled
@@ -400,7 +448,7 @@ class HomeAssistant:
 
         return task
 
-    def create_task(self, target: Awaitable) -> None:
+    def create_task(self, target: Awaitable[Any]) -> None:
         """Add task to the executor pool.
 
         target: target to call.
@@ -408,14 +456,14 @@ class HomeAssistant:
         self.loop.call_soon_threadsafe(self.async_create_task, target)
 
     @callback
-    def async_create_task(self, target: Awaitable) -> asyncio.Task:
+    def async_create_task(self, target: Awaitable[_R]) -> asyncio.Task[_R]:
         """Create a task from within the eventloop.
 
         This method must be run in the event loop.
 
         target: target to call.
         """
-        task: asyncio.Task = self.loop.create_task(target)
+        task = self.loop.create_task(target)
 
         if self._track_task:
             self._pending_tasks.append(task)
@@ -425,7 +473,7 @@ class HomeAssistant:
     @callback
     def async_add_executor_job(
         self, target: Callable[..., T], *args: Any
-    ) -> Awaitable[T]:
+    ) -> asyncio.Future[T]:  # pylint: disable=unsubscriptable-object
         """Add an executor job from within the event loop."""
         task = self.loop.run_in_executor(None, target, *args)
 
@@ -445,8 +493,24 @@ class HomeAssistant:
         """Stop track tasks so you can't wait for all tasks to be done."""
         self._track_task = False
 
+    @overload
     @callback
-    def async_run_hass_job(self, hassjob: HassJob, *args: Any) -> asyncio.Future | None:
+    def async_run_hass_job(
+        self, hassjob: HassJob[Awaitable[_R]], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @overload
+    @callback
+    def async_run_hass_job(
+        self, hassjob: HassJob[Awaitable[_R] | _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @callback
+    def async_run_hass_job(
+        self, hassjob: HassJob[Awaitable[_R] | _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
         """Run a HassJob from within the event loop.
 
         This method must be run in the event loop.
@@ -455,15 +519,38 @@ class HomeAssistant:
         args: parameters for method to call.
         """
         if hassjob.job_type == HassJobType.Callback:
-            hassjob.target(*args)
+            cast(Callable[..., _R], hassjob.target)(*args)
             return None
 
         return self.async_add_hass_job(hassjob, *args)
 
+    @overload
     @callback
     def async_run_job(
-        self, target: Callable[..., None | Awaitable], *args: Any
-    ) -> asyncio.Future | None:
+        self, target: Callable[..., Awaitable[_R]], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @overload
+    @callback
+    def async_run_job(
+        self, target: Callable[..., Awaitable[_R] | _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @overload
+    @callback
+    def async_run_job(
+        self, target: Coroutine[Any, Any, _R], *args: Any
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
+        ...
+
+    @callback
+    def async_run_job(
+        self,
+        target: Callable[..., Awaitable[_R] | _R] | Coroutine[Any, Any, _R],
+        *args: Any,
+    ) -> asyncio.Future[_R] | None:  # pylint: disable=unsubscriptable-object
         """Run a job from within the event loop.
 
         This method must be run in the event loop.
@@ -474,6 +561,7 @@ class HomeAssistant:
         if asyncio.iscoroutine(target):
             return self.async_create_task(target)
 
+        target = cast(Callable[..., _R], target)
         return self.async_run_hass_job(HassJob(target), *args)
 
     def block_till_done(self) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -773,7 +773,7 @@ class Event:
 class _FilterableJob(NamedTuple):
     """Event listener job to be executed with optional filter."""
 
-    job: HassJob
+    job: HassJob[None | Awaitable[None]]
     event_filter: Callable[[Event], bool] | None
 
 

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,8 +1,9 @@
 """Helpers for data entry flows for config entries."""
 from __future__ import annotations
 
+import asyncio  # pylint: disable=unused-import  # used in cast as string
 import logging
-from typing import Any, Awaitable, Callable, Union
+from typing import Any, Awaitable, Callable, Union, cast
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp, mqtt, ssdp, zeroconf
@@ -55,9 +56,10 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
             # Get current discovered entries.
             in_progress = self._async_in_progress()
 
-            if not (has_devices := in_progress):
-                has_devices = await self.hass.async_add_job(  # type: ignore
-                    self._discovery_function, self.hass
+            if not (has_devices := bool(in_progress)):
+                has_devices = await cast(
+                    "asyncio.Future[bool]",
+                    self.hass.async_add_job(self._discovery_function, self.hass),
                 )
 
             if not has_devices:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -77,7 +77,7 @@ async def async_setup_component(
     )
 
     try:
-        return await task  # type: ignore
+        return await task
     finally:
         if domain in hass.data.get(DATA_SETUP_DONE, {}):
             hass.data[DATA_SETUP_DONE].pop(domain).set()


### PR DESCRIPTION
## Proposed change
The fifth PR in a series to enable strict typing for `homeassistant/core.py`.
This one uses a few TypeVars and Generics to properly type the `async_create_task` and `async_run_job` methods. Unfortunately, I needed to add Overloads to some methods in order to work around a mypy issue where it couldn't infer the correct TypeVar from the signature alone.

~This PR should be merged after #63239 in order to prevent merge conflicts.~ **Edit:** All previous PRs have been merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
