### PR TITLE
Enable strict typing for `core.py`

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -2,6 +2,7 @@
 # If component is fully covered with type annotations, please add it here
 # to enable strict mypy checks.
 
+homeassistant.core
 homeassistant.components
 homeassistant.components.acer_projector.*
 homeassistant.components.accuweather.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -169,4 +169,3 @@ homeassistant.components.zodiac.*
 homeassistant.components.zeroconf.*
 homeassistant.components.zone.*
 homeassistant.components.zwave_js.*
-homeassistant.core

--- a/.strict-typing
+++ b/.strict-typing
@@ -169,3 +169,4 @@ homeassistant.components.zodiac.*
 homeassistant.components.zeroconf.*
 homeassistant.components.zone.*
 homeassistant.components.zwave_js.*
+homeassistant.core

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,7 +24,6 @@ warn_unreachable = true
 
 [mypy-homeassistant.core]
 disallow_any_generics = true
-no_implicit_reexport = true
 
 [mypy-homeassistant.components.*]
 check_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1870,17 +1870,6 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
-[mypy-homeassistant.core]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-warn_return_any = true
-warn_unreachable = true
-
 [mypy-tests.*]
 check_untyped_defs = false
 disallow_incomplete_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1870,6 +1870,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.core]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-tests.*]
 check_untyped_defs = false
 disallow_incomplete_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,6 +22,10 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.core]
+disallow_any_generics = true
+no_implicit_reexport = true
+
 [mypy-homeassistant.components.*]
 check_untyped_defs = false
 disallow_incomplete_defs = false

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -179,7 +179,6 @@ STRICT_SETTINGS: Final[list[str]] = [
 # To enable granular typing, add additional settings if core files are given.
 STRICT_SETTINGS_CORE: Final[list[str]] = [
     "disallow_any_generics",
-    "no_implicit_reexport",
 ]
 
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -175,6 +175,13 @@ STRICT_SETTINGS: Final[list[str]] = [
     # "no_implicit_reexport",
 ]
 
+# Strict settings are already applied for core files.
+# To enable granular typing, add additional settings if core files are given.
+STRICT_SETTINGS_CORE: Final[list[str]] = [
+    "disallow_any_generics",
+    "no_implicit_reexport",
+]
+
 
 def generate_and_validate(config: Config) -> str:
     """Validate and generate mypy config."""
@@ -185,11 +192,19 @@ def generate_and_validate(config: Config) -> str:
         lines = fp.readlines()
 
     # Filter empty and commented lines.
-    strict_modules: list[str] = [
+    parsed_modules: list[str] = [
         line.strip()
         for line in lines
         if line.strip() != "" and not line.startswith("#")
     ]
+
+    strict_modules: list[str] = []
+    strict_core_modules: list[str] = []
+    for module in parsed_modules:
+        if module.startswith("homeassistant.components"):
+            strict_modules.append(module)
+        else:
+            strict_core_modules.append(module)
 
     ignored_modules_set: set[str] = set(IGNORED_MODULES)
     for module in strict_modules:
@@ -206,7 +221,7 @@ def generate_and_validate(config: Config) -> str:
             )
 
     # Validate that all modules exist.
-    all_modules = strict_modules + IGNORED_MODULES
+    all_modules = strict_modules + strict_core_modules + IGNORED_MODULES
     for module in all_modules:
         if module.endswith(".*"):
             module_path = Path(module[:-2].replace(".", os.path.sep))
@@ -233,6 +248,12 @@ def generate_and_validate(config: Config) -> str:
         mypy_config.set(general_section, key, value)
     for key in STRICT_SETTINGS:
         mypy_config.set(general_section, key, "true")
+
+    for core_module in strict_core_modules:
+        core_section = f"mypy-{core_module}"
+        mypy_config.add_section(core_section)
+        for key in STRICT_SETTINGS_CORE:
+            mypy_config.set(core_section, key, "true")
 
     # By default strict checks are disabled for components.
     components_section = "mypy-homeassistant.components.*"

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -193,12 +193,10 @@ def generate_and_validate(config: Config) -> str:
 
     ignored_modules_set: set[str] = set(IGNORED_MODULES)
     for module in strict_modules:
-        if (
-            not module.startswith("homeassistant.components.")
-            and module != "homeassistant.components"
-        ):
+        if not module.startswith("homeassistant."):
             config.add_error(
-                "mypy_config", f"Only components should be added: {module}"
+                "mypy_config",
+                f"The module or file must start with 'homeassistant.': {module}",
             )
         if module in ignored_modules_set:
             config.add_error(

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -193,10 +193,12 @@ def generate_and_validate(config: Config) -> str:
 
     ignored_modules_set: set[str] = set(IGNORED_MODULES)
     for module in strict_modules:
-        if not module.startswith("homeassistant."):
+        if (
+            not module.startswith("homeassistant.components.")
+            and module != "homeassistant.components"
+        ):
             config.add_error(
-                "mypy_config",
-                f"The module or file must start with 'homeassistant.': {module}",
+                "mypy_config", f"Only components should be added: {module}"
             )
         if module in ignored_modules_set:
             config.add_error(


### PR DESCRIPTION
## Proposed change
The last one in a series to ultimately enable strict typing for `homeassistant/core.py`. It depends on all previous ones being merged and needs to be rebased afterwards.

### PR List
* #63239
* #63240
* #63241
* #63242
* #63243
* #63345

<details>
<summary>Mypy output without changes</summary>

```
homeassistant/core.py:178: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:191: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:230: error: Implicit generic "Any". Use "typing.List" and specify generic parameters  [type-arg]
homeassistant/core.py:351: error: Missing type parameters for generic type "Future"  [type-arg]
homeassistant/core.py:351: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#not-generic-runtime
homeassistant/core.py:371: error: Missing type parameters for generic type "Future"  [type-arg]
homeassistant/core.py:371: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#not-generic-runtime
homeassistant/core.py:394: error: Missing type parameters for generic type "Awaitable"  [type-arg]
homeassistant/core.py:402: error: Missing type parameters for generic type "Task"  [type-arg]
homeassistant/core.py:402: error: Missing type parameters for generic type "Awaitable"  [type-arg]
homeassistant/core.py:409: error: Missing type parameters for generic type "Task"  [type-arg]
homeassistant/core.py:440: error: Missing type parameters for generic type "Future"  [type-arg]
homeassistant/core.py:440: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#not-generic-runtime
homeassistant/core.py:456: error: Missing type parameters for generic type "Awaitable"  [type-arg]
homeassistant/core.py:457: error: Missing type parameters for generic type "Future"  [type-arg]
homeassistant/core.py:457: note: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#not-generic-runtime
homeassistant/core.py:681: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:700: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:752: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:772: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:773: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:794: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:825: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:835: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:863: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:949: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:974: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:1045: error: Missing type parameters for generic type "Iterable"  [type-arg]
homeassistant/core.py:1065: error: Missing type parameters for generic type "Iterable"  [type-arg]
homeassistant/core.py:1081: error: Missing type parameters for generic type "Iterable"  [type-arg]
homeassistant/core.py:1088: error: Missing type parameters for generic type "Iterable"  [type-arg]
homeassistant/core.py:1264: error: Missing type parameters for generic type "Callable"  [type-arg]
homeassistant/core.py:1282: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:1406: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:1410: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:1428: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:1432: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters  [type-arg]
homeassistant/core.py:1521: error: Missing type parameters for generic type "Task"  [type-arg]
homeassistant/core.py:1521: error: Missing type parameters for generic type "Coroutine"  [type-arg]
homeassistant/components/light/__init__.py:21: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/sensor/device_condition.py:10: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/select/device_condition.py:14: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/select/device_action.py:13: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/scsgate/__init__.py:12: error: Module "homeassistant.core" has no attribute "EVENT_HOMEASSISTANT_STOP"; maybe "EVENT_HOMEASSISTANT_START", "EVENT_HOMEASSISTANT_STARTED", or "EVENT_HOMEASSISTANT_CLOSE"?  [attr-defined]
homeassistant/components/sensor/device_trigger.py:18: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/select/device_trigger.py:27: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/universal/media_player.py:92: error: Module "homeassistant.core" has no attribute "EVENT_HOMEASSISTANT_START"; maybe "EVENT_HOMEASSISTANT_STARTED", "EVENT_HOMEASSISTANT_STOP", or "EVENT_HOMEASSISTANT_CLOSE"?  [attr-defined]
homeassistant/components/climate/device_condition.py:14: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/climate/device_action.py:13: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/light/device_action.py:15: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
homeassistant/components/ecobee/config_flow.py:12: error: Module "homeassistant.core" has no attribute "HomeAssistantError"; maybe "HomeAssistant"?  [attr-defined]
Found 47 errors in 13 files (checked 4471 source files)
```
</details>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
