### PR TITLE
Add hardware version to Roku device info

### DIFF
--- a/homeassistant/components/roku/entity.py
+++ b/homeassistant/components/roku/entity.py
@@ -31,6 +31,7 @@ class RokuEntity(CoordinatorEntity):
             name=self.coordinator.data.info.name,
             manufacturer=self.coordinator.data.info.brand,
             model=self.coordinator.data.info.model_name,
+            hw_version=self.coordinator.data.info.model_number,
             sw_version=self.coordinator.data.info.version,
             suggested_area=self.coordinator.data.info.device_location,
         )

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -85,12 +85,26 @@ async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -
     await setup_integration(hass, aioclient_mock)
 
     entity_registry = er.async_get(hass)
-    main = entity_registry.async_get(MAIN_ENTITY_ID)
+    device_registry = dr.async_get(hass)
 
-    assert hass.states.get(MAIN_ENTITY_ID)
-    assert main
-    assert main.original_device_class is MediaPlayerDeviceClass.RECEIVER
-    assert main.unique_id == UPNP_SERIAL
+    state = hass.states.get(MAIN_ENTITY_ID)
+    entry = entity_registry.async_get(MAIN_ENTITY_ID)
+
+    assert state
+    assert entry
+    assert entry.original_device_class is MediaPlayerDeviceClass.RECEIVER
+    assert entry.unique_id == UPNP_SERIAL
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.identifiers == {(DOMAIN, UPNP_SERIAL)}
+    assert device_entry.manufacturer == "Roku"
+    assert device_entry.model == "Roku 3"
+    assert device_entry.name == "My Roku 3"
+    assert device_entry.entry_type is None
+    assert device_entry.hw_version == "4200X"
+    assert device_entry.sw_version == "7.5.0"
 
 
 async def test_idle_setup(
@@ -117,12 +131,25 @@ async def test_tv_setup(
     )
 
     entity_registry = er.async_get(hass)
-    tv = entity_registry.async_get(TV_ENTITY_ID)
 
-    assert hass.states.get(TV_ENTITY_ID)
-    assert tv
-    assert tv.original_device_class is MediaPlayerDeviceClass.TV
-    assert tv.unique_id == TV_SERIAL
+    state = hass.states.get(TV_ENTITY_ID)
+    entry = entity_registry.async_get(TV_ENTITY_ID)
+
+    assert state
+    assert entry
+    assert entry.original_device_class is MediaPlayerDeviceClass.TV
+    assert entry.unique_id == TV_SERIAL
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.identifiers == {(DOMAIN, "YN00H5555555")}
+    assert device_entry.manufacturer == "Onn"
+    assert device_entry.model == "100005844"
+    assert device_entry.name == '58" Onn Roku TV'
+    assert device_entry.entry_type is None
+    assert device_entry.hw_version == "7820X"
+    assert device_entry.sw_version == "9.2.0"
 
 
 async def test_availability(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -144,13 +144,13 @@ async def test_tv_setup(
     assert entry.device_id
     device_entry = device_registry.async_get(entry.device_id)
     assert device_entry
-    assert device_entry.identifiers == {(DOMAIN, "YN00H5555555")}
-    assert device_entry.manufacturer == "Onn"
-    assert device_entry.model == "100005844"
+    assert device_entry.identifiers == {(DOMAIN, TV_SERIAL)}
+    assert device_entry.manufacturer == TV_MANUFACTURER
+    assert device_entry.model == TV_MODEL
     assert device_entry.name == '58" Onn Roku TV'
     assert device_entry.entry_type is None
     assert device_entry.hw_version == "7820X"
-    assert device_entry.sw_version == "9.2.0"
+    assert device_entry.sw_version == TV_SW_VERSION
 
 
 async def test_availability(

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -131,6 +131,7 @@ async def test_tv_setup(
     )
 
     entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
 
     state = hass.states.get(TV_ENTITY_ID)
     entry = entity_registry.async_get(TV_ENTITY_ID)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
