### PR TITLE
Add support for Steamist steam showers

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -130,6 +130,7 @@ homeassistant.components.sonos.media_player
 homeassistant.components.ssdp.*
 homeassistant.components.stookalert.*
 homeassistant.components.statistics.*
+homeassistant.components.steamist.*
 homeassistant.components.stream.*
 homeassistant.components.sun.*
 homeassistant.components.surepetcare.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -882,6 +882,8 @@ homeassistant/components/starline/* @anonym-tsk
 tests/components/starline/* @anonym-tsk
 homeassistant/components/statistics/* @fabaff @ThomDietrich
 tests/components/statistics/* @fabaff @ThomDietrich
+homeassistant/components/steamist/* @bdraco
+tests/components/steamist/* @bdraco
 homeassistant/components/stiebel_eltron/* @fucm
 homeassistant/components/stookalert/* @fwestenberg @frenck
 tests/components/stookalert/* @fwestenberg @frenck

--- a/homeassistant/components/steamist/__init__.py
+++ b/homeassistant/components/steamist/__init__.py
@@ -1,0 +1,38 @@
+"""The Steamist integration."""
+from __future__ import annotations
+
+import logging
+
+from aiosteamist import Steamist
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+from .coordinator import SteamistDataUpdateCoordinator
+
+PLATFORMS: list[str] = [Platform.SWITCH]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Steamist from a config entry."""
+    coordinator = SteamistDataUpdateCoordinator(
+        hass,
+        Steamist(entry.data[CONF_HOST], async_get_clientsession(hass)),
+        entry.data[CONF_HOST],
+    )
+    await coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/homeassistant/components/steamist/__init__.py
+++ b/homeassistant/components/steamist/__init__.py
@@ -1,8 +1,6 @@
 """The Steamist integration."""
 from __future__ import annotations
 
-import logging
-
 from aiosteamist import Steamist
 
 from homeassistant.config_entries import ConfigEntry
@@ -14,8 +12,6 @@ from .const import DOMAIN
 from .coordinator import SteamistDataUpdateCoordinator
 
 PLATFORMS: list[str] = [Platform.SWITCH]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/steamist/config_flow.py
+++ b/homeassistant/components/steamist/config_flow.py
@@ -1,0 +1,52 @@
+"""Config flow for Steamist integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiosteamist import Steamist
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import CONNECTION_EXCEPTIONS, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Steamist."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                await Steamist(
+                    user_input[CONF_HOST],
+                    async_get_clientsession(self.hass),
+                ).async_get_status()
+            except CONNECTION_EXCEPTIONS:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            errors=errors,
+        )

--- a/homeassistant/components/steamist/const.py
+++ b/homeassistant/components/steamist/const.py
@@ -1,0 +1,9 @@
+"""Constants for the Steamist integration."""
+
+import asyncio
+
+import aiohttp
+
+DOMAIN = "steamist"
+
+CONNECTION_EXCEPTIONS = (asyncio.TimeoutError, aiohttp.ClientError)

--- a/homeassistant/components/steamist/coordinator.py
+++ b/homeassistant/components/steamist/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
-class SteamistDataUpdateCoordinator(DataUpdateCoordinator):
+class SteamistDataUpdateCoordinator(DataUpdateCoordinator[SteamistStatus]):
     """DataUpdateCoordinator to gather data from a steamist steam shower."""
 
     def __init__(

--- a/homeassistant/components/steamist/coordinator.py
+++ b/homeassistant/components/steamist/coordinator.py
@@ -1,0 +1,35 @@
+"""DataUpdateCoordinator for steamist."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from aiosteamist import Steamist, SteamistStatus
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SteamistDataUpdateCoordinator(DataUpdateCoordinator):
+    """DataUpdateCoordinator to gather data from a steamist steam shower."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: Steamist,
+        host: str,
+    ) -> None:
+        """Initialize DataUpdateCoordinator to gather data for specific steamist."""
+        self.client = client
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"Steamist {host}",
+            update_interval=timedelta(seconds=5),
+        )
+
+    async def _async_update_data(self) -> SteamistStatus:
+        """Fetch data from steamist."""
+        return await self.client.async_get_status()

--- a/homeassistant/components/steamist/entity.py
+++ b/homeassistant/components/steamist/entity.py
@@ -1,0 +1,35 @@
+"""Support for Steamist sensors."""
+from __future__ import annotations
+
+from aiosteamist import SteamistStatus
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .coordinator import SteamistDataUpdateCoordinator
+
+
+class SteamistEntity(CoordinatorEntity, Entity):
+    """Representation of an Steamist entity."""
+
+    coordinator: SteamistDataUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        entry: ConfigEntry,
+        description: EntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+
+    @property
+    def _status(self) -> SteamistStatus:
+        """Return the steamist status."""
+        return self.coordinator.data

--- a/homeassistant/components/steamist/entity.py
+++ b/homeassistant/components/steamist/entity.py
@@ -34,4 +34,4 @@ class SteamistEntity(CoordinatorEntity, Entity):
     @property
     def _status(self) -> SteamistStatus:
         """Return the steamist status."""
-        return cast(SteamistStatus, self.coordinator.data)
+        return self.coordinator.data

--- a/homeassistant/components/steamist/entity.py
+++ b/homeassistant/components/steamist/entity.py
@@ -1,6 +1,8 @@
 """Support for Steamist sensors."""
 from __future__ import annotations
 
+from typing import cast
+
 from aiosteamist import SteamistStatus
 
 from homeassistant.config_entries import ConfigEntry
@@ -32,4 +34,4 @@ class SteamistEntity(CoordinatorEntity, Entity):
     @property
     def _status(self) -> SteamistStatus:
         """Return the steamist status."""
-        return self.coordinator.data
+        return cast(SteamistStatus, self.coordinator.data)

--- a/homeassistant/components/steamist/entity.py
+++ b/homeassistant/components/steamist/entity.py
@@ -1,8 +1,6 @@
 """Support for Steamist sensors."""
 from __future__ import annotations
 
-from typing import cast
-
 from aiosteamist import SteamistStatus
 
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/steamist/manifest.json
+++ b/homeassistant/components/steamist/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "steamist",
+  "name": "Steamist",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/steamist",
+  "requirements": ["aiosteamist==0.3.1"],
+  "codeowners": ["@bdraco"],
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/steamist/strings.json
+++ b/homeassistant/components/steamist/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/steamist/switch.py
+++ b/homeassistant/components/steamist/switch.py
@@ -36,7 +36,7 @@ class SteamistSwitchEntity(SteamistEntity, SwitchEntity):
         return self._status.active
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the specified device on."""
+        """Turn the steam on."""
         await self.coordinator.client.async_turn_on_steam()
         await self.coordinator.async_request_refresh()
 

--- a/homeassistant/components/steamist/switch.py
+++ b/homeassistant/components/steamist/switch.py
@@ -41,6 +41,6 @@ class SteamistSwitchEntity(SteamistEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the specified device off."""
+        """Turn the steam off."""
         await self.coordinator.client.async_turn_off_steam()
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/steamist/switch.py
+++ b/homeassistant/components/steamist/switch.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
 
 
 class SteamistSwitchEntity(SteamistEntity, SwitchEntity):
-    """Representation of an Steamist binary sensor."""
+    """Representation of an Steamist steam switch."""
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/steamist/switch.py
+++ b/homeassistant/components/steamist/switch.py
@@ -1,0 +1,46 @@
+"""Support for Steamist switches."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+from .entity import SteamistEntity
+
+ACTIVE_SWITCH = SwitchEntityDescription(
+    key="active", icon="mdi:pot-steam", name="Steam Active"
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors."""
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities([SteamistSwitchEntity(coordinator, config_entry, ACTIVE_SWITCH)])
+
+
+class SteamistSwitchEntity(SteamistEntity, SwitchEntity):
+    """Representation of an Steamist binary sensor."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the steam is active."""
+        return self._status.active
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the specified device on."""
+        await self.coordinator.client.async_turn_on_steam()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the specified device off."""
+        await self.coordinator.client.async_turn_off_steam()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/steamist/translations/en.json
+++ b/homeassistant/components/steamist/translations/en.json
@@ -1,0 +1,18 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -297,6 +297,7 @@ FLOWS = [
     "squeezebox",
     "srp_energy",
     "starline",
+    "steamist",
     "stookalert",
     "subaru",
     "surepetcare",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1441,6 +1441,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.steamist.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.stream.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -256,6 +256,9 @@ aioridwell==2021.12.2
 # homeassistant.components.shelly
 aioshelly==1.0.7
 
+# homeassistant.components.steamist
+aiosteamist==0.3.1
+
 # homeassistant.components.switcher_kis
 aioswitcher==2.0.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -185,6 +185,9 @@ aioridwell==2021.12.2
 # homeassistant.components.shelly
 aioshelly==1.0.7
 
+# homeassistant.components.steamist
+aiosteamist==0.3.1
+
 # homeassistant.components.switcher_kis
 aioswitcher==2.0.6
 

--- a/tests/components/steamist/__init__.py
+++ b/tests/components/steamist/__init__.py
@@ -1,0 +1,46 @@
+"""Tests for the Steamist integration."""
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiosteamist import Steamist, SteamistStatus
+
+MOCK_ASYNC_GET_STATUS_INACTIVE = SteamistStatus(
+    temp=70, temp_units="F", minutes_remain=0, active=False
+)
+MOCK_ASYNC_GET_STATUS_ACTIVE = SteamistStatus(
+    temp=102, temp_units="F", minutes_remain=14, active=True
+)
+
+
+def _mocked_steamist() -> Steamist:
+    client = MagicMock(auto_spec=Steamist)
+    client.async_turn_on_steam = AsyncMock()
+    client.async_turn_off_steam = AsyncMock()
+    client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_ACTIVE)
+    return client
+
+
+def _patch_status_active(client=None):
+    if client is None:
+        client = _mocked_steamist()
+        client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_ACTIVE)
+
+    @contextmanager
+    def _patcher():
+        with patch("homeassistant.components.steamist.Steamist", return_value=client):
+            yield
+
+    return _patcher()
+
+
+def _patch_status_inactive(client=None):
+    if client is None:
+        client = _mocked_steamist()
+        client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_INACTIVE)
+
+    @contextmanager
+    def _patcher():
+        with patch("homeassistant.components.steamist.Steamist", return_value=client):
+            yield
+
+    return _patcher()

--- a/tests/components/steamist/test_config_flow.py
+++ b/tests/components/steamist/test_config_flow.py
@@ -1,0 +1,80 @@
+"""Test the Steamist config flow."""
+import asyncio
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.steamist.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.steamist.config_flow.Steamist.async_get_status"
+    ), patch(
+        "homeassistant.components.steamist.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "127.0.0.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "127.0.0.1"
+    assert result2["data"] == {
+        "host": "127.0.0.1",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.steamist.config_flow.Steamist.async_get_status",
+        side_effect=asyncio.TimeoutError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "127.0.0.1",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_unknown_exception(hass: HomeAssistant) -> None:
+    """Test we handle unknown exceptions."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.steamist.config_flow.Steamist.async_get_status",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "127.0.0.1",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/steamist/test_init.py
+++ b/tests/components/steamist/test_init.py
@@ -1,0 +1,48 @@
+"""Tests for the steamist component."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from homeassistant.components import steamist
+from homeassistant.components.steamist.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import _patch_status_active
+
+from tests.common import MockConfigEntry
+
+
+async def test_config_entry_reload(hass: HomeAssistant) -> None:
+    """Test that a config entry can be reloaded."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1"},
+    )
+    config_entry.add_to_hass(hass)
+    with _patch_status_active():
+        await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
+        await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.LOADED
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+
+
+async def test_config_entry_retry_later(hass: HomeAssistant) -> None:
+    """Test that a config entry retry on connection error."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1"},
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.steamist.Steamist.async_get_status",
+        side_effect=asyncio.TimeoutError,
+    ):
+        await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
+        await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY

--- a/tests/components/steamist/test_switch.py
+++ b/tests/components/steamist/test_switch.py
@@ -1,0 +1,81 @@
+"""Tests for the steamist switch."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from homeassistant.components import steamist
+from homeassistant.components.steamist.const import DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from . import (
+    MOCK_ASYNC_GET_STATUS_ACTIVE,
+    MOCK_ASYNC_GET_STATUS_INACTIVE,
+    _mocked_steamist,
+    _patch_status_active,
+    _patch_status_inactive,
+)
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_steam_active(hass: HomeAssistant) -> None:
+    """Test that the binary sensors are setup with the expected values when steam is active."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1"},
+    )
+    config_entry.add_to_hass(hass)
+    client = _mocked_steamist()
+    client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_ACTIVE)
+    with _patch_status_active(client):
+        await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
+        await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert len(hass.states.async_all("switch")) == 1
+    assert hass.states.get("switch.steam_active").state == STATE_ON
+
+    client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_INACTIVE)
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {ATTR_ENTITY_ID: "switch.steam_active"},
+        blocking=True,
+    )
+    client.async_turn_off_steam.assert_called_once()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.steam_active").state == STATE_OFF
+
+
+async def test_steam_inactive(hass: HomeAssistant) -> None:
+    """Test that the binary sensors are setup with the expected values when steam is not active."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1"},
+    )
+    config_entry.add_to_hass(hass)
+    client = _mocked_steamist()
+    client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_INACTIVE)
+    with _patch_status_inactive(client):
+        await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
+        await hass.async_block_till_done()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert len(hass.states.async_all("switch")) == 1
+    assert hass.states.get("switch.steam_active").state == STATE_OFF
+
+    client.async_get_status = AsyncMock(return_value=MOCK_ASYNC_GET_STATUS_ACTIVE)
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: "switch.steam_active"}, blocking=True
+    )
+    client.async_turn_on_steam.assert_called_once()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.steam_active").state == STATE_ON


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for [Steamist models](https://steamist.com/digital-controls/)

- 450 Digital Control
- 550 Digital Control


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20995

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
