### PR TITLE
Address late review comments for version integration

### DIFF
--- a/homeassistant/components/version/coordinator.py
+++ b/homeassistant/components/version/coordinator.py
@@ -29,7 +29,6 @@ class VersionDataUpdateCoordinator(DataUpdateCoordinator):
             hass=hass,
             logger=LOGGER,
             name=DOMAIN,
-            update_method=self._async_update_version_data,
             update_interval=UPDATE_COORDINATOR_UPDATE_INTERVAL,
         )
         self._api = api
@@ -46,7 +45,7 @@ class VersionDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the version data."""
         return self._version_data or {}
 
-    async def _async_update_version_data(self) -> None:
+    async def _async_update_data(self) -> None:
         """Update version data."""
         try:
             self._version, self._version_data = await self._api.get_version()

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -113,7 +113,7 @@ class VersionSensorEntity(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._attr_unique_id = (
-            f"{coordinator.config_entry.unique_id}_{entity_description.key}"
+            f"{coordinator.config_entry.entry_id}_{entity_description.key}"
         )
 
     @property

--- a/tests/components/version/common.py
+++ b/tests/components/version/common.py
@@ -14,7 +14,6 @@ from homeassistant.components.version.const import (
 )
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -55,7 +54,6 @@ async def mock_get_version_update(
 
 async def setup_version_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the Version integration."""
-    await async_setup_component(hass, "persistent_notification", {})
     mock_entry = MockConfigEntry(**MOCK_VERSION_CONFIG_ENTRY_DATA)
     mock_entry.add_to_hass(hass)
 

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pyhaversion.consts import HaVersionChannel, HaVersionSource
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.version.const import (
     CONF_BETA,
     CONF_BOARD,
@@ -34,9 +34,10 @@ from tests.components.version.common import (
 )
 
 
-async def test_reload(hass: HomeAssistant):
-    """Test the Version sensor with different sources."""
+async def test_reload_config_entry(hass: HomeAssistant):
+    """Test reloading the config entry."""
     config_entry = await setup_version_integration(hass)
+    assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
     with patch(
         "pyhaversion.HaVersion.get_version",
@@ -48,12 +49,10 @@ async def test_reload(hass: HomeAssistant):
 
     entry = hass.config_entries.async_get_entry(config_entry.entry_id)
     assert entry.state == config_entries.ConfigEntryState.LOADED
-    assert hass.states.get("sensor.local_installation").state == MOCK_VERSION
 
 
 async def test_basic_form(hass: HomeAssistant) -> None:
-    """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+    """Test that we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER, "show_advanced_options": False},
@@ -82,7 +81,6 @@ async def test_basic_form(hass: HomeAssistant) -> None:
 
 async def test_advanced_form_pypi(hass: HomeAssistant) -> None:
     """Show advanced form when pypi is selected."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
@@ -124,7 +122,6 @@ async def test_advanced_form_pypi(hass: HomeAssistant) -> None:
 
 async def test_advanced_form_container(hass: HomeAssistant) -> None:
     """Show advanced form when container source is selected."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
@@ -166,7 +163,6 @@ async def test_advanced_form_container(hass: HomeAssistant) -> None:
 
 async def test_advanced_form_supervisor(hass: HomeAssistant) -> None:
     """Show advanced form when docker source is selected."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},

--- a/tests/components/version/test_sensor.py
+++ b/tests/components/version/test_sensor.py
@@ -47,7 +47,6 @@ async def async_setup_sensor_wrapper(
         await hass.async_block_till_done()
 
     config_entries = hass.config_entries.async_entries(DOMAIN)
-    print(config_entries)
     config_entry = config_entries[-1]
     assert config_entry.source == "import"
     return config_entry

--- a/tests/components/version/test_sensor.py
+++ b/tests/components/version/test_sensor.py
@@ -36,7 +36,6 @@ async def async_setup_sensor_wrapper(
     hass: HomeAssistant, config: dict[str, Any]
 ) -> ConfigEntry:
     """Set up the Version sensor platform."""
-    await async_setup_component(hass, "persistent_notification", {})
     with patch(
         "pyhaversion.HaVersion.get_version",
         return_value=(MOCK_VERSION, MOCK_VERSION_DATA),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/home-assistant/core/pull/54642

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
