### PR TITLE
Fix `ensure_list` typing

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -264,7 +264,7 @@ def ensure_list(value: T | None) -> list[T] | list[Any]:
     """Wrap value in list if it is not one."""
     if value is None:
         return []
-    return cast(list[T], value) if isinstance(value, list) else [value]
+    return cast("list[T]", value) if isinstance(value, list) else [value]
 
 
 def entity_id(value: Any) -> str:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -251,15 +251,20 @@ def ensure_list(value: None) -> list[Any]:
 
 
 @overload
-def ensure_list(value: T | list[T]) -> list[T]:
+def ensure_list(value: list[T]) -> list[T]:
     ...
 
 
-def ensure_list(value: T | list[T] | None) -> list[T] | list[Any]:
+@overload
+def ensure_list(value: list[T] | T) -> list[T]:
+    ...
+
+
+def ensure_list(value: T | None) -> list[T] | list[Any]:
     """Wrap value in list if it is not one."""
     if value is None:
         return []
-    return value if isinstance(value, list) else [value]
+    return cast(list[T], value) if isinstance(value, list) else [value]
 
 
 def entity_id(value: Any) -> str:


### PR DESCRIPTION
## Proposed change
Followup to #62642 where @cgtobi and I discussed how to best type the `ensure_list` function in `helpers/config_validation.py`. After some feedback from the typing community, I stumbled across a solution that would work in all relevant cases. For more details, see: https://github.com/python/typing/discussions/995.

The test cases I used to validate the change. Note the comment is the expected type.
```py
def func(
    x1: None,
    x2: int,
    x3: list[int],
    x4: list[Any],
    x5: list,

    x6: list[str] | str,
    x7: str | list[str],
) -> None:
    reveal_type(ensure_list(x1))  # list[Any]
    reveal_type(ensure_list(x2))  # list[int]
    reveal_type(ensure_list(x3))  # list[int]
    reveal_type(ensure_list(x4))  # list[Any]
    reveal_type(ensure_list(x5))  # list[Any]

    reveal_type(ensure_list(x6))  # list[str]
    reveal_type(ensure_list(x7))  # list[str]
```

<details>
<summary>Mypy output</summary>

```
note: Revealed type is "builtins.list[Any]"
note: Revealed type is "builtins.list[builtins.int*]"
note: Revealed type is "builtins.list[builtins.int*]"
note: Revealed type is "builtins.list[Any]"
note: Revealed type is "builtins.list[Any]"

note: Revealed type is "builtins.list[builtins.str*]"
note: Revealed type is "builtins.list[builtins.str*]"
```
</details>

<details>
<summary>Mypy output - without this PR</summary>

```
note: Revealed type is "builtins.list[Any]"
note: Revealed type is "builtins.list[builtins.int*]"
note: Revealed type is "builtins.list[<nothing>]"
error: Argument 1 to "ensure_list" has incompatible type "List[int]"; expected "List[<nothing>]"  [arg-type]
note: Revealed type is "builtins.list[Union[builtins.list[Any], Any]]"
note: Revealed type is "builtins.list[Union[builtins.list[Any], Any]]"

note: Revealed type is "builtins.list[builtins.str*]"
note: Revealed type is "builtins.list[builtins.str*]"
```
Here mypy has issues with `x3` - `x5`.
</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
