### PR TITLE
Make device tracker entities work better

### DIFF
--- a/homeassistant/components/asuswrt/device_tracker.py
+++ b/homeassistant/components/asuswrt/device_tracker.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_DEFAULT_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DATA_ASUSWRT, DOMAIN
 from .router import AsusWrtRouter
@@ -62,12 +59,6 @@ class AsusWrtDevice(ScannerEntity):
         self._device = device
         self._attr_unique_id = device.mac
         self._attr_name = device.name or DEFAULT_DEVICE_NAME
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, device.mac)},
-            default_model="ASUSWRT Tracked device",
-        )
-        if device.name:
-            self._attr_device_info[ATTR_DEFAULT_NAME] = device.name
 
     @property
     def is_connected(self):

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -48,4 +48,5 @@ def is_on(hass: HomeAssistant, entity_id: str) -> bool:
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the device tracker."""
     await async_setup_legacy_integration(hass, config)
+
     return True

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -2,8 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME  # noqa: F401
-from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
@@ -44,77 +43,6 @@ from .legacy import (  # noqa: F401
 def is_on(hass: HomeAssistant, entity_id: str) -> bool:
     """Return the state if any or a specified device is home."""
     return hass.states.is_state(entity_id, STATE_HOME)
-
-
-@callback
-def async_register_mac(
-    hass: HomeAssistant, domain: str, mac: str, unique_id: str | None = None
-) -> None:
-    """Register a mac address with a unique ID.
-
-    If no unique ID given, it is assumed to be the mac.
-    """
-    data_key = "device_tracker_mac"
-    mac = dr.format_mac(mac)
-    if data_key in hass.data:
-        hass.data[data_key][mac] = (domain, unique_id or mac)
-        return
-
-    # Setup listening.
-
-    # dict mapping mac -> partial unique ID
-    data = hass.data[data_key] = {mac: (domain, unique_id or mac)}
-
-    @callback
-    def handle_device_event(ev: Event) -> None:
-        """Enable the online status entity for the mac of a newly created device."""
-        # Only for new devices
-        if ev.data["action"] != "create":
-            return
-
-        dev_reg = dr.async_get(hass)
-        device_entry = dev_reg.async_get(ev.data["device_id"])
-
-        if device_entry is None:
-            return
-
-        # Check if device has a mac
-        mac = None
-        for conn in device_entry.connections:
-            if conn[0] == dr.CONNECTION_NETWORK_MAC:
-                mac = conn[1]
-                break
-
-        if mac is None:
-            return
-
-        # Check if we have an entity for this mac
-        if (unique_id := data.get(mac)) is None:
-            return
-
-        ent_reg = er.async_get(hass)
-        entity_id = ent_reg.async_get_entity_id(DOMAIN, *unique_id)
-
-        if entity_id is None:
-            return
-
-        entity_entry = ent_reg.async_get(entity_id)
-
-        if entity_entry is None:
-            return
-
-        # Make sure entity has a config entry and was disabled by the
-        # default disable logic in the integration.
-        if (
-            entity_entry.config_entry_id is None
-            or entity_entry.disabled_by != er.RegistryEntryDisabler.INTEGRATION
-        ):
-            return
-
-        # Enable entity
-        ent_reg.async_update_entity(entity_id, disabled_by=None)
-
-    hass.bus.async_listen(dr.EVENT_DEVICE_REGISTRY_UPDATED, handle_device_event)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -1,6 +1,9 @@
 """Provide functionality to keep track of devices."""
+from __future__ import annotations
+
 from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME  # noqa: F401
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
@@ -43,8 +46,77 @@ def is_on(hass: HomeAssistant, entity_id: str) -> bool:
     return hass.states.is_state(entity_id, STATE_HOME)
 
 
+@callback
+def async_register_mac(
+    hass: HomeAssistant, domain: str, mac: str, unique_id: str | None = None
+) -> None:
+    """Register a mac address with a unique ID.
+
+    If no unique ID given, it is assumed to be the mac.
+    """
+    data_key = "device_tracker_mac"
+    if data_key in hass.data:
+        hass.data[data_key][mac] = (domain, unique_id or mac)
+        return
+
+    # Setup listening.
+
+    # dict mapping mac -> partial unique ID
+    data = hass.data[data_key] = {mac: (domain, unique_id or mac)}
+
+    @callback
+    def handle_device_event(ev: Event) -> None:
+        """Enable the online status entity for the mac of a newly created device."""
+        # Only for new devices
+        if ev.data["action"] != "create":
+            return
+
+        dev_reg = dr.async_get(hass)
+        device_entry = dev_reg.async_get(ev.data["device_id"])
+
+        if device_entry is None:
+            return
+
+        # Check if device has a mac
+        mac = None
+        for conn in device_entry.connections:
+            if conn[0] == dr.CONNECTION_NETWORK_MAC:
+                mac = conn[1]
+                break
+
+        if mac is None:
+            return
+
+        # Check if we have an entity for this mac
+        if (unique_id := data.get(mac)) is None:
+            return
+
+        ent_reg = er.async_get(hass)
+        entity_id = ent_reg.async_get_entity_id(DOMAIN, *unique_id)
+
+        if entity_id is None:
+            return
+
+        entity_entry = ent_reg.async_get(entity_id)
+
+        if entity_entry is None:
+            return
+
+        # Make sure entity has a config entry and was disabled by the
+        # default disable logic in the integration.
+        if (
+            entity_entry.config_entry_id is None
+            or entity_entry.disabled_by != er.DISABLED_INTEGRATION
+        ):
+            return
+
+        # Enable entity
+        ent_reg.async_update_entity(entity_id, disabled_by=None)
+
+    hass.bus.async_listen(dr.EVENT_DEVICE_REGISTRY_UPDATED, handle_device_event)
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the device tracker."""
     await async_setup_legacy_integration(hass, config)
-
     return True

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -55,6 +55,7 @@ def async_register_mac(
     If no unique ID given, it is assumed to be the mac.
     """
     data_key = "device_tracker_mac"
+    mac = dr.format_mac(mac)
     if data_key in hass.data:
         hass.data[data_key][mac] = (domain, unique_id or mac)
         return
@@ -106,7 +107,7 @@ def async_register_mac(
         # default disable logic in the integration.
         if (
             entity_entry.config_entry_id is None
-            or entity_entry.disabled_by != er.DISABLED_INTEGRATION
+            or entity_entry.disabled_by != er.RegistryEntryDisabler.INTEGRATION
         ):
             return
 

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -276,7 +276,8 @@ class ScannerEntity(BaseTrackerEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if entity is enabled by default."""
-        return self.find_device_entry() is not None
+        # If mac_address is None, we can never find a device entry.
+        return self.mac_address is None or self.find_device_entry() is not None
 
     @callback
     def add_to_platform_start(
@@ -295,8 +296,7 @@ class ScannerEntity(BaseTrackerEntity):
     @callback
     def find_device_entry(self) -> dr.DeviceEntry | None:
         """Return device entry."""
-        if self.mac_address is None:
-            return None
+        assert self.mac_address is not None
 
         return dr.async_get(self.hass).async_get_device(
             set(), {(dr.CONNECTION_NETWORK_MAC, self.mac_address)}

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -196,6 +196,7 @@ class ScannerEntity(BaseTrackerEntity):
             not self.registry_entry
             or not self.platform
             or not self.platform.config_entry
+            or not self.mac_address
             # Entities should not have a device info. We opt them out
             # of this logic if they do.
             or self.device_info

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -140,6 +140,7 @@ def _async_register_mac(
 class BaseTrackerEntity(Entity):
     """Represent a tracked device."""
 
+    _attr_device_info: None = None
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -192,14 +192,13 @@ class ScannerEntity(BaseTrackerEntity):
 
     async def async_internal_added_to_hass(self) -> None:
         """Handle added to Home Assistant."""
-        await super().async_internal_added_to_hass()
-
         # Entities without a unique ID don't have a device
         if (
             not self.registry_entry
             or not self.platform
             or not self.platform.config_entry
         ):
+            await super().async_internal_added_to_hass()
             return
 
         device_entry = self.find_device_entry()
@@ -214,21 +213,22 @@ class ScannerEntity(BaseTrackerEntity):
             dr.async_get(self.hass).async_remove_device(device_entry.id)
             device_entry = None
 
-        if device_entry is None:
-            return
+        if device_entry is not None:
+            # Attach entry to device
+            if self.registry_entry.device_id != device_entry.id:
+                self.registry_entry = er.async_get(self.hass).async_update_entity(
+                    self.entity_id, device_id=device_entry.id
+                )
 
-        # Attach entry to device
-        if self.registry_entry.device_id != device_entry.id:
-            er.async_get(self.hass).async_update_entity(
-                self.entity_id, device_id=device_entry.id
-            )
+            # Attach device to config entry
+            if self.platform.config_entry.entry_id not in device_entry.config_entries:
+                dr.async_get(self.hass).async_update_device(
+                    device_entry.id,
+                    add_config_entry_id=self.platform.config_entry.entry_id,
+                )
 
-        # Attach device to config entry
-        if self.platform.config_entry.entry_id not in device_entry.config_entries:
-            dr.async_get(self.hass).async_update_device(
-                device_entry.id,
-                add_config_entry_id=self.platform.config_entry.entry_id,
-            )
+        # Do this last or else the entity registry update listener has been installed
+        await super().async_internal_added_to_hass()
 
     @final
     @property

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -68,10 +68,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 def _async_register_mac(
     hass: HomeAssistant, domain: str, mac: str, unique_id: str
 ) -> None:
-    """Register a mac address with a unique ID.
-
-    If no unique ID given, it is assumed to be the unformatted mac.
-    """
+    """Register a mac address with a unique ID."""
     data_key = "device_tracker_mac"
     mac = dr.format_mac(mac)
     if data_key in hass.data:

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -277,7 +277,13 @@ class ScannerEntity(BaseTrackerEntity):
     def entity_registry_enabled_default(self) -> bool:
         """Return if entity is enabled by default."""
         # If mac_address is None, we can never find a device entry.
-        return self.mac_address is None or self.find_device_entry() is not None
+        return (
+            # Do not disable if we won't activate our attach to device logic
+            self.mac_address is None
+            or self.device_info is not None
+            # Disable if we automatically attach but there is no device
+            or self.find_device_entry() is not None
+        )
 
     @callback
     def add_to_platform_start(
@@ -316,7 +322,7 @@ class ScannerEntity(BaseTrackerEntity):
             or self.device_info
         ):
             if self.device_info:
-                LOGGER.warning("Entity %s unexpectedly has a device info")
+                LOGGER.debug("Entity %s unexpectedly has a device info", self.entity_id)
             await super().async_internal_added_to_hass()
             return
 

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -66,15 +66,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 @callback
 def _async_register_mac(
-    hass: HomeAssistant, domain: str, mac: str, unique_id: str | None = None
+    hass: HomeAssistant, domain: str, mac: str, unique_id: str
 ) -> None:
     """Register a mac address with a unique ID.
 
     If no unique ID given, it is assumed to be the unformatted mac.
     """
     data_key = "device_tracker_mac"
-    if unique_id is None:
-        unique_id = mac
     mac = dr.format_mac(mac)
     if data_key in hass.data:
         hass.data[data_key][mac] = (domain, unique_id)
@@ -292,7 +290,7 @@ class ScannerEntity(BaseTrackerEntity):
     ) -> None:
         """Start adding an entity to a platform."""
         super().add_to_platform_start(hass, platform, parallel_updates)
-        if self.mac_address:
+        if self.mac_address and self.unique_id:
             _async_register_mac(
                 hass, platform.platform_name, self.mac_address, self.unique_id
             )

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -314,6 +314,7 @@ class ScannerEntity(BaseTrackerEntity):
             or not self.platform
             or not self.platform.config_entry
             or not self.mac_address
+            or (device_entry := self.find_device_entry()) is None
             # Entities should not have a device info. We opt them out
             # of this logic if they do.
             or self.device_info
@@ -323,22 +324,18 @@ class ScannerEntity(BaseTrackerEntity):
             await super().async_internal_added_to_hass()
             return
 
-        device_entry = self.find_device_entry()
-        assert device_entry is not None
+        # Attach entry to device
+        if self.registry_entry.device_id != device_entry.id:
+            self.registry_entry = er.async_get(self.hass).async_update_entity(
+                self.entity_id, device_id=device_entry.id
+            )
 
-        if device_entry is not None:
-            # Attach entry to device
-            if self.registry_entry.device_id != device_entry.id:
-                self.registry_entry = er.async_get(self.hass).async_update_entity(
-                    self.entity_id, device_id=device_entry.id
-                )
-
-            # Attach device to config entry
-            if self.platform.config_entry.entry_id not in device_entry.config_entries:
-                dr.async_get(self.hass).async_update_device(
-                    device_entry.id,
-                    add_config_entry_id=self.platform.config_entry.entry_id,
-                )
+        # Attach device to config entry
+        if self.platform.config_entry.entry_id not in device_entry.config_entries:
+            dr.async_get(self.hass).async_update_device(
+                device_entry.id,
+                add_config_entry_id=self.platform.config_entry.entry_id,
+            )
 
         # Do this last or else the entity registry update listener has been installed
         await super().async_internal_added_to_hass()

--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -8,9 +8,7 @@ from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DEFAULT_DEVICE_NAME, DEVICE_ICONS, DOMAIN
 from .router import FreeboxRouter
@@ -110,16 +108,6 @@ class FreeboxDevice(ScannerEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes."""
         return self._attrs
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self._mac)},
-            identifiers={(DOMAIN, self.unique_id)},
-            manufacturer=self._manufacturer,
-            name=self.name,
-        )
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/freebox/device_tracker.py
+++ b/homeassistant/components/freebox/device_tracker.py
@@ -80,7 +80,7 @@ class FreeboxDevice(ScannerEntity):
             self._attrs = device["attrs"]
 
     @property
-    def unique_id(self) -> str:
+    def mac_address(self) -> str:
         """Return a unique ID."""
         return self._mac
 

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -520,21 +520,6 @@ class FritzDeviceBase(update_coordinator.CoordinatorEntity):
         return None
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self._mac)},
-            default_manufacturer="AVM",
-            default_model="FRITZ!Box Tracked device",
-            default_name=self.name,
-            identifiers={(DOMAIN, self._mac)},
-            via_device=(
-                DOMAIN,
-                self._router.unique_id,
-            ),
-        )
-
-    @property
     def should_poll(self) -> bool:
         """No polling needed."""
         return False

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -131,6 +131,11 @@ class FritzBoxTracker(FritzDeviceBase, ScannerEntity):
         return f"{self._mac}_tracker"
 
     @property
+    def mac_address(self) -> str:
+        """Return mac_address."""
+        return self._mac
+
+    @property
     def icon(self) -> str:
         """Return device icon."""
         if self.is_connected:

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -19,8 +19,9 @@ from homeassistant.components.network import async_get_source_ip
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity, EntityCategory
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
@@ -604,6 +605,21 @@ class FritzBoxProfileSwitch(FritzDeviceBase, SwitchEntity):
     def is_on(self) -> bool:
         """Switch status."""
         return self._router.devices[self._mac].wan_access
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, self._mac)},
+            default_manufacturer="AVM",
+            default_model="FRITZ!Box Tracked device",
+            default_name=self.name,
+            identifiers={(DOMAIN, self._mac)},
+            via_device=(
+                DOMAIN,
+                self._router.unique_id,
+            ),
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -653,14 +653,6 @@ class HuaweiLteBaseEntity(Entity):
         """Huawei LTE entities report their state without polling."""
         return False
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Get info for matching with parent router."""
-        return DeviceInfo(
-            connections=self.router.device_connections,
-            identifiers=self.router.device_identifiers,
-        )
-
     async def async_update(self) -> None:
         """Update state."""
         raise NotImplementedError
@@ -681,3 +673,15 @@ class HuaweiLteBaseEntity(Entity):
         for unsub in self._unsub_handlers:
             unsub()
         self._unsub_handlers.clear()
+
+
+class HuaweiLteBaseEntityWithDevice(HuaweiLteBaseEntity):
+    """Base entity with device info."""
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Get info for matching with parent router."""
+        return DeviceInfo(
+            connections=self.router.device_connections,
+            identifiers=self.router.device_identifiers,
+        )

--- a/homeassistant/components/huawei_lte/binary_sensor.py
+++ b/homeassistant/components/huawei_lte/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import HuaweiLteBaseEntity
+from . import HuaweiLteBaseEntityWithDevice
 from .const import (
     DOMAIN,
     KEY_MONITORING_CHECK_NOTIFICATIONS,
@@ -49,7 +49,7 @@ async def async_setup_entry(
 
 
 @dataclass
-class HuaweiLteBaseBinarySensor(HuaweiLteBaseEntity, BinarySensorEntity):
+class HuaweiLteBaseBinarySensor(HuaweiLteBaseEntityWithDevice, BinarySensorEntity):
     """Huawei LTE binary sensor device base class."""
 
     key: str = field(init=False)

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.entity import Entity, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import HuaweiLteBaseEntity
+from . import HuaweiLteBaseEntityWithDevice
 from .const import (
     DOMAIN,
     KEY_DEVICE_INFORMATION,
@@ -523,7 +523,7 @@ def format_default(value: StateType) -> tuple[StateType, str | None]:
 
 
 @dataclass
-class HuaweiLteSensor(HuaweiLteBaseEntity, SensorEntity):
+class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
     """Huawei LTE sensor entity."""
 
     key: str

--- a/homeassistant/components/huawei_lte/switch.py
+++ b/homeassistant/components/huawei_lte/switch.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import HuaweiLteBaseEntity
+from . import HuaweiLteBaseEntityWithDevice
 from .const import DOMAIN, KEY_DIALUP_MOBILE_DATASWITCH
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ async def async_setup_entry(
 
 
 @dataclass
-class HuaweiLteBaseSwitch(HuaweiLteBaseEntity, SwitchEntity):
+class HuaweiLteBaseSwitch(HuaweiLteBaseEntityWithDevice, SwitchEntity):
     """Huawei LTE switch device base class."""
 
     key: str = field(init=False)

--- a/homeassistant/components/keenetic_ndms2/device_tracker.py
+++ b/homeassistant/components/keenetic_ndms2/device_tracker.py
@@ -24,9 +24,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 import homeassistant.util.dt as dt_util
 
 from .const import (
@@ -216,15 +214,6 @@ class KeeneticTracker(ScannerEntity):
                 "interface": self._device.interface,
             }
         return None
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a client description for device registry."""
-        return DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self._device.mac)},
-            identifiers={(DOMAIN, self._device.mac)},
-            name=self._device.name if self._device.name else None,
-        )
 
     async def async_added_to_hass(self):
         """Client entity created."""

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -8,9 +8,7 @@ from homeassistant.components.device_tracker.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
@@ -129,17 +127,6 @@ class MikrotikHubTracker(ScannerEntity):
         if self.is_connected:
             return {k: v for k, v in self.device.attrs.items() if k not in FILTER_ATTRS}
         return None
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a client description for device registry."""
-        # We only get generic info from device discovery and so don't want
-        # to override API specific info that integrations can provide
-        return DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
-            default_name=self.name,
-            identifiers={(DOMAIN, self.device.mac)},
-        )
 
     async def async_added_to_hass(self):
         """Client entity created."""

--- a/homeassistant/components/nmap_tracker/device_tracker.py
+++ b/homeassistant/components/nmap_tracker/device_tracker.py
@@ -22,9 +22,7 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, CONF_HOSTS
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
 from . import NmapDevice, NmapDeviceScanner, short_hostname, signal_device_update
@@ -168,15 +166,6 @@ class NmapTrackerEntity(ScannerEntity):
     def source_type(self) -> str:
         """Return tracker source type."""
         return SOURCE_TYPE_ROUTER
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self._mac_address)},
-            default_manufacturer=self._device.manufacturer,
-            default_name=self.name,
-        )
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -90,8 +90,8 @@ class RuckusUnleashedDevice(CoordinatorEntity, ScannerEntity):
         self._name = name
 
     @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
+    def mac_address(self) -> str:
+        """Return a mac address."""
         return self._mac
 
     @property

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -6,12 +6,9 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    API_ACCESS_POINT,
     API_CLIENTS,
     API_NAME,
     COORDINATOR,
@@ -116,17 +113,3 @@ class RuckusUnleashedDevice(CoordinatorEntity, ScannerEntity):
     def source_type(self) -> str:
         """Return the source type."""
         return SOURCE_TYPE_ROUTER
-
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device information."""
-        if self.is_connected:
-            return DeviceInfo(
-                name=self.name,
-                connections={(CONNECTION_NETWORK_MAC, self._mac)},
-                via_device=(
-                    CONNECTION_NETWORK_MAC,
-                    self.coordinator.data[API_CLIENTS][self._mac][API_ACCESS_POINT],
-                ),
-            )
-        return None

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -243,6 +243,11 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         self.async_write_ha_state()
 
     @property
+    def device_info(self) -> None:
+        """Return no device info."""
+        return None
+
+    @property
     def is_connected(self):
         """Return true if the client is connected to the network."""
         if (
@@ -324,14 +329,6 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         self._is_connected = device.state == 1
         self._controller_connection_state_changed = False
         self.schedule_update = False
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
-            manufacturer=ATTR_MANUFACTURER,
-            model=self.device.model,
-            sw_version=self.device.version,
-        )
-        if self.device.name:
-            self._attr_device_info[ATTR_NAME] = self.device.name
 
     async def async_added_to_hass(self) -> None:
         """Watch object when added."""
@@ -419,6 +416,21 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     def available(self) -> bool:
         """Return if controller is available."""
         return not self.device.disabled and self.controller.available
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return a device description for device registry."""
+        info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
+            manufacturer=ATTR_MANUFACTURER,
+            model=self.device.model,
+            sw_version=self.device.version,
+        )
+
+        if self.device.name:
+            info[ATTR_NAME] = self.device.name
+
+        return info
 
     async def async_update_device_registry(self) -> None:
         """Update device registry."""

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -324,6 +324,14 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
         self._is_connected = device.state == 1
         self._controller_connection_state_changed = False
         self.schedule_update = False
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
+            manufacturer=ATTR_MANUFACTURER,
+            model=self.device.model,
+            sw_version=self.device.version,
+        )
+        if self.device.name:
+            self._attr_device_info[ATTR_NAME] = self.device.name
 
     async def async_added_to_hass(self) -> None:
         """Watch object when added."""
@@ -411,21 +419,6 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     def available(self) -> bool:
         """Return if controller is available."""
         return not self.device.disabled and self.controller.available
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a device description for device registry."""
-        info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
-            manufacturer=ATTR_MANUFACTURER,
-            model=self.device.model,
-            sw_version=self.device.version,
-        )
-
-        if self.device.name:
-            info[ATTR_NAME] = self.device.name
-
-        return info
 
     async def async_update_device_registry(self) -> None:
         """Update device registry."""

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -15,7 +15,7 @@ from aiounifi.events import (
     WIRELESS_GUEST_ROAMRADIO,
 )
 
-from homeassistant.components.device_tracker import DOMAIN
+from homeassistant.components.device_tracker import DOMAIN, async_register_mac
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.config_entries import ConfigEntry
@@ -88,7 +88,7 @@ async def async_setup_entry(
     ) -> None:
         """Update the values of the controller."""
         if controller.option_track_clients:
-            add_client_entities(controller, async_add_entities, clients)
+            add_client_entities(hass, controller, async_add_entities, clients)
 
         if controller.option_track_devices:
             add_device_entities(controller, async_add_entities, devices)
@@ -102,7 +102,7 @@ async def async_setup_entry(
 
 
 @callback
-def add_client_entities(controller, async_add_entities, clients):
+def add_client_entities(hass, controller, async_add_entities, clients):
     """Add new client tracker entities from the controller."""
     trackers = []
 
@@ -123,6 +123,7 @@ def add_client_entities(controller, async_add_entities, clients):
             continue
 
         trackers.append(UniFiClientTracker(client, controller))
+        async_register_mac(hass, UNIFI_DOMAIN, mac, f"{mac}-{controller.site}")
 
     if trackers:
         async_add_entities(trackers)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -19,16 +19,14 @@ from homeassistant.components.device_tracker import DOMAIN
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import ATTR_MANUFACTURER, DOMAIN as UNIFI_DOMAIN
+from .const import DOMAIN as UNIFI_DOMAIN
 from .unifi_client import UniFiClient
 from .unifi_entity_base import UniFiBase
 
@@ -420,17 +418,7 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
-        info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
-            manufacturer=ATTR_MANUFACTURER,
-            model=self.device.model,
-            sw_version=self.device.version,
-        )
-
-        if self.device.name:
-            info[ATTR_NAME] = self.device.name
-
-        return info
+        return None
 
     async def async_update_device_registry(self) -> None:
         """Update device registry."""

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -20,9 +20,7 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
@@ -368,13 +366,6 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
             self._is_connected = True
             self.schedule_update = True
 
-        elif (
-            self.device.last_updated == SOURCE_EVENT
-            and self.device.event.event in DEVICE_UPGRADED
-        ):
-            self.hass.async_create_task(self.async_update_device_registry())
-            return
-
         if self.schedule_update:
             self.schedule_update = False
             self.controller.async_heartbeat(
@@ -414,18 +405,6 @@ class UniFiDeviceTracker(UniFiBase, ScannerEntity):
     def available(self) -> bool:
         """Return if controller is available."""
         return not self.device.disabled and self.controller.available
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a device description for device registry."""
-        return None
-
-    async def async_update_device_registry(self) -> None:
-        """Update device registry."""
-        device_registry = dr.async_get(self.hass)
-        device_registry.async_get_or_create(
-            config_entry_id=self.controller.config_entry.entry_id, **self.device_info
-        )
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -15,7 +15,7 @@ from aiounifi.events import (
     WIRELESS_GUEST_ROAMRADIO,
 )
 
-from homeassistant.components.device_tracker import DOMAIN, async_register_mac
+from homeassistant.components.device_tracker import DOMAIN
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.config_entries import ConfigEntry
@@ -88,7 +88,7 @@ async def async_setup_entry(
     ) -> None:
         """Update the values of the controller."""
         if controller.option_track_clients:
-            add_client_entities(hass, controller, async_add_entities, clients)
+            add_client_entities(controller, async_add_entities, clients)
 
         if controller.option_track_devices:
             add_device_entities(controller, async_add_entities, devices)
@@ -102,7 +102,7 @@ async def async_setup_entry(
 
 
 @callback
-def add_client_entities(hass, controller, async_add_entities, clients):
+def add_client_entities(controller, async_add_entities, clients):
     """Add new client tracker entities from the controller."""
     trackers = []
 
@@ -123,7 +123,6 @@ def add_client_entities(hass, controller, async_add_entities, clients):
             continue
 
         trackers.append(UniFiClientTracker(client, controller))
-        async_register_mac(hass, UNIFI_DOMAIN, mac, f"{mac}-{controller.site}")
 
     if trackers:
         async_add_entities(trackers)

--- a/homeassistant/components/unifi/unifi_entity_base.py
+++ b/homeassistant/components/unifi/unifi_entity_base.py
@@ -6,7 +6,6 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_registry import async_entries_for_device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,35 +101,10 @@ class UniFiBase(Entity):
             entity_registry.async_remove(self.entity_id)
             return
 
-        if (
-            len(
-                entries_for_device := async_entries_for_device(
-                    entity_registry,
-                    entity_entry.device_id,
-                    include_disabled_entities=True,
-                )
-            )
-        ) == 1:
-            device_registry.async_remove_device(device_entry.id)
-            return
-
-        if (
-            len(
-                entries_for_device_from_this_config_entry := [
-                    entry_for_device
-                    for entry_for_device in entries_for_device
-                    if entry_for_device.config_entry_id
-                    == self.controller.config_entry.entry_id
-                ]
-            )
-            != len(entries_for_device)
-            and len(entries_for_device_from_this_config_entry) == 1
-        ):
-            device_registry.async_update_device(
-                entity_entry.device_id,
-                remove_config_entry_id=self.controller.config_entry.entry_id,
-            )
-
+        device_registry.async_update_device(
+            entity_entry.device_id,
+            remove_config_entry_id=self.controller.config_entry.entry_id,
+        )
         entity_registry.async_remove(self.entity_id)
 
     @property

--- a/homeassistant/components/wled/models.py
+++ b/homeassistant/components/wled/models.py
@@ -1,4 +1,5 @@
 """Models for WLED."""
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -15,6 +16,9 @@ class WLEDEntity(CoordinatorEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information about this WLED device."""
         return DeviceInfo(
+            connections={
+                (CONNECTION_NETWORK_MAC, self.coordinator.data.info.mac_address)
+            },
             identifiers={(DOMAIN, self.coordinator.data.info.mac_address)},
             name=self.coordinator.data.info.name,
             manufacturer=self.coordinator.data.info.brand,

--- a/homeassistant/components/wled/models.py
+++ b/homeassistant/components/wled/models.py
@@ -1,5 +1,4 @@
 """Models for WLED."""
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -16,9 +15,6 @@ class WLEDEntity(CoordinatorEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information about this WLED device."""
         return DeviceInfo(
-            connections={
-                (CONNECTION_NETWORK_MAC, self.coordinator.data.info.mac_address)
-            },
             identifiers={(DOMAIN, self.coordinator.data.info.mac_address)},
             name=self.coordinator.data.info.name,
             manufacturer=self.coordinator.data.info.brand,

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -474,7 +474,9 @@ class ZHADevice(LogMixin):
         device_info["entities"] = [
             {
                 "entity_id": entity_ref.reference_id,
-                ATTR_NAME: entity_ref.device_info[ATTR_NAME],
+                ATTR_NAME: entity_ref.device_info[ATTR_NAME]
+                if entity_ref.device_info
+                else None,
             }
             for entity_ref in self.gateway.device_registry[self.ieee]
         ]

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -474,9 +474,7 @@ class ZHADevice(LogMixin):
         device_info["entities"] = [
             {
                 "entity_id": entity_ref.reference_id,
-                ATTR_NAME: entity_ref.device_info[ATTR_NAME]
-                if entity_ref.device_info
-                else None,
+                ATTR_NAME: entity_ref.device_info[ATTR_NAME],
             }
             for entity_ref in self.gateway.device_registry[self.ieee]
         ]

--- a/homeassistant/components/zha/device_tracker.py
+++ b/homeassistant/components/zha/device_tracker.py
@@ -1,4 +1,6 @@
 """Support for the ZHA platform."""
+from __future__ import annotations
+
 import functools
 import time
 
@@ -8,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .core import discovery
@@ -103,3 +106,15 @@ class ZHADeviceScannerEntity(ScannerEntity, ZhaEntity):
         Percentage from 0-100.
         """
         return self._battery_level
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device info."""
+        # Call Super because ScannerEntity overrode it.
+        return super(ZhaEntity, self).device_info
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return unique ID."""
+        # Call Super because ScannerEntity overrode it.
+        return super(ZhaEntity, self).unique_id

--- a/homeassistant/components/zha/device_tracker.py
+++ b/homeassistant/components/zha/device_tracker.py
@@ -108,8 +108,12 @@ class ZHADeviceScannerEntity(ScannerEntity, ZhaEntity):
         return self._battery_level
 
     @property
-    def device_info(self) -> DeviceInfo | None:
+    def device_info(  # pylint: disable=overridden-final-method
+        self,
+    ) -> DeviceInfo | None:
         """Return device info."""
+        # We opt ZHA device tracker back into overriding this method because
+        # it doesn't track IP-based devices.
         # Call Super because ScannerEntity overrode it.
         return super(ZhaEntity, self).device_info
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -372,7 +372,7 @@ class DeviceRegistry:
             )
             entry_type = DeviceEntryType(entry_type)
 
-        device = self._async_update_device(
+        device = self.async_update_device(
             device.id,
             add_config_entry_id=config_entry_id,
             configuration_url=configuration_url,
@@ -396,45 +396,6 @@ class DeviceRegistry:
 
     @callback
     def async_update_device(
-        self,
-        device_id: str,
-        *,
-        add_config_entry_id: str | UndefinedType = UNDEFINED,
-        area_id: str | None | UndefinedType = UNDEFINED,
-        configuration_url: str | None | UndefinedType = UNDEFINED,
-        disabled_by: DeviceEntryDisabler | None | UndefinedType = UNDEFINED,
-        manufacturer: str | None | UndefinedType = UNDEFINED,
-        model: str | None | UndefinedType = UNDEFINED,
-        name_by_user: str | None | UndefinedType = UNDEFINED,
-        name: str | None | UndefinedType = UNDEFINED,
-        new_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
-        remove_config_entry_id: str | UndefinedType = UNDEFINED,
-        suggested_area: str | None | UndefinedType = UNDEFINED,
-        sw_version: str | None | UndefinedType = UNDEFINED,
-        hw_version: str | None | UndefinedType = UNDEFINED,
-        via_device_id: str | None | UndefinedType = UNDEFINED,
-    ) -> DeviceEntry | None:
-        """Update properties of a device."""
-        return self._async_update_device(
-            device_id,
-            add_config_entry_id=add_config_entry_id,
-            area_id=area_id,
-            configuration_url=configuration_url,
-            disabled_by=disabled_by,
-            manufacturer=manufacturer,
-            model=model,
-            name_by_user=name_by_user,
-            name=name,
-            new_identifiers=new_identifiers,
-            remove_config_entry_id=remove_config_entry_id,
-            suggested_area=suggested_area,
-            sw_version=sw_version,
-            hw_version=hw_version,
-            via_device_id=via_device_id,
-        )
-
-    @callback
-    def _async_update_device(
         self,
         device_id: str,
         *,
@@ -568,7 +529,7 @@ class DeviceRegistry:
         )
         for other_device in list(self.devices.values()):
             if other_device.via_device_id == device_id:
-                self._async_update_device(other_device.id, via_device_id=None)
+                self.async_update_device(other_device.id, via_device_id=None)
         self.hass.bus.async_fire(
             EVENT_DEVICE_REGISTRY_UPDATED, {"action": "remove", "device_id": device_id}
         )
@@ -669,7 +630,7 @@ class DeviceRegistry:
         """Clear config entry from registry entries."""
         now_time = time.time()
         for device in list(self.devices.values()):
-            self._async_update_device(device.id, remove_config_entry_id=config_entry_id)
+            self.async_update_device(device.id, remove_config_entry_id=config_entry_id)
         for deleted_device in list(self.deleted_devices.values()):
             config_entries = deleted_device.config_entries
             if config_entry_id not in config_entries:
@@ -711,7 +672,7 @@ class DeviceRegistry:
         """Clear area id from registry entries."""
         for dev_id, device in self.devices.items():
             if area_id == device.area_id:
-                self._async_update_device(dev_id, area_id=None)
+                self.async_update_device(dev_id, area_id=None)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -335,7 +335,7 @@ class EntityRegistry:
         entity_id = self.async_get_entity_id(domain, platform, unique_id)
 
         if entity_id:
-            return self._async_update_entity(
+            return self.async_update_entity(
                 entity_id,
                 area_id=area_id or UNDEFINED,
                 capabilities=capabilities or UNDEFINED,
@@ -460,43 +460,6 @@ class EntityRegistry:
 
     @callback
     def async_update_entity(
-        self,
-        entity_id: str,
-        *,
-        area_id: str | None | UndefinedType = UNDEFINED,
-        config_entry_id: str | None | UndefinedType = UNDEFINED,
-        device_class: str | None | UndefinedType = UNDEFINED,
-        disabled_by: RegistryEntryDisabler | None | UndefinedType = UNDEFINED,
-        entity_category: str | None | UndefinedType = UNDEFINED,
-        icon: str | None | UndefinedType = UNDEFINED,
-        name: str | None | UndefinedType = UNDEFINED,
-        new_entity_id: str | UndefinedType = UNDEFINED,
-        new_unique_id: str | UndefinedType = UNDEFINED,
-        original_device_class: str | None | UndefinedType = UNDEFINED,
-        original_icon: str | None | UndefinedType = UNDEFINED,
-        original_name: str | None | UndefinedType = UNDEFINED,
-        unit_of_measurement: str | None | UndefinedType = UNDEFINED,
-    ) -> RegistryEntry:
-        """Update properties of an entity."""
-        return self._async_update_entity(
-            entity_id,
-            area_id=area_id,
-            config_entry_id=config_entry_id,
-            device_class=device_class,
-            disabled_by=disabled_by,
-            entity_category=entity_category,
-            icon=icon,
-            name=name,
-            new_entity_id=new_entity_id,
-            new_unique_id=new_unique_id,
-            original_device_class=original_device_class,
-            original_icon=original_icon,
-            original_name=original_name,
-            unit_of_measurement=unit_of_measurement,
-        )
-
-    @callback
-    def _async_update_entity(
         self,
         entity_id: str,
         *,
@@ -693,7 +656,7 @@ class EntityRegistry:
         """Clear area id from registry entries."""
         for entity_id, entry in self.entities.items():
             if area_id == entry.area_id:
-                self._async_update_entity(entity_id, area_id=None)
+                self.async_update_entity(entity_id, area_id=None)
 
 
 @callback

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -39,7 +39,7 @@ async def test_cleanup_legacy(hass, enable_custom_integrations):
         config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "device3")}
     )
 
-    # Eevice with light + device tracker entity
+    # Device with light + device tracker entity
     entity1a = ent_reg.async_get_or_create(
         DOMAIN,
         "test",

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -1,11 +1,14 @@
 """Test Device Tracker config entry things."""
-from homeassistant.components.device_tracker import config_entry
+from homeassistant.components.device_tracker import config_entry as ce
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
 
 
 def test_tracker_entity():
     """Test tracker entity."""
 
-    class TestEntry(config_entry.TrackerEntity):
+    class TestEntry(ce.TrackerEntity):
         """Mock tracker class."""
 
         should_poll = False
@@ -17,3 +20,36 @@ def test_tracker_entity():
     instance.should_poll = True
 
     assert not instance.force_update
+
+
+async def test_register_mac(hass):
+    """Test registering a mac."""
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    mac1 = "12:34:56:AB:CD:EF"
+
+    entity_entry_1 = ent_reg.async_get_or_create(
+        "device_tracker",
+        "test",
+        mac1 + "yo1",
+        original_name="name 1",
+        config_entry=config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    ce._async_register_mac(hass, "test", mac1, mac1 + "yo1")
+
+    dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac1)},
+    )
+
+    await hass.async_block_till_done()
+
+    entity_entry_1 = ent_reg.async_get(entity_entry_1.entity_id)
+
+    assert entity_entry_1.disabled_by is None

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -35,7 +35,11 @@ async def test_cleanup_legacy(hass, enable_custom_integrations):
     device2 = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "device2")}
     )
+    device3 = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "device3")}
+    )
 
+    # Eevice with light + device tracker entity
     entity1a = ent_reg.async_get_or_create(
         DOMAIN,
         "test",
@@ -50,6 +54,7 @@ async def test_cleanup_legacy(hass, enable_custom_integrations):
         config_entry=config_entry,
         device_id=device1.id,
     )
+    # Just device tracker entity
     entity2a = ent_reg.async_get_or_create(
         DOMAIN,
         "test",
@@ -57,12 +62,35 @@ async def test_cleanup_legacy(hass, enable_custom_integrations):
         config_entry=config_entry,
         device_id=device2.id,
     )
+    # Device with no device tracker entities
+    entity3a = ent_reg.async_get_or_create(
+        "light",
+        "test",
+        "entity3a-unique",
+        config_entry=config_entry,
+        device_id=device3.id,
+    )
+    # Device tracker but no device
+    entity4a = ent_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        "entity4a-unique",
+        config_entry=config_entry,
+    )
+    # Completely different entity
+    entity5a = ent_reg.async_get_or_create(
+        "light",
+        "test",
+        "entity4a-unique",
+        config_entry=config_entry,
+    )
 
     await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
     await hass.async_block_till_done()
 
-    assert ent_reg.async_get(entity1a.entity_id) is not None
-    assert ent_reg.async_get(entity1b.entity_id) is not None
+    for entity in (entity1a, entity1b, entity3a, entity4a, entity5a):
+        assert ent_reg.async_get(entity.entity_id) is not None
+
     # We've removed device so device ID cleared
     assert ent_reg.async_get(entity2a.entity_id).device_id is None
     # Removed because only had device tracker entity

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -14,19 +14,27 @@ from homeassistant.components.device_tracker.const import (
     SOURCE_TYPE_ROUTER,
 )
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_HOME, STATE_NOT_HOME
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
 
 async def test_scanner_entity_device_tracker(hass, enable_custom_integrations):
     """Test ScannerEntity based device tracker."""
+    # Make device tied to other integration so device tracker entities get enabled
+    dr.async_get(hass).async_get_or_create(
+        name="Device from other integration",
+        config_entry_id=MockConfigEntry().entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "ad:de:ef:be:ed:fe:")},
+    )
+
     config_entry = MockConfigEntry(domain="test")
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
     await hass.async_block_till_done()
 
-    entity_id = "device_tracker.unnamed_device"
+    entity_id = "device_tracker.test_ad_de_ef_be_ed_fe"
     entity_state = hass.states.get(entity_id)
     assert entity_state.attributes == {
         ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER,

--- a/tests/components/device_tracker/test_entities.py
+++ b/tests/components/device_tracker/test_entities.py
@@ -25,7 +25,7 @@ async def test_scanner_entity_device_tracker(hass, enable_custom_integrations):
     dr.async_get(hass).async_get_or_create(
         name="Device from other integration",
         config_entry_id=MockConfigEntry().entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, "ad:de:ef:be:ed:fe:")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "ad:de:ef:be:ed:fe")},
     )
 
     config_entry = MockConfigEntry(domain="test")
@@ -40,7 +40,7 @@ async def test_scanner_entity_device_tracker(hass, enable_custom_integrations):
         ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER,
         ATTR_BATTERY_LEVEL: 100,
         ATTR_IP: "0.0.0.0",
-        ATTR_MAC: "ad:de:ef:be:ed:fe:",
+        ATTR_MAC: "ad:de:ef:be:ed:fe",
         ATTR_HOST_NAME: "test.hostname.org",
     }
     assert entity_state.state == STATE_NOT_HOME

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -23,13 +23,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import State, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry, discovery, entity_registry
+from homeassistant.helpers import discovery
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    MockConfigEntry,
     assert_setup_component,
     async_fire_time_changed,
     mock_registry,
@@ -642,36 +641,3 @@ def test_see_schema_allowing_ios_calls():
             "hostname": "beer",
         }
     )
-
-
-async def test_register_mac(hass):
-    """Test registering a mac."""
-    dev_reg = device_registry.async_get(hass)
-    ent_reg = entity_registry.async_get(hass)
-
-    config_entry = MockConfigEntry(domain="test")
-    config_entry.add_to_hass(hass)
-
-    mac1 = "12:34:56:AB:CD:EF"
-
-    entity_entry_1 = ent_reg.async_get_or_create(
-        "device_tracker",
-        "test",
-        mac1 + "yo1",
-        original_name="name 1",
-        config_entry=config_entry,
-        disabled_by=entity_registry.RegistryEntryDisabler.INTEGRATION,
-    )
-
-    device_tracker.async_register_mac(hass, "test", mac1, mac1 + "yo1")
-
-    dev_reg.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        connections={(device_registry.CONNECTION_NETWORK_MAC, mac1)},
-    )
-
-    await hass.async_block_till_done()
-
-    entity_entry_1 = ent_reg.async_get(entity_entry_1.entity_id)
-
-    assert entity_entry_1.disabled_by is None

--- a/tests/components/freebox/conftest.py
+++ b/tests/components/freebox/conftest.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from homeassistant.helpers import device_registry as dr
+
 from .const import (
     DATA_CALL_GET_CALLS_LOG,
     DATA_CONNECTION_GET_STATUS,
@@ -12,6 +14,8 @@ from .const import (
     WIFI_GET_GLOBAL_CONFIG,
 )
 
+from tests.common import MockConfigEntry
+
 
 @pytest.fixture(autouse=True)
 def mock_path():
@@ -20,8 +24,30 @@ def mock_path():
         yield
 
 
+@pytest.fixture
+def mock_device_registry_devices(hass):
+    """Create device registry devices so the device tracker entities are enabled."""
+    dev_reg = dr.async_get(hass)
+    config_entry = MockConfigEntry(domain="something_else")
+
+    for idx, device in enumerate(
+        (
+            "68:A3:78:00:00:00",
+            "8C:97:EA:00:00:00",
+            "DE:00:B0:00:00:00",
+            "DC:00:B0:00:00:00",
+            "5E:65:55:00:00:00",
+        )
+    ):
+        dev_reg.async_get_or_create(
+            name=f"Device {idx}",
+            config_entry_id=config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, device)},
+        )
+
+
 @pytest.fixture(name="router")
-def mock_router():
+def mock_router(mock_device_registry_devices):
     """Mock a successful connection."""
     with patch("homeassistant.components.freebox.router.Freepybox") as service_mock:
         instance = service_mock.return_value

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -1,9 +1,11 @@
 """The tests for the Mikrotik device tracker platform."""
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components import mikrotik
 import homeassistant.components.device_tracker as device_tracker
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -13,6 +15,25 @@ from .test_hub import setup_mikrotik_entry
 from tests.common import MockConfigEntry, patch
 
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
+
+
+@pytest.fixture
+def mock_device_registry_devices(hass):
+    """Create device registry devices so the device tracker entities are enabled."""
+    dev_reg = dr.async_get(hass)
+    config_entry = MockConfigEntry(domain="something_else")
+
+    for idx, device in enumerate(
+        (
+            "00:00:00:00:00:01",
+            "00:00:00:00:00:02",
+        )
+    ):
+        dev_reg.async_get_or_create(
+            name=f"Device {idx}",
+            config_entry_id=config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, device)},
+        )
 
 
 def mock_command(self, cmd, params=None):
@@ -39,7 +60,9 @@ async def test_platform_manually_configured(hass):
     assert mikrotik.DOMAIN not in hass.data
 
 
-async def test_device_trackers(hass, legacy_patchable_time):
+async def test_device_trackers(
+    hass, legacy_patchable_time, mock_device_registry_devices
+):
     """Test device_trackers created by mikrotik."""
 
     # test devices are added from wireless list only

--- a/tests/components/ruckus_unleashed/__init__.py
+++ b/tests/components/ruckus_unleashed/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.components.ruckus_unleashed.const import (
     API_VERSION,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -68,6 +69,13 @@ def mock_config_entry() -> MockConfigEntry:
 async def init_integration(hass) -> MockConfigEntry:
     """Set up the Ruckus Unleashed integration in Home Assistant."""
     entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    # Make device tied to other integration so device tracker entities get enabled
+    dr.async_get(hass).async_get_or_create(
+        name="Device from other integration",
+        config_entry_id=MockConfigEntry().entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, TEST_CLIENT[API_MAC])},
+    )
     with patch(
         "homeassistant.components.ruckus_unleashed.Ruckus.connect",
         return_value=None,
@@ -86,7 +94,6 @@ async def init_integration(hass) -> MockConfigEntry:
             TEST_CLIENT[API_MAC]: TEST_CLIENT,
         },
     ):
-        entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -3,10 +3,8 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.components.ruckus_unleashed import API_MAC, DOMAIN
-from homeassistant.components.ruckus_unleashed.const import API_AP, API_ID, API_NAME
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import utcnow
 
 from tests.common import async_fire_time_changed
@@ -112,24 +110,3 @@ async def test_restoring_clients(hass):
     device = hass.states.get(TEST_CLIENT_ENTITY_ID)
     assert device is not None
     assert device.state == STATE_NOT_HOME
-
-
-async def test_client_device_setup(hass):
-    """Test a client device is created."""
-    await init_integration(hass)
-
-    router_info = DEFAULT_AP_INFO[API_AP][API_ID]["1"]
-
-    device_registry = dr.async_get(hass)
-    client_device = device_registry.async_get_device(
-        identifiers={},
-        connections={(CONNECTION_NETWORK_MAC, TEST_CLIENT[API_MAC])},
-    )
-    router_device = device_registry.async_get_device(
-        identifiers={(CONNECTION_NETWORK_MAC, router_info[API_MAC])},
-        connections={(CONNECTION_NETWORK_MAC, router_info[API_MAC])},
-    )
-
-    assert client_device
-    assert client_device.name == TEST_CLIENT[API_NAME]
-    assert client_device.via_device_id == router_device.id

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -6,6 +6,10 @@ from unittest.mock import patch
 from aiounifi.websocket import SIGNAL_CONNECTION_STATE, SIGNAL_DATA
 import pytest
 
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
 
 @pytest.fixture(autouse=True)
 def mock_unifi_websocket():
@@ -34,3 +38,27 @@ def mock_discovery():
         return_value=None,
     ) as mock:
         yield mock
+
+
+@pytest.fixture
+def mock_device_registry(hass):
+    """Mock device registry."""
+    dev_reg = dr.async_get(hass)
+    config_entry = MockConfigEntry(domain="something_else")
+
+    for idx, device in enumerate(
+        (
+            "00:00:00:00:00:01",
+            "00:00:00:00:00:02",
+            "00:00:00:00:00:03",
+            "00:00:00:00:00:04",
+            "00:00:00:00:00:05",
+            "00:00:00:00:01:01",
+            "00:00:00:00:02:02",
+        )
+    ):
+        dev_reg.async_get_or_create(
+            name=f"Device {idx}",
+            config_entry_id=config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, device)},
+        )

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -346,7 +346,9 @@ async def test_reset_fails(hass, aioclient_mock):
     assert result is False
 
 
-async def test_connection_state_signalling(hass, aioclient_mock, mock_unifi_websocket):
+async def test_connection_state_signalling(
+    hass, aioclient_mock, mock_unifi_websocket, mock_device_registry
+):
     """Verify connection statesignalling and connection state are working."""
     client = {
         "hostname": "client",

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from aiounifi.controller import MESSAGE_CLIENT_REMOVED, MESSAGE_EVENT
 
 from homeassistant import config_entries, core
-from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
@@ -783,8 +782,6 @@ async def test_ignore_multiple_poe_clients_on_same_port(hass, aioclient_mock):
         clients_response=POE_SWITCH_CLIENTS,
         devices_response=[DEVICE_1],
     )
-
-    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 3
 
     switch_1 = hass.states.get("switch.poe_client_1")
     switch_2 = hass.states.get("switch.poe_client_2")

--- a/tests/testing_config/custom_components/test/device_tracker.py
+++ b/tests/testing_config/custom_components/test/device_tracker.py
@@ -18,7 +18,7 @@ class MockScannerEntity(ScannerEntity):
         self.connected = False
         self._hostname = "test.hostname.org"
         self._ip_address = "0.0.0.0"
-        self._mac_address = "ad:de:ef:be:ed:fe:"
+        self._mac_address = "ad:de:ef:be:ed:fe"
 
     @property
     def source_type(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes device tracker entities based on a config entry work better by adding extra constraints to what an entity extended from ScannerEntity can/should do:

 - Do not create devices based on device tracker entities (remove `device_info`)
 - Disable device tracker entities by default if no device exists with that mac
 - `ScannerEntity.async_internal_added_to_hass``: Connect device tracker entities to a device in entity registry if it exists
 - When a new device is registered in device registry and it has a MAC address, enable the device tracker entity if it was disabled because no device existed
 - Temporary during startup to clean up old approach: remove device if only bound to device tracker entry
 - This only works if the entity has no device info specified and has a unique ID. I've removed a bunch that are no longer necessary. If device info is specified, it will opt-out of this logic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
