### PR TITLE
Add input_number.add service

### DIFF
--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -41,10 +41,12 @@ ATTR_VALUE = "value"
 ATTR_MIN = "min"
 ATTR_MAX = "max"
 ATTR_STEP = "step"
+ATTR_AMOUNT = "amount"
 
 SERVICE_SET_VALUE = "set_value"
 SERVICE_INCREMENT = "increment"
 SERVICE_DECREMENT = "decrement"
+SERVICE_ADD = "add"
 
 
 def _cv_input_number(cfg):
@@ -168,6 +170,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(SERVICE_INCREMENT, {}, "async_increment")
 
     component.async_register_entity_service(SERVICE_DECREMENT, {}, "async_decrement")
+
+    component.async_register_entity_service(
+        SERVICE_ADD,
+        {vol.Required(ATTR_AMOUNT): vol.Coerce(float)},
+        "async_add",
+    )
 
     return True
 
@@ -301,6 +309,11 @@ class InputNumber(RestoreEntity):
     async def async_decrement(self):
         """Decrement value."""
         await self.async_set_value(max(self._current_value - self._step, self._minimum))
+
+    async def async_add(self, amount):
+        """Increase current value by a certain amount."""
+        new_value = self._current_value + amount
+        await self.async_set_value(max(self._minimum, min(new_value, self._maximum)))
 
     async def async_update_config(self, config: dict) -> None:
         """Handle when the config is updated."""

--- a/homeassistant/components/input_number/services.yaml
+++ b/homeassistant/components/input_number/services.yaml
@@ -30,6 +30,24 @@ set_value:
           step: 0.001
           mode: box
 
+add:
+  name: Add
+  description: Increase the value of an input number entity by specified amount.
+  target:
+    entity:
+      domain: input_number
+  fields:
+    amount:
+      name: Amount
+      description: The amount to increase the current value by.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 9223372036854775807
+          step: 0.001
+          mode: box
+
 reload:
   name: Reload
   description: Reload the input_number configuration.

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -6,8 +6,10 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.input_number import (
+    ATTR_AMOUNT,
     ATTR_VALUE,
     DOMAIN,
+    SERVICE_ADD,
     SERVICE_DECREMENT,
     SERVICE_INCREMENT,
     SERVICE_RELOAD,
@@ -203,6 +205,48 @@ async def test_decrement(hass):
 
     state = hass.states.get(entity_id)
     assert float(state.state) == 49
+
+
+async def test_add(hass):
+    """Test add method."""
+    assert await async_setup_component(
+        hass, DOMAIN, {DOMAIN: {"test_4": {"initial": 50, "min": 0, "max": 100}}}
+    )
+
+    entity_id = "input_number.test_4"
+
+    state = hass.states.get(entity_id)
+    assert float(state.state) == 50
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD,
+        {ATTR_ENTITY_ID: entity_id, ATTR_AMOUNT: 10},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert float(state.state) == 60
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD,
+        {ATTR_ENTITY_ID: entity_id, ATTR_AMOUNT: 20},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert float(state.state) == 80
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD,
+        {ATTR_ENTITY_ID: entity_id, ATTR_AMOUNT: 100},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert float(state.state) == 100
 
 
 async def test_mode(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently input number has services to increment and decrement the number by a predefined step but no way to increase/decrease it by a custom amount. I know it can be done by calling `set_value` service but it's nice to have a shortcut.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21006

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
