### PR TITLE
Address late review of vicare config flow

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -10,13 +10,7 @@ from PyViCare.PyViCareDevice import Device
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_CLIENT_ID,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
@@ -26,6 +20,7 @@ from .const import (
     CONF_CIRCUIT,
     CONF_HEATING_TYPE,
     DEFAULT_HEATING_TYPE,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     HEATING_TYPE_TO_CREATOR_METHOD,
     PLATFORMS,
@@ -46,28 +41,28 @@ class ViCareRequiredKeysMixin:
 
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.deprecated(CONF_CIRCUIT),
-            vol.Schema(
-                {
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                    vol.Required(CONF_CLIENT_ID): cv.string,
-                    vol.Optional(CONF_SCAN_INTERVAL, default=60): vol.All(
-                        cv.time_period, lambda value: value.total_seconds()
-                    ),
-                    vol.Optional(
-                        CONF_CIRCUIT
-                    ): int,  # Ignored: All circuits are now supported. Will be removed when switching to Setup via UI.
-                    vol.Optional(CONF_NAME, default="ViCare"): cv.string,
-                    vol.Optional(
-                        CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE.value
-                    ): vol.In([e.value for e in HeatingType]),
-                }
-            ),
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.All(
+                cv.deprecated(CONF_CIRCUIT),
+                cv.deprecated(DOMAIN),
+                vol.Schema(
+                    {
+                        vol.Required(CONF_USERNAME): cv.string,
+                        vol.Required(CONF_PASSWORD): cv.string,
+                        vol.Required(CONF_CLIENT_ID): cv.string,
+                        vol.Optional(
+                            CONF_CIRCUIT
+                        ): int,  # Ignored: All circuits are now supported. Will be removed when switching to Setup via UI.
+                        vol.Optional(
+                            CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE.value
+                        ): vol.In([e.value for e in HeatingType]),
+                    }
+                ),
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -106,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 def vicare_login(hass, entry_data):
     """Login via PyVicare API."""
     vicare_api = PyViCare()
-    vicare_api.setCacheDuration(entry_data[CONF_SCAN_INTERVAL])
+    vicare_api.setCacheDuration(DEFAULT_SCAN_INTERVAL)
     vicare_api.initWithCredentials(
         entry_data[CONF_USERNAME],
         entry_data[CONF_PASSWORD],

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -93,7 +93,7 @@ def _build_entity(name, vicare_api, device_config, sensor):
 
 
 async def _entities_from_descriptions(
-    hass, name, all_devices, sensor_descriptions, iterables, config_entry
+    hass, name, entities, sensor_descriptions, iterables, config_entry
 ):
     """Create entities from descriptions and list of burners/circuits."""
     for description in sensor_descriptions:
@@ -109,7 +109,7 @@ async def _entities_from_descriptions(
                 description,
             )
             if entity is not None:
-                all_devices.append(entity)
+                entities.append(entity)
 
 
 async def async_setup_entry(
@@ -121,7 +121,7 @@ async def async_setup_entry(
     name = VICARE_NAME
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
 
-    all_devices = []
+    entities = []
 
     for description in CIRCUIT_SENSORS:
         for circuit in hass.data[DOMAIN][config_entry.entry_id][VICARE_CIRCUITS]:
@@ -136,23 +136,23 @@ async def async_setup_entry(
                 description,
             )
             if entity is not None:
-                all_devices.append(entity)
+                entities.append(entity)
 
     try:
         await _entities_from_descriptions(
-            hass, name, all_devices, BURNER_SENSORS, api.burners, config_entry
+            hass, name, entities, BURNER_SENSORS, api.burners, config_entry
         )
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("No burners found")
 
     try:
         await _entities_from_descriptions(
-            hass, name, all_devices, COMPRESSOR_SENSORS, api.compressors, config_entry
+            hass, name, entities, COMPRESSOR_SENSORS, api.compressors, config_entry
         )
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("No compressors found")
 
-    async_add_entities(all_devices)
+    async_add_entities(entities)
 
 
 class ViCareBinarySensor(BinarySensorEntity):

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -18,12 +18,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ViCareRequiredKeysMixin
-from .const import DOMAIN, VICARE_API, VICARE_CIRCUITS, VICARE_DEVICE_CONFIG
+from .const import (
+    DOMAIN,
+    VICARE_API,
+    VICARE_CIRCUITS,
+    VICARE_DEVICE_CONFIG,
+    VICARE_NAME,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,10 +115,10 @@ async def _entities_from_descriptions(
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_devices: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create the ViCare binary sensor devices."""
-    name = config_entry.data[CONF_NAME]
+    name = VICARE_NAME
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
 
     all_devices = []
@@ -147,7 +152,7 @@ async def async_setup_entry(
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("No compressors found")
 
-    async_add_devices(all_devices)
+    async_add_entities(all_devices)
 
 
 class ViCareBinarySensor(BinarySensorEntity):

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -23,12 +23,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_NAME,
-    PRECISION_WHOLE,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
@@ -40,6 +35,7 @@ from .const import (
     VICARE_API,
     VICARE_CIRCUITS,
     VICARE_DEVICE_CONFIG,
+    VICARE_NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,7 +108,7 @@ async def async_setup_entry(
     async_add_devices: AddEntitiesCallback,
 ) -> None:
     """Set up the ViCare climate platform."""
-    name = config_entry.data[CONF_NAME]
+    name = VICARE_NAME
 
     all_devices = []
 

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -105,12 +105,12 @@ def _build_entity(name, vicare_api, circuit, device_config, heating_type):
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_devices: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the ViCare climate platform."""
     name = VICARE_NAME
 
-    all_devices = []
+    entities = []
 
     for circuit in hass.data[DOMAIN][config_entry.entry_id][VICARE_CIRCUITS]:
         suffix = ""
@@ -124,7 +124,7 @@ async def async_setup_entry(
             config_entry.data[CONF_HEATING_TYPE],
         )
         if entity is not None:
-            all_devices.append(entity)
+            entities.append(entity)
 
     platform = entity_platform.async_get_current_platform()
 
@@ -134,7 +134,7 @@ async def async_setup_entry(
         "set_vicare_mode",
     )
 
-    async_add_devices(all_devices)
+    async_add_entities(entities)
 
 
 class ViCareClimate(ClimateEntity):

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -82,7 +82,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         # Remove now unsupported config parameters
-        import_info.pop(CONF_CIRCUIT, 0)
+        import_info.pop(CONF_CIRCUIT, None)
 
         # CONF_HEATING_TYPE is now required but was optional in yaml config. Add if missing.
         if import_info.get(CONF_HEATING_TYPE) is None:

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -9,13 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp
-from homeassistant.const import (
-    CONF_CLIENT_ID,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
@@ -25,8 +19,8 @@ from .const import (
     CONF_CIRCUIT,
     CONF_HEATING_TYPE,
     DEFAULT_HEATING_TYPE,
-    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    VICARE_NAME,
     HeatingType,
 )
 
@@ -50,10 +44,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE.value): vol.In(
                 [e.value for e in HeatingType]
             ),
-            vol.Optional(CONF_NAME, default="ViCare"): cv.string,
-            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
-                vol.Coerce(int), vol.Range(min=30)
-            ),
         }
         errors: dict[str, str] = {}
 
@@ -62,12 +52,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(
                     vicare_login, self.hass, user_input
                 )
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
-                )
-            except PyViCareInvalidCredentialsError as ex:
-                _LOGGER.debug("Could not log in to ViCare, %s", ex)
+            except PyViCareInvalidCredentialsError:
                 errors["base"] = "invalid_auth"
+            else:
+                return self.async_create_entry(title=VICARE_NAME, data=user_input)
 
         return self.async_show_form(
             step_id="user",
@@ -90,22 +78,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_info):
         """Handle a flow initiated by a YAML config import."""
-
-        await self.async_set_unique_id("Configuration.yaml")
-        self._abort_if_unique_id_configured()
-
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
         # Remove now unsupported config parameters
-        if import_info.get(CONF_CIRCUIT):
-            import_info.pop(CONF_CIRCUIT)
+        import_info.pop(CONF_CIRCUIT, 0)
 
-        # Add former optional config if missing
+        # CONF_HEATING_TYPE is now required but was optional in yaml config. Add if missing.
         if import_info.get(CONF_HEATING_TYPE) is None:
             import_info[CONF_HEATING_TYPE] = DEFAULT_HEATING_TYPE.value
 
-        return self.async_create_entry(
-            title="Configuration.yaml",
-            data=import_info,
-        )
+        return await self.async_step_user(import_info)

--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -16,6 +16,7 @@ PLATFORMS = [
 VICARE_DEVICE_CONFIG = "device_conf"
 VICARE_API = "api"
 VICARE_CIRCUITS = "circuits"
+VICARE_NAME = "ViCare"
 
 CONF_CIRCUIT = "circuit"
 CONF_HEATING_TYPE = "heating_type"

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -22,7 +22,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_NAME,
     ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
     POWER_WATT,
@@ -39,6 +38,7 @@ from .const import (
     VICARE_API,
     VICARE_CIRCUITS,
     VICARE_DEVICE_CONFIG,
+    VICARE_NAME,
     VICARE_UNIT_TO_DEVICE_CLASS,
     VICARE_UNIT_TO_UNIT_OF_MEASUREMENT,
 )
@@ -364,7 +364,7 @@ async def async_setup_entry(
     async_add_devices: AddEntitiesCallback,
 ) -> None:
     """Create the ViCare sensor devices."""
-    name = config_entry.data[CONF_NAME]
+    name = VICARE_NAME
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
 
     all_devices = []

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -339,7 +339,7 @@ def _build_entity(name, vicare_api, device_config, sensor):
 
 
 async def _entities_from_descriptions(
-    hass, name, all_devices, sensor_descriptions, iterables, config_entry
+    hass, name, entities, sensor_descriptions, iterables, config_entry
 ):
     """Create entities from descriptions and list of burners/circuits."""
     for description in sensor_descriptions:
@@ -355,19 +355,19 @@ async def _entities_from_descriptions(
                 description,
             )
             if entity is not None:
-                all_devices.append(entity)
+                entities.append(entity)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_devices: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create the ViCare sensor devices."""
     name = VICARE_NAME
     api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
 
-    all_devices = []
+    entities = []
     for description in GLOBAL_SENSORS:
         entity = await hass.async_add_executor_job(
             _build_entity,
@@ -377,7 +377,7 @@ async def async_setup_entry(
             description,
         )
         if entity is not None:
-            all_devices.append(entity)
+            entities.append(entity)
 
     for description in CIRCUIT_SENSORS:
         for circuit in hass.data[DOMAIN][config_entry.entry_id][VICARE_CIRCUITS]:
@@ -392,23 +392,23 @@ async def async_setup_entry(
                 description,
             )
             if entity is not None:
-                all_devices.append(entity)
+                entities.append(entity)
 
     try:
         await _entities_from_descriptions(
-            hass, name, all_devices, BURNER_SENSORS, api.burners, config_entry
+            hass, name, entities, BURNER_SENSORS, api.burners, config_entry
         )
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("No burners found")
 
     try:
         await _entities_from_descriptions(
-            hass, name, all_devices, COMPRESSOR_SENSORS, api.compressors, config_entry
+            hass, name, entities, COMPRESSOR_SENSORS, api.compressors, config_entry
         )
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("No compressors found")
 
-    async_add_devices(all_devices)
+    async_add_entities(entities)
 
 
 class ViCareSensor(SensorEntity):

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -7,7 +7,6 @@
                 "description": "Set up ViCare integration. To generate API key go to https://developer.viessmann.com",
                 "data": {
                     "name": "[%key:common::config_flow::data::name%]",
-                    "scan_interval": "Scan Interval (seconds)",
                     "username": "[%key:common::config_flow::data::email%]",
                     "password": "[%key:common::config_flow::data::password%]",
                     "client_id": "[%key:common::config_flow::data::api_key%]",

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -6,7 +6,6 @@
                 "title": "{name}",
                 "description": "Set up ViCare integration. To generate API key go to https://developer.viessmann.com",
                 "data": {
-                    "name": "[%key:common::config_flow::data::name%]",
                     "username": "[%key:common::config_flow::data::email%]",
                     "password": "[%key:common::config_flow::data::password%]",
                     "client_id": "[%key:common::config_flow::data::api_key%]",

--- a/homeassistant/components/vicare/translations/en.json
+++ b/homeassistant/components/vicare/translations/en.json
@@ -15,7 +15,6 @@
                     "heating_type": "Heating type",
                     "name": "Name",
                     "password": "Password",
-                    "scan_interval": "Scan Interval (seconds)",
                     "username": "Email"
                 },
                 "description": "Set up ViCare integration. To generate API key go to https://developer.viessmann.com",

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -14,12 +14,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_NAME,
-    PRECISION_WHOLE,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,6 +24,7 @@ from .const import (
     VICARE_API,
     VICARE_CIRCUITS,
     VICARE_DEVICE_CONFIG,
+    VICARE_NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,7 +75,7 @@ async def async_setup_entry(
     async_add_devices: AddEntitiesCallback,
 ) -> None:
     """Set up the ViCare climate platform."""
-    name = config_entry.data[CONF_NAME]
+    name = VICARE_NAME
 
     all_devices = []
     for circuit in hass.data[DOMAIN][config_entry.entry_id][VICARE_CIRCUITS]:

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -72,12 +72,12 @@ def _build_entity(name, vicare_api, circuit, device_config, heating_type):
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_devices: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the ViCare climate platform."""
     name = VICARE_NAME
 
-    all_devices = []
+    entities = []
     for circuit in hass.data[DOMAIN][config_entry.entry_id][VICARE_CIRCUITS]:
         suffix = ""
         if len(hass.data[DOMAIN][config_entry.entry_id][VICARE_CIRCUITS]) > 1:
@@ -90,9 +90,9 @@ async def async_setup_entry(
             config_entry.data[CONF_HEATING_TYPE],
         )
         if entity is not None:
-            all_devices.append(entity)
+            entities.append(entity)
 
-    async_add_devices(all_devices)
+    async_add_entities(entities)
 
 
 class ViCareWater(WaterHeaterEntity):

--- a/tests/components/vicare/__init__.py
+++ b/tests/components/vicare/__init__.py
@@ -1,20 +1,22 @@
 """Test for ViCare."""
-from homeassistant.components.vicare.const import CONF_HEATING_TYPE
-from homeassistant.const import (
-    CONF_CLIENT_ID,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-)
+from __future__ import annotations
 
-ENTRY_CONFIG = {
+from typing import Final
+
+from homeassistant.components.vicare.const import CONF_HEATING_TYPE
+from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
+
+ENTRY_CONFIG: Final[dict[str, str]] = {
     CONF_USERNAME: "foo@bar.com",
     CONF_PASSWORD: "1234",
     CONF_CLIENT_ID: "5678",
     CONF_HEATING_TYPE: "auto",
-    CONF_SCAN_INTERVAL: 60,
-    CONF_NAME: "ViCare",
+}
+
+ENTRY_CONFIG_NO_HEATING_TYPE: Final[dict[str, str]] = {
+    CONF_USERNAME: "foo@bar.com",
+    CONF_PASSWORD: "1234",
+    CONF_CLIENT_ID: "5678",
 }
 
 MOCK_MAC = "B874241B7B9"

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -197,7 +197,6 @@ async def test_import_single_instance_allowed(hass):
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=VICARE_NAME,
         data=ENTRY_CONFIG,
     )
     mock_entry.add_to_hass(hass)
@@ -215,7 +214,6 @@ async def test_dhcp_single_instance_allowed(hass):
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id=VICARE_NAME,
         data=ENTRY_CONFIG,
     )
     mock_entry.add_to_hass(hass)

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -3,23 +3,18 @@ from unittest.mock import patch
 
 from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
-from homeassistant.components.vicare.const import (
-    CONF_CIRCUIT,
-    CONF_HEATING_TYPE,
-    DOMAIN,
-)
+from homeassistant.components.vicare.const import CONF_CIRCUIT, DOMAIN, VICARE_NAME
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 
-from . import ENTRY_CONFIG, MOCK_MAC
+from . import ENTRY_CONFIG, ENTRY_CONFIG_NO_HEATING_TYPE, MOCK_MAC
 
 from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -54,7 +49,6 @@ async def test_form(hass):
 
 async def test_import(hass):
     """Test that the import works."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.vicare.config_flow.vicare_login",
@@ -71,7 +65,7 @@ async def test_import(hass):
             data=ENTRY_CONFIG,
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Configuration.yaml"
+        assert result["title"] == VICARE_NAME
         assert result["data"] == ENTRY_CONFIG
 
         await hass.async_block_till_done()
@@ -81,7 +75,6 @@ async def test_import(hass):
 
 async def test_import_removes_circuit(hass):
     """Test that the import works."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.vicare.config_flow.vicare_login",
@@ -99,7 +92,7 @@ async def test_import_removes_circuit(hass):
             data=ENTRY_CONFIG,
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Configuration.yaml"
+        assert result["title"] == VICARE_NAME
         assert result["data"] == ENTRY_CONFIG
 
         await hass.async_block_till_done()
@@ -109,7 +102,6 @@ async def test_import_removes_circuit(hass):
 
 async def test_import_adds_heating_type(hass):
     """Test that the import works."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.vicare.config_flow.vicare_login",
@@ -120,14 +112,13 @@ async def test_import_adds_heating_type(hass):
         "homeassistant.components.vicare.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        del ENTRY_CONFIG[CONF_HEATING_TYPE]
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
-            data=ENTRY_CONFIG,
+            data=ENTRY_CONFIG_NO_HEATING_TYPE,
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Configuration.yaml"
+        assert result["title"] == VICARE_NAME
         assert result["data"] == ENTRY_CONFIG
 
         await hass.async_block_till_done()
@@ -162,7 +153,6 @@ async def test_invalid_login(hass) -> None:
 
 async def test_form_dhcp(hass):
     """Test we can setup from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -203,29 +193,11 @@ async def test_form_dhcp(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_import_already_configured(hass):
-    """Test that configuring same instance is rejectes."""
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="Configuration.yaml",
-        data=ENTRY_CONFIG,
-    )
-    mock_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=ENTRY_CONFIG,
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
-
-
 async def test_import_single_instance_allowed(hass):
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="Configuration.yaml",
+        unique_id=VICARE_NAME,
         data=ENTRY_CONFIG,
     )
     mock_entry.add_to_hass(hass)
@@ -236,14 +208,14 @@ async def test_import_single_instance_allowed(hass):
         data=ENTRY_CONFIG,
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_dhcp_single_instance_allowed(hass):
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="Configuration.yaml",
+        unique_id=VICARE_NAME,
         data=ENTRY_CONFIG,
     )
     mock_entry.add_to_hass(hass)
@@ -263,7 +235,6 @@ async def test_dhcp_single_instance_allowed(hass):
 
 async def test_user_input_single_instance_allowed(hass):
     """Test that configuring more than one instance is rejected."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="ViCare",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The scan interval option was removed since the default scan_interval should be fine for most users.
If you really need more fine-grained control you can disable automatic updates in the system settings for the vicare integration and automate the polling of the entities with the [homeassistant.update_entity](https://www.home-assistant.io/docs/scripts/service-calls#homeassistant-services) service.

## Proposed change
Addresses some comments from  @MartinHjelmare in #56691

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
