### PR TITLE
Add core support for custom unit systems

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -118,6 +118,7 @@ CONF_CONTINUE_ON_TIMEOUT: Final = "continue_on_timeout"
 CONF_COUNT: Final = "count"
 CONF_COVERS: Final = "covers"
 CONF_CURRENCY: Final = "currency"
+CONF_CUSTOM_UNITS: Final = "custom_units"
 CONF_CUSTOMIZE: Final = "customize"
 CONF_CUSTOMIZE_DOMAIN: Final = "customize_domain"
 CONF_CUSTOMIZE_GLOB: Final = "customize_glob"
@@ -384,6 +385,7 @@ ATTR_UNIT_OF_MEASUREMENT: Final = "unit_of_measurement"
 
 CONF_UNIT_SYSTEM_METRIC: Final = "metric"
 CONF_UNIT_SYSTEM_IMPERIAL: Final = "imperial"
+CONF_UNIT_SYSTEM_CUSTOM: Final = "custom"
 
 # Electrical attributes
 ATTR_VOLTAGE: Final = "voltage"

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -34,6 +34,7 @@ from .const import (
     ATTR_SECONDS,
     ATTR_SERVICE,
     ATTR_SERVICE_DATA,
+    CONF_UNIT_SYSTEM_CUSTOM,
     CONF_UNIT_SYSTEM_IMPERIAL,
     EVENT_CALL_SERVICE,
     EVENT_CORE_CONFIG_UPDATE,
@@ -68,7 +69,12 @@ from .util.async_ import (
     shutdown_run_callback_threadsafe,
 )
 from .util.timeout import TimeoutManager
-from .util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+from .util.unit_system import (
+    IMPERIAL_SYSTEM,
+    METRIC_SYSTEM,
+    CustomUnitSystem,
+    UnitSystem,
+)
 
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:
@@ -1562,6 +1568,7 @@ class Config:
         self.elevation: int = 0
         self.location_name: str = "Home"
         self.time_zone: str = "UTC"
+        self.custom_units: dict[str, str] = {}
         self.units: UnitSystem = METRIC_SYSTEM
         self.internal_url: str | None = None
         self.external_url: str | None = None
@@ -1690,6 +1697,7 @@ class Config:
         latitude: float | None = None,
         longitude: float | None = None,
         elevation: int | None = None,
+        custom_units: dict[str, str] | None = None,
         unit_system: str | None = None,
         location_name: str | None = None,
         time_zone: str | None = None,
@@ -1706,9 +1714,13 @@ class Config:
             self.longitude = longitude
         if elevation is not None:
             self.elevation = elevation
+        if custom_units is not None:
+            self.custom_units = custom_units
         if unit_system is not None:
             if unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
                 self.units = IMPERIAL_SYSTEM
+            elif unit_system == CONF_UNIT_SYSTEM_CUSTOM:
+                self.units = CustomUnitSystem(self.custom_units)
             else:
                 self.units = METRIC_SYSTEM
         if location_name is not None:
@@ -1756,6 +1768,7 @@ class Config:
             latitude=data.get("latitude"),
             longitude=data.get("longitude"),
             elevation=data.get("elevation"),
+            custom_units=data.get("custom_units"),
             unit_system=data.get("unit_system"),
             location_name=data.get("location_name"),
             time_zone=data.get("time_zone"),
@@ -1770,6 +1783,7 @@ class Config:
             "latitude": self.latitude,
             "longitude": self.longitude,
             "elevation": self.elevation,
+            "custom_units": self.custom_units,
             "unit_system": self.units.name,
             "location_name": self.location_name,
             "time_zone": self.time_zone,

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -5,6 +5,7 @@ from numbers import Number
 
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
+    CONF_UNIT_SYSTEM_CUSTOM,
     CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM_METRIC,
     LENGTH,
@@ -187,6 +188,32 @@ class UnitSystem:
             VOLUME: self.volume_unit,
             WIND_SPEED: self.wind_speed_unit,
         }
+
+
+class CustomUnitSystem(UnitSystem):
+    """User-defined unit system defaulting missing units to metric."""
+
+    def __init__(
+        self,
+        units: dict[str, str],
+    ) -> None:
+        """Initialize the unit system object."""
+        super().__init__(
+            name=CONF_UNIT_SYSTEM_CUSTOM,
+            temperature=units.get(TEMPERATURE) or METRIC_SYSTEM.temperature_unit,
+            length=units.get(LENGTH) or METRIC_SYSTEM.length_unit,
+            wind_speed=units.get(WIND_SPEED) or METRIC_SYSTEM.wind_speed_unit,
+            volume=units.get(VOLUME) or METRIC_SYSTEM.volume_unit,
+            mass=units.get(MASS) or METRIC_SYSTEM.mass_unit,
+            pressure=units.get(PRESSURE) or METRIC_SYSTEM.pressure_unit,
+            accumulated_precipitation=units.get(ACCUMULATED_PRECIPITATION)
+            or METRIC_SYSTEM.accumulated_precipitation_unit,
+        )
+
+    @property
+    def is_metric(self) -> bool:
+        """Determine if this is the metric unit system."""
+        return self.temperature_unit != TEMP_FAHRENHEIT
 
 
 METRIC_SYSTEM = UnitSystem(

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -3,22 +3,33 @@ import pytest
 
 from homeassistant.const import (
     ACCUMULATED_PRECIPITATION,
+    CONF_UNIT_SYSTEM_CUSTOM,
     LENGTH,
+    LENGTH_INCHES,
     LENGTH_KILOMETERS,
     LENGTH_METERS,
     LENGTH_MILLIMETERS,
     MASS,
     MASS_GRAMS,
+    MASS_KILOGRAMS,
     PRESSURE,
     PRESSURE_PA,
+    PRESSURE_PSI,
+    SPEED_KILOMETERS_PER_HOUR,
     SPEED_METERS_PER_SECOND,
     TEMP_CELSIUS,
     TEMPERATURE,
     VOLUME,
+    VOLUME_CUBIC_FEET,
     VOLUME_LITERS,
     WIND_SPEED,
 )
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+from homeassistant.util.unit_system import (
+    IMPERIAL_SYSTEM,
+    METRIC_SYSTEM,
+    CustomUnitSystem,
+    UnitSystem,
+)
 
 SYSTEM_NAME = "TEST"
 INVALID_UNIT = "INVALID"
@@ -293,3 +304,31 @@ def test_is_metric():
     """Test the is metric flag."""
     assert METRIC_SYSTEM.is_metric
     assert not IMPERIAL_SYSTEM.is_metric
+
+
+def test_custom_system():
+    """Test the custom system initializes correctly."""
+    system = CustomUnitSystem({})
+
+    assert system.as_dict() == METRIC_SYSTEM.as_dict()
+
+    system = CustomUnitSystem(
+        {
+            LENGTH: LENGTH_METERS,
+            WIND_SPEED: SPEED_KILOMETERS_PER_HOUR,
+            TEMPERATURE: TEMP_CELSIUS,
+            VOLUME: VOLUME_CUBIC_FEET,
+            MASS: MASS_KILOGRAMS,
+            PRESSURE: PRESSURE_PSI,
+            ACCUMULATED_PRECIPITATION: LENGTH_INCHES,
+        }
+    )
+
+    assert system.name == CONF_UNIT_SYSTEM_CUSTOM
+    assert system.length_unit == LENGTH_METERS
+    assert system.wind_speed_unit == SPEED_KILOMETERS_PER_HOUR
+    assert system.temperature_unit == TEMP_CELSIUS
+    assert system.volume_unit == VOLUME_CUBIC_FEET
+    assert system.mass_unit == MASS_KILOGRAMS
+    assert system.pressure_unit == PRESSURE_PSI
+    assert system.accumulated_precipitation_unit == LENGTH_INCHES


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Basic foundation for supporting custom unit systems. A proof of concept for this architecture discussion: https://github.com/home-assistant/architecture/discussions/682

Essentially, adding another option to unit system config as well as a dictionary representing what "custom" means.
I believe, this should be enough to hook up frontend to use and modify these things.

One problem is that `UnitSystem` has `is_metric` property which is used by a bunch of integrations. Since most of them are weather integrations, I populated it based on temperature unit for now but would really appreciate some suggestions what to do with it...

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
