### PR TITLE
Bump rtsp_to_webrtc to 0.4.0

### DIFF
--- a/homeassistant/components/rtsp_to_webrtc/__init__.py
+++ b/homeassistant/components/rtsp_to_webrtc/__init__.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 import logging
 
 import async_timeout
-from rtsp_to_webrtc.client import Client
+from rtsp_to_webrtc.client import get_adaptive_client
 from rtsp_to_webrtc.exceptions import ClientError, ResponseError
+from rtsp_to_webrtc.interface import WebRTCClientInterface
 
 from homeassistant.components import camera
 from homeassistant.config_entries import ConfigEntry
@@ -42,10 +43,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up RTSPtoWebRTC from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    client = Client(async_get_clientsession(hass), entry.data[DATA_SERVER_URL])
+    client: WebRTCClientInterface
     try:
         async with async_timeout.timeout(TIMEOUT):
-            await client.heartbeat()
+            client = await get_adaptive_client(
+                async_get_clientsession(hass), entry.data[DATA_SERVER_URL]
+            )
     except ResponseError as err:
         raise ConfigEntryNotReady from err
     except (TimeoutError, ClientError) as err:

--- a/homeassistant/components/rtsp_to_webrtc/manifest.json
+++ b/homeassistant/components/rtsp_to_webrtc/manifest.json
@@ -3,7 +3,7 @@
   "name": "RTSPtoWebRTC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rtsp_to_webrtc",
-  "requirements": ["rtsp-to-webrtc==0.2.7"],
+  "requirements": ["rtsp-to-webrtc==0.4.0"],
   "dependencies": ["camera"],
   "codeowners": [
     "@allenporter"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2114,7 +2114,7 @@ rpi-bad-power==0.1.0
 # rpi-rf==0.9.7
 
 # homeassistant.components.rtsp_to_webrtc
-rtsp-to-webrtc==0.2.7
+rtsp-to-webrtc==0.4.0
 
 # homeassistant.components.russound_rnet
 russound==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1279,7 +1279,7 @@ roonapi==0.0.38
 rpi-bad-power==0.1.0
 
 # homeassistant.components.rtsp_to_webrtc
-rtsp-to-webrtc==0.2.7
+rtsp-to-webrtc==0.4.0
 
 # homeassistant.components.yamaha
 rxv==0.7.0

--- a/tests/components/rtsp_to_webrtc/test_init.py
+++ b/tests/components/rtsp_to_webrtc/test_init.py
@@ -31,6 +31,16 @@ SERVER_URL = "http://127.0.0.1:8083"
 CONFIG_ENTRY_DATA = {"server_url": SERVER_URL}
 
 
+@pytest.fixture(autouse=True)
+async def webrtc_server() -> None:
+    """Patch client library to force usage of RTSPtoWebRTC server."""
+    with patch(
+        "rtsp_to_webrtc.client.WebClient.heartbeat",
+        side_effect=rtsp_to_webrtc.exceptions.ResponseError(),
+    ):
+        yield
+
+
 @pytest.fixture
 async def mock_camera(hass) -> AsyncGenerator[None, None]:
     """Initialize a demo camera platform."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for the new client library that can adapt to either an RTSPtoWeb server or RTSPtoWebRTC server. The client library send a heartbeat to the server using both formats, and based on the success/failure of the heartbeats, decides which client library to return. Both implement the same API, and leave the request details to the python library.

The tests are updated to still prefer RTSPtoWebRTC and leave testing RSTPtoWeb for the libary tests. Manually tested this against both server types and was able to bring up a WebRTC stream on a Nest camera.

RTSPtoWeb supports everything that the RTSP server does, plus HLS, plus RTSP, and has a nicer API for updating streams.

https://github.com/allenporter/rtsp-to-webrtc-client/compare/0.2.7...0.4.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
