### PR TITLE
Add unique_id to tellstick devices

### DIFF
--- a/homeassistant/components/tellstick/__init__.py
+++ b/homeassistant/components/tellstick/__init__.py
@@ -179,7 +179,10 @@ class TellstickDevice(Entity):
 
         # Look up our corresponding tellcore device
         self._tellcore_device = tellcore_device
-        self._name = tellcore_device.name
+        self._attr_assumed_state = True
+        self._attr_name = tellcore_device.name
+        self._attr_should_poll = False
+        self._attr_unique_id = tellcore_device.id
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -188,21 +191,6 @@ class TellstickDevice(Entity):
                 SIGNAL_TELLCORE_CALLBACK, self.update_from_callback
             )
         )
-
-    @property
-    def should_poll(self):
-        """Tell Home Assistant not to poll this device."""
-        return False
-
-    @property
-    def assumed_state(self):
-        """Tellstick devices are always assumed state."""
-        return True
-
-    @property
-    def name(self):
-        """Return the name of the device as reported by tellcore."""
-        return self._name
 
     @property
     def is_on(self):

--- a/homeassistant/components/tellstick/__init__.py
+++ b/homeassistant/components/tellstick/__init__.py
@@ -169,6 +169,9 @@ class TellstickDevice(Entity):
     Contains the common logic for all Tellstick devices.
     """
 
+    _attr_assumed_state = True
+    _attr_should_poll = False
+
     def __init__(self, tellcore_device, signal_repetitions):
         """Init the Tellstick device."""
         self._signal_repetitions = signal_repetitions
@@ -179,9 +182,7 @@ class TellstickDevice(Entity):
 
         # Look up our corresponding tellcore device
         self._tellcore_device = tellcore_device
-        self._attr_assumed_state = True
         self._attr_name = tellcore_device.name
-        self._attr_should_poll = False
         self._attr_unique_id = tellcore_device.id
 
     async def async_added_to_hass(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add a `unique_id` to the tellstick devices. This allows them to be updated from the UI.
Also moved `name`, `should_poll` and `assumed_state` to `attr_*` properties.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://community.home-assistant.io/t/unique-ids-for-tellstick-entities/368206
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
