### PR TITLE
Add configuration_url for BleBox

### DIFF
--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -95,7 +95,7 @@ class BleBoxEntity(Entity):
             model=product.model,
             name=product.name,
             sw_version=product.firmware_version,
-            configuration_url=product.address,
+            configuration_url=f"http://{product.address}",
         )
 
     async def async_update(self):

--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -95,6 +95,7 @@ class BleBoxEntity(Entity):
             model=product.model,
             name=product.name,
             sw_version=product.firmware_version,
+            configuration_url=f"http://{product._session.host}:{product._session.port}",
         )
 
     async def async_update(self):

--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -95,7 +95,7 @@ class BleBoxEntity(Entity):
             model=product.model,
             name=product.name,
             sw_version=product.firmware_version,
-            configuration_url=f"http://{product._session.host}:{product._session.port}",
+            configuration_url=product.configuration_url,
         )
 
     async def async_update(self):

--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -95,7 +95,7 @@ class BleBoxEntity(Entity):
             model=product.model,
             name=product.name,
             sw_version=product.firmware_version,
-            configuration_url=product.configuration_url,
+            configuration_url=product.address,
         )
 
     async def async_update(self):

--- a/homeassistant/components/blebox/manifest.json
+++ b/homeassistant/components/blebox/manifest.json
@@ -3,7 +3,7 @@
   "name": "BleBox devices",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/blebox",
-  "requirements": ["blebox_uniapi==1.3.3"],
+  "requirements": ["blebox_uniapi==1.3.4"],
   "codeowners": ["@bbx-a", "@bbx-jp"],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,7 +404,7 @@ bimmer_connected==0.8.7
 bizkaibus==0.1.1
 
 # homeassistant.components.blebox
-blebox_uniapi==1.3.3
+blebox_uniapi==1.3.4
 
 # homeassistant.components.blink
 blinkpy==0.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -270,7 +270,7 @@ bellows==0.29.0
 bimmer_connected==0.8.7
 
 # homeassistant.components.blebox
-blebox_uniapi==1.3.3
+blebox_uniapi==1.3.4
 
 # homeassistant.components.blink
 blinkpy==0.18.0

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -56,7 +56,7 @@ def mock_feature(category, spec, **kwargs):
     type(feature_mock.product).brand = PropertyMock(return_value="BleBox")
     type(feature_mock.product).firmware_version = PropertyMock(return_value="1.23")
     type(feature_mock.product).unique_id = PropertyMock(return_value="abcd0123ef5678")
-    type(feature_mock.product).configuration_url = PropertyMock(
+    type(feature_mock.product).address = PropertyMock(
         return_value="http://172.100.123.4:80"
     )
     type(feature_mock).product = PropertyMock(return_value=product)

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -56,6 +56,9 @@ def mock_feature(category, spec, **kwargs):
     type(feature_mock.product).brand = PropertyMock(return_value="BleBox")
     type(feature_mock.product).firmware_version = PropertyMock(return_value="1.23")
     type(feature_mock.product).unique_id = PropertyMock(return_value="abcd0123ef5678")
+    type(feature_mock.product).configuration_url = PropertyMock(
+        return_value="http://172.100.123.4:80"
+    )
     type(feature_mock).product = PropertyMock(return_value=product)
     return feature_mock
 

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -56,9 +56,7 @@ def mock_feature(category, spec, **kwargs):
     type(feature_mock.product).brand = PropertyMock(return_value="BleBox")
     type(feature_mock.product).firmware_version = PropertyMock(return_value="1.23")
     type(feature_mock.product).unique_id = PropertyMock(return_value="abcd0123ef5678")
-    type(feature_mock.product).address = PropertyMock(
-        return_value="http://172.100.123.4:80"
-    )
+    type(feature_mock.product).address = PropertyMock(return_value="172.100.123.4:80")
     type(feature_mock).product = PropertyMock(return_value=product)
     return feature_mock
 

--- a/tests/components/blebox/test_air_quality.py
+++ b/tests/components/blebox/test_air_quality.py
@@ -57,6 +57,7 @@ async def test_init(airsensor, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "airSensor"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_update(airsensor, hass, config):

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -87,6 +87,7 @@ async def test_init(saunabox, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "saunaBox"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_update(saunabox, hass, config):

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -32,6 +32,7 @@ def create_valid_feature_mock(path="homeassistant.components.blebox.Products"):
     type(product).brand = PropertyMock(return_value="BleBox")
     type(product).firmware_version = PropertyMock(return_value="1.23")
     type(product).unique_id = PropertyMock(return_value="abcd0123ef5678")
+    type(product).configuration_url = PropertyMock(return_value="http://172.2.3.4:80")
 
     return feature
 

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -32,7 +32,7 @@ def create_valid_feature_mock(path="homeassistant.components.blebox.Products"):
     type(product).brand = PropertyMock(return_value="BleBox")
     type(product).firmware_version = PropertyMock(return_value="1.23")
     type(product).unique_id = PropertyMock(return_value="abcd0123ef5678")
-    type(product).address = PropertyMock(return_value="http://172.2.3.4:80")
+    type(product).address = PropertyMock(return_value="172.2.3.4:80")
 
     return feature
 

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -32,7 +32,7 @@ def create_valid_feature_mock(path="homeassistant.components.blebox.Products"):
     type(product).brand = PropertyMock(return_value="BleBox")
     type(product).firmware_version = PropertyMock(return_value="1.23")
     type(product).unique_id = PropertyMock(return_value="abcd0123ef5678")
-    type(product).configuration_url = PropertyMock(return_value="http://172.2.3.4:80")
+    type(product).address = PropertyMock(return_value="http://172.2.3.4:80")
 
     return feature
 

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -123,6 +123,7 @@ async def test_init_gatecontroller(gatecontroller, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "gateController"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_init_shutterbox(shutterbox, hass, config):
@@ -153,6 +154,7 @@ async def test_init_shutterbox(shutterbox, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "shutterBox"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_init_gatebox(gatebox, hass, config):
@@ -185,6 +187,7 @@ async def test_init_gatebox(gatebox, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "gateBox"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -65,6 +65,7 @@ async def test_dimmer_init(dimmer, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "dimmerBox"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_dimmer_update(dimmer, hass, config):
@@ -236,6 +237,7 @@ async def test_wlightbox_s_init(wlightbox_s, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "wLightBoxS"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_wlightbox_s_update(wlightbox_s, hass, config):
@@ -337,6 +339,7 @@ async def test_wlightbox_init(wlightbox, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "wLightBox"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_wlightbox_update(wlightbox, hass, config):

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -57,6 +57,7 @@ async def test_init(tempsensor, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "tempSensor"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_update(tempsensor, hass, config):

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -180,6 +180,7 @@ def switchbox_d_fixture():
     type(product).brand = PropertyMock(return_value="BleBox")
     type(product).firmware_version = PropertyMock(return_value="1.23")
     type(product).unique_id = PropertyMock(return_value="abcd0123ef5678")
+    type(product).configuration_url = PropertyMock(return_value="http://172.2.3.4:80")
 
     type(relay1).product = product
     type(relay2).product = product

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -180,7 +180,7 @@ def switchbox_d_fixture():
     type(product).brand = PropertyMock(return_value="BleBox")
     type(product).firmware_version = PropertyMock(return_value="1.23")
     type(product).unique_id = PropertyMock(return_value="abcd0123ef5678")
-    type(product).configuration_url = PropertyMock(return_value="http://172.2.3.4:80")
+    type(product).address = PropertyMock(return_value="http://172.2.3.4:80")
 
     type(relay1).product = product
     type(relay2).product = product

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -66,6 +66,7 @@ async def test_switchbox_init(switchbox, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "switchBox"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.100.123.4:80"
 
 
 async def test_switchbox_update_when_off(switchbox, hass, config):
@@ -180,7 +181,7 @@ def switchbox_d_fixture():
     type(product).brand = PropertyMock(return_value="BleBox")
     type(product).firmware_version = PropertyMock(return_value="1.23")
     type(product).unique_id = PropertyMock(return_value="abcd0123ef5678")
-    type(product).address = PropertyMock(return_value="http://172.2.3.4:80")
+    type(product).address = PropertyMock(return_value="172.2.3.4:80")
 
     type(relay1).product = product
     type(relay2).product = product
@@ -213,6 +214,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "switchBoxD"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.2.3.4:80"
 
     entry = entries[1]
     assert entry.unique_id == "BleBox-switchBoxD-1afe34e750b8-1.relay"
@@ -230,6 +232,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     assert device.manufacturer == "BleBox"
     assert device.model == "switchBoxD"
     assert device.sw_version == "1.23"
+    assert device.configuration_url == "http://172.2.3.4:80"
 
 
 async def test_switchbox_d_update_when_off(switchbox_d, hass, config):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

![image](https://user-images.githubusercontent.com/2270505/148109727-313f48c2-c8d9-4690-9943-6c11c32a535b.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
