### PR TITLE
Add sensor tests to PVOutput

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -865,7 +865,6 @@ omit =
     homeassistant/components/pushbullet/sensor.py
     homeassistant/components/pushover/notify.py
     homeassistant/components/pushsafer/notify.py
-    homeassistant/components/pvoutput/sensor.py
     homeassistant/components/pyload/sensor.py
     homeassistant/components/qbittorrent/sensor.py
     homeassistant/components/qnap/sensor.py

--- a/homeassistant/components/pvoutput/sensor.py
+++ b/homeassistant/components/pvoutput/sensor.py
@@ -195,7 +195,7 @@ class PVOutputSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{system_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             configuration_url=f"https://pvoutput.org/list.jsp?sid={system_id}",
-            identifiers={(DOMAIN, system_id)},
+            identifiers={(DOMAIN, str(system_id))},
             manufacturer="PVOutput",
             model=system.inverter_brand,
             name=system.system_name,

--- a/tests/components/pvoutput/test_sensor.py
+++ b/tests/components/pvoutput/test_sensor.py
@@ -1,0 +1,138 @@
+"""Tests for the sensors provided by the PVOutput integration."""
+from homeassistant.components.pvoutput.const import DOMAIN
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    ELECTRIC_POTENTIAL_VOLT,
+    ENERGY_KILO_WATT_HOUR,
+    ENERGY_WATT_HOUR,
+    POWER_KILO_WATT,
+    POWER_WATT,
+    TEMP_CELSIUS,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensors(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the PVOutput sensors."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    state = hass.states.get("sensor.energy_consumed")
+    entry = entity_registry.async_get("sensor.energy_consumed")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_energy_consumption"
+    assert entry.entity_category is None
+    assert state.state == "1000"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Energy Consumed"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.TOTAL_INCREASING
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_WATT_HOUR
+    assert ATTR_ICON not in state.attributes
+
+    state = hass.states.get("sensor.energy_generated")
+    entry = entity_registry.async_get("sensor.energy_generated")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_energy_generation"
+    assert entry.entity_category is None
+    assert state.state == "500"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Energy Generated"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.TOTAL_INCREASING
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_WATT_HOUR
+    assert ATTR_ICON not in state.attributes
+
+    state = hass.states.get("sensor.efficiency")
+    entry = entity_registry.async_get("sensor.efficiency")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_normalized_output"
+    assert entry.entity_category is None
+    assert state.state == "0.5"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Efficiency"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == f"{ENERGY_KILO_WATT_HOUR}/{POWER_KILO_WATT}"
+    )
+    assert ATTR_DEVICE_CLASS not in state.attributes
+    assert ATTR_ICON not in state.attributes
+
+    state = hass.states.get("sensor.power_consumed")
+    entry = entity_registry.async_get("sensor.power_consumed")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_power_consumption"
+    assert entry.entity_category is None
+    assert state.state == "2500"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Power Consumed"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == POWER_WATT
+    assert ATTR_ICON not in state.attributes
+
+    state = hass.states.get("sensor.power_generated")
+    entry = entity_registry.async_get("sensor.power_generated")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_power_generation"
+    assert entry.entity_category is None
+    assert state.state == "1500"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Power Generated"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == POWER_WATT
+    assert ATTR_ICON not in state.attributes
+
+    state = hass.states.get("sensor.temperature")
+    entry = entity_registry.async_get("sensor.temperature")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_temperature"
+    assert entry.entity_category is None
+    assert state.state == "20.2"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Temperature"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
+    assert ATTR_ICON not in state.attributes
+
+    state = hass.states.get("sensor.voltage")
+    entry = entity_registry.async_get("sensor.voltage")
+    assert entry
+    assert state
+    assert entry.unique_id == "12345_voltage"
+    assert entry.entity_category is None
+    assert state.state == "220.5"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.VOLTAGE
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Voltage"
+    assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ELECTRIC_POTENTIAL_VOLT
+    assert ATTR_ICON not in state.attributes
+
+    assert entry.device_id
+    device_entry = device_registry.async_get(entry.device_id)
+    assert device_entry
+    assert device_entry.identifiers == {(DOMAIN, "12345")}
+    assert device_entry.manufacturer == "PVOutput"
+    assert device_entry.model == "Super Inverters Inc."
+    assert device_entry.name == "Frenck's Solar Farm"
+    assert device_entry.configuration_url == "https://pvoutput.org/list.jsp?sid=12345"
+    assert device_entry.entry_type is None
+    assert device_entry.sw_version is None
+    assert device_entry.hw_version is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds sensor tests for the PVOutput integration, making the integration fully covered.

```
----------- coverage: platform linux, python 3.9.9-final-0 -----------
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
homeassistant/components/pvoutput/__init__.py         15      0   100%
homeassistant/components/pvoutput/config_flow.py      51      0   100%
homeassistant/components/pvoutput/const.py            16      0   100%
homeassistant/components/pvoutput/coordinator.py      20      0   100%
homeassistant/components/pvoutput/sensor.py           46      0   100%
--------------------------------------------------------------------------------
TOTAL                                                148      0   100%
```

Found 1 issue when writing the tests, the device identifier had the wrong type. This has been fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
