### PR TITLE
2021.12.8

### DIFF
--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -248,8 +248,10 @@ class ConfiguredDoorBird:
         if self.custom_url is not None:
             hass_url = self.custom_url
 
+        favorites = self.device.favorites()
+
         for event in self.doorstation_events:
-            self._register_event(hass_url, event)
+            self._register_event(hass_url, event, favs=favorites)
 
             _LOGGER.info("Successfully registered URL for %s on %s", event, self.name)
 
@@ -261,15 +263,15 @@ class ConfiguredDoorBird:
     def _get_event_name(self, event):
         return f"{self.slug}_{event}"
 
-    def _register_event(self, hass_url, event):
+    def _register_event(self, hass_url, event, favs=None):
         """Add a schedule entry in the device for a sensor."""
         url = f"{hass_url}{API_URL}/{event}?token={self._token}"
 
         # Register HA URL as webhook if not already, then get the ID
-        if not self.webhook_is_registered(url):
+        if not self.webhook_is_registered(url, favs=favs):
             self.device.change_favorite("http", f"Home Assistant ({event})", url)
 
-        if not self.get_webhook_id(url):
+        if not self.get_webhook_id(url, favs=favs):
             _LOGGER.warning(
                 'Could not find favorite for URL "%s". ' 'Skipping sensor "%s"',
                 url,

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flux LED/MagicHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.27.21"],
+  "requirements": ["flux_led==0.27.28"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch"],
   "iot_class": "local_push",

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flux LED/MagicHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.27.28"],
+  "requirements": ["flux_led==0.27.32"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch"],
   "iot_class": "local_push",

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -160,7 +160,10 @@ class FroniusSolarNet:
         )
         if self.logger_coordinator:
             _logger_info = self.logger_coordinator.data[SOLAR_NET_ID_SYSTEM]
-            solar_net_device[ATTR_MODEL] = _logger_info["product_type"]["value"]
+            # API v0 doesn't provide product_type
+            solar_net_device[ATTR_MODEL] = _logger_info.get("product_type", {}).get(
+                "value", "Datalogger Web"
+            )
             solar_net_device[ATTR_SW_VERSION] = _logger_info["software_version"][
                 "value"
             ]

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -2296,8 +2296,8 @@ class SensorStateTrait(_Trait):
 
     sensor_types = {
         sensor.DEVICE_CLASS_AQI: ("AirQuality", "AQI"),
-        sensor.DEVICE_CLASS_CO: ("CarbonDioxideLevel", "PARTS_PER_MILLION"),
-        sensor.DEVICE_CLASS_CO2: ("CarbonMonoxideLevel", "PARTS_PER_MILLION"),
+        sensor.DEVICE_CLASS_CO: ("CarbonMonoxideLevel", "PARTS_PER_MILLION"),
+        sensor.DEVICE_CLASS_CO2: ("CarbonDioxideLevel", "PARTS_PER_MILLION"),
         sensor.DEVICE_CLASS_PM25: ("PM2.5", "MICROGRAMS_PER_CUBIC_METER"),
         sensor.DEVICE_CLASS_PM10: ("PM10", "MICROGRAMS_PER_CUBIC_METER"),
         sensor.DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS: (

--- a/homeassistant/components/gree/manifest.json
+++ b/homeassistant/components/gree/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gree Climate",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gree",
-  "requirements": ["greeclimate==0.12.5"],
+  "requirements": ["greeclimate==1.0.1"],
   "codeowners": ["@cmroche"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/gtfs/sensor.py
+++ b/homeassistant/components/gtfs/sensor.py
@@ -619,7 +619,9 @@ class GTFSDepartureSensor(SensorEntity):
             if not self._departure:
                 self._state = None
             else:
-                self._state = self._departure["departure_time"]
+                self._state = self._departure["departure_time"].replace(
+                    tzinfo=dt_util.UTC
+                )
 
             # Fetch trip and route details once, unless updated
             if not self._departure:

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -134,7 +134,7 @@ class HassIOIngress(HomeAssistantView):
             if (
                 hdrs.CONTENT_LENGTH in result.headers
                 and int(result.headers.get(hdrs.CONTENT_LENGTH, 0)) < 4194000
-            ):
+            ) or result.status in (204, 304):
                 # Return Response
                 body = await result.read()
                 return web.Response(

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "hue"
 
 CONF_API_VERSION = "api_version"
+CONF_IGNORE_AVAILABILITY = "ignore_availability"
 
 CONF_SUBTYPE = "subtype"
 

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -70,7 +70,8 @@
         "data": {
           "allow_hue_groups": "Allow Hue groups",
           "allow_hue_scenes": "Allow Hue scenes",
-          "allow_unreachable": "Allow unreachable bulbs to report their state correctly"
+          "allow_unreachable": "Allow unreachable bulbs to report their state correctly",
+          "ignore_availability": "Ignore connectivity status for the given devices"
         }
       }
     }

--- a/homeassistant/components/hue/translations/en.json
+++ b/homeassistant/components/hue/translations/en.json
@@ -69,7 +69,8 @@
                 "data": {
                     "allow_hue_groups": "Allow Hue groups",
                     "allow_hue_scenes": "Allow Hue scenes",
-                    "allow_unreachable": "Allow unreachable bulbs to report their state correctly"
+                    "allow_unreachable": "Allow unreachable bulbs to report their state correctly",
+                    "ignore_availability": "Ignore connectivity status for the given devices"
                 }
             }
         }

--- a/homeassistant/components/hue/translations/nl.json
+++ b/homeassistant/components/hue/translations/nl.json
@@ -69,7 +69,8 @@
                 "data": {
                     "allow_hue_groups": "Sta Hue-groepen toe",
                     "allow_hue_scenes": "Sta Hue sc\u00e8nes toe",
-                    "allow_unreachable": "Onbereikbare lampen toestaan hun status correct te melden"
+                    "allow_unreachable": "Onbereikbare lampen toestaan hun status correct te melden",
+                    "ignore_availability": "Negeer beschikbaarheid status voor deze apparaten"
                 }
             }
         }

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 
 from ..bridge import HueBridge
-from ..const import DOMAIN
+from ..const import CONF_IGNORE_AVAILABILITY, DOMAIN
 
 RESOURCE_TYPE_NAMES = {
     # a simple mapping of hue resource type to Hass name
@@ -71,7 +71,7 @@ class HueBaseEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        self._check_availability_workaround()
+        self._check_availability()
         # Add value_changed callbacks.
         self.async_on_remove(
             self.controller.subscribe(
@@ -80,7 +80,7 @@ class HueBaseEntity(Entity):
                 (EventType.RESOURCE_UPDATED, EventType.RESOURCE_DELETED),
             )
         )
-        # also subscribe to device update event to catch devicer changes (e.g. name)
+        # also subscribe to device update event to catch device changes (e.g. name)
         if self.device is None:
             return
         self.async_on_remove(
@@ -92,25 +92,27 @@ class HueBaseEntity(Entity):
         )
         # subscribe to zigbee_connectivity to catch availability changes
         if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
-            self.bridge.api.sensors.zigbee_connectivity.subscribe(
-                self._handle_event,
-                zigbee.id,
-                EventType.RESOURCE_UPDATED,
+            self.async_on_remove(
+                self.bridge.api.sensors.zigbee_connectivity.subscribe(
+                    self._handle_event,
+                    zigbee.id,
+                    EventType.RESOURCE_UPDATED,
+                )
             )
 
     @property
     def available(self) -> bool:
         """Return entity availability."""
+        # entities without a device attached should be always available
         if self.device is None:
-            # entities without a device attached should be always available
             return True
+        # the zigbee connectivity sensor itself should be always available
         if self.resource.type == ResourceTypes.ZIGBEE_CONNECTIVITY:
-            # the zigbee connectivity sensor itself should be always available
             return True
         if self._ignore_availability:
             return True
+        # all device-attached entities get availability from the zigbee connectivity
         if zigbee := self.bridge.api.devices.get_zigbee_connectivity(self.device.id):
-            # all device-attached entities get availability from the zigbee connectivity
             return zigbee.status == ConnectivityServiceStatus.CONNECTED
         return True
 
@@ -130,30 +132,41 @@ class HueBaseEntity(Entity):
             ent_reg.async_remove(self.entity_id)
         else:
             self.logger.debug("Received status update for %s", self.entity_id)
-            self._check_availability_workaround()
+            self._check_availability()
             self.on_update()
             self.async_write_ha_state()
 
     @callback
-    def _check_availability_workaround(self):
+    def _check_availability(self):
         """Check availability of the device."""
-        if self.resource.type != ResourceTypes.LIGHT:
-            return
+        # return if we already processed this entity
         if self._ignore_availability is not None:
-            # already processed
             return
+        # only do the availability check for entities connected to a device
+        if self.device is None:
+            return
+        # ignore availability if user added device to ignore list
+        if self.device.id in self.bridge.config_entry.options.get(
+            CONF_IGNORE_AVAILABILITY, []
+        ):
+            self._ignore_availability = True
+            self.logger.info(
+                "Device %s is configured to ignore availability status. ",
+                self.name,
+            )
+            return
+        # certified products (normally) report their state correctly
+        # no need for workaround/reporting
         if self.device.product_data.certified:
-            # certified products report their state correctly
             self._ignore_availability = False
             return
         # some (3th party) Hue lights report their connection status incorrectly
         # causing the zigbee availability to report as disconnected while in fact
-        # it can be controlled. Although this is in fact something the device manufacturer
-        # should fix, we work around it here. If the light is reported unavailable
+        # it can be controlled. If the light is reported unavailable
         # by the zigbee connectivity but the state changes its considered as a
         # malfunctioning device and we report it.
-        # while the user should actually fix this issue instead of ignoring it, we
-        # ignore the availability for this light from this point.
+        # While the user should actually fix this issue, we allow to
+        # ignore the availability for this light/device from the config options.
         cur_state = self.resource.on.on
         if self._last_state is None:
             self._last_state = cur_state
@@ -166,9 +179,10 @@ class HueBaseEntity(Entity):
                 # the device state changed from on->off or off->on
                 # while it was reported as not connected!
                 self.logger.warning(
-                    "Light %s changed state while reported as disconnected. "
-                    "This might be an indicator that routing is not working for this device. "
-                    "Home Assistant will ignore availability for this light from now on. "
+                    "Device %s changed state while reported as disconnected. "
+                    "This might be an indicator that routing is not working for this device "
+                    "or the device is having connectivity issues. "
+                    "You can disable availability reporting for this device in the Hue options. "
                     "Device details: %s - %s (%s) fw: %s",
                     self.name,
                     self.device.product_data.manufacturer_name,
@@ -178,6 +192,4 @@ class HueBaseEntity(Entity):
                 )
                 # do we want to store this in some persistent storage?
                 self._ignore_availability = True
-            else:
-                self._ignore_availability = False
         self._last_state = cur_state

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -102,7 +102,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
         # Entities for Hue groups are disabled by default
         # unless they were enabled in old version (legacy option)
-        self._attr_entity_registry_enabled_default = bridge.config_entry.data.get(
+        self._attr_entity_registry_enabled_default = bridge.config_entry.options.get(
             CONF_ALLOW_HUE_GROUPS, False
         )
 

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -298,7 +298,10 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             supported_color_modes.add(COLOR_MODE_ONOFF)
         self._attr_supported_color_modes = supported_color_modes
         # pick a winner for the current colormode
-        if lights_in_colortemp_mode == lights_with_color_temp_support:
+        if (
+            lights_with_color_temp_support > 0
+            and lights_in_colortemp_mode == lights_with_color_temp_support
+        ):
             self._attr_color_mode = COLOR_MODE_COLOR_TEMP
         elif lights_with_color_support > 0:
             self._attr_color_mode = COLOR_MODE_XY

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -7,7 +7,6 @@ from typing import Any
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.groups import GroupedLight, Room, Zone
-from aiohue.v2.models.feature import AlertEffectType
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -193,7 +192,6 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                     color_xy=xy_color if light.supports_color else None,
                     color_temp=color_temp if light.supports_color_temperature else None,
                     transition_time=transition,
-                    alert=AlertEffectType.BREATHE if flash is not None else None,
                     allowed_errors=ALLOWED_ERRORS,
                 )
                 for light in self.controller.get_lights(self.resource.id)

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -512,11 +512,6 @@ class ZoneDevice(ClimateEntity):
         return self._controller.available
 
     @property
-    def assumed_state(self) -> bool:
-        """Return True if unable to access real state of the entity."""
-        return self._controller.assumed_state
-
-    @property
     def unique_id(self):
         """Return the ID of the controller device."""
         return f"{self._controller.unique_id}_z{self._zone.index + 1}"

--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -2,11 +2,11 @@
   "domain": "izone",
   "name": "iZone",
   "documentation": "https://www.home-assistant.io/integrations/izone",
-  "requirements": ["python-izone==1.1.8"],
+  "requirements": ["python-izone==1.2.3"],
   "codeowners": ["@Swamp-Ig"],
   "config_flow": true,
   "homekit": {
     "models": ["iZone"]
   },
-  "iot_class": "local_push"
+  "iot_class": "local_polling"
 }

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -28,6 +28,7 @@ from .schema import ConnectionSchema
 
 CONF_KNX_GATEWAY: Final = "gateway"
 CONF_MAX_RATE_LIMIT: Final = 60
+CONF_DEFAULT_LOCAL_IP: Final = "0.0.0.0"
 
 DEFAULT_ENTRY_DATA: Final = {
     ConnectionSchema.CONF_KNX_STATE_UPDATER: ConnectionSchema.CONF_KNX_DEFAULT_STATE_UPDATER,
@@ -328,6 +329,12 @@ class KNXOptionsFlowHandler(OptionsFlow):
         entry_data = {
             **DEFAULT_ENTRY_DATA,
             **self.general_settings,
+            ConnectionSchema.CONF_KNX_LOCAL_IP: self.general_settings.get(
+                ConnectionSchema.CONF_KNX_LOCAL_IP
+            )
+            if self.general_settings.get(ConnectionSchema.CONF_KNX_LOCAL_IP)
+            != CONF_DEFAULT_LOCAL_IP
+            else None,
             CONF_HOST: self.current_config.get(CONF_HOST, ""),
         }
 
@@ -337,7 +344,7 @@ class KNXOptionsFlowHandler(OptionsFlow):
                 **user_input,
             }
 
-        entry_title = entry_data[CONF_KNX_CONNECTION_TYPE].capitalize()
+        entry_title = str(entry_data[CONF_KNX_CONNECTION_TYPE]).capitalize()
         if entry_data[CONF_KNX_CONNECTION_TYPE] == CONF_KNX_TUNNELING:
             entry_title = f"{CONF_KNX_TUNNELING.capitalize()} @ {entry_data[CONF_HOST]}"
 
@@ -388,12 +395,16 @@ class KNXOptionsFlowHandler(OptionsFlow):
         }
 
         if self.show_advanced_options:
+            local_ip = (
+                self.current_config.get(ConnectionSchema.CONF_KNX_LOCAL_IP)
+                if self.current_config.get(ConnectionSchema.CONF_KNX_LOCAL_IP)
+                is not None
+                else CONF_DEFAULT_LOCAL_IP
+            )
             data_schema[
-                vol.Optional(
+                vol.Required(
                     ConnectionSchema.CONF_KNX_LOCAL_IP,
-                    default=self.current_config.get(
-                        ConnectionSchema.CONF_KNX_LOCAL_IP,
-                    ),
+                    default=local_ip,
                 )
             ] = str
             data_schema[

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -20,7 +20,7 @@
           "host": "[%key:common::config_flow::data::host%]",
           "individual_address": "Individual address for the connection",
           "route_back": "Route Back / NAT Mode",
-          "local_ip": "Local IP (leave empty if unsure)"
+          "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)"
         }
       },
       "routing": {
@@ -29,7 +29,7 @@
           "individual_address": "Individual address for the routing connection",
           "multicast_group": "The multicast group used for routing",
           "multicast_port": "The multicast port used for routing",
-          "local_ip": "Local IP (leave empty if unsure)"
+          "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)"
         }
       }
     },
@@ -49,7 +49,7 @@
           "individual_address": "Default individual address",
           "multicast_group": "Multicast group used for routing and discovery",
           "multicast_port": "Multicast port used for routing and discovery",
-          "local_ip": "Local IP (leave empty if unsure)",
+          "local_ip": "Local IP of Home Assistant (use 0.0.0.0 for automatic detection)",
           "state_updater": "Globally enable reading states from the KNX Bus",
           "rate_limit": "Maximum outgoing telegrams per second"
         }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -47,13 +47,9 @@
                 "data": {
                     "connection_type": "KNX Connection Type",
                     "individual_address": "Default individual address",
-<<<<<<< HEAD
-=======
                     "local_ip": "Local IP of Home Assistant (use 0.0.0.0 for automatic detection)",
->>>>>>> b9247f3952 (Fix local_ip handling in KNX options flow (#62969))
                     "multicast_group": "Multicast group used for routing and discovery",
                     "multicast_port": "Multicast port used for routing and discovery",
-                    "local_ip": "Local IP (leave empty if unsure)",
                     "rate_limit": "Maximum outgoing telegrams per second",
                     "state_updater": "Globally enable reading states from the KNX Bus"
                 }

--- a/homeassistant/components/knx/translations/en.json
+++ b/homeassistant/components/knx/translations/en.json
@@ -12,7 +12,7 @@
                 "data": {
                     "host": "Host",
                     "individual_address": "Individual address for the connection",
-                    "local_ip": "Local IP (leave empty if unsure)",
+                    "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)",
                     "port": "Port",
                     "route_back": "Route Back / NAT Mode"
                 },
@@ -21,9 +21,9 @@
             "routing": {
                 "data": {
                     "individual_address": "Individual address for the routing connection",
+                    "local_ip": "Local IP of Home Assistant (leave empty for automatic detection)",
                     "multicast_group": "The multicast group used for routing",
-                    "multicast_port": "The multicast port used for routing",
-                    "local_ip": "Local IP (leave empty if unsure)"
+                    "multicast_port": "The multicast port used for routing"
                 },
                 "description": "Please configure the routing options."
             },
@@ -47,6 +47,10 @@
                 "data": {
                     "connection_type": "KNX Connection Type",
                     "individual_address": "Default individual address",
+<<<<<<< HEAD
+=======
+                    "local_ip": "Local IP of Home Assistant (use 0.0.0.0 for automatic detection)",
+>>>>>>> b9247f3952 (Fix local_ip handling in KNX options flow (#62969))
                     "multicast_group": "Multicast group used for routing and discovery",
                     "multicast_port": "Multicast port used for routing and discovery",
                     "local_ip": "Local IP (leave empty if unsure)",

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -136,14 +136,13 @@ async def async_setup_entry(
     for home_id in climate_topology.home_ids:
         signal_name = f"{CLIMATE_STATE_CLASS_NAME}-{home_id}"
 
-        try:
-            await data_handler.register_data_class(
-                CLIMATE_STATE_CLASS_NAME, signal_name, None, home_id=home_id
-            )
-        except KeyError:
+        await data_handler.register_data_class(
+            CLIMATE_STATE_CLASS_NAME, signal_name, None, home_id=home_id
+        )
+
+        if (climate_state := data_handler.data[signal_name]) is None:
             continue
 
-        climate_state = data_handler.data[signal_name]
         climate_topology.register_handler(home_id, climate_state.process_topology)
 
         for room in climate_state.homes[home_id].rooms.values():

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": [
-    "pyatmo==6.2.1"
+    "pyatmo==6.2.2"
   ],
   "after_dependencies": [
     "cloud",

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/integrations/netatmo",
   "requirements": [
-    "pyatmo==6.2.0"
+    "pyatmo==6.2.1"
   ],
   "after_dependencies": [
     "cloud",

--- a/homeassistant/components/netatmo/select.py
+++ b/homeassistant/components/netatmo/select.py
@@ -49,17 +49,13 @@ async def async_setup_entry(
     for home_id in climate_topology.home_ids:
         signal_name = f"{CLIMATE_STATE_CLASS_NAME}-{home_id}"
 
-        try:
-            await data_handler.register_data_class(
-                CLIMATE_STATE_CLASS_NAME, signal_name, None, home_id=home_id
-            )
-        except KeyError:
-            continue
-
         await data_handler.register_data_class(
             CLIMATE_STATE_CLASS_NAME, signal_name, None, home_id=home_id
         )
-        climate_state = data_handler.data.get(signal_name)
+
+        if (climate_state := data_handler.data[signal_name]) is None:
+            continue
+
         climate_topology.register_handler(home_id, climate_state.process_topology)
 
         hass.data[DOMAIN][DATA_SCHEDULES][home_id] = climate_state.homes[

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 from ipaddress import IPv4Address, IPv6Address, ip_interface
+import logging
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
@@ -11,6 +13,8 @@ from . import util
 from .const import IPV4_BROADCAST_ADDR, PUBLIC_TARGET_IP
 from .models import Adapter
 from .network import Network, async_get_network
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @bind_hass
@@ -32,6 +36,16 @@ async def async_get_source_ip(
             all_ipv4s.extend([ipv4["address"] for ipv4 in ipv4s])
 
     source_ip = util.async_get_source_ip(target_ip)
+    if not all_ipv4s:
+        _LOGGER.warning(
+            "Because the system does not have any enabled IPv4 addresses, source address detection may be inaccurate"
+        )
+        if source_ip is None:
+            raise HomeAssistantError(
+                "Could not determine source ip because the system does not have any enabled IPv4 addresses and creating a socket failed"
+            )
+        return source_ip
+
     return source_ip if source_ip in all_ipv4s else all_ipv4s[0]
 
 

--- a/homeassistant/components/no_ip/__init__.py
+++ b/homeassistant/components/no_ip/__init__.py
@@ -35,7 +35,7 @@ NO_IP_ERRORS = {
     "911": "A fatal error on NO-IP's side such as a database outage",
 }
 
-UPDATE_URL = "https://dynupdate.noip.com/nic/update"
+UPDATE_URL = "https://dynupdate.no-ip.com/nic/update"
 HA_USER_AGENT = f"{SERVER_SOFTWARE} {EMAIL}"
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -32,6 +32,8 @@ from .const import (
     UNDO_UPDATE_LISTENER,
 )
 
+NUT_FAKE_SERIAL = ["unknown", "blank"]
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -140,7 +142,9 @@ def _firmware_from_status(status):
 def _serial_from_status(status):
     """Find the best serialvalue from the status."""
     serial = status.get("device.serial") or status.get("ups.serial")
-    if serial and (serial.lower() == "unknown" or serial.count("0") == len(serial)):
+    if serial and (
+        serial.lower() in NUT_FAKE_SERIAL or serial.count("0") == len(serial)
+    ):
         return None
     return serial
 

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -380,6 +380,7 @@ class PlexOptionsFlowHandler(config_entries.OptionsFlow):
                 for user in plex_server.option_monitored_users
                 if plex_server.option_monitored_users[user]["enabled"]
             }
+            default_accounts.intersection_update(plex_server.accounts)
             for user in plex_server.accounts:
                 if user not in known_accounts:
                     available_accounts[user] += " [New]"

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -219,7 +219,7 @@ class BlockSleepingClimate(
             return CURRENT_HVAC_OFF
 
         return (
-            CURRENT_HVAC_IDLE if self.device_block.status == "0" else CURRENT_HVAC_HEAT
+            CURRENT_HVAC_HEAT if bool(self.device_block.status) else CURRENT_HVAC_IDLE
         )
 
     @property

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -123,6 +123,9 @@ async def async_get_triggers(
             append_input_triggers(triggers, input_triggers, device_id)
             return triggers
 
+        if not block_wrapper.device.initialized:
+            return triggers
+
         assert block_wrapper.device.blocks
 
         for block in block_wrapper.device.blocks:

--- a/homeassistant/components/sisyphus/media_player.py
+++ b/homeassistant/components/sisyphus/media_player.py
@@ -163,7 +163,7 @@ class SisyphusPlayer(MediaPlayerEntity):
         if self._table.active_track:
             return self._table.active_track.get_thumbnail_url(Track.ThumbnailSize.LARGE)
 
-        return super.media_image_url()
+        return super().media_image_url
 
     async def async_turn_on(self):
         """Wake up a sleeping table."""

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -307,6 +307,7 @@ CPU_SENSOR_PREFIXES = [
     "soc_thermal 1",
     "Tctl",
     "cpu0-thermal",
+    "cpu0_thermal",
 ]
 
 

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -112,9 +112,9 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
             self._supported_features |= SUPPORT_FAN_SPEED
             self._fan_speed_type = EnumTypeData.from_json(function.values)
 
-        if function := device.function.get(DPCode.ELECTRICITY_LEFT):
+        if status_range := device.status_range.get(DPCode.ELECTRICITY_LEFT):
             self._supported_features |= SUPPORT_BATTERY
-            self._battery_level_type = IntegerTypeData.from_json(function.values)
+            self._battery_level_type = IntegerTypeData.from_json(status_range.values)
 
     @property
     def battery_level(self) -> int | None:

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.10.56", "micloud==0.4", "python-miio==0.5.9.2"],
+  "requirements": ["construct==2.10.56", "micloud==0.5", "python-miio==0.5.9.2"],
   "codeowners": ["@rytilahti", "@syssi", "@starkillerOG", "@bieniu"],
   "zeroconf": ["_miio._udp.local."],
   "iot_class": "local_polling"

--- a/homeassistant/components/xiaomi_miio/number.py
+++ b/homeassistant/components/xiaomi_miio/number.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.components.number.const import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import DEGREE, ENTITY_CATEGORY_CONFIG, TIME_MINUTES
 from homeassistant.core import callback
 
@@ -248,6 +249,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         return
 
     for feature, description in NUMBER_TYPES.items():
+        if feature == FEATURE_SET_LED_BRIGHTNESS and model != MODEL_FAN_ZA5:
+            # Delete LED bightness entity created by mistake if it exists
+            entity_reg = hass.helpers.entity_registry.async_get()
+            entity_id = entity_reg.async_get_entity_id(
+                PLATFORM_DOMAIN, DOMAIN, f"{description.key}_{config_entry.unique_id}"
+            )
+            if entity_id:
+                entity_reg.async_remove(entity_id)
+            continue
         if feature & features:
             if (
                 description.key == ATTR_OSCILLATION_ANGLE

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from homeassistant.backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "7"
+PATCH_VERSION: Final = "8"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -659,7 +659,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.27.21
+flux_led==0.27.28
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1364,7 +1364,7 @@ pyarlo==0.2.4
 pyatag==0.3.5.3
 
 # homeassistant.components.netatmo
-pyatmo==6.2.1
+pyatmo==6.2.2
 
 # homeassistant.components.atome
 pyatome==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -659,7 +659,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.27.28
+flux_led==0.27.32
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -754,7 +754,7 @@ gpiozero==1.5.1
 gps3==0.33.3
 
 # homeassistant.components.gree
-greeclimate==0.12.5
+greeclimate==1.0.1
 
 # homeassistant.components.greeneye_monitor
 greeneye_monitor==2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1890,7 +1890,7 @@ python-gitlab==1.6.0
 python-hpilo==4.3
 
 # homeassistant.components.izone
-python-izone==1.1.8
+python-izone==1.2.3
 
 # homeassistant.components.joaoapps_join
 python-join-api==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1364,7 +1364,7 @@ pyarlo==0.2.4
 pyatag==0.3.5.3
 
 # homeassistant.components.netatmo
-pyatmo==6.2.0
+pyatmo==6.2.1
 
 # homeassistant.components.atome
 pyatome==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1006,7 +1006,7 @@ meteofrance-api==1.0.2
 mficlient==0.3.0
 
 # homeassistant.components.xiaomi_miio
-micloud==0.4
+micloud==0.5
 
 # homeassistant.components.miflora
 miflora==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -467,7 +467,7 @@ google-nest-sdm==0.4.9
 googlemaps==2.5.1
 
 # homeassistant.components.gree
-greeclimate==0.12.5
+greeclimate==1.0.1
 
 # homeassistant.components.greeneye_monitor
 greeneye_monitor==2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1136,7 +1136,7 @@ python-ecobee-api==0.2.14
 python-forecastio==1.4.0
 
 # homeassistant.components.izone
-python-izone==1.1.8
+python-izone==1.2.3
 
 # homeassistant.components.juicenet
 python-juicenet==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,7 +399,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.27.21
+flux_led==0.27.28
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,7 +399,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.27.28
+flux_led==0.27.32
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -832,7 +832,7 @@ pyarlo==0.2.4
 pyatag==0.3.5.3
 
 # homeassistant.components.netatmo
-pyatmo==6.2.1
+pyatmo==6.2.2
 
 # homeassistant.components.apple_tv
 pyatv==0.8.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -832,7 +832,7 @@ pyarlo==0.2.4
 pyatag==0.3.5.3
 
 # homeassistant.components.netatmo
-pyatmo==6.2.0
+pyatmo==6.2.1
 
 # homeassistant.components.apple_tv
 pyatv==0.8.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -612,7 +612,7 @@ meteofrance-api==1.0.2
 mficlient==0.3.0
 
 # homeassistant.components.xiaomi_miio
-micloud==0.4
+micloud==0.5
 
 # homeassistant.components.mill
 mill-local==0.1.0

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -3030,8 +3030,8 @@ async def test_sensorstate(hass):
     """Test SensorState trait support for sensor domain."""
     sensor_types = {
         sensor.DEVICE_CLASS_AQI: ("AirQuality", "AQI"),
-        sensor.DEVICE_CLASS_CO: ("CarbonDioxideLevel", "PARTS_PER_MILLION"),
-        sensor.DEVICE_CLASS_CO2: ("CarbonMonoxideLevel", "PARTS_PER_MILLION"),
+        sensor.DEVICE_CLASS_CO: ("CarbonMonoxideLevel", "PARTS_PER_MILLION"),
+        sensor.DEVICE_CLASS_CO2: ("CarbonDioxideLevel", "PARTS_PER_MILLION"),
         sensor.DEVICE_CLASS_PM25: ("PM2.5", "MICROGRAMS_PER_CUBIC_METER"),
         sensor.DEVICE_CLASS_PM10: ("PM10", "MICROGRAMS_PER_CUBIC_METER"),
         sensor.DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS: (

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -3,6 +3,7 @@ from ipaddress import IPv4Address
 from unittest.mock import MagicMock, Mock, patch
 
 import ifaddr
+import pytest
 
 from homeassistant.components import network
 from homeassistant.components.network.const import (
@@ -13,6 +14,7 @@ from homeassistant.components.network.const import (
     STORAGE_KEY,
     STORAGE_VERSION,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 _NO_LOOPBACK_IPADDR = "192.168.1.5"
@@ -602,3 +604,49 @@ async def test_async_get_ipv4_broadcast_addresses_multiple(hass, hass_storage):
         IPv4Address("192.168.1.255"),
         IPv4Address("169.254.255.255"),
     }
+
+
+async def test_async_get_source_ip_no_enabled_addresses(hass, hass_storage, caplog):
+    """Test getting the source ip address when all adapters are disabled."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "key": STORAGE_KEY,
+        "data": {ATTR_CONFIGURED_ADAPTERS: ["eth1"]},
+    }
+
+    with patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=[],
+    ), patch(
+        "homeassistant.components.network.util.socket.socket",
+        return_value=_mock_socket(["192.168.1.5"]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+
+        assert await network.async_get_source_ip(hass, MDNS_TARGET_IP) == "192.168.1.5"
+
+    assert "source address detection may be inaccurate" in caplog.text
+
+
+async def test_async_get_source_ip_cannot_be_determined_and_no_enabled_addresses(
+    hass, hass_storage, caplog
+):
+    """Test getting the source ip address when all adapters are disabled and getting it fails."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "key": STORAGE_KEY,
+        "data": {ATTR_CONFIGURED_ADAPTERS: ["eth1"]},
+    }
+
+    with patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=[],
+    ), patch(
+        "homeassistant.components.network.util.socket.socket",
+        return_value=_mock_socket([None]),
+    ):
+        assert not await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+        with pytest.raises(HomeAssistantError):
+            await network.async_get_source_ip(hass, MDNS_TARGET_IP)

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -198,7 +198,7 @@ async def test_get_triggers_non_initialized_devices(hass):
     expected_triggers = []
 
     triggers = await async_get_device_automations(
-        hass, DeviceAutomationType.TRIGGER, coap_wrapper.device_id
+        hass, "trigger", coap_wrapper.device_id
     )
 
     assert_lists_same(triggers, expected_triggers)


### PR DESCRIPTION
- Update version of iZone library to add some bug fixes ([@Swamp-Ig] - [#61548]) ([izone docs])
- Fix Tuya vacuum display battery level ([@dougiteixeira] - [#61643]) ([tuya docs])
- Update no_ip URL ([@fabaff] - [#62477]) ([no_ip docs])
- Do not create a number LED brightness entity for Xiaomi Miio devices that do not support it ([@bieniu] - [#62819]) ([xiaomi_miio docs])
- Fix local_ip handling in KNX options flow ([@marvin-w] - [#62969]) ([knx docs])
- Fix reporting correct colormode for 3rd party Hue lights ([@marcelveldt] - [#63015]) ([hue docs])
- Hue allow per-device availability override ([@marcelveldt] - [#63025]) ([hue docs])
- Bump pyatmo to 6.2.1 ([@cgtobi] - [#62291]) ([netatmo docs])
- Bump pyatmo to v6.2.2 ([@cgtobi] - [#63053]) ([netatmo docs])
- Ignore serial number "blank" from NUT ([@ollo69] - [#63066]) ([nut docs])
- Bump greeclimate to 1.0.1 ([@cmroche] - [#63092]) ([gree docs])
- Fix Shelly error fetching device triggers for sleeping devices ([@thecode] - [#63103]) ([shelly docs])
- Fix systemmonitor CPU temp for Armbian on PineA64 ([@ktaragorn] - [#63111]) ([systemmonitor docs])
- Fix CO/CO2 sensors mixup in Google Assistant ([@ryborg] - [#63152]) ([google_assistant docs])
- Bump flux_led to 0.27.28 to fix missing white channel on SK6812RGBW strips ([@bdraco] - [#63154]) ([flux_led docs])
- Add default Fronius logger model for v0 API ([@trdischat] - [#63184]) ([fronius docs])
- Prevent doorbird integration from overloading the device on startup ([@bdraco] - [#63253]) ([doorbird docs])
- Bump flux_led to 0.27.32 to fix incorrect strip order on A2 devices ([@bdraco] - [#63262]) ([flux_led docs])
- Sisyphus: Fix bad super call ([@balloob] - [#63327]) ([sisyphus docs])
- Fix status type in Shelly climate platform ([@bieniu] - [#63347]) ([shelly docs])
- Bump micloud to 0.5 ([@starkillerOG] - [#63348]) ([xiaomi_miio docs])
- Work around ingress glitch with 304 responses ([@masto] - [#63355]) ([hassio docs])
- Fix Hue grouped light color_mode calculation ([@marcelveldt] - [#63374]) ([hue docs])
- Fix missing timezone in GTFS timestamp sensor ([@frenck] - [#63401]) ([gtfs docs])
- Handle missing monitored users in Plex options (#63411) @jjlawren
- Handle no enabled ipv4 addresses in the network integration (#63416) @bdraco

[#61548]: https://github.com/home-assistant/core/pull/61548
[#61643]: https://github.com/home-assistant/core/pull/61643
[#62291]: https://github.com/home-assistant/core/pull/62291
[#62477]: https://github.com/home-assistant/core/pull/62477
[#62819]: https://github.com/home-assistant/core/pull/62819
[#62969]: https://github.com/home-assistant/core/pull/62969
[#63015]: https://github.com/home-assistant/core/pull/63015
[#63025]: https://github.com/home-assistant/core/pull/63025
[#63053]: https://github.com/home-assistant/core/pull/63053
[#63066]: https://github.com/home-assistant/core/pull/63066
[#63092]: https://github.com/home-assistant/core/pull/63092
[#63103]: https://github.com/home-assistant/core/pull/63103
[#63111]: https://github.com/home-assistant/core/pull/63111
[#63152]: https://github.com/home-assistant/core/pull/63152
[#63154]: https://github.com/home-assistant/core/pull/63154
[#63184]: https://github.com/home-assistant/core/pull/63184
[#63253]: https://github.com/home-assistant/core/pull/63253
[#63262]: https://github.com/home-assistant/core/pull/63262
[#63327]: https://github.com/home-assistant/core/pull/63327
[#63347]: https://github.com/home-assistant/core/pull/63347
[#63348]: https://github.com/home-assistant/core/pull/63348
[#63355]: https://github.com/home-assistant/core/pull/63355
[#63374]: https://github.com/home-assistant/core/pull/63374
[#63401]: https://github.com/home-assistant/core/pull/63401
[@Swamp-Ig]: https://github.com/Swamp-Ig
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@cgtobi]: https://github.com/cgtobi
[@cmroche]: https://github.com/cmroche
[@dougiteixeira]: https://github.com/dougiteixeira
[@fabaff]: https://github.com/fabaff
[@frenck]: https://github.com/frenck
[@ktaragorn]: https://github.com/ktaragorn
[@marcelveldt]: https://github.com/marcelveldt
[@marvin-w]: https://github.com/marvin-w
[@masto]: https://github.com/masto
[@ollo69]: https://github.com/ollo69
[@ryborg]: https://github.com/ryborg
[@starkillerOG]: https://github.com/starkillerOG
[@thecode]: https://github.com/thecode
[@trdischat]: https://github.com/trdischat
[doorbird docs]: https://www.home-assistant.io/integrations/doorbird/
[flux_led docs]: https://www.home-assistant.io/integrations/flux_led/
[fronius docs]: https://www.home-assistant.io/integrations/fronius/
[google_assistant docs]: https://www.home-assistant.io/integrations/google_assistant/
[gree docs]: https://www.home-assistant.io/integrations/gree/
[gtfs docs]: https://www.home-assistant.io/integrations/gtfs/
[hassio docs]: https://www.home-assistant.io/integrations/hassio/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[izone docs]: https://www.home-assistant.io/integrations/izone/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[netatmo docs]: https://www.home-assistant.io/integrations/netatmo/
[no_ip docs]: https://www.home-assistant.io/integrations/no_ip/
[nut docs]: https://www.home-assistant.io/integrations/nut/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[sisyphus docs]: https://www.home-assistant.io/integrations/sisyphus/
[systemmonitor docs]: https://www.home-assistant.io/integrations/systemmonitor/
[tuya docs]: https://www.home-assistant.io/integrations/tuya/
[xiaomi_miio docs]: https://www.home-assistant.io/integrations/xiaomi_miio/	