### PR TITLE
Handle no enabled ipv4 addresses in the network integration

### DIFF
--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address, IPv6Address, ip_interface
 import logging
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
@@ -39,6 +40,10 @@ async def async_get_source_ip(
         _LOGGER.warning(
             "Because the system does not have any enabled IPv4 addresses, source address detection may be inaccurate"
         )
+        if source_ip is None:
+            raise HomeAssistantError(
+                "Could not determine source ip because the system does not have any enabled IPv4 addresses and creating a socket failed"
+            )
         return source_ip
 
     return source_ip if source_ip in all_ipv4s else all_ipv4s[0]

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from ipaddress import IPv4Address, IPv6Address, ip_interface
+import logging
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import ConfigType
@@ -11,6 +12,8 @@ from . import util
 from .const import IPV4_BROADCAST_ADDR, PUBLIC_TARGET_IP
 from .models import Adapter
 from .network import Network, async_get_network
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @bind_hass
@@ -32,6 +35,12 @@ async def async_get_source_ip(
             all_ipv4s.extend([ipv4["address"] for ipv4 in ipv4s])
 
     source_ip = util.async_get_source_ip(target_ip)
+    if not all_ipv4s:
+        _LOGGER.warning(
+            "Because the system does not have any enabled IPv4 addresses, source address detection may be inaccurate"
+        )
+        return source_ip
+
     return source_ip if source_ip in all_ipv4s else all_ipv4s[0]
 
 

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -3,6 +3,7 @@ from ipaddress import IPv4Address
 from unittest.mock import MagicMock, Mock, patch
 
 import ifaddr
+import pytest
 
 from homeassistant.components import network
 from homeassistant.components.network.const import (
@@ -13,6 +14,7 @@ from homeassistant.components.network.const import (
     STORAGE_KEY,
     STORAGE_VERSION,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 _NO_LOOPBACK_IPADDR = "192.168.1.5"
@@ -625,3 +627,26 @@ async def test_async_get_source_ip_no_enabled_addresses(hass, hass_storage, capl
         assert await network.async_get_source_ip(hass, MDNS_TARGET_IP) == "192.168.1.5"
 
     assert "source address detection may be inaccurate" in caplog.text
+
+
+async def test_async_get_source_ip_cannot_be_determined_and_no_enabled_addresses(
+    hass, hass_storage, caplog
+):
+    """Test getting the source ip address when all adapters are disabled and getting it fails."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "key": STORAGE_KEY,
+        "data": {ATTR_CONFIGURED_ADAPTERS: ["eth1"]},
+    }
+
+    with patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=[],
+    ), patch(
+        "homeassistant.components.network.util.socket.socket",
+        return_value=_mock_socket([None]),
+    ):
+        assert not await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+        with pytest.raises(HomeAssistantError):
+            await network.async_get_source_ip(hass, MDNS_TARGET_IP)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes
```
2022-01-03 13:46:08 ERROR (MainThread) [homeassistant.setup] Error during setup of component http
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.9/site-packages/homeassistant/setup.py", line 229, in _async_setup_component
    result = await task
  File "/srv/homeassistant/lib/python3.9/site-packages/homeassistant/components/http/__init__.py", line 192, in async_setup
    local_ip = await async_get_source_ip(hass)
  File "/srv/homeassistant/lib/python3.9/site-packages/homeassistant/components/network/__init__.py", line 35, in async_get_source_ip
    return source_ip if source_ip in all_ipv4s else all_ipv4s[0]
IndexError: list index out of range
```

Reported here: https://community.home-assistant.io/t/2021-12-new-configuration-menu-the-button-entity-and-gorgeous-area-cards/365680/776?u=bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
