### PR TITLE
Minor bugfixes for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -203,10 +203,6 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
             self._async_update_extra_attrs_from_protect()
         )
 
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed from hass."""
-        return await super().async_will_remove_from_hass()
-
 
 class ProtectDiskBinarySensor(ProtectNVREntity, BinarySensorEntity):
     """A UniFi Protect NVR Disk Binary Sensor."""

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from copy import copy
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 import logging
-from typing import Any, Final
+from typing import Any
 
 from pyunifiprotect.data import NVR, Camera, Light, Sensor
 
@@ -13,17 +12,16 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_OCCUPANCY,
     DEVICE_CLASS_PROBLEM,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_LAST_TRIP_TIME, ATTR_MODEL
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
-from homeassistant.util.dt import utcnow
 
 from .const import DOMAIN
 from .data import ProtectData
@@ -48,18 +46,15 @@ _KEY_DARK = "dark"
 _KEY_BATTERY_LOW = "battery_low"
 _KEY_DISK_HEALTH = "disk_health"
 
-DEVICE_CLASS_RING: Final = "unifiprotect__ring"
-RING_INTERVAL = timedelta(seconds=3)
-
 
 CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key=_KEY_DOORBELL,
-        name="Doorbell Chime",
-        device_class=DEVICE_CLASS_RING,
+        name="Doorbell",
+        device_class=DEVICE_CLASS_OCCUPANCY,
         icon="mdi:doorbell-video",
         ufp_required_field="feature_flags.has_chime",
-        ufp_value="last_ring",
+        ufp_value="is_ringing",
     ),
     ProtectBinaryEntityDescription(
         key=_KEY_DARK,
@@ -169,7 +164,6 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
             self.device: Camera | Light | Sensor = device
         self.entity_description: ProtectBinaryEntityDescription = description
         super().__init__(data)
-        self._doorbell_callback: CALLBACK_TYPE | None = None
 
     @callback
     def _async_update_extra_attrs_from_protect(self) -> dict[str, Any]:
@@ -202,40 +196,9 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
 
         assert self.entity_description.ufp_value is not None
 
-        self._attr_extra_state_attributes = (
-            self._async_update_extra_attrs_from_protect()
+        self._attr_is_on = get_nested_attr(
+            self.device, self.entity_description.ufp_value
         )
-
-        if self.entity_description.key == _KEY_DOORBELL:
-            last_ring = get_nested_attr(self.device, self.entity_description.ufp_value)
-            now = utcnow()
-
-            is_ringing = (
-                False if last_ring is None else (now - last_ring) < RING_INTERVAL
-            )
-            _LOGGER.warning("%s, %s, %s", last_ring, now, is_ringing)
-            if is_ringing:
-                self._async_cancel_doorbell_callback()
-                self._doorbell_callback = async_call_later(
-                    self.hass, RING_INTERVAL, self._async_reset_doorbell
-                )
-            self._attr_is_on = is_ringing
-        else:
-            self._attr_is_on = get_nested_attr(
-                self.device, self.entity_description.ufp_value
-            )
-
-    @callback
-    def _async_cancel_doorbell_callback(self) -> None:
-        if self._doorbell_callback is not None:
-            _LOGGER.debug("Canceling doorbell ring callback")
-            self._doorbell_callback()
-            self._doorbell_callback = None
-
-    async def _async_reset_doorbell(self, now: datetime) -> None:
-        _LOGGER.debug("Doorbell ring ended")
-        self._doorbell_callback = None
-        self._async_updated_event()
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -199,10 +199,12 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
         self._attr_is_on = get_nested_attr(
             self.device, self.entity_description.ufp_value
         )
+        self._attr_extra_state_attributes = (
+            self._async_update_extra_attrs_from_protect()
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        self._async_cancel_doorbell_callback()
         return await super().async_will_remove_from_hass()
 
 

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 import logging
 
 from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import Camera as UFPCamera
+from pyunifiprotect.data import Camera as UFPCamera, StateType
 from pyunifiprotect.data.devices import CameraChannel
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
@@ -137,9 +137,12 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
         super()._async_update_device_from_protect()
         self.channel = self.device.channels[self.channel.id]
         self._attr_motion_detection_enabled = (
-            self.device.is_connected and self.device.feature_flags.has_motion_zones
+            self.device.state == StateType.CONNECTED
+            and self.device.feature_flags.has_motion_zones
         )
-        self._attr_is_recording = self.device.is_connected and self.device.is_recording
+        self._attr_is_recording = (
+            self.device.state == StateType.CONNECTED and self.device.is_recording
+        )
 
         self._async_set_stream_source()
         self._attr_extra_state_attributes = {

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "requirements": [
-    "pyunifiprotect==1.4.8"
+    "pyunifiprotect==1.5.3"
   ],
   "codeowners": [
     "@briis",

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -443,6 +443,9 @@ class ProtectNVRSensor(SensorValueMixin, ProtectNVREntity, SensorEntity):
         # _KEY_MEMORY
         if self.entity_description.ufp_value is None:
             memory = self.device.system_info.memory
+            if memory.available is None or memory.total is None:
+                self._attr_available = False
+                return
             value = (1 - memory.available / memory.total) * 100
         else:
             value = get_nested_attr(self.device, self.entity_description.ufp_value)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2006,7 +2006,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==1.4.8
+pyunifiprotect==1.5.3
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==21.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1228,7 +1228,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==1.4.8
+pyunifiprotect==1.5.3
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==21.11.0

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -2,9 +2,7 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
-from copy import copy
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 
 import pytest
 from pyunifiprotect.data import Camera, Light
@@ -13,7 +11,6 @@ from pyunifiprotect.data.devices import Sensor
 from homeassistant.components.unifiprotect.binary_sensor import (
     CAMERA_SENSORS,
     LIGHT_SENSORS,
-    RING_INTERVAL,
     SENSE_SENSORS,
 )
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
@@ -21,18 +18,15 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_LAST_TRIP_TIME,
     STATE_OFF,
-    STATE_ON,
     Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.dt import utcnow
 
 from .conftest import (
     MockEntityFixture,
     assert_entity_counts,
     ids_from_device_description,
-    time_changed,
 )
 
 
@@ -209,22 +203,35 @@ async def test_binary_sensor_setup_camera_all(
 
     entity_registry = er.async_get(hass)
 
-    for index, description in enumerate(CAMERA_SENSORS):
-        unique_id, entity_id = ids_from_device_description(
-            Platform.BINARY_SENSOR, camera, description
-        )
+    description = CAMERA_SENSORS[0]
+    unique_id, entity_id = ids_from_device_description(
+        Platform.BINARY_SENSOR, camera, description
+    )
 
-        entity = entity_registry.async_get(entity_id)
-        assert entity
-        assert entity.unique_id == unique_id
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert entity.unique_id == unique_id
 
-        state = hass.states.get(entity_id)
-        assert state
-        assert state.state == STATE_OFF
-        assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
-        if index == 0:
-            assert state.attributes[ATTR_LAST_TRIP_TIME] == now - timedelta(hours=1)
+    assert state.attributes[ATTR_LAST_TRIP_TIME] == now - timedelta(hours=1)
+
+    description = CAMERA_SENSORS[1]
+    unique_id, entity_id = ids_from_device_description(
+        Platform.BINARY_SENSOR, camera, description
+    )
+
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert entity.unique_id == unique_id
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
 
 async def test_binary_sensor_setup_camera_none(
@@ -274,52 +281,3 @@ async def test_binary_sensor_setup_sensor(
 
         if index != 1:
             assert state.attributes[ATTR_LAST_TRIP_TIME] == expected_trip_time
-
-
-async def test_binary_sensor_update_doorbell(
-    hass: HomeAssistant,
-    mock_entry: MockEntityFixture,
-    camera: Camera,
-):
-    """Test select entity update (change doorbell message)."""
-
-    _, entity_id = ids_from_device_description(
-        Platform.BINARY_SENSOR, camera, CAMERA_SENSORS[0]
-    )
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-
-    new_bootstrap = copy(mock_entry.api.bootstrap)
-    new_camera = camera.copy()
-    new_camera.last_ring = utcnow()
-
-    mock_msg = Mock()
-    mock_msg.changed_data = {}
-    mock_msg.new_obj = new_camera
-
-    new_bootstrap.cameras = {new_camera.id: new_camera}
-    mock_entry.api.bootstrap = new_bootstrap
-    mock_entry.api.ws_subscription(mock_msg)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON
-
-    # fire event a second time for code coverage (cancel existing)
-    mock_entry.api.ws_subscription(mock_msg)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON
-
-    # since time is not really changing, switch the last ring back to allow turn off
-    new_camera.last_ring = utcnow() - RING_INTERVAL
-    await time_changed(hass, RING_INTERVAL.total_seconds())
-    await hass.async_block_till_done()
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A backport of some bugfixes from HACS integration:

* Upgrade `pyunifiprotect` to 1.5.3. Changelog: https://github.com/briis/pyunifiprotect/compare/v1.4.8...v1.5.3 
    * Most notable is better UP Sense support, so no errors are thrown about the new events and some bugfixes
* Fixes NVR memory sensor if no data was reported
* Fixes "is connected" check for camera entities
* Removes custom device class for Doorbell Ring sensor since downstream things (i.e. HomeKit) expect a doorbell ring to be an occupancy 
* Reworks Doorbell Ring sensor to make it significantly more reliable and work like other binary sensors
    * This also addresses @MartinHjelmare's feedback: https://github.com/home-assistant/core/pull/63489#discussion_r779503963

TODO for the rest of the UniFi Protect HACS migration after this PR:

* camera motion sensors + views & docs
* `ufp_value` -> lambda refactor (ref: https://github.com/home-assistant/core/pull/63220#discussion_r777231482)
* global services & docs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
