### PR TITLE
Add last_reset for Sense trend sensors

### DIFF
--- a/homeassistant/components/emulated_kasa/manifest.json
+++ b/homeassistant/components/emulated_kasa/manifest.json
@@ -2,7 +2,7 @@
   "domain": "emulated_kasa",
   "name": "Emulated Kasa",
   "documentation": "https://www.home-assistant.io/integrations/emulated_kasa",
-  "requirements": ["sense_energy==0.9.3"],
+  "requirements": ["sense_energy==0.9.4"],
   "codeowners": ["@kbickar"],
   "quality_scale": "internal",
   "iot_class": "local_push"

--- a/homeassistant/components/emulated_kasa/manifest.json
+++ b/homeassistant/components/emulated_kasa/manifest.json
@@ -2,7 +2,7 @@
   "domain": "emulated_kasa",
   "name": "Emulated Kasa",
   "documentation": "https://www.home-assistant.io/integrations/emulated_kasa",
-  "requirements": ["sense_energy==0.9.4"],
+  "requirements": ["sense_energy==0.9.6"],
   "codeowners": ["@kbickar"],
   "quality_scale": "internal",
   "iot_class": "local_push"

--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+import homeassistant.util.dt as dt_util
 
 from .const import (
     ACTIVE_UPDATE_RATE,
@@ -91,11 +92,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except SENSE_EXCEPTIONS as err:
         raise ConfigEntryNotReady(str(err) or "Error during realtime update") from err
 
+    async def _update_func():
+        await gateway.update_trend_data(dt_util.now())
+
     trends_coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=f"Sense Trends {email}",
-        update_method=gateway.update_trend_data,
+        update_method=_update_func,
         update_interval=timedelta(seconds=300),
     )
     # Start out as unavailable so we do not report 0 data

--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-import homeassistant.util.dt as dt_util
 
 from .const import (
     ACTIVE_UPDATE_RATE,
@@ -92,14 +91,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except SENSE_EXCEPTIONS as err:
         raise ConfigEntryNotReady(str(err) or "Error during realtime update") from err
 
-    async def _update_func():
-        await gateway.update_trend_data(dt_util.now())
-
     trends_coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=f"Sense Trends {email}",
-        update_method=_update_func,
+        update_method=gateway.update_trend_data,
         update_interval=timedelta(seconds=300),
     )
     # Start out as unavailable so we do not report 0 data

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sense",
   "name": "Sense",
   "documentation": "https://www.home-assistant.io/integrations/sense",
-  "requirements": ["sense_energy==0.9.3"],
+  "requirements": ["sense_energy==0.9.4"],
   "codeowners": ["@kbickar"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sense",
   "name": "Sense",
   "documentation": "https://www.home-assistant.io/integrations/sense",
-  "requirements": ["sense_energy==0.9.4"],
+  "requirements": ["sense_energy==0.9.6"],
   "codeowners": ["@kbickar"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -1,4 +1,5 @@
 """Support for monitoring a Sense energy sensor."""
+from datetime import timedelta
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -15,7 +16,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import homeassistant.util.dt as dt_util
-from datetime import timedelta
 
 from .const import (
     ACTIVE_NAME,

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -1,5 +1,6 @@
 """Support for monitoring a Sense energy sensor."""
 from datetime import timedelta
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -1,5 +1,4 @@
 """Support for monitoring a Sense energy sensor."""
-from datetime import timedelta
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -16,7 +15,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-import homeassistant.util.dt as dt_util
 
 from .const import (
     ACTIVE_NAME,
@@ -61,7 +59,6 @@ ACTIVE_SENSOR_TYPE = SensorConfig(ACTIVE_NAME, ACTIVE_TYPE)
 
 # Sensor types/ranges
 TRENDS_SENSOR_TYPES = {
-    "hourly": SensorConfig("Hourly", "HOUR"),
     "daily": SensorConfig("Daily", "DAY"),
     "weekly": SensorConfig("Weekly", "WEEK"),
     "monthly": SensorConfig("Monthly", "MONTH"),
@@ -277,27 +274,6 @@ class SenseTrendsSensor(CoordinatorEntity, SensorEntity):
         self._sensor_type = sensor_type
         self._variant_id = variant_id
         self._had_any_update = False
-        self._last_update = None
-        if self._sensor_type == "DAY":
-            self._last_update = dt_util.now().day
-            self._attr_last_reset = dt_util.now().replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-        elif self._sensor_type == "WEEK":
-            self._last_update = dt_util.now().day
-            self._attr_last_reset = (dt_util.now() - timedelta(days=7)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-        elif self._sensor_type == "MONTH":
-            self._last_update = dt_util.now().month
-            self._attr_last_reset = dt_util.now().replace(
-                day=1, hour=0, minute=0, second=0, microsecond=0
-            )
-        elif self._sensor_type == "YEAR":
-            self._last_update = dt_util.now().year
-            self._attr_last_reset = dt_util.now().replace(
-                month=1, day=1, hour=0, minute=0, second=0, microsecond=0
-            )
         if variant_id in [PRODUCTION_PCT_ID, SOLAR_POWERED_ID]:
             self._attr_native_unit_of_measurement = PERCENTAGE
             self._attr_entity_registry_enabled_default = False
@@ -316,28 +292,10 @@ class SenseTrendsSensor(CoordinatorEntity, SensorEntity):
         """Return the state of the sensor."""
         return round(self._data.get_trend(self._sensor_type, self._variant_id), 1)
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-
-        if self._sensor_type == "DAY":
-            new_update = dt_util.now().day
-        elif self._sensor_type == "WEEK":
-            new_update = dt_util.now().day
-        elif self._sensor_type == "MONTH":
-            new_update = dt_util.now().month
-        elif self._sensor_type == "YEAR":
-            new_update = dt_util.now().year
-        else:
-            new_update = -1
-        if self._last_update != new_update:
-            self._last_update = new_update
-            if self._sensor_type == "WEEK":
-                # Week trend sensor is a rolling window of the past 7 days, not a calendar week
-                self._attr_last_reset = dt_util.utcnow() - timedelta(days=7)
-            else:
-                self._attr_last_reset = dt_util.utcnow()
-        super()._handle_coordinator_update()
+    @property
+    def last_reset(self):
+        """Return the time when the sensor was last reset, if any."""
+        return self._data.trend_start(self._sensor_type)
 
 
 class SenseEnergyDevice(SensorEntity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2151,7 +2151,7 @@ sense-hat==2.2.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.9.3
+sense_energy==0.9.4
 
 # homeassistant.components.sentry
 sentry-sdk==1.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2151,7 +2151,7 @@ sense-hat==2.2.0
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.9.4
+sense_energy==0.9.6
 
 # homeassistant.components.sentry
 sentry-sdk==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1295,7 +1295,7 @@ screenlogicpy==0.5.3
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.9.3
+sense_energy==0.9.4
 
 # homeassistant.components.sentry
 sentry-sdk==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1295,7 +1295,7 @@ screenlogicpy==0.5.3
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense_energy==0.9.4
+sense_energy==0.9.6
 
 # homeassistant.components.sentry
 sentry-sdk==1.5.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the last_reset attribute for trend sensors.  This prevents them from showing a large spike at the start of the day

A small update was needed for the sense api library to allow the date to be passed to fix a problem with the last_reset not being set correctly if the timezone of the HA machine didn't match.
 https://github.com/scottbonline/sense/releases/tag/0.9.4
 https://github.com/scottbonline/sense/releases/tag/0.9.5
 https://github.com/scottbonline/sense/releases/tag/0.9.6

https://github.com/scottbonline/sense/compare/0.9.3...0.9.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #59801
  - fixes #62568
  - fixes #63226
- This PR is related to issue: 
- Link to documentation pull request: 
- 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
