### PR TITLE
Allow registering a webhook as local only

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -288,6 +288,7 @@ class AbstractConfig(ABC):
                     "Local Support for " + user_agent_id,
                     webhook_id,
                     self._handle_local_webhook,
+                    local_only=True,
                 )
                 setup_webhook_ids.append(webhook_id)
             except ValueError:

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -118,7 +118,7 @@ async def async_handle_webhook(hass, webhook_id, request):
             return Response(status=HTTPStatus.OK)
 
         if not network.is_local(remote):
-            _LOGGER.debug("Received remote request for local webhook %s", webhook_id)
+            _LOGGER.warning("Received remote request for local webhook %s", webhook_id)
             return Response(status=HTTPStatus.OK)
 
     try:

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
+from ipaddress import ip_address
 import logging
 import secrets
 
@@ -15,6 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
+from homeassistant.util import network
 from homeassistant.util.aiohttp import MockRequest
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +40,8 @@ def async_register(
     name: str,
     webhook_id: str,
     handler: Callable[[HomeAssistant, str, Request], Awaitable[Response | None]],
+    *,
+    local_only=False,
 ) -> None:
     """Register a webhook."""
     handlers = hass.data.setdefault(DOMAIN, {})
@@ -45,7 +49,12 @@ def async_register(
     if webhook_id in handlers:
         raise ValueError("Handler is already defined!")
 
-    handlers[webhook_id] = {"domain": domain, "name": name, "handler": handler}
+    handlers[webhook_id] = {
+        "domain": domain,
+        "name": name,
+        "handler": handler,
+        "local_only": local_only,
+    }
 
 
 @callback
@@ -101,6 +110,17 @@ async def async_handle_webhook(hass, webhook_id, request):
         _LOGGER.debug("%s", content)
         return Response(status=HTTPStatus.OK)
 
+    if webhook["local_only"]:
+        try:
+            remote = ip_address(request.remote)
+        except ValueError:
+            _LOGGER.debug("Unable to parse remote ip %s", request.remote)
+            return Response(status=HTTPStatus.OK)
+
+        if not network.is_local(remote):
+            _LOGGER.debug("Received remote request for local webhook %s", webhook_id)
+            return Response(status=HTTPStatus.OK)
+
     try:
         response = await webhook["handler"](hass, webhook_id, request)
         if response is None:
@@ -145,7 +165,12 @@ def websocket_list(hass, connection, msg):
     """Return a list of webhooks."""
     handlers = hass.data.setdefault(DOMAIN, {})
     result = [
-        {"webhook_id": webhook_id, "domain": info["domain"], "name": info["name"]}
+        {
+            "webhook_id": webhook_id,
+            "domain": info["domain"],
+            "name": info["name"],
+            "local_only": info["local_only"],
+        }
         for webhook_id, info in handlers.items()
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows registering a webhook as local only. It will no longer respond to requests received via remote if set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
