### PR TITLE
Revert "Bump google-cloud-pubsub to 2.9.0 (to bump grpcio)"

### DIFF
--- a/homeassistant/components/google_pubsub/manifest.json
+++ b/homeassistant/components/google_pubsub/manifest.json
@@ -2,7 +2,7 @@
   "domain": "google_pubsub",
   "name": "Google Pub/Sub",
   "documentation": "https://www.home-assistant.io/integrations/google_pubsub",
-  "requirements": ["google-cloud-pubsub==2.9.0"],
+  "requirements": ["google-cloud-pubsub==2.1.0"],
   "codeowners": [],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -53,6 +53,16 @@ h11>=0.12.0
 # https://github.com/advisories/GHSA-93xj-8mrv-444m
 httplib2>=0.19.0
 
+# gRPC 1.32+ currently causes issues on ARMv7, see:
+# https://github.com/home-assistant/core/issues/40148
+# Newer versions of some other libraries pin a higher version of grpcio,
+# so those also need to be kept at an old version until the grpcio pin
+# is reverted, see:
+# https://github.com/home-assistant/core/issues/53427
+grpcio==1.31.0
+google-cloud-pubsub==2.1.0
+google-api-core<=1.31.2
+
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -746,7 +746,7 @@ goodwe==0.2.10
 google-api-python-client==1.6.4
 
 # homeassistant.components.google_pubsub
-google-cloud-pubsub==2.9.0
+google-cloud-pubsub==2.1.0
 
 # homeassistant.components.google_cloud
 google-cloud-texttospeech==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -474,7 +474,7 @@ goodwe==0.2.10
 google-api-python-client==1.6.4
 
 # homeassistant.components.google_pubsub
-google-cloud-pubsub==2.9.0
+google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
 google-nest-sdm==1.3.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -79,6 +79,16 @@ h11>=0.12.0
 # https://github.com/advisories/GHSA-93xj-8mrv-444m
 httplib2>=0.19.0
 
+# gRPC 1.32+ currently causes issues on ARMv7, see:
+# https://github.com/home-assistant/core/issues/40148
+# Newer versions of some other libraries pin a higher version of grpcio,
+# so those also need to be kept at an old version until the grpcio pin
+# is reverted, see:
+# https://github.com/home-assistant/core/issues/53427
+grpcio==1.31.0
+google-cloud-pubsub==2.1.0
+google-api-core<=1.31.2
+
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
 


### PR DESCRIPTION
Reverts home-assistant/core#63493

https://github.com/home-assistant/core/runs/4719615426?check_suite_focus=true

Make our wheels builds fail.

```
39-i386-linux-gnu.so -lpthread -Wl,-wrap,memcpy -static-libgcc -lexecinfo
  /usr/lib/gcc/i586-alpine-linux-musl/10.3.1/../../../../i586-alpine-linux-musl/bin/ld: cannot find -lpthread -Wl,-wrap,memcpy -static-libgcc -lexecinfo
  collect2: error: ld returned 1 exit status
  Traceback (most recent call last):
    File "/usr/local/lib/python3.9/distutils/unixccompiler.py", line 204, in link
      self.spawn(linker + ld_args)
    File "/tmp/pip-wheel-z3akzlva/grpcio/src/python/grpcio/_spawn_patch.py", line 54, in _commandfile_spawn
      _classic_spawn(self, command)
    File "/usr/local/lib/python3.9/distutils/ccompiler.py", line 910, in spawn
      spawn(cmd, dry_run=self.dry_run)
    File "/usr/local/lib/python3.9/distutils/spawn.py", line 91, in spawn
      raise DistutilsExecError(
```

Discussed this with @allenporter on Discord as the best action to take for now.