### PR TITLE
Use device properties for WeMo Insight sensors

### DIFF
--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -63,16 +63,11 @@ async def async_setup_entry(
 
     async def _discovered_wemo(coordinator: DeviceCoordinator) -> None:
         """Handle a discovered Wemo device."""
-        sensors: list[SensorEntity] = []
-
-        # Add attribute sensors.
-        sensors.extend(
+        async_add_entities(
             AttributeSensor(coordinator, description)
             for description in ATTRIBUTE_SENSORS
             if hasattr(coordinator.wemo, description.key)
         )
-
-        async_add_entities(sensors)
 
     async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.sensor", _discovered_wemo)
 

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -115,10 +115,7 @@ class AttributeSensor(WemoEntity, SensorEntity):
             return value
         if (convert := self.entity_description.state_conversion) is None:
             return value
-        try:
-            return convert(self, value)
-        except ValueError:
-            return None
+        return convert(self, value)
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -100,17 +100,14 @@ class AttributeSensor(WemoEntity, SensorEntity):
     @property
     def unique_id_suffix(self) -> str | None:
         """Suffix to append to the WeMo device's unique ID."""
-        if (suffix := self.entity_description.unique_id_suffix) is not None:
-            return suffix
-        return super().unique_id_suffix
+        assert self.entity_description.unique_id_suffix
+        return self.entity_description.unique_id_suffix
 
     def convert_state(self, value: StateType) -> StateType:
         """Convert native state to a value appropriate for the sensor."""
-        if value is None:
-            return value
-        if (convert := self.entity_description.state_conversion) is None:
-            return value
-        return convert(value)
+        assert value is not None
+        assert self.entity_description.state_conversion
+        return self.entity_description.state_conversion(value)
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -87,13 +87,13 @@ class AttributeSensor(WemoEntity, SensorEntity):
     def __init__(
         self, coordinator: DeviceCoordinator, description: AttributeSensorDescription
     ) -> None:
-        """Init InsightSensor."""
+        """Init AttributeSensor."""
         super().__init__(coordinator)
         self.entity_description = description
 
     @property
     def name_suffix(self) -> str:
-        """Return the name of the entity if any."""
+        """Return the name of the entity."""
         assert self.entity_description.name
         return self.entity_description.name
 

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -104,7 +104,7 @@ class AttributeSensor(WemoEntity, SensorEntity):
     def convert_state(self, value: StateType) -> StateType:
         """Convert native state to a value appropriate for the sensor."""
         if (convert := self.entity_description.state_conversion) is None:
-            return value
+            return None
         return convert(value)
 
     @property

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -1,5 +1,10 @@
 """Support for power sensors in WeMo Insight devices."""
+from __future__ import annotations
+
 import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -13,11 +18,40 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.util import convert
 
 from .const import DOMAIN as WEMO_DOMAIN
 from .entity import WemoEntity
 from .wemo_device import DeviceCoordinator
+
+
+@dataclass
+class AttributeSensorDescription(SensorEntityDescription):
+    """SensorEntityDescription for WeMo AttributeSensor entities."""
+
+    state_conversion: Callable[[AttributeSensor, StateType], StateType] | None = None
+    unique_id_suffix: str | None = None
+
+
+ATTRIBUTE_SENSORS = (
+    AttributeSensorDescription(
+        name="Current Power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=POWER_WATT,
+        key="current_power_watts",
+        unique_id_suffix="currentpower",
+        state_conversion=lambda sensor, state: round(cast(float, state), 2),
+    ),
+    AttributeSensorDescription(
+        name="Today Energy",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        key="today_kwh",
+        unique_id_suffix="todaymw",
+        state_conversion=lambda sensor, state: round(cast(float, state), 2),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -29,9 +63,16 @@ async def async_setup_entry(
 
     async def _discovered_wemo(coordinator: DeviceCoordinator) -> None:
         """Handle a discovered Wemo device."""
-        async_add_entities(
-            [InsightCurrentPower(coordinator), InsightTodayEnergy(coordinator)]
+        sensors: list[SensorEntity] = []
+
+        # Add attribute sensors.
+        sensors.extend(
+            AttributeSensor(coordinator, description)
+            for description in ATTRIBUTE_SENSORS
+            if hasattr(coordinator.wemo, description.key)
         )
+
+        async_add_entities(sensors)
 
     async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.sensor", _discovered_wemo)
 
@@ -43,8 +84,17 @@ async def async_setup_entry(
     )
 
 
-class InsightSensor(WemoEntity, SensorEntity):
-    """Common base for WeMo Insight power sensors."""
+class AttributeSensor(WemoEntity, SensorEntity):
+    """Sensor that reads attributes of a wemo device."""
+
+    entity_description: AttributeSensorDescription
+
+    def __init__(
+        self, coordinator: DeviceCoordinator, description: AttributeSensorDescription
+    ) -> None:
+        """Init InsightSensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
 
     @property
     def name_suffix(self) -> str:
@@ -53,56 +103,24 @@ class InsightSensor(WemoEntity, SensorEntity):
         return self.entity_description.name
 
     @property
-    def unique_id_suffix(self) -> str:
-        """Return the id of this entity."""
-        return self.entity_description.key
+    def unique_id_suffix(self) -> str | None:
+        """Suffix to append to the WeMo device's unique ID."""
+        if (suffix := self.entity_description.unique_id_suffix) is not None:
+            return suffix
+        return super().unique_id_suffix
 
-    @property
-    def available(self) -> bool:
-        """Return true if sensor is available."""
-        return (
-            self.entity_description.key in self.wemo.insight_params
-            and super().available
-        )
-
-
-class InsightCurrentPower(InsightSensor):
-    """Current instantaineous power consumption."""
-
-    entity_description = SensorEntityDescription(
-        key="currentpower",
-        name="Current Power",
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=POWER_WATT,
-    )
+    def convert_state(self, value: StateType) -> StateType:
+        """Convert native state to a value appropriate for the sensor."""
+        if value is None:
+            return value
+        if (convert := self.entity_description.state_conversion) is None:
+            return value
+        try:
+            return convert(self, value)
+        except ValueError:
+            return None
 
     @property
     def native_value(self) -> StateType:
-        """Return the current power consumption."""
-        milliwatts = convert(
-            self.wemo.insight_params.get(self.entity_description.key), float, 0.0
-        )
-        assert isinstance(milliwatts, float)
-        return milliwatts / 1000.0
-
-
-class InsightTodayEnergy(InsightSensor):
-    """Energy used today."""
-
-    entity_description = SensorEntityDescription(
-        key="todaymw",
-        name="Today Energy",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-    )
-
-    @property
-    def native_value(self) -> StateType:
-        """Return the current energy use today."""
-        milliwatt_seconds = convert(
-            self.wemo.insight_params.get(self.entity_description.key), float, 0.0
-        )
-        assert isinstance(milliwatt_seconds, float)
-        return round(milliwatt_seconds / (1000.0 * 1000.0 * 60), 2)
+        """Return the value of the device attribute."""
+        return self.convert_state(getattr(self.wemo, self.entity_description.key))

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -28,7 +28,7 @@ from .wemo_device import DeviceCoordinator
 class AttributeSensorDescription(SensorEntityDescription):
     """SensorEntityDescription for WeMo AttributeSensor entities."""
 
-    state_conversion: Callable[[AttributeSensor, StateType], StateType] | None = None
+    state_conversion: Callable[[StateType], StateType] | None = None
     unique_id_suffix: str | None = None
 
 
@@ -40,7 +40,7 @@ ATTRIBUTE_SENSORS = (
         native_unit_of_measurement=POWER_WATT,
         key="current_power_watts",
         unique_id_suffix="currentpower",
-        state_conversion=lambda sensor, state: round(cast(float, state), 2),
+        state_conversion=lambda state: round(cast(float, state), 2),
     ),
     AttributeSensorDescription(
         name="Today Energy",
@@ -49,7 +49,7 @@ ATTRIBUTE_SENSORS = (
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         key="today_kwh",
         unique_id_suffix="todaymw",
-        state_conversion=lambda sensor, state: round(cast(float, state), 2),
+        state_conversion=lambda state: round(cast(float, state), 2),
     ),
 )
 
@@ -110,7 +110,7 @@ class AttributeSensor(WemoEntity, SensorEntity):
             return value
         if (convert := self.entity_description.state_conversion) is None:
             return value
-        return convert(self, value)
+        return convert(value)
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -103,8 +103,9 @@ class AttributeSensor(WemoEntity, SensorEntity):
 
     def convert_state(self, value: StateType) -> StateType:
         """Convert native state to a value appropriate for the sensor."""
-        assert self.entity_description.state_conversion
-        return self.entity_description.state_conversion(value)
+        if (convert := self.entity_description.state_conversion) is None:
+            return value
+        return convert(value)
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -92,20 +92,17 @@ class AttributeSensor(WemoEntity, SensorEntity):
         self.entity_description = description
 
     @property
-    def name_suffix(self) -> str:
+    def name_suffix(self) -> str | None:
         """Return the name of the entity."""
-        assert self.entity_description.name
         return self.entity_description.name
 
     @property
     def unique_id_suffix(self) -> str | None:
         """Suffix to append to the WeMo device's unique ID."""
-        assert self.entity_description.unique_id_suffix
         return self.entity_description.unique_id_suffix
 
     def convert_state(self, value: StateType) -> StateType:
         """Convert native state to a value appropriate for the sensor."""
-        assert value is not None
         assert self.entity_description.state_conversion
         return self.entity_description.state_conversion(value)
 

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -15,6 +15,9 @@ MOCK_PORT = 50000
 MOCK_NAME = "WemoDeviceName"
 MOCK_SERIAL_NUMBER = "WemoSerialNumber"
 MOCK_FIRMWARE_VERSION = "WeMo_WW_2.00.XXXXX.PVT-OWRT"
+MOCK_INSIGHT_CURRENT_WATTS = 0.01
+MOCK_INSIGHT_TODAY_KWH = 3.33
+MOCK_INSIGHT_STATE_THRESHOLD_POWER = 8.0
 
 
 @pytest.fixture(name="pywemo_model")
@@ -63,6 +66,15 @@ def pywemo_device_fixture(pywemo_registry, pywemo_model):
     device.firmware_version = MOCK_FIRMWARE_VERSION
     device.get_state.return_value = 0  # Default to Off
     device.supports_long_press.return_value = cls.supports_long_press()
+
+    if issubclass(cls, pywemo.Insight):
+        device.get_standby_state = pywemo.StandbyState.OFF
+        device.current_power_watts = MOCK_INSIGHT_CURRENT_WATTS
+        device.today_kwh = MOCK_INSIGHT_TODAY_KWH
+        device.threshold_power_watts = MOCK_INSIGHT_STATE_THRESHOLD_POWER
+        device.on_for = 1234
+        device.today_on_time = 5678
+        device.total_on_time = 9012
 
     url = f"http://{MOCK_HOST}:{MOCK_PORT}/setup.xml"
     with patch("pywemo.setup_url_for_address", return_value=url), patch(

--- a/tests/components/wemo/test_sensor.py
+++ b/tests/components/wemo/test_sensor.py
@@ -2,13 +2,7 @@
 
 import pytest
 
-from homeassistant.components.homeassistant import (
-    DOMAIN as HA_DOMAIN,
-    SERVICE_UPDATE_ENTITY,
-)
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
-from homeassistant.setup import async_setup_component
-
+from .conftest import MOCK_INSIGHT_CURRENT_WATTS, MOCK_INSIGHT_TODAY_KWH
 from .entity_test_helpers import EntityTestHelpers
 
 
@@ -38,7 +32,6 @@ class InsightTestTemplate(EntityTestHelpers):
 
     ENTITY_ID_SUFFIX: str
     EXPECTED_STATE_VALUE: str
-    INSIGHT_PARAM_NAME: str
 
     @pytest.fixture(name="wemo_entity_suffix")
     @classmethod
@@ -46,30 +39,20 @@ class InsightTestTemplate(EntityTestHelpers):
         """Select the appropriate entity for the test."""
         return cls.ENTITY_ID_SUFFIX
 
-    async def test_state_unavailable(self, hass, wemo_entity, pywemo_device):
-        """Test that there is no failure if the insight_params is not populated."""
-        del pywemo_device.insight_params[self.INSIGHT_PARAM_NAME]
-        await async_setup_component(hass, HA_DOMAIN, {})
-        await hass.services.async_call(
-            HA_DOMAIN,
-            SERVICE_UPDATE_ENTITY,
-            {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
-            blocking=True,
-        )
-        assert hass.states.get(wemo_entity.entity_id).state == STATE_UNAVAILABLE
+    def test_state(self, hass, wemo_entity):
+        """Test the sensor state."""
+        assert hass.states.get(wemo_entity.entity_id).state == self.EXPECTED_STATE_VALUE
 
 
 class TestInsightCurrentPower(InsightTestTemplate):
     """Test the InsightCurrentPower class."""
 
     ENTITY_ID_SUFFIX = "_current_power"
-    EXPECTED_STATE_VALUE = "0.001"
-    INSIGHT_PARAM_NAME = "currentpower"
+    EXPECTED_STATE_VALUE = str(MOCK_INSIGHT_CURRENT_WATTS)
 
 
 class TestInsightTodayEnergy(InsightTestTemplate):
     """Test the InsightTodayEnergy class."""
 
     ENTITY_ID_SUFFIX = "_today_energy"
-    EXPECTED_STATE_VALUE = "3.33"
-    INSIGHT_PARAM_NAME = "todaymw"
+    EXPECTED_STATE_VALUE = str(MOCK_INSIGHT_TODAY_KWH)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/pywemo/pywemo/pull/307 in pyWeMo version [0.7.0](https://github.com/pywemo/pywemo/releases/tag/0.7.0) added `today_kwh` & `current_power_watts` properties on the Insight device class. This PR uses those properties to avoid duplicating the calculations here in Home Assistant.

This also offered the chance to simplify the sensor logic. The wemo sensor component can now more easily use a list of `SensorEntityDescription` instances like many other sensor implementations do.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
