### PR TITLE
Add config flow to the Matrix integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -631,7 +631,9 @@ omit =
     homeassistant/components/mailgun/notify.py
     homeassistant/components/map/*
     homeassistant/components/mastodon/notify.py
-    homeassistant/components/matrix/*
+    homeassistant/components/matrix/notify.py
+    homeassistant/components/matrix/__init__.py
+    homeassistant/components/matrix/const.py
     homeassistant/components/mcp23017/*
     homeassistant/components/media_extractor/*
     homeassistant/components/mediaroom/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -521,6 +521,7 @@ homeassistant/components/lyric/* @timmo001
 tests/components/lyric/* @timmo001
 homeassistant/components/mastodon/* @fabaff
 homeassistant/components/matrix/* @tinloaf
+tests/components/matrix/* @tinloaf
 homeassistant/components/mazda/* @bdr99
 tests/components/mazda/* @bdr99
 homeassistant/components/mcp23017/* @jardiamj

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -16,6 +16,7 @@ from matrix_client.room import Room
 import voluptuous as vol
 
 from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
@@ -115,6 +116,27 @@ def setup_bot(hass: HomeAssistant, config: ConfigType) -> bool:
         bot.handle_send_message,
         schema=SERVICE_SCHEMA_SEND_MESSAGE,
     )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up the Matrix bot from config entry."""
+
+    status: Final[bool] = await hass.async_add_executor_job(
+        setup_bot, hass, config_entry.data
+    )
+
+    return status
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload config entry."""
+
+    # Remove the registered service
+    hass.services.async_remove(DOMAIN, SERVICE_SEND_MESSAGE)
+    # Remove the bot
+    del hass.data[DOMAIN]
 
     return True
 

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -127,6 +127,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         setup_bot, hass, config_entry.data
     )
 
+    config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
+
     return status
 
 
@@ -139,6 +141,21 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     del hass.data[DOMAIN]
 
     return True
+
+
+async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Handle options update."""
+    bot: MatrixBot = hass.data[DOMAIN]
+    # Update listening rooms
+    await hass.async_add_executor_job(
+        bot.set_listening_rooms,
+        config_entry.options.get(CONF_ROOMS, []),
+    )
+    # Update listening commands
+    await hass.async_add_executor_job(
+        bot.set_listening_commands,
+        config_entry.options.get(CONF_COMMANDS, []),
+    )
 
 
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/matrix/config_flow.py
+++ b/homeassistant/components/matrix/config_flow.py
@@ -13,16 +13,45 @@ from homeassistant import config_entries
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_BASE,
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
 from . import MatrixAuthentication
-from .const import CONF_COMMANDS, CONF_HOMESERVER, CONF_ROOMS, DOMAIN, SESSION_FILE
+from .const import (
+    CONF_COMMANDS,
+    CONF_EXPRESSION,
+    CONF_HOMESERVER,
+    CONF_ROOMS,
+    CONF_WORD,
+    DOMAIN,
+    SESSION_FILE,
+)
+
+OPTION_LIST_COMMAND: Final = "list_command"
+OPTION_ADD_COMMAND: Final = "add_command"
+OPTION_DELETE_COMMAND: Final = "delete_command"
+
+ROOMS_SCHEMA: vol.Schema = vol.All(cv.ensure_list, [cv.string])
+
+COMMAND_SCHEMA: vol.Schema = vol.All(
+    vol.Schema(
+        {
+            vol.Optional(CONF_WORD): cv.string,
+            vol.Optional(CONF_EXPRESSION): cv.is_regex,
+            vol.Required(CONF_NAME): cv.string,
+            vol.Optional(CONF_ROOMS, default=[]): ROOMS_SCHEMA,
+            vol.Optional(OPTION_DELETE_COMMAND, default=False): cv.boolean,
+        },
+    ),
+    cv.has_at_least_one_key(CONF_WORD, CONF_EXPRESSION),
+)
 
 CONFIG_FLOW_ADDITIONAL_SCHEMA: vol.Schema = vol.Schema(
     {
@@ -77,6 +106,14 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Matrix."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> OptionsFlowHandler:
+        """Get options flow."""
+        return OptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -149,3 +186,231 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Matrix integration options flow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """
+        Gather information from the current config entry.
+
+        self._options can contain:
+        - CONF_ROOMS: [str]
+        - CONF_COMMANDS: [dict[str, str | list[str]]
+        """
+        self._options: dict[str, Any] = dict(config_entry.options)
+
+        self._commands: dict[str, dict[str, Any]] = {}
+
+        """
+        config_entry.options.get(CONF_COMMANDS, []) can return:
+        [
+            {
+                CONF_WORD: str,
+                CONF_EXPRESSION: str,
+                CONF_NAME: str,
+                CONF_ROOMS: [str],
+            },
+            ...
+        ]
+        """
+        for command in config_entry.options.get(CONF_COMMANDS, []):
+            self._commands[command[CONF_NAME]] = command
+
+        # Used in self.async_step_add_remove_command to store the command name that is currently being handled.
+        self.__current_command_name: str | None = None
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """
+        Manage the options.
+
+        Some possible procedures:
+        - Main step -> (User: Do nothing and submit) -> End
+        - Main step -> (User: Change CONF_ROOMS) -> <ROOMS_SCHEMA check passes> -> [Update CONF_ROOMS] -> [Save new options] -> End
+                                                 -> <ROOMS_SCHEMA check fails>  -> Main step with error information -> ...
+        - Main step -> (User: Choose an option in the list) -> Command step -> (User: Add/modify a command) -> <COMMAND_SCHEMA check passes> -> [Update self._commands] -> Main step
+                                                                                                               <COMMAND_SCHEMA check fails>  -> Command step with error information -> ...
+        - Main step -> (User: Change CONF_ROOMS and choose an option in the list) -> <ROOMS_SCHEMA check passes> -> Command step -> ...
+                                                                                     <ROOMS_SCHEMA check fails>  -> Main step with error information -> ...
+        """
+
+        if user_input is not None:
+            # CONF_ROOMS: convert str to list because voluptuous_serialize does not support List type
+            user_input[CONF_ROOMS] = (
+                user_input[CONF_ROOMS].split(",") if user_input[CONF_ROOMS] else []
+            )
+
+            # Check the format of CONF_ROOMS if it's not empty
+            if user_input[CONF_ROOMS]:
+                ROOMS_SCHEMA(user_input[CONF_ROOMS])
+
+            # Update CONF_ROOMS
+            self._options[CONF_ROOMS] = user_input[CONF_ROOMS]
+
+            if user_input[CONF_COMMANDS] == OPTION_LIST_COMMAND:
+                # Update CONF_COMMANDS
+                self._options[CONF_COMMANDS] = list(self._commands.values())
+                # Call async_create_entry and exit
+                return self.async_create_entry(title="", data=self._options)
+            elif user_input[CONF_COMMANDS] == OPTION_ADD_COMMAND:
+                # Add a new command
+                return await self.async_step_add_command(user_input=None)
+            elif user_input[CONF_COMMANDS] in self._commands:
+                # Modify/Delete an existing command
+                return await self.async_step_modify_command(
+                    user_input=self._commands[user_input[CONF_COMMANDS]]
+                )
+
+        return self._show_main_form()
+
+    async def async_step_add_command(
+        self, user_input: dict[str, Any] | None, is_add: bool = False
+    ) -> FlowResult:
+        """Add commands step."""
+        return self._show_add_remove_command_form(user_input=user_input, is_add=True)
+
+    async def async_step_modify_command(
+        self, user_input: dict[str, Any] | None, is_add: bool = False
+    ) -> FlowResult:
+        """Modify/Delete commands step."""
+        return self._show_add_remove_command_form(user_input=user_input, is_add=False)
+
+    @callback
+    def _show_main_form(self, errors: dict[str, str] | None = None) -> FlowResult:
+        """Handle the main options."""
+
+        options_schema: vol.Schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_ROOMS,
+                    default=",".join(self._options.get(CONF_ROOMS, [])),
+                ): str,  # Multiple rooms are split by commas
+            }
+        )
+
+        # Add existing commands to the combobox
+        option_commands: dict[str, str] = {}
+        option_commands[OPTION_LIST_COMMAND] = "--Commands--"
+        option_commands[OPTION_ADD_COMMAND] = "Add command..."
+
+        # Propagate the combobox
+        for command in self._commands.values():
+            name: str = command[CONF_NAME]
+            word_or_expression: str | None = command.get(CONF_WORD) or command.get(
+                CONF_EXPRESSION
+            )
+            option_commands[name] = f"{name} ({word_or_expression})"
+
+        config_schema: vol.Schema = options_schema.extend(
+            {
+                vol.Optional(CONF_COMMANDS, default=OPTION_LIST_COMMAND): vol.In(
+                    option_commands
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=config_schema,
+            errors=errors,
+        )
+
+    @callback
+    def _show_add_remove_command_form(
+        self, user_input: dict[str, Any] | None, is_add: bool = False
+    ) -> FlowResult:
+        """
+        Add/remove commands step.
+
+        user_input can contain:
+        - CONF_NAME: str
+        - CONF_WORD: str
+        - CONF_EXPRESSION: str
+        - CONF_ROOMS: list[str]
+        - OPTION_DELETE_COMMAND: bool
+        """
+
+        errors: dict[str, str] = {}
+
+        if user_input is None:
+            user_input = {}
+        else:
+            # When entering the step from the main step, the type of user_input[CONF_ROOMS] is list.
+            if isinstance(user_input[CONF_ROOMS], str):
+                # CONF_ROOMS: convert str to list because voluptuous_serialize does not support List type
+                user_input[CONF_ROOMS] = (
+                    user_input[CONF_ROOMS].split(",") if user_input[CONF_ROOMS] else []
+                )
+
+            try:
+                # Check the format of user input
+                COMMAND_SCHEMA(user_input)
+
+                if user_input[CONF_NAME] in [*self._commands]:
+                    if is_add:
+                        # Duplicate name when adding a new command
+                        raise DuplicateNameError
+                    elif self.__current_command_name is None:
+                        # Raise the exception to set self.__current_command_name
+                        raise CurrentCommandNameEmpty
+                    else:
+                        # Duplicate name when modifying the name of an existing command
+                        raise DuplicateNameError
+
+            except CurrentCommandNameEmpty:
+                # Store the command name that is currently being handled
+                self.__current_command_name = user_input[CONF_NAME]
+                # Delete the existing command in the temporary list because we will add it back after this step is finished
+                del self._commands[str(self.__current_command_name)]
+
+            except DuplicateNameError:
+                errors[CONF_NAME] = "duplicate_name"
+
+            else:
+                # Store the command in the list (the config will be updated after the user submits the form in the main step)
+                if not user_input.get(OPTION_DELETE_COMMAND):
+                    self._commands[user_input[CONF_NAME]] = user_input
+                # Reset the command name that is currently being handled
+                self.__current_command_name = None
+                # Return to the main step when a command is created/modified successfully
+                return self._show_main_form()
+
+        # When the user is modifying an existing command or any error occurs in this step,
+        # user_input will not be None.
+        option_schema: vol.Schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME, default=user_input.get(CONF_NAME, "")): str,
+                vol.Optional(CONF_WORD, default=user_input.get(CONF_WORD, "")): str,
+                vol.Optional(
+                    CONF_EXPRESSION, default=user_input.get(CONF_EXPRESSION, "")
+                ): str,
+                vol.Optional(
+                    CONF_ROOMS, default=",".join(user_input.get(CONF_ROOMS, []))
+                ): str,  # Multiple rooms are split by commas
+            }
+        )
+
+        if not is_add:
+            # Provide an option to delete the existing command
+            option_schema = option_schema.extend(
+                {
+                    vol.Optional(OPTION_DELETE_COMMAND, default=False): bool,
+                }
+            )
+
+        return self.async_show_form(
+            step_id="add_command" if is_add else "modify_command",
+            data_schema=option_schema,
+            errors=errors,
+        )
+
+
+class DuplicateNameError(HomeAssistantError):
+    """Error to indicate the provided name already exists."""
+
+
+class CurrentCommandNameEmpty(HomeAssistantError):
+    """Error to indicate the current command name is not set."""

--- a/homeassistant/components/matrix/config_flow.py
+++ b/homeassistant/components/matrix/config_flow.py
@@ -162,6 +162,10 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=info["title"],
                     data=user_input,
+                    options={
+                        CONF_ROOMS: user_input.get(CONF_ROOMS, []),
+                        CONF_COMMANDS: user_input.get(CONF_COMMANDS, []),
+                    },
                 )
 
         return self.async_show_form(
@@ -186,6 +190,10 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
+        """Import a config entry."""
+        return await self.async_step_user(user_input=user_input)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/matrix/config_flow.py
+++ b/homeassistant/components/matrix/config_flow.py
@@ -1,0 +1,151 @@
+"""Config flow for the Matrix integration."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Final
+
+from matrix_client.client import MatrixClient
+from matrix_client.errors import MatrixHttpLibError, MatrixRequestError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_BASE,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+
+from . import MatrixAuthentication
+from .const import CONF_COMMANDS, CONF_HOMESERVER, CONF_ROOMS, DOMAIN, SESSION_FILE
+
+CONFIG_FLOW_ADDITIONAL_SCHEMA: vol.Schema = vol.Schema(
+    {
+        vol.Required(CONF_HOMESERVER): cv.url,
+        vol.Required(CONF_USERNAME): cv.matches_regex("@[^:]*:.*"),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Validate the user input allows us to log in.
+
+    :return: A dict containing the title and the access token corresponding to the settings provided by the input data.
+    :raises vol.Invalid: if the format check fails
+    :raises vol.MultipleInvalid: if multiple format checks fail
+    :raises MatrixHttpLibError: if the connection fails
+    :raises MatrixRequestError: if login fails
+    """
+
+    # Check the format
+    CONFIG_FLOW_ADDITIONAL_SCHEMA(data)
+
+    auth: MatrixAuthentication = MatrixAuthentication(
+        config_file=os.path.join(hass.config.path(), SESSION_FILE),
+        homeserver=data[CONF_HOMESERVER],
+        verify_ssl=data[CONF_VERIFY_SSL],
+        username=data[CONF_USERNAME],
+        password=data[CONF_PASSWORD],
+    )
+
+    # Check if we can log in
+    client: MatrixClient = await hass.async_add_executor_job(auth.login)
+
+    # If no exception is thrown during logging in
+    token: str | None = ""
+    if hasattr(client, "token"):
+        # A new token will be assigned on first login
+        token = client.token
+    else:
+        # Use the token from the previous login if there is no token from the client
+        token = auth.auth_token(data[CONF_USERNAME])
+
+    return {
+        "title": data[CONF_USERNAME],
+        CONF_ACCESS_TOKEN: token,
+    }
+
+
+class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for Matrix."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        errors: dict[str, str] = {}
+
+        if user_input is None:
+            user_input = {}
+        else:
+            try:
+                info: dict[str, str] = await validate_input(self.hass, user_input)
+
+            except MatrixHttpLibError:
+                # Network error
+                errors[CONF_BASE] = "cannot_connect"
+
+            except MatrixRequestError as ex:
+                # Error code definitions: https://spec.matrix.org/latest/client-server-api/#standard-error-response
+                try:
+                    error_code: Final[str] = json.loads(ex.content).get("errcode")
+
+                except ValueError:
+                    # The error content is not a valid JSON string.
+                    errors[CONF_BASE] = "unknown"
+
+                else:
+                    if error_code in ("M_FORBIDDEN", "M_UNAUTHORIZED"):
+                        errors[CONF_PASSWORD] = "invalid_auth"
+                    elif error_code in ("M_INVALID_USERNAME", "M_USER_DEACTIVATED"):
+                        errors[CONF_USERNAME] = "invalid_auth"
+                    elif error_code in ("M_UNKNOWN_TOKEN", "M_MISSING_TOKEN"):
+                        errors[CONF_BASE] = "invalid_access_token"
+                    else:
+                        errors[CONF_BASE] = "unknown"
+
+            else:
+                # Use access token as unique id as it can't be duplicated
+                await self.async_set_unique_id(info[CONF_ACCESS_TOKEN])
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=info["title"],
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOMESERVER,
+                        default=user_input.get(CONF_HOMESERVER)
+                        or "https://matrix-client.matrix.org",
+                    ): str,
+                    vol.Required(
+                        CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")
+                    ): str,
+                    vol.Required(
+                        CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")
+                    ): str,
+                    vol.Optional(
+                        CONF_VERIFY_SSL, default=user_input.get(CONF_VERIFY_SSL) or True
+                    ): bool,
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/matrix/const.py
+++ b/homeassistant/components/matrix/const.py
@@ -1,4 +1,14 @@
 """Constants for the Matrix integration."""
-DOMAIN = "matrix"
+from typing import Final
 
-SERVICE_SEND_MESSAGE = "send_message"
+DOMAIN: Final = "matrix"
+
+CONF_HOMESERVER: Final = "homeserver"
+CONF_ROOMS: Final = "rooms"
+CONF_COMMANDS: Final = "commands"
+CONF_WORD: Final = "word"
+CONF_EXPRESSION: Final = "expression"
+
+SESSION_FILE: Final = ".matrix.conf"
+
+SERVICE_SEND_MESSAGE: Final = "send_message"

--- a/homeassistant/components/matrix/manifest.json
+++ b/homeassistant/components/matrix/manifest.json
@@ -1,8 +1,13 @@
 {
   "domain": "matrix",
   "name": "Matrix",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/matrix",
-  "requirements": ["matrix-client==0.4.0"],
-  "codeowners": ["@tinloaf"],
+  "requirements": [
+    "matrix-client==0.4.0"
+  ],
+  "codeowners": [
+    "@tinloaf"
+  ],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/matrix/strings.json
+++ b/homeassistant/components/matrix/strings.json
@@ -19,5 +19,37 @@
         }
       }
     }
+  },
+  "options": {
+    "error": {
+      "duplicate_name": "Name already in use"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "rooms": "Rooms (Split multiple rooms with commas \",\")",
+          "commands": "Commands",
+          "list_command": "--Commands--",
+          "add_command": "Add command..."
+        }
+      },
+      "add_command": {
+        "data": {
+          "word": "Word",
+          "expression": "Expression",
+          "name": "[%key:common::config_flow::data::name%]",
+          "rooms": "Rooms (Split multiple rooms with commas \",\")"
+        }
+      },
+      "modify_command": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "word": "Word",
+          "expression": "Expression",
+          "rooms": "Rooms (Split multiple rooms with commas \",\")",
+          "delete_command": "Delete command"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/matrix/strings.json
+++ b/homeassistant/components/matrix/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_access_token": "[%key:common::config_flow::error::invalid_access_token%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "homeserver": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/matrix/translations/en.json
+++ b/homeassistant/components/matrix/translations/en.json
@@ -1,0 +1,55 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Service is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_access_token": "Invalid access token",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "homeserver": "URL",
+                    "password": "Password",
+                    "username": "Username",
+                    "verify_ssl": "Verify SSL certificate"
+                }
+            }
+        }
+    },
+    "options": {
+        "error": {
+            "duplicate_name": "Name already in use"
+        },
+        "step": {
+            "add_command": {
+                "data": {
+                    "expression": "Expression",
+                    "name": "Name",
+                    "rooms": "Rooms (Split multiple rooms with commas \",\")",
+                    "word": "Word"
+                }
+            },
+            "init": {
+                "data": {
+                    "add_command": "Add command...",
+                    "commands": "Commands",
+                    "list_command": "--Commands--",
+                    "rooms": "Rooms (Split multiple rooms with commas \",\")"
+                }
+            },
+            "modify_command": {
+                "data": {
+                    "delete_command": "Delete command",
+                    "expression": "Expression",
+                    "name": "Name",
+                    "rooms": "Rooms (Split multiple rooms with commas \",\")",
+                    "word": "Word"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -179,6 +179,7 @@ FLOWS = [
     "lutron_caseta",
     "lyric",
     "mailgun",
+    "matrix",
     "mazda",
     "melcloud",
     "met",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -618,6 +618,9 @@ luftdaten==0.7.1
 # homeassistant.components.nmap_tracker
 mac-vendor-lookup==0.1.11
 
+# homeassistant.components.matrix
+matrix-client==0.4.0
+
 # homeassistant.components.maxcube
 maxcube-api==0.4.3
 

--- a/tests/components/matrix/__init__.py
+++ b/tests/components/matrix/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Matrix integration."""

--- a/tests/components/matrix/test_config_flow.py
+++ b/tests/components/matrix/test_config_flow.py
@@ -1,0 +1,355 @@
+"""Tests for the Matrix config flow."""
+from __future__ import annotations
+
+from typing import Any, Final
+from unittest.mock import patch
+
+from matrix_client.errors import MatrixRequestError
+from requests.exceptions import ConnectionError
+from requests_mock import ANY
+import voluptuous as vol
+
+from homeassistant.components.matrix.config_flow import (
+    CONFIG_FLOW_ADDITIONAL_SCHEMA,
+    validate_input,
+)
+from homeassistant.components.matrix.const import (
+    CONF_COMMANDS,
+    CONF_EXPRESSION,
+    CONF_HOMESERVER,
+    CONF_ROOMS,
+    CONF_WORD,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_BASE,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+    FlowResult,
+)
+
+from tests.common import MockConfigEntry
+
+FIXTURE_USER_INPUT: Final[dict[str, Any]] = {
+    CONF_HOMESERVER: "https://matrix-client.matrix.org",
+    CONF_USERNAME: "@dummyuser:matrix.org",
+    CONF_PASSWORD: "secret",
+    CONF_VERIFY_SSL: True,
+}
+
+FIXTURE_ALTER_USER_INPUT: Final[dict[str, Any]] = {
+    CONF_HOMESERVER: "https://mozilla.modular.im",
+    CONF_USERNAME: "@foobar:mozilla.org",
+    CONF_PASSWORD: "password",
+    CONF_VERIFY_SSL: False,
+}
+
+FIXTURE_USER_INPUT_FROM_YAML: Final[dict[str, Any]] = {
+    CONF_HOMESERVER: "https://matrix-client.matrix.org",
+    CONF_USERNAME: "@dummyuser:matrix.org",
+    CONF_PASSWORD: "secret",
+    CONF_VERIFY_SSL: True,
+    CONF_ROOMS: ["#matrix:matrix.org", "#general:mozilla.org"],
+    CONF_COMMANDS: [
+        {
+            CONF_WORD: "ping",
+            CONF_NAME: "ping",
+            CONF_ROOMS: ["#matrix:matrix.org"],
+        },
+        {
+            CONF_EXPRESSION: ".*hello.*",
+            CONF_NAME: "hello",
+            CONF_ROOMS: ["#general:mozilla.org"],
+        },
+    ],
+}
+
+FIXTURE_INVALID_USER_INPUT: Final[dict[str, Any]] = {
+    CONF_HOMESERVER: "Any invalid URL",
+    CONF_USERNAME: "dummyuser",
+    CONF_PASSWORD: "secret",
+    CONF_VERIFY_SSL: True,
+}
+
+FIXTURE_UNIQUE_ID: Final[str] = FIXTURE_USER_INPUT[CONF_USERNAME]
+FIXTURE_ACCESS_TOKEN: Final[str] = "syt_dummytoken_dummytoken_dummytoken"
+
+
+class DummyAuthWithToken:
+    """An authentication class with the token property available."""
+
+    def __init__(self, token: str) -> None:
+        """Initialize the class."""
+        self.token: str = token
+
+
+class DummyAuthWithoutToken:
+    """An authentication class without any token property."""
+
+    def __init__(self) -> None:
+        """Initialize the class."""
+        pass
+
+
+async def validate_login_result(result: FlowResult, user_input: dict[str, Any]):
+    """Validate the login result matches the user input."""
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == user_input[CONF_USERNAME]
+    assert result["data"][CONF_HOMESERVER] == user_input[CONF_HOMESERVER]
+    assert result["data"][CONF_USERNAME] == user_input[CONF_USERNAME]
+    assert result["data"][CONF_PASSWORD] == user_input[CONF_PASSWORD]
+    assert result["data"][CONF_VERIFY_SSL] == user_input[CONF_VERIFY_SSL]
+
+
+async def finish_login(hass: HomeAssistant, previous_result: FlowResult):
+    """Finish the login procedure."""
+    dummy_auth: DummyAuthWithToken = DummyAuthWithToken(FIXTURE_ACCESS_TOKEN)
+
+    with patch(
+        "homeassistant.components.matrix.MatrixAuthentication.login",
+        return_value=dummy_auth,
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_configure(
+            flow_id=previous_result["flow_id"],
+            user_input=FIXTURE_USER_INPUT,
+        )
+        await hass.async_block_till_done()
+
+    await validate_login_result(result, FIXTURE_USER_INPUT)
+
+
+async def test_config_flow_schema(hass: HomeAssistant) -> None:
+    """Test CONFIG_FLOW_ADDITIONAL_SCHEMA can verify the user input correctly."""
+    try:
+        CONFIG_FLOW_ADDITIONAL_SCHEMA(FIXTURE_USER_INPUT)
+        CONFIG_FLOW_ADDITIONAL_SCHEMA(FIXTURE_ALTER_USER_INPUT)
+    except vol.Invalid:
+        # Shouldn't happen
+        assert False
+
+    try:
+        await validate_input(hass, FIXTURE_INVALID_USER_INPUT)
+    except vol.MultipleInvalid as ex:
+        invalid_list: tuple = (e.path[0] for e in ex.errors)
+        assert CONF_HOMESERVER in invalid_list
+        assert CONF_USERNAME in invalid_list
+
+
+async def test_import(hass: HomeAssistant):
+    """Test that we can import a config entry."""
+    dummy_auth: DummyAuthWithToken = DummyAuthWithToken(FIXTURE_ACCESS_TOKEN)
+
+    with patch(
+        "homeassistant.components.matrix.MatrixAuthentication.login",
+        return_value=dummy_auth,
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT_FROM_YAML,
+        )
+        await hass.async_block_till_done()
+
+    await validate_login_result(result, FIXTURE_USER_INPUT_FROM_YAML)
+
+    # Validate the options are imported.
+    assert len(result["options"][CONF_ROOMS]) == len(
+        FIXTURE_USER_INPUT_FROM_YAML[CONF_ROOMS]
+    )
+    for room_id in result["options"][CONF_ROOMS]:
+        assert room_id in FIXTURE_USER_INPUT_FROM_YAML[CONF_ROOMS]
+
+    assert len(result["options"][CONF_COMMANDS]) == len(
+        FIXTURE_USER_INPUT_FROM_YAML[CONF_COMMANDS]
+    )
+    for command in result["options"][CONF_COMMANDS]:
+        assert command in FIXTURE_USER_INPUT_FROM_YAML[CONF_COMMANDS]
+
+
+async def test_login_success(hass: HomeAssistant) -> None:
+    """Test successful flow provides entry creation data."""
+    result: FlowResult = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=None
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    dummy_auth: DummyAuthWithToken = DummyAuthWithToken(FIXTURE_ACCESS_TOKEN)
+
+    with patch(
+        "homeassistant.components.matrix.MatrixAuthentication.login",
+        return_value=dummy_auth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=FIXTURE_USER_INPUT
+        )
+        await hass.async_block_till_done()
+
+    await validate_login_result(result2, FIXTURE_USER_INPUT)
+
+
+async def test_login_success_with_local_token(hass: HomeAssistant) -> None:
+    """Test successful flow provides entry creation data."""
+    dummy_auth: DummyAuthWithoutToken = DummyAuthWithoutToken()
+
+    with patch(
+        "homeassistant.components.matrix.MatrixAuthentication.login",
+        return_value=dummy_auth,
+    ), patch(
+        "homeassistant.components.matrix.MatrixAuthentication.auth_token",
+        return_value=FIXTURE_ACCESS_TOKEN,
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+        await hass.async_block_till_done()
+
+    await validate_login_result(result, FIXTURE_USER_INPUT)
+
+
+async def test_already_configured(hass: HomeAssistant) -> None:
+    """Test we only allow a single config flow."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=FIXTURE_UNIQUE_ID,
+        data=FIXTURE_USER_INPUT,
+        title="Already configured",
+    ).add_to_hass(hass)
+
+    result: FlowResult = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=FIXTURE_ALTER_USER_INPUT,
+    )
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_connection_error(hass: HomeAssistant, requests_mock) -> None:
+    """Test we show user form on connection error."""
+    requests_mock.request(ANY, ANY, exc=ConnectionError())
+    result: FlowResult = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=FIXTURE_USER_INPUT,
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_BASE: "cannot_connect"}
+
+
+async def test_password_error(hass: HomeAssistant) -> None:
+    """Test that errors are shown when password is wrong."""
+    with patch(
+        "homeassistant.components.matrix.config_flow.validate_input",
+        side_effect=MatrixRequestError(code=401, content='{"errcode": "M_FORBIDDEN"}'),
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_PASSWORD: "invalid_auth"}
+
+    await finish_login(hass, result)
+
+
+async def test_invalid_json_string(hass: HomeAssistant) -> None:
+    """Test that errors are shown when username is invalid."""
+    with patch(
+        "homeassistant.components.matrix.config_flow.validate_input",
+        side_effect=MatrixRequestError(code=401, content='{"noerrcode": "noerrcode"}'),
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_BASE: "unknown"}
+
+    await finish_login(hass, result)
+
+
+async def test_username_error(hass: HomeAssistant) -> None:
+    """Test that errors are shown when username is invalid."""
+    with patch(
+        "homeassistant.components.matrix.config_flow.validate_input",
+        side_effect=MatrixRequestError(
+            code=401, content='{"errcode": "M_INVALID_USERNAME"}'
+        ),
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_USERNAME: "invalid_auth"}
+
+    await finish_login(hass, result)
+
+
+async def test_token_error(hass: HomeAssistant) -> None:
+    """Test that errors are shown when access token is invalid."""
+    with patch(
+        "homeassistant.components.matrix.config_flow.validate_input",
+        side_effect=MatrixRequestError(
+            code=401, content='{"errcode": "M_UNKNOWN_TOKEN"}'
+        ),
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_BASE: "invalid_access_token"}
+
+    await finish_login(hass, result)
+
+
+async def test_other_error(hass: HomeAssistant) -> None:
+    """Test that errors are shown when access token is invalid."""
+    with patch(
+        "homeassistant.components.matrix.config_flow.validate_input",
+        side_effect=MatrixRequestError(
+            code=401, content='{"errcode": "M_DUMMY_ERROR"}'
+        ),
+    ):
+        result: FlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=FIXTURE_USER_INPUT,
+        )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_BASE: "unknown"}
+
+    await finish_login(hass, result)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a config flow to the Matrix integration with no change in functions.

To validate the user input allows us to log in, the authentication part
of MatrixBot is separated into a new class named MatrixAuthentication.

Currently rooms and commands are not configurable through the config
flow because voluptuous_serialize does not support List type. 

_If converting a string to a list is acceptable, I will submit following changes later._

|Setup|Integration|Send Message|
|--|--|--|
|![图片](https://user-images.githubusercontent.com/23738961/148329778-341ddcbf-e645-49f5-aab8-f4dae99c9881.png)|![图片](https://user-images.githubusercontent.com/23738961/148329494-44ec6c24-3bea-4fc1-8a8d-0626cfcc658d.png)|![图片](https://user-images.githubusercontent.com/23738961/148330145-a9e1f709-8fe1-4d22-a5e2-81fd7624e92e.png)|




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
