### PR TITLE
Add broadlink lb2 support

### DIFF
--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -31,7 +31,7 @@ DOMAINS_AND_TYPES = {
         "SP4",
         "SP4B",
     },
-    Platform.LIGHT: {"LB1"},
+    Platform.LIGHT: {"LB1","LB2"},
 }
 DEVICE_TYPES = set.union(*DOMAINS_AND_TYPES.values())
 

--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -31,7 +31,7 @@ DOMAINS_AND_TYPES = {
         "SP4",
         "SP4B",
     },
-    Platform.LIGHT: {"LB1","LB2"},
+    Platform.LIGHT: {"LB1", "LB2"},
 }
 DEVICE_TYPES = set.union(*DOMAINS_AND_TYPES.values())
 

--- a/homeassistant/components/broadlink/light.py
+++ b/homeassistant/components/broadlink/light.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
     device = hass.data[DOMAIN].devices[config_entry.entry_id]
     lights = []
 
-    if device.api.type == "LB1":
+    if device.api.type in {"LB1", "LB2"}:
         lights.append(BroadlinkLight(device))
 
     async_add_entities(lights)

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -17,6 +17,7 @@ def get_update_manager(device):
         "A1": BroadlinkA1UpdateManager,
         "BG1": BroadlinkBG1UpdateManager,
         "LB1": BroadlinkLB1UpdateManager,
+        "LB2": BroadlinkLB2UpdateManager,
         "MP1": BroadlinkMP1UpdateManager,
         "RM4MINI": BroadlinkRMUpdateManager,
         "RM4PRO": BroadlinkRMUpdateManager,
@@ -180,6 +181,13 @@ class BroadlinkSP4UpdateManager(BroadlinkUpdateManager):
 
 class BroadlinkLB1UpdateManager(BroadlinkUpdateManager):
     """Manages updates for Broadlink LB1 devices."""
+
+    async def async_fetch_data(self):
+        """Fetch data from the device."""
+        return await self.device.async_request(self.device.api.get_state)
+
+class BroadlinkLB2UpdateManager(BroadlinkUpdateManager):
+    """Manages updates for Broadlink LB2 devices."""
 
     async def async_fetch_data(self):
         """Fetch data from the device."""

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -17,7 +17,7 @@ def get_update_manager(device):
         "A1": BroadlinkA1UpdateManager,
         "BG1": BroadlinkBG1UpdateManager,
         "LB1": BroadlinkLB1UpdateManager,
-        "LB2": BroadlinkLB2UpdateManager,
+        "LB2": BroadlinkLB1UpdateManager,
         "MP1": BroadlinkMP1UpdateManager,
         "RM4MINI": BroadlinkRMUpdateManager,
         "RM4PRO": BroadlinkRMUpdateManager,
@@ -181,13 +181,6 @@ class BroadlinkSP4UpdateManager(BroadlinkUpdateManager):
 
 class BroadlinkLB1UpdateManager(BroadlinkUpdateManager):
     """Manages updates for Broadlink LB1 devices."""
-
-    async def async_fetch_data(self):
-        """Fetch data from the device."""
-        return await self.device.async_request(self.device.api.get_state)
-
-class BroadlinkLB2UpdateManager(BroadlinkUpdateManager):
-    """Manages updates for Broadlink LB2 devices."""
 
     async def async_fetch_data(self):
         """Fetch data from the device."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change
This is a small addition to the Broadlink Integration to add support for the LB2 series smart bulbs (LB26 and LB27).

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #61911
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21055

## Checklist
- [x] The code change is tested and works locally. 
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
Unchanged

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
