### PR TITLE
Bump greeneye_monitor to v3.0.1

### DIFF
--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -127,13 +127,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DATA_GREENEYE_MONITOR] = monitors
 
     server_config = config[DOMAIN]
-    server = await monitors.start_server(server_config[CONF_PORT])
+    await monitors.start_server(server_config[CONF_PORT])
 
-    async def close_server(event: Event) -> None:
-        """Close the monitoring server."""
-        await server.close()
+    async def close_monitors(event: Event) -> None:
+        """Close the Monitors object."""
+        await monitors.close()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_server)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_monitors)
 
     all_sensors = []
     for monitor_config in server_config[CONF_MONITORS]:

--- a/homeassistant/components/greeneye_monitor/manifest.json
+++ b/homeassistant/components/greeneye_monitor/manifest.json
@@ -2,7 +2,11 @@
   "domain": "greeneye_monitor",
   "name": "GreenEye Monitor (GEM)",
   "documentation": "https://www.home-assistant.io/integrations/greeneye_monitor",
-  "requirements": ["greeneye_monitor==2.1"],
-  "codeowners": ["@jkeljo"],
+  "requirements": [
+    "greeneye_monitor==3.0"
+  ],
+  "codeowners": [
+    "@jkeljo"
+  ],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/greeneye_monitor/manifest.json
+++ b/homeassistant/components/greeneye_monitor/manifest.json
@@ -3,7 +3,7 @@
   "name": "GreenEye Monitor (GEM)",
   "documentation": "https://www.home-assistant.io/integrations/greeneye_monitor",
   "requirements": [
-    "greeneye_monitor==3.0"
+    "greeneye_monitor==3.0.1"
   ],
   "codeowners": [
     "@jkeljo"

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -96,9 +96,9 @@ async def async_setup_platform(
 
 UnderlyingSensorType = Union[
     greeneye.monitor.Channel,
-    greeneye.monitor.Monitor,
     greeneye.monitor.PulseCounter,
     greeneye.monitor.TemperatureSensor,
+    greeneye.monitor.VoltageSensor,
 ]
 
 
@@ -295,9 +295,9 @@ class VoltageSensor(GEMSensor):
         super().__init__(monitor_serial_number, name, "volts", number)
 
     @property
-    def _sensor(self) -> greeneye.monitor.Monitor | None:
+    def _sensor(self) -> greeneye.monitor.VoltageSensor | None:
         """Wire the updates to the monitor itself, since there is no voltage element in the API."""
-        return self._monitor
+        return self._monitor.voltage_sensor if self._monitor else None
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -1,7 +1,7 @@
 """Support for the sensors in a GreenEye Monitor."""
 from __future__ import annotations
 
-from typing import Any, Optional, Union, cast
+from typing import Any, Union
 
 import greeneye
 
@@ -178,7 +178,7 @@ class CurrentSensor(GEMSensor):
         if not self._sensor:
             return None
 
-        return cast(Optional[float], self._sensor.watts)
+        return self._sensor.watts
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -229,7 +229,7 @@ class PulseCounter(GEMSensor):
             * self._counted_quantity_per_pulse
             * self._seconds_per_time_unit
         )
-        return cast(float, result)
+        return result
 
     @property
     def _seconds_per_time_unit(self) -> int:
@@ -281,7 +281,7 @@ class TemperatureSensor(GEMSensor):
         if not self._sensor:
             return None
 
-        return cast(Optional[float], self._sensor.temperature)
+        return self._sensor.temperature
 
 
 class VoltageSensor(GEMSensor):
@@ -305,4 +305,4 @@ class VoltageSensor(GEMSensor):
         if not self._sensor:
             return None
 
-        return cast(Optional[float], self._sensor.voltage)
+        return self._sensor.voltage

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -770,7 +770,7 @@ gps3==0.33.3
 greeclimate==1.0.1
 
 # homeassistant.components.greeneye_monitor
-greeneye_monitor==2.1
+greeneye_monitor==3.0
 
 # homeassistant.components.greenwave
 greenwavereality==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -770,7 +770,7 @@ gps3==0.33.3
 greeclimate==1.0.1
 
 # homeassistant.components.greeneye_monitor
-greeneye_monitor==3.0
+greeneye_monitor==3.0.1
 
 # homeassistant.components.greenwave
 greenwavereality==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -483,7 +483,7 @@ googlemaps==2.5.1
 greeclimate==1.0.1
 
 # homeassistant.components.greeneye_monitor
-greeneye_monitor==3.0
+greeneye_monitor==3.0.1
 
 # homeassistant.components.growatt_server
 growattServer==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -483,7 +483,7 @@ googlemaps==2.5.1
 greeclimate==1.0.1
 
 # homeassistant.components.greeneye_monitor
-greeneye_monitor==2.1
+greeneye_monitor==3.0
 
 # homeassistant.components.growatt_server
 growattServer==1.1.0

--- a/tests/components/greeneye_monitor/common.py
+++ b/tests/components/greeneye_monitor/common.py
@@ -185,6 +185,13 @@ def mock_temperature_sensor() -> MagicMock:
     return temperature_sensor
 
 
+def mock_voltage_sensor() -> MagicMock:
+    """Create a mock GreenEye Monitor voltage sensor."""
+    voltage_sensor = mock_with_listeners()
+    voltage_sensor.voltage = 120.0
+    return voltage_sensor
+
+
 def mock_channel() -> MagicMock:
     """Create a mock GreenEye Monitor CT channel."""
     channel = mock_with_listeners()
@@ -198,7 +205,7 @@ def mock_monitor(serial_number: int) -> MagicMock:
     """Create a mock GreenEye Monitor."""
     monitor = mock_with_listeners()
     monitor.serial_number = serial_number
-    monitor.voltage = 120.0
+    monitor.voltage_sensor = mock_voltage_sensor()
     monitor.pulse_counters = [mock_pulse_counter() for i in range(0, 4)]
     monitor.temperature_sensors = [mock_temperature_sensor() for i in range(0, 8)]
     monitor.channels = [mock_channel() for i in range(0, 32)]

--- a/tests/components/greeneye_monitor/test_init.py
+++ b/tests/components/greeneye_monitor/test_init.py
@@ -188,12 +188,12 @@ async def test_multi_monitor_config(hass: HomeAssistant, monitors: AsyncMock) ->
 
 async def test_setup_and_shutdown(hass: HomeAssistant, monitors: AsyncMock) -> None:
     """Test that the component can set up and shut down cleanly, closing the underlying server on shutdown."""
-    server = AsyncMock()
-    monitors.start_server = AsyncMock(return_value=server)
+    monitors.start_server = AsyncMock(return_value=None)
+    monitors.close = AsyncMock(return_value=None)
     assert await setup_greeneye_monitor_component_with_config(
         hass, SINGLE_MONITOR_CONFIG_POWER_SENSORS
     )
 
     await hass.async_stop()
 
-    assert server.close.called
+    assert monitors.close.called

--- a/tests/components/greeneye_monitor/test_sensor.py
+++ b/tests/components/greeneye_monitor/test_sensor.py
@@ -64,9 +64,9 @@ async def test_disable_sensor_after_monitor_connected(
     )
     monitor = connect_monitor(monitors, SINGLE_MONITOR_SERIAL_NUMBER)
 
-    assert len(monitor.listeners) == 1
+    assert len(monitor.voltage_sensor.listeners) == 1
     await disable_entity(hass, "sensor.voltage_1")
-    assert len(monitor.listeners) == 0
+    assert len(monitor.voltage_sensor.listeners) == 0
 
 
 async def test_updates_state_when_sensor_pushes(
@@ -80,8 +80,8 @@ async def test_updates_state_when_sensor_pushes(
     monitor = connect_monitor(monitors, SINGLE_MONITOR_SERIAL_NUMBER)
     assert_sensor_state(hass, "sensor.voltage_1", "120.0")
 
-    monitor.voltage = 119.8
-    monitor.notify_all_listeners()
+    monitor.voltage_sensor.voltage = 119.8
+    monitor.voltage_sensor.notify_all_listeners()
     assert_sensor_state(hass, "sensor.voltage_1", "119.8")
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is part of a series of pull requests aiming to support the energy dashboard and long-term statistics in the `greeneye_monitor` component (tracking issue: #55112). 

This PR is upgrading the helper library (also called `greeneye_monitor`) to a version that has sufficient functionality for me to migrate the `greeneye_monitor` component from YAML config to a UI config flow, which is required by Home Assistant policy before I can make the configuration changes necessary to support the energy dashboard and long-term statistics.

`greeneye_monitor` 3.0.1 also has a few breaking changes and provides type information which led to new mypy failures. This PR performs the appropriate migrations for all of that. No breaking changes will be occur for users of Home Assistant.

Changelog: https://github.com/jkeljo/greeneye-monitor/blob/v3.0.1/CHANGELOG.rst
Diff: https://github.com/jkeljo/greeneye-monitor/compare/v2.1...v3.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #55112
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
