### PR TITLE
Revert "Bump google-cloud-pubsub to 2.9.0 (attempt #2)"

### DIFF
--- a/homeassistant/components/google_pubsub/manifest.json
+++ b/homeassistant/components/google_pubsub/manifest.json
@@ -2,7 +2,7 @@
   "domain": "google_pubsub",
   "name": "Google Pub/Sub",
   "documentation": "https://www.home-assistant.io/integrations/google_pubsub",
-  "requirements": ["google-cloud-pubsub==2.9.0"],
+  "requirements": ["google-cloud-pubsub==2.1.0"],
   "codeowners": [],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -53,10 +53,15 @@ h11>=0.12.0
 # https://github.com/advisories/GHSA-93xj-8mrv-444m
 httplib2>=0.19.0
 
-# gRPC is an implicit dependency that we want to make explicit so we manage
-# upgrades intentionally. It is a large package to build from source and we
-# want to ensure we have wheels built.
-grpcio==1.43.0
+# gRPC 1.32+ currently causes issues on ARMv7, see:
+# https://github.com/home-assistant/core/issues/40148
+# Newer versions of some other libraries pin a higher version of grpcio,
+# so those also need to be kept at an old version until the grpcio pin
+# is reverted, see:
+# https://github.com/home-assistant/core/issues/53427
+grpcio==1.31.0
+google-cloud-pubsub==2.1.0
+google-api-core<=1.31.2
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -749,7 +749,7 @@ goodwe==0.2.10
 google-api-python-client==1.6.4
 
 # homeassistant.components.google_pubsub
-google-cloud-pubsub==2.9.0
+google-cloud-pubsub==2.1.0
 
 # homeassistant.components.google_cloud
 google-cloud-texttospeech==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -477,7 +477,7 @@ goodwe==0.2.10
 google-api-python-client==1.6.4
 
 # homeassistant.components.google_pubsub
-google-cloud-pubsub==2.9.0
+google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest
 google-nest-sdm==1.3.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -79,10 +79,15 @@ h11>=0.12.0
 # https://github.com/advisories/GHSA-93xj-8mrv-444m
 httplib2>=0.19.0
 
-# gRPC is an implicit dependency that we want to make explicit so we manage
-# upgrades intentionally. It is a large package to build from source and we
-# want to ensure we have wheels built.
-grpcio==1.43.0
+# gRPC 1.32+ currently causes issues on ARMv7, see:
+# https://github.com/home-assistant/core/issues/40148
+# Newer versions of some other libraries pin a higher version of grpcio,
+# so those also need to be kept at an old version until the grpcio pin
+# is reverted, see:
+# https://github.com/home-assistant/core/issues/53427
+grpcio==1.31.0
+google-cloud-pubsub==2.1.0
+google-api-core<=1.31.2
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0


### PR DESCRIPTION
Reverts home-assistant/core#63522

Rolling back again because it still downloaded the existing armv7 wheel.