### PR TITLE
Handle zwave_js metadata/value updates when the unit changes

### DIFF
--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -317,17 +317,8 @@ class ZWaveNumericSensor(ZwaveSensorBase):
         )
 
     @callback
-    def _handle_scale_change_on_value_updated(self, event_data: dict) -> None:
+    def on_value_update(self) -> None:
         """Handle scale changes for this value on value updated event."""
-        value_data = event_data["args"]
-        # If this event is for a different value, we can return early
-        if (
-            value_data["commandClass"] != self.info.primary_value.command_class
-            or value_data["property"] != self.info.primary_value.property_
-            or value_data.get("endpoint") != self.info.primary_value.endpoint
-            or value_data.get("propertyKey") != self.info.primary_value.property_key
-        ):
-            return
         # If the scale hasn't changed, we can return early
         if self._scale == (
             new_scale := self.info.primary_value.metadata.cc_specific.get(
@@ -342,12 +333,6 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             .resolve_data(self.info.primary_value)
             .unit_of_measurement
         )
-        self.async_write_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        """Call when entity is added."""
-        await super().async_added_to_hass()
-        self.info.node.on("value updated", self._handle_scale_change_on_value_updated)
 
     @property
     def native_value(self) -> float:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -320,6 +320,7 @@ class ZWaveNumericSensor(ZwaveSensorBase):
     def _handle_scale_change_on_value_updated(self, event_data: dict) -> None:
         """Handle scale changes for this value on value updated event."""
         value_data = event_data["args"]
+        # If this event is for a different value, we can return early
         if (
             value_data["commandClass"] != self.info.primary_value.command_class
             or value_data["property"] != self.info.primary_value.property_
@@ -327,8 +328,7 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             or value_data.get("propertyKey") != self.info.primary_value.property_key
         ):
             return
-
-        # If the scale hasn't changed, we don't need to update the entity
+        # If the scale hasn't changed, we can return early
         if self._scale == (
             new_scale := self.info.primary_value.metadata.cc_specific.get(
                 CC_SPECIFIC_SCALE
@@ -337,7 +337,6 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             return
 
         self._scale = new_scale
-
         self._attr_native_unit_of_measurement = (
             NumericSensorDataTemplate()
             .resolve_data(self.info.primary_value)

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass, ConfigurationValueType, NodeStatus
 from zwave_js_server.const.command_class.meter import (
-    CC_SPECIFIC_SCALE,
     RESET_METER_OPTION_TARGET_VALUE,
     RESET_METER_OPTION_TYPE,
 )
@@ -300,34 +299,9 @@ class ZWaveStringSensor(ZwaveSensorBase):
 class ZWaveNumericSensor(ZwaveSensorBase):
     """Representation of a Z-Wave Numeric sensor."""
 
-    def __init__(
-        self,
-        config_entry: ConfigEntry,
-        client: ZwaveClient,
-        info: ZwaveDiscoveryInfo,
-        entity_description: SensorEntityDescription,
-        unit_of_measurement: str | None = None,
-    ) -> None:
-        """Initialize a ZWaveNumericSensor entity."""
-        super().__init__(
-            config_entry, client, info, entity_description, unit_of_measurement
-        )
-        self._scale = self.info.primary_value.metadata.cc_specific.get(
-            CC_SPECIFIC_SCALE
-        )
-
     @callback
     def on_value_update(self) -> None:
         """Handle scale changes for this value on value updated event."""
-        # If the scale hasn't changed, we can return early
-        if self._scale == (
-            new_scale := self.info.primary_value.metadata.cc_specific.get(
-                CC_SPECIFIC_SCALE
-            )
-        ):
-            return
-
-        self._scale = new_scale
         self._attr_native_unit_of_measurement = (
             NumericSensorDataTemplate()
             .resolve_data(self.info.primary_value)

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -363,7 +363,6 @@ async def test_special_meters(hass, aeon_smart_switch_6_state, client, integrati
 async def test_unit_change(hass, zp3111, client, integration):
     """Test unit change via metadata updated event is handled by numeric sensors."""
     entity_id = "sensor.4_in_1_sensor_air_temperature"
-    assert hass.states.get(entity_id)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "21.98"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -358,3 +358,38 @@ async def test_special_meters(hass, aeon_smart_switch_6_state, client, integrati
     assert state
     assert ATTR_DEVICE_CLASS not in state.attributes
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.MEASUREMENT
+
+
+async def test_unit_change(hass, zp3111, client, integration):
+    """Test unit change via metadata updated event is handled by numeric sensors."""
+    entity_id = "sensor.4_in_1_sensor_air_temperature"
+    assert hass.states.get(entity_id)
+    state = hass.states.get(entity_id)
+    assert state.state == "21.98"
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": zp3111.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": "Air temperature",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Air temperature",
+                    "ccSpecific": {"sensorType": 1, "scale": 1},
+                    "unit": "°F",
+                },
+                "propertyName": "Air temperature",
+                "nodeId": zp3111.node_id,
+            },
+        },
+    )
+    zp3111.receive_event(event)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == "-5.57"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -391,5 +391,22 @@ async def test_unit_change(hass, zp3111, client, integration):
         },
     )
     zp3111.receive_event(event)
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": zp3111.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": "Air temperature",
+                "newValue": 71.56,
+                "prevValue": 21.98,
+                "propertyName": "Air temperature",
+            },
+        },
+    )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == "-5.57"
+    assert hass.states.get(entity_id).state == "21.98"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -365,6 +365,7 @@ async def test_unit_change(hass, zp3111, client, integration):
     entity_id = "sensor.4_in_1_sensor_air_temperature"
     assert hass.states.get(entity_id)
     state = hass.states.get(entity_id)
+    assert state
     assert state.state == "21.98"
     event = Event(
         "metadata updated",

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -409,4 +409,6 @@ async def test_unit_change(hass, zp3111, client, integration):
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == "21.98"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "21.98"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -402,13 +402,14 @@ async def test_unit_change(hass, zp3111, client, integration):
                 "commandClass": 49,
                 "endpoint": 0,
                 "property": "Air temperature",
-                "newValue": 71.56,
+                "newValue": 212,
                 "prevValue": 21.98,
                 "propertyName": "Air temperature",
             },
         },
     )
+    zp3111.receive_event(event)
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "21.98"
+    assert state.state == "100.0"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -391,6 +391,10 @@ async def test_unit_change(hass, zp3111, client, integration):
         },
     )
     zp3111.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "21.98"
     event = Event(
         "value updated",
         {

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -395,6 +395,7 @@ async def test_unit_change(hass, zp3111, client, integration):
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "21.98"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
     event = Event(
         "value updated",
         {
@@ -417,3 +418,4 @@ async def test_unit_change(hass, zp3111, client, integration):
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "100.0"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -366,6 +366,7 @@ async def test_unit_change(hass, zp3111, client, integration):
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "21.98"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
     event = Event(
         "metadata updated",
         {


### PR DESCRIPTION
## Proposed change
In https://github.com/home-assistant/core/issues/62325 we are seeing a device change units on one of its values after startup. Because we get the unit of measurement during startup, HA currently doesn't detect this unit change properly. With this change, we do. In this particular case, two events get fired, a `metadata updated` event and `value updated` event, which in combination recalibrate the values on the device, but with this change should have no impact to the user.

~~We can reduce the code complexity once this gets merged and released: https://github.com/home-assistant-libs/zwave-js-server-python/pull/342~~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/62325
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
