### PR TITLE
Add telegram message_tag, disable_notification, parse_mode

### DIFF
--- a/homeassistant/components/telegram/notify.py
+++ b/homeassistant/components/telegram/notify.py
@@ -12,9 +12,9 @@ from homeassistant.components.notify import (
     BaseNotificationService,
 )
 from homeassistant.components.telegram_bot import (
+    ATTR_DISABLE_NOTIF,
     ATTR_MESSAGE_TAG,
     ATTR_PARSER,
-    ATTR_DISABLE_NOTIF,
 )
 from homeassistant.const import ATTR_LOCATION
 from homeassistant.helpers.reload import setup_reload_service

--- a/homeassistant/components/telegram/notify.py
+++ b/homeassistant/components/telegram/notify.py
@@ -11,6 +11,11 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
 )
+from homeassistant.components.telegram_bot import (
+    ATTR_MESSAGE_TAG,
+    ATTR_PARSER,
+    ATTR_DISABLE_NOTIF,
+)
 from homeassistant.const import ATTR_LOCATION
 from homeassistant.helpers.reload import setup_reload_service
 
@@ -55,6 +60,21 @@ class TelegramNotificationService(BaseNotificationService):
         if message:
             service_data.update({ATTR_MESSAGE: message})
         data = kwargs.get(ATTR_DATA)
+
+        # Set message tag
+        if data is not None and ATTR_MESSAGE_TAG in data:
+            message_tag = data.get(ATTR_MESSAGE_TAG)
+            service_data.update({ATTR_MESSAGE_TAG: message_tag})
+
+        # Set disable_notification
+        if data is not None and ATTR_DISABLE_NOTIF in data:
+            disable_notification = data.get(ATTR_DISABLE_NOTIF)
+            service_data.update({ATTR_DISABLE_NOTIF: disable_notification})
+
+        # Set parse_mode
+        if data is not None and ATTR_PARSER in data:
+            parse_mode = data.get(ATTR_PARSER)
+            service_data.update({ATTR_PARSER: parse_mode})
 
         # Get keyboard info
         if data is not None and ATTR_KEYBOARD in data:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
adds ability to specify message_tag, disable_notification, parse_mode to telegram.notify

## Example
```yaml
# Example configuration.yaml entry
- service: notify.telegram
  data:
    message: "message"
    title: "title"
    data:
      message_tag: "message_tag"
      disable_notification: True
      parse_mode: html
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21129

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
