### PR TITLE
Autogenerate unique IDs for sensors, binary_sensors, switches and camera in android_webcam_integration

### DIFF
--- a/homeassistant/components/android_ip_webcam/__init__.py
+++ b/homeassistant/components/android_ip_webcam/__init__.py
@@ -332,3 +332,8 @@ class AndroidIPCamEntity(Entity):
         state_attr[ATTR_AUD_CONNS] = self._ipcam.status_data.get("audio_connections")
 
         return state_attr
+    
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this entity."""
+        return "ip_webcam"

--- a/homeassistant/components/android_ip_webcam/binary_sensor.py
+++ b/homeassistant/components/android_ip_webcam/binary_sensor.py
@@ -47,3 +47,8 @@ class IPWebcamBinarySensor(AndroidIPCamEntity, BinarySensorEntity):
         """Retrieve latest state."""
         state, _ = self._ipcam.export_sensor(self._sensor)
         self._attr_is_on = state == 1.0
+        
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this entity."""
+        return f"{name}_{self._sensor}"    

--- a/homeassistant/components/android_ip_webcam/binary_sensor.py
+++ b/homeassistant/components/android_ip_webcam/binary_sensor.py
@@ -42,6 +42,7 @@ class IPWebcamBinarySensor(AndroidIPCamEntity, BinarySensorEntity):
         self._mapped_name = KEY_MAP.get(self._sensor, self._sensor)
         self._attr_name = f"{name} {self._mapped_name}"
         self._attr_is_on = None
+        self._name = name
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -51,4 +52,4 @@ class IPWebcamBinarySensor(AndroidIPCamEntity, BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this entity."""
-        return f"{name}_{self._sensor}"    
+        return f"{self._name}_{self._sensor}"    

--- a/homeassistant/components/android_ip_webcam/sensor.py
+++ b/homeassistant/components/android_ip_webcam/sensor.py
@@ -73,3 +73,8 @@ class IPWebcamSensor(AndroidIPCamEntity, SensorEntity):
         if self._sensor == "battery_level" and self._attr_native_value is not None:
             return icon_for_battery_level(int(self._attr_native_value))
         return ICON_MAP.get(self._sensor, "mdi:eye")
+    
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this entity."""
+        return f"{name}_{self._sensor}"

--- a/homeassistant/components/android_ip_webcam/sensor.py
+++ b/homeassistant/components/android_ip_webcam/sensor.py
@@ -53,6 +53,7 @@ class IPWebcamSensor(AndroidIPCamEntity, SensorEntity):
         self._attr_name = f"{name} {self._mapped_name}"
         self._attr_native_value = None
         self._attr_native_unit_of_measurement = None
+        self._name = name
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -77,4 +78,4 @@ class IPWebcamSensor(AndroidIPCamEntity, SensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this entity."""
-        return f"{name}_{self._sensor}"
+        return f"{self._name}_{self._sensor}"

--- a/homeassistant/components/android_ip_webcam/switch.py
+++ b/homeassistant/components/android_ip_webcam/switch.py
@@ -86,3 +86,9 @@ class IPWebcamSettingsSwitch(AndroidIPCamEntity, SwitchEntity):
     def icon(self):
         """Return the icon for the switch."""
         return ICON_MAP.get(self._setting, "mdi:flash")
+    
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this entity."""
+        return f"{name}_{self._setting}"
+

--- a/homeassistant/components/android_ip_webcam/switch.py
+++ b/homeassistant/components/android_ip_webcam/switch.py
@@ -51,6 +51,7 @@ class IPWebcamSettingsSwitch(AndroidIPCamEntity, SwitchEntity):
         self._mapped_name = KEY_MAP.get(self._setting, self._setting)
         self._attr_name = f"{name} {self._mapped_name}"
         self._attr_is_on = False
+        self._name = name
 
     async def async_update(self):
         """Get the updated status of the switch."""
@@ -90,5 +91,5 @@ class IPWebcamSettingsSwitch(AndroidIPCamEntity, SwitchEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this entity."""
-        return f"{name}_{self._setting}"
+        return f"{self._name}_{self._setting}"
 


### PR DESCRIPTION
## Proposed change
Missing unique IDs make the following impossible in Lovelace:
1. renaming the sensor
2. assigning the sensor to a room
    
All integrations should either provide unique IDs or allow the provision of them in the configuration.yaml file.



## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
