### PR TITLE
Tibber cost statistics

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -539,67 +539,67 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
         for home in self._tibber_connection.get_homes():
             if not home.hourly_consumption_data:
                 continue
+            for sensor_type in ["consumption", "totalCost"]:
+                statistic_id = f"{TIBBER_DOMAIN}:energy_{sensor_type.lower()}_{home.home_id.replace('-', '')}"
 
-            statistic_id = (
-                f"{TIBBER_DOMAIN}:energy_consumption_{home.home_id.replace('-', '')}"
-            )
-
-            last_stats = await self.hass.async_add_executor_job(
-                get_last_statistics, self.hass, 1, statistic_id, True
-            )
-
-            if not last_stats:
-                # First time we insert 5 years of data (if available)
-                hourly_consumption_data = await home.get_historic_data(5 * 365 * 24)
-
-                _sum = 0
-                last_stats_time = None
-            else:
-                # hourly_consumption_data contains the last 30 days of consumption data.
-                # We update the statistics with the last 30 days of data to handle corrections in the data.
-                hourly_consumption_data = home.hourly_consumption_data
-
-                start = dt_util.parse_datetime(
-                    hourly_consumption_data[0]["from"]
-                ) - timedelta(hours=1)
-                stat = await self.hass.async_add_executor_job(
-                    statistics_during_period,
-                    self.hass,
-                    start,
-                    None,
-                    [statistic_id],
-                    "hour",
-                    True,
+                last_stats = await self.hass.async_add_executor_job(
+                    get_last_statistics, self.hass, 1, statistic_id, True
                 )
-                _sum = stat[statistic_id][0]["sum"]
-                last_stats_time = stat[statistic_id][0]["start"]
 
-            statistics = []
+                if not last_stats:
+                    # First time we insert 5 years of data (if available)
+                    hourly_consumption_data = await home.get_historic_data(5 * 365 * 24)
 
-            for data in hourly_consumption_data:
-                if data.get("consumption") is None:
-                    continue
+                    _sum = 0
+                    last_stats_time = None
+                else:
+                    # hourly_consumption_data contains the last 30 days of consumption data.
+                    # We update the statistics with the last 30 days of data to handle corrections in the data.
+                    hourly_consumption_data = home.hourly_consumption_data
 
-                start = dt_util.parse_datetime(data["from"])
-                if last_stats_time is not None and start <= last_stats_time:
-                    continue
-
-                _sum += data["consumption"]
-
-                statistics.append(
-                    StatisticData(
-                        start=start,
-                        state=data["consumption"],
-                        sum=_sum,
+                    start = dt_util.parse_datetime(
+                        hourly_consumption_data[0]["from"]
+                    ) - timedelta(hours=1)
+                    stat = await self.hass.async_add_executor_job(
+                        statistics_during_period,
+                        self.hass,
+                        start,
+                        None,
+                        [statistic_id],
+                        "hour",
+                        True,
                     )
-                )
+                    _sum = stat[statistic_id][0]["sum"]
+                    last_stats_time = stat[statistic_id][0]["start"]
 
-            metadata = StatisticMetaData(
-                has_mean=False,
-                has_sum=True,
-                name=f"{home.name} consumption",
-                source=TIBBER_DOMAIN,
-                statistic_id=statistic_id,
-                unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-            )
-            async_add_external_statistics(self.hass, metadata, statistics)
+                statistics = []
+
+                for data in hourly_consumption_data:
+                    if data.get(sensor_type) is None:
+                        continue
+
+                    start = dt_util.parse_datetime(data["from"])
+                    if last_stats_time is not None and start <= last_stats_time:
+                        continue
+
+                    _sum += data[sensor_type]
+
+                    statistics.append(
+                        StatisticData(
+                            start=start,
+                            state=data[sensor_type],
+                            sum=_sum,
+                        )
+                    )
+
+                metadata = StatisticMetaData(
+                    has_mean=False,
+                    has_sum=True,
+                    name=f"{home.name} {sensor_type}",
+                    source=TIBBER_DOMAIN,
+                    statistic_id=statistic_id,
+                    unit_of_measurement=ENERGY_KILO_WATT_HOUR
+                    if sensor_type == "consumption"
+                    else home.currency,
+                )
+                async_add_external_statistics(self.hass, metadata, statistics)

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -595,11 +595,10 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
                         )
                     )
 
-                unit = (
-                    ENERGY_KILO_WATT_HOUR
-                    if sensor_type == "consumption"
-                    else home.currency
-                )
+                if sensor_type == "consumption":
+                    unit = ENERGY_KILO_WATT_HOUR
+                else:
+                    unit = home.currency
                 metadata = StatisticMetaData(
                     has_mean=False,
                     has_sum=True,

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -556,7 +556,8 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
                     _sum = 0
                     last_stats_time = None
                 else:
-                    # hourly_consumption_data contains the last 30 days of consumption data.
+                    # hourly_consumption_data contains the last 30 days
+                    # of consumption data.
                     # We update the statistics with the last 30 days of data to handle corrections in the data.
                     hourly_consumption_data = home.hourly_consumption_data
 

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -539,7 +539,10 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
         for home in self._tibber_connection.get_homes():
             if not home.hourly_consumption_data:
                 continue
-            for sensor_type in ["consumption", "totalCost"]:
+            for sensor_type in (
+                "consumption",
+                "totalCost",
+            ):
                 statistic_id = f"{TIBBER_DOMAIN}:energy_{sensor_type.lower()}_{home.home_id.replace('-', '')}"
 
                 last_stats = await self.hass.async_add_executor_job(

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -543,7 +543,11 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
                 "consumption",
                 "totalCost",
             ):
-                statistic_id = f"{TIBBER_DOMAIN}:energy_{sensor_type.lower()}_{home.home_id.replace('-', '')}"
+                statistic_id = (
+                    f"{TIBBER_DOMAIN}:energy_"
+                    f"{sensor_type.lower()}_"
+                    f"{home.home_id.replace('-', '')}"
+                )
 
                 last_stats = await self.hass.async_add_executor_job(
                     get_last_statistics, self.hass, 1, statistic_id, True

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -595,14 +595,17 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
                         )
                     )
 
+                unit = (
+                    ENERGY_KILO_WATT_HOUR
+                    if sensor_type == "consumption"
+                    else home.currency
+                )
                 metadata = StatisticMetaData(
                     has_mean=False,
                     has_sum=True,
                     name=f"{home.name} {sensor_type}",
                     source=TIBBER_DOMAIN,
                     statistic_id=statistic_id,
-                    unit_of_measurement=ENERGY_KILO_WATT_HOUR
-                    if sensor_type == "consumption"
-                    else home.currency,
+                    unit_of_measurement=unit,
                 )
                 async_add_external_statistics(self.hass, metadata, statistics)

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -558,7 +558,8 @@ class TibberDataCoordinator(update_coordinator.DataUpdateCoordinator):
                 else:
                     # hourly_consumption_data contains the last 30 days
                     # of consumption data.
-                    # We update the statistics with the last 30 days of data to handle corrections in the data.
+                    # We update the statistics with the last 30 days
+                    # of data to handle corrections in the data.
                     hourly_consumption_data = home.hourly_consumption_data
 
                     start = dt_util.parse_datetime(


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Tibber cost statistics
The change is smaller than the git diff looks like. It is basically adding a for loop `            for sensor_type in ["consumption", "totalCost"]:` to also add the cost

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21083

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
