### PR TITLE
Ensure selected entity is pre-selected in homekit options flow

### DIFF
--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -453,11 +453,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.hass,
             domains=self.hk_options[CONF_DOMAINS],
         )
+        supported_entities_not_in_domains = {
+            entity
+            for entity in entities
+            if entity not in all_supported_entities and self.hass.states.get(entity)
+        }
         # In accessory mode, CONF_DOMAINS will be empty
-        for entity in entities:
-            if entity not in all_supported_entities and self.hass.states.get(entity):
-                all_supported_entities.add(entity)
-
+        all_supported_entities |= supported_entities_not_in_domains
         data_schema = {}
         entity_schema = vol.In
         entities_schema_required = vol.Required

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -460,7 +460,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         data_schema = {}
         entity_schema = vol.In
+        entities_schema_required = vol.Required
         if self.hk_options[CONF_HOMEKIT_MODE] != HOMEKIT_MODE_ACCESSORY:
+            entities_schema_required = vol.Optional
             include_exclude_mode = MODE_INCLUDE
             if not entities:
                 include_exclude_mode = MODE_EXCLUDE
@@ -475,7 +477,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             entity_id for entity_id in entities if entity_id in all_supported_entities
         ]
         data_schema[
-            vol.Optional(CONF_ENTITIES, default=valid_entities)
+            entities_schema_required(CONF_ENTITIES, default=valid_entities)
         ] = entity_schema(all_supported_entities)
 
         return self.async_show_form(

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -453,24 +453,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.hass,
             domains=self.hk_options[CONF_DOMAINS],
         )
-        supported_entities_not_in_domains = {
-            entity
-            for entity in entities
-            if entity not in all_supported_entities and self.hass.states.get(entity)
-        }
-        # In accessory mode, CONF_DOMAINS will be empty
-        all_supported_entities |= supported_entities_not_in_domains
         data_schema = {}
-        entity_schema = vol.In
-        entities_schema_required = vol.Required
         # Strip out entities that no longer exist to prevent error in the UI
         valid_entities = [
             entity_id for entity_id in entities if entity_id in all_supported_entities
         ]
-        # In accessory mode we can only have one
-        default_value = valid_entities[0] if valid_entities else None
-
-        if self.hk_options[CONF_HOMEKIT_MODE] != HOMEKIT_MODE_ACCESSORY:
+        if self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_ACCESSORY:
+            # In accessory mode we can only have one
+            default_value = valid_entities[0] if valid_entities else None
+            entity_schema = vol.In
+            entities_schema_required = vol.Required
+        else:
+            # Bridge mode
             entities_schema_required = vol.Optional
             include_exclude_mode = MODE_INCLUDE
             if not entities:

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -447,14 +447,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             return await self.async_step_advanced()
 
         entity_filter = self.hk_options.get(CONF_FILTER, {})
+        entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
+
         all_supported_entities = _async_get_matching_entities(
             self.hass,
             domains=self.hk_options[CONF_DOMAINS],
         )
+        # In accessory mode, CONF_DOMAINS will be empty
+        for entity in entities:
+            if entity not in all_supported_entities and self.hass.states.get(entity):
+                all_supported_entities.add(entity)
 
         data_schema = {}
         entity_schema = vol.In
-        entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
         if self.hk_options[CONF_HOMEKIT_MODE] != HOMEKIT_MODE_ACCESSORY:
             include_exclude_mode = MODE_INCLUDE
             if not entities:

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -7,6 +7,8 @@ from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT
 from homeassistant.setup import async_setup_component
 
+from .util import PATH_HOMEKIT, async_init_entry
+
 from tests.common import MockConfigEntry
 
 
@@ -1065,11 +1067,13 @@ async def test_options_flow_blocked_when_from_yaml(hass, mock_get_source_ip):
         assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
 
-async def test_options_flow_include_mode_basic_accessory(hass, mock_get_source_ip):
+@patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+async def test_options_flow_include_mode_basic_accessory(
+    port_mock, hass, mock_get_source_ip, hk_driver, mock_async_zeroconf
+):
     """Test config flow options in include mode with a single accessory."""
-
     config_entry = _mock_config_entry_with_options_populated()
-    config_entry.add_to_hass(hass)
+    await async_init_entry(hass, config_entry)
 
     hass.states.async_set("media_player.tv", "off")
     hass.states.async_set("media_player.sonos", "off")
@@ -1102,6 +1106,46 @@ async def test_options_flow_include_mode_basic_accessory(hass, mock_get_source_i
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["step_id"] == "include_exclude"
     assert _get_schema_default(result2["data_schema"].schema, "entities") == []
+
+    result3 = await hass.config_entries.options.async_configure(
+        result2["flow_id"],
+        user_input={"entities": "media_player.tv"},
+    )
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {
+        "mode": "accessory",
+        "filter": {
+            "exclude_domains": [],
+            "exclude_entities": [],
+            "include_domains": [],
+            "include_entities": ["media_player.tv"],
+        },
+    }
+
+    # Now we check again to make sure the single entity is still
+    # preselected
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id, context={"show_advanced_options": False}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+    assert result["data_schema"]({}) == {
+        "domains": ["media_player"],
+        "mode": "accessory",
+    }
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"domains": ["media_player"], "mode": "accessory"},
+    )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["step_id"] == "include_exclude"
+    assert _get_schema_default(result2["data_schema"].schema, "entities") == [
+        "media_player.tv"
+    ]
 
     result3 = await hass.config_entries.options.async_configure(
         result2["flow_id"],

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1105,7 +1105,7 @@ async def test_options_flow_include_mode_basic_accessory(
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["step_id"] == "include_exclude"
-    assert _get_schema_default(result2["data_schema"].schema, "entities") == []
+    assert _get_schema_default(result2["data_schema"].schema, "entities") is None
 
     result3 = await hass.config_entries.options.async_configure(
         result2["flow_id"],
@@ -1143,9 +1143,10 @@ async def test_options_flow_include_mode_basic_accessory(
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["step_id"] == "include_exclude"
-    assert _get_schema_default(result2["data_schema"].schema, "entities") == [
-        "media_player.tv"
-    ]
+    assert (
+        _get_schema_default(result2["data_schema"].schema, "entities")
+        == "media_player.tv"
+    )
 
     result3 = await hass.config_entries.options.async_configure(
         result2["flow_id"],


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We recently adjusted the flow to exclude entities that had
  been deleted from breaking the UI validation. We need to include
  single entities in the set of all supported entities since
  accessory mode has no domain filter


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
