### PR TITLE
Handle missing values in alpha_vantage sensor

### DIFF
--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -130,7 +130,7 @@ class AlphaVantageSensor(SensorEntity):
         _LOGGER.debug("Requesting new data for symbol %s", self._symbol)
         all_values, _ = self._timeseries.get_intraday(self._symbol)
         values = next(iter(all_values.values()))
-        if "1. open" in values:  # jms
+        if values is not None and "1. open" in values:  # jms
             self._attr_native_value = values["1. open"]
         else:
             self._attr_native_value = None
@@ -173,7 +173,7 @@ class AlphaVantageForeignExchange(SensorEntity):
         values, _ = self._foreign_exchange.get_currency_exchange_rate(
             from_currency=self._from_currency, to_currency=self._to_currency
         )
-        if "5. Exchange Rate" in values:  # jms
+        if values is not None and "5. Exchange Rate" in values:  # jms
             self._attr_native_value = round(float(values["5. Exchange Rate"]), 4)
         else:
             self._attr_native_value = None

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -130,7 +130,10 @@ class AlphaVantageSensor(SensorEntity):
         _LOGGER.debug("Requesting new data for symbol %s", self._symbol)
         all_values, _ = self._timeseries.get_intraday(self._symbol)
         values = next(iter(all_values.values()))
-        self._attr_native_value = values["1. open"]
+        if "1. open" in values: # jms
+            self._attr_native_value = values["1. open"]
+        else:
+            self._attr_native_value = None
         self._attr_extra_state_attributes = (
             {
                 ATTR_ATTRIBUTION: ATTRIBUTION,
@@ -138,7 +141,7 @@ class AlphaVantageSensor(SensorEntity):
                 ATTR_HIGH: values["2. high"],
                 ATTR_LOW: values["3. low"],
             }
-            if values is not None
+            if (values is not None) and (type(values) is dict)
             else None
         )
         _LOGGER.debug("Received new values for symbol %s", self._symbol)
@@ -170,7 +173,10 @@ class AlphaVantageForeignExchange(SensorEntity):
         values, _ = self._foreign_exchange.get_currency_exchange_rate(
             from_currency=self._from_currency, to_currency=self._to_currency
         )
-        self._attr_native_value = round(float(values["5. Exchange Rate"]), 4)
+        if "5. Exchange Rate" in values: # jms
+            self._attr_native_value = round(float(values["5. Exchange Rate"]), 4)
+        else:
+            self._attr_native_value = None
         self._attr_extra_state_attributes = (
             {
                 ATTR_ATTRIBUTION: ATTRIBUTION,

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -141,7 +141,7 @@ class AlphaVantageSensor(SensorEntity):
                 ATTR_HIGH: values["2. high"],
                 ATTR_LOW: values["3. low"],
             }
-            if (values is not None) and (isinstance(values,dict))
+            if (values is not None) and (isinstance(values, dict))
             else None
         )
         _LOGGER.debug("Received new values for symbol %s", self._symbol)

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -130,7 +130,7 @@ class AlphaVantageSensor(SensorEntity):
         _LOGGER.debug("Requesting new data for symbol %s", self._symbol)
         all_values, _ = self._timeseries.get_intraday(self._symbol)
         values = next(iter(all_values.values()))
-        if values is not None and "1. open" in values:  # jms
+        if isinstance(values, dict) and "1. open" in values:  # jms
             self._attr_native_value = values["1. open"]
         else:
             self._attr_native_value = None
@@ -173,7 +173,7 @@ class AlphaVantageForeignExchange(SensorEntity):
         values, _ = self._foreign_exchange.get_currency_exchange_rate(
             from_currency=self._from_currency, to_currency=self._to_currency
         )
-        if values is not None and "5. Exchange Rate" in values:  # jms
+        if isinstance(values, dict) and "5. Exchange Rate" in values:  # jms
             self._attr_native_value = round(float(values["5. Exchange Rate"]), 4)
         else:
             self._attr_native_value = None

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -130,7 +130,7 @@ class AlphaVantageSensor(SensorEntity):
         _LOGGER.debug("Requesting new data for symbol %s", self._symbol)
         all_values, _ = self._timeseries.get_intraday(self._symbol)
         values = next(iter(all_values.values()))
-        if "1. open" in values: # jms
+        if "1. open" in values:  # jms
             self._attr_native_value = values["1. open"]
         else:
             self._attr_native_value = None
@@ -141,7 +141,7 @@ class AlphaVantageSensor(SensorEntity):
                 ATTR_HIGH: values["2. high"],
                 ATTR_LOW: values["3. low"],
             }
-            if (values is not None) and (type(values) is dict)
+            if (values is not None) and (isinstance(values,dict))
             else None
         )
         _LOGGER.debug("Received new values for symbol %s", self._symbol)
@@ -173,7 +173,7 @@ class AlphaVantageForeignExchange(SensorEntity):
         values, _ = self._foreign_exchange.get_currency_exchange_rate(
             from_currency=self._from_currency, to_currency=self._to_currency
         )
-        if "5. Exchange Rate" in values: # jms
+        if "5. Exchange Rate" in values:  # jms
             self._attr_native_value = round(float(values["5. Exchange Rate"]), 4)
         else:
             self._attr_native_value = None

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -130,7 +130,7 @@ class AlphaVantageSensor(SensorEntity):
         _LOGGER.debug("Requesting new data for symbol %s", self._symbol)
         all_values, _ = self._timeseries.get_intraday(self._symbol)
         values = next(iter(all_values.values()))
-        if isinstance(values, dict) and "1. open" in values:  # jms
+        if isinstance(values, dict) and "1. open" in values:
             self._attr_native_value = values["1. open"]
         else:
             self._attr_native_value = None
@@ -141,7 +141,7 @@ class AlphaVantageSensor(SensorEntity):
                 ATTR_HIGH: values["2. high"],
                 ATTR_LOW: values["3. low"],
             }
-            if (values is not None) and (isinstance(values, dict))
+            if values is not None and isinstance(values, dict)
             else None
         )
         _LOGGER.debug("Received new values for symbol %s", self._symbol)
@@ -173,7 +173,7 @@ class AlphaVantageForeignExchange(SensorEntity):
         values, _ = self._foreign_exchange.get_currency_exchange_rate(
             from_currency=self._from_currency, to_currency=self._to_currency
         )
-        if isinstance(values, dict) and "5. Exchange Rate" in values:  # jms
+        if isinstance(values, dict) and "5. Exchange Rate" in values:
             self._attr_native_value = round(float(values["5. Exchange Rate"]), 4)
         else:
             self._attr_native_value = None

--- a/homeassistant/components/alpha_vantage/sensor.py
+++ b/homeassistant/components/alpha_vantage/sensor.py
@@ -141,7 +141,7 @@ class AlphaVantageSensor(SensorEntity):
                 ATTR_HIGH: values["2. high"],
                 ATTR_LOW: values["3. low"],
             }
-            if values is not None and isinstance(values, dict)
+            if isinstance(values, dict)
             else None
         )
         _LOGGER.debug("Received new values for symbol %s", self._symbol)


### PR DESCRIPTION
Catch error condition if returned values does not contain expected values.
The code was fetching items from a dictionary, but sometimes the items were not present or the dictionary as such was not a dictionary but only an error text.
If the user exceeds the API call limit, he gets a warning instead of the requested data:
{'Note': 'Thank you for using Alpha Vantage! Our standard API call frequency is 5 calls per minute and 500 calls per day. Please visit https://www.alphavantage.co/premium/ if you would like to target a higher API call frequency.'}

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many times, the integration gets invalid results from the website, mainly the first time when a greeting is sent. To avoid python errors because of non existant dictionary elements, I introduced some checks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x ] The code change is tested and works locally.
- [ x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
