### PR TITLE
Fix units not being pulled from source sensor

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -158,9 +158,7 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             if self._unit_of_measurement is None:
                 unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
                 if unit is not None:
-                    self._unit_of_measurement = self._unit_template.format(
-                        "" if unit is None else unit
-                    )
+                    self._unit_of_measurement = self._unit_template.format(unit)
                     update_state = True
 
             if (

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -150,17 +150,29 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             old_state = event.data.get("old_state")
             new_state = event.data.get("new_state")
 
+            # We may want to update our state before an early return,
+            # based on the source sensor's unit_of_measurement
+            # or device_class.
+            update_state = False
+
             if self._unit_of_measurement is None:
                 unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-                self._unit_of_measurement = self._unit_template.format(
-                    "" if unit is None else unit
-                )
+                if unit is not None:
+                    self._unit_of_measurement = self._unit_template.format(
+                        "" if unit is None else unit
+                    )
+                    update_state = True
+
             if (
                 self.device_class is None
                 and new_state.attributes.get(ATTR_DEVICE_CLASS)
                 == SensorDeviceClass.POWER
             ):
                 self._attr_device_class = SensorDeviceClass.ENERGY
+                update_state = True
+
+            if update_state:
+                self.async_write_ha_state()
 
             if (
                 old_state is None

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
     POWER_WATT,
+    STATE_UNKNOWN,
     TIME_SECONDS,
 )
 from homeassistant.core import HomeAssistant, State
@@ -324,3 +325,84 @@ async def test_units(hass):
     # Testing the sensor ignored the source sensor's units until
     # they became valid
     assert state.attributes.get("unit_of_measurement") == ENERGY_WATT_HOUR
+
+
+async def test_device_class(hass):
+    """Test integration sensor units using a power source."""
+    config = {
+        "sensor": {
+            "platform": "integration",
+            "name": "integration",
+            "source": "sensor.power",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    entity_id = config["sensor"]["source"]
+    # This replicates the current sequence when HA starts up in a real runtime
+    # by updating the base sensor state before the base sensor's units
+    # or state have been correctly populated.  Those interim updates
+    # include states of None and Unknown
+    hass.states.async_set(entity_id, STATE_UNKNOWN, {})
+    await hass.async_block_till_done()
+    hass.states.async_set(entity_id, 100, {"device_class": None})
+    await hass.async_block_till_done()
+    hass.states.async_set(entity_id, 200, {"device_class": None})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    assert "device_class" not in state.attributes
+
+    hass.states.async_set(
+        entity_id, 300, {"device_class": SensorDeviceClass.POWER}, force_update=True
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    assert state is not None
+    # Testing the sensor ignored the source sensor's device class until
+    # it became valid
+    assert state.attributes.get("device_class") == SensorDeviceClass.ENERGY
+
+
+async def test_calc_errors(hass):
+    """Test integration sensor units using a power source."""
+    config = {
+        "sensor": {
+            "platform": "integration",
+            "name": "integration",
+            "source": "sensor.power",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    entity_id = config["sensor"]["source"]
+
+    hass.states.async_set(entity_id, None, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    # With the source sensor in a None state, the Reimann sensor should be
+    # unknown
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # Moving from an unknown state to a value is a calc error and should
+    # not change the value of the Reimann sensor.
+    hass.states.async_set(entity_id, 0, {"device_class": None})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # With the source sensor updated successfully, the Reimann sensor
+    # should have a zero (known) value.
+    hass.states.async_set(entity_id, 1, {"device_class": None})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    assert state is not None
+    assert round(float(state.state)) == 0

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -3,7 +3,12 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_WATT, TIME_SECONDS
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    ENERGY_WATT_HOUR,
+    POWER_WATT,
+    TIME_SECONDS,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -287,3 +292,35 @@ async def test_suffix(hass):
 
     # Testing a network speed sensor at 1000 bytes/s over 10s  = 10kbytes
     assert round(float(state.state)) == 10
+
+
+async def test_units(hass):
+    """Test integration sensor units using a power source."""
+    config = {
+        "sensor": {
+            "platform": "integration",
+            "name": "integration",
+            "source": "sensor.power",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+
+    entity_id = config["sensor"]["source"]
+    # This replicates the current sequence when HA starts up in a real runtime
+    # by updating the base sensor state before the base sensor's units
+    # or state have been correctly populated.  Those interim updates
+    # include states of None and Unknown
+    hass.states.async_set(entity_id, 100, {"unit_of_measurement": None})
+    await hass.async_block_till_done()
+    hass.states.async_set(entity_id, 200, {"unit_of_measurement": None})
+    await hass.async_block_till_done()
+    hass.states.async_set(entity_id, 300, {"unit_of_measurement": POWER_WATT})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    assert state is not None
+
+    # Testing the sensor ignored the source sensor's units until
+    # they became valid
+    assert state.attributes.get("unit_of_measurement") == ENERGY_WATT_HOUR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current Reimann integration doesn't pull unit_of_measurement from the source sensor, as intended.  This is a regression from the previous functionality due to change https://github.com/home-assistant/core/pull/54802 .  While well intentioned, the change created a situation where two things happened:
1) The Reimann sensor would attempt to update it's own unit_of_measurement based on the source sensor, which wasn't ready yet.  This resulted in the Reimann sensor setting its units to a value that included the prefix and time, but not the source units.  Since the value of the Reimann units was no longer None, these never got updated once the source sensor units were actually available.  The end result of this is that Reimann sensors all have unit_of_measurement that were "h" instead of "Wh" in the case of a source sensor that used Watts.  
2) The intended state wasn't actually changed in the Reimann sensor because the function returned before the state was written.  This has been addressed using the local update_state variable.  

The reason this regression likely wasn't found earlier is because it only affects new sensors.  Anyone who set one up previously would have an existing unit_of_measurement from the database or the restore_state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/reimann-integration-has-wrong-unit-of-measurement/376402
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
