### PR TITLE
Get rid of name collision in iaqualink tests

### DIFF
--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -1,5 +1,6 @@
 """Configuration for iAqualink tests."""
 import random
+import string
 from unittest.mock import AsyncMock
 
 from iaqualink.client import AqualinkClient
@@ -55,8 +56,8 @@ def get_aqualink_device(system, cls=None, data=None):
     if data is None:
         data = {}
 
-    num = random.randint(0, 999)
-    data["name"] = f"name_{num:03}"
+    name = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
+    data["name"] = name
 
     return cls(system=system, data=data)
 

--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -1,6 +1,5 @@
 """Configuration for iAqualink tests."""
 import random
-import string
 from unittest.mock import AsyncMock
 
 from iaqualink.client import AqualinkClient
@@ -55,9 +54,6 @@ def get_aqualink_device(system, cls=None, data=None):
 
     if data is None:
         data = {}
-
-    name = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
-    data["name"] = name
 
     return cls(system=system, data=data)
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -67,7 +67,8 @@ async def test_setup_systems_exception(hass, config_entry):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         side_effect=AqualinkServiceException,
@@ -83,7 +84,8 @@ async def test_setup_no_systems_recognized(hass, config_entry):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value={},
@@ -102,7 +104,8 @@ async def test_setup_devices_exception(hass, config_entry, client):
     systems = {system.serial: system}
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
@@ -123,11 +126,12 @@ async def test_setup_all_good_no_recognized_devices(hass, config_entry, client):
     system = get_aqualink_system(client)
     systems = {system.serial: system}
 
-    device = get_aqualink_device(system, AqualinkDevice)
+    device = get_aqualink_device(system, AqualinkDevice, data={"name": "dev_1"})
     devices = {device.name: device}
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
@@ -160,18 +164,23 @@ async def test_setup_all_good_all_device_types(hass, config_entry, client):
     systems = {system.serial: system}
 
     devices = [
-        get_aqualink_device(system, AqualinkAuxToggle),
-        get_aqualink_device(system, AqualinkBinarySensor),
-        get_aqualink_device(system, AqualinkLightToggle),
-        get_aqualink_device(system, AqualinkSensor),
-        get_aqualink_device(system, AqualinkThermostat),
+        get_aqualink_device(system, AqualinkAuxToggle, data={"name": "aux_1"}),
+        get_aqualink_device(
+            system, AqualinkBinarySensor, data={"name": "freeze_protection"}
+        ),
+        get_aqualink_device(system, AqualinkLightToggle, data={"name": "aux_2"}),
+        get_aqualink_device(system, AqualinkSensor, data={"name": "ph"}),
+        get_aqualink_device(
+            system, AqualinkThermostat, data={"name": "pool_set_point"}
+        ),
     ]
     devices = {d.name: d for d in devices}
 
     system.get_devices = AsyncMock(return_value=devices)
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
@@ -205,7 +214,8 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     caplog.set_level(logging.WARNING)
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,
@@ -303,13 +313,16 @@ async def test_entity_assumed_and_available(hass, config_entry, client):
     system = get_aqualink_system(client)
     systems = {system.serial: system}
 
-    light = get_aqualink_device(system, AqualinkLightToggle, data={"state": "1"})
+    light = get_aqualink_device(
+        system, AqualinkLightToggle, data={"name": "aux_1", "state": "1"}
+    )
     devices = {d.name: d for d in [light]}
     system.get_devices = AsyncMock(return_value=devices)
     system.update = AsyncMock()
 
     with patch(
-        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+        "homeassistant.components.iaqualink.AqualinkClient.login",
+        return_value=None,
     ), patch(
         "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value=systems,


### PR DESCRIPTION
## Proposed change

Change name generator to reduce risk of collision (10^3 -> 26^8).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63583
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
