### PR TITLE
Add support for managing 2.4G remotes in flux_led

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -49,6 +49,7 @@ PLATFORMS_BY_TYPE: Final = {
         Platform.LIGHT,
         Platform.NUMBER,
         Platform.SELECT,
+        Platform.SENSOR,
         Platform.SWITCH,
     ],
     DeviceType.Switch: [Platform.BUTTON, Platform.SELECT, Platform.SWITCH],

--- a/homeassistant/components/flux_led/button.py
+++ b/homeassistant/components/flux_led/button.py
@@ -5,7 +5,11 @@ from flux_led.aio import AIOWifiLedBulb
 from flux_led.protocol import RemoteConfig
 
 from homeassistant import config_entries
-from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -19,7 +23,7 @@ _RESTART_KEY = "restart"
 _UNPAIR_REMOTES_KEY = "unpair_remotes"
 
 RESTART_BUTTON_DESCRIPTION = ButtonEntityDescription(
-    key=_RESTART_KEY, name="Restart", icon="mdi:restart"
+    key=_RESTART_KEY, name="Restart", device_class=ButtonDeviceClass.RESTART
 )
 UNPAIR_REMOTES_DESCRIPTION = ButtonEntityDescription(
     key=_UNPAIR_REMOTES_KEY, name="Unpair Remotes", icon="mdi:remote-off"

--- a/homeassistant/components/flux_led/button.py
+++ b/homeassistant/components/flux_led/button.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from flux_led.aio import AIOWifiLedBulb
+from flux_led.protocol import RemoteConfig
 
 from homeassistant import config_entries
-from homeassistant.components.button import ButtonEntity
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -14,6 +15,16 @@ from .const import DOMAIN
 from .coordinator import FluxLedUpdateCoordinator
 from .entity import FluxBaseEntity
 
+_RESTART_KEY = "restart"
+_UNPAIR_REMOTES_KEY = "unpair_remotes"
+
+RESTART_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key=_RESTART_KEY, name="Restart", icon="mdi:restart"
+)
+UNPAIR_REMOTES_DESCRIPTION = ButtonEntityDescription(
+    key=_UNPAIR_REMOTES_KEY, name="Unpair Remotes", icon="mdi:remote-off"
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -22,11 +33,20 @@ async def async_setup_entry(
 ) -> None:
     """Set up Magic Home button based on a config entry."""
     coordinator: FluxLedUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([FluxRestartButton(coordinator.device, entry)])
+    device = coordinator.device
+    entities: list[FluxButton] = [
+        FluxButton(coordinator.device, entry, RESTART_BUTTON_DESCRIPTION)
+    ]
+    if device.paired_remotes is not None:
+        entities.append(
+            FluxButton(coordinator.device, entry, UNPAIR_REMOTES_DESCRIPTION)
+        )
+
+    async_add_entities(entities)
 
 
-class FluxRestartButton(FluxBaseEntity, ButtonEntity):
-    """Representation of a Flux restart button."""
+class FluxButton(FluxBaseEntity, ButtonEntity):
+    """Representation of a Flux button."""
 
     _attr_entity_category = EntityCategory.CONFIG
 
@@ -34,13 +54,19 @@ class FluxRestartButton(FluxBaseEntity, ButtonEntity):
         self,
         device: AIOWifiLedBulb,
         entry: config_entries.ConfigEntry,
+        description: ButtonEntityDescription,
     ) -> None:
-        """Initialize the reboot button."""
+        """Initialize the button."""
+        self.entity_description = description
         super().__init__(device, entry)
-        self._attr_name = f"{entry.data[CONF_NAME]} Restart"
+        self._attr_name = f"{entry.data[CONF_NAME]} {description.name}"
         if entry.unique_id:
-            self._attr_unique_id = f"{entry.unique_id}_restart"
+            self._attr_unique_id = f"{entry.unique_id}_{description.key}"
 
     async def async_press(self) -> None:
-        """Send out a restart command."""
-        await self._device.async_reboot()
+        """Send out a command."""
+        if self.entity_description.key == _RESTART_KEY:
+            await self._device.async_reboot()
+        else:
+            await self._device.async_unpair_remotes()
+            await self._device.async_config_remotes(RemoteConfig.OPEN)

--- a/homeassistant/components/flux_led/sensor.py
+++ b/homeassistant/components/flux_led/sensor.py
@@ -40,6 +40,7 @@ class FluxPairedRemotes(FluxEntity, SensorEntity):
     _attr_entity_category = EntityCategory.CONFIG
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> int:
         """Return the number of paired remotes."""
+        assert self._device.paired_remotes is not None
         return self._device.paired_remotes

--- a/homeassistant/components/flux_led/sensor.py
+++ b/homeassistant/components/flux_led/sensor.py
@@ -1,0 +1,45 @@
+"""Support for Magic Home sensors."""
+from __future__ import annotations
+
+from homeassistant import config_entries
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import FluxLedUpdateCoordinator
+from .entity import FluxEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Magic Home sensors."""
+    coordinator: FluxLedUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    if coordinator.device.paired_remotes is not None:
+        async_add_entities(
+            [
+                FluxPairedRemotes(
+                    coordinator,
+                    entry.unique_id,
+                    f"{entry.data[CONF_NAME]} Paired Remotes",
+                    "paired_remotes",
+                )
+            ]
+        )
+
+
+class FluxPairedRemotes(FluxEntity, SensorEntity):
+    """Representation of a Magic Home paired remotes sensor."""
+
+    _attr_icon = "mdi:remote"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the number of paired remotes."""
+        return self._device.paired_remotes

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -14,18 +14,28 @@ from flux_led.const import (
     COLOR_MODE_RGB as FLUX_COLOR_MODE_RGB,
 )
 from flux_led.models_db import MODEL_MAP
-from flux_led.protocol import LEDENETRawState, PowerRestoreState, PowerRestoreStates
+from flux_led.protocol import (
+    LEDENETRawState,
+    PowerRestoreState,
+    PowerRestoreStates,
+    RemoteConfig,
+)
 from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant.components import dhcp
+from homeassistant.components.flux_led.const import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 MODULE = "homeassistant.components.flux_led"
 MODULE_CONFIG_FLOW = "homeassistant.components.flux_led.config_flow"
 IP_ADDRESS = "127.0.0.1"
 MODEL_NUM_HEX = "0x35"
 MODEL_NUM = 0x35
-MODEL = "AZ120444"
+MODEL = "AK001-ZJ2149"
 MODEL_DESCRIPTION = "Bulb RGBCW"
 MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
 FLUX_MAC_ADDRESS = "AABBCCDDEEFF"
@@ -64,6 +74,16 @@ FLUX_DISCOVERY = FluxLEDDiscovery(
 )
 
 
+def _mock_config_entry_for_bulb(hass: HomeAssistant) -> ConfigEntry:
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
 def _mocked_bulb() -> AIOWifiLedBulb:
     bulb = MagicMock(auto_spec=AIOWifiLedBulb)
 
@@ -74,6 +94,8 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.requires_turn_on = True
     bulb.async_setup = AsyncMock(side_effect=_save_setup_callback)
     bulb.effect_list = ["some_effect"]
+    bulb.remote_config = RemoteConfig.OPEN
+    bulb.async_unpair_remotes = AsyncMock()
     bulb.async_set_time = AsyncMock()
     bulb.async_set_music_mode = AsyncMock()
     bulb.async_set_custom_pattern = AsyncMock()
@@ -82,6 +104,8 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.async_set_white_temp = AsyncMock()
     bulb.async_set_brightness = AsyncMock()
     bulb.async_set_device_config = AsyncMock()
+    bulb.async_config_remotes = AsyncMock()
+    bulb.paired_remotes = 2
     bulb.pixels_per_segment = 300
     bulb.segments = 2
     bulb.music_pixels_per_segment = 150

--- a/tests/components/flux_led/test_button.py
+++ b/tests/components/flux_led/test_button.py
@@ -8,8 +8,11 @@ from homeassistant.setup import async_setup_component
 
 from . import (
     DEFAULT_ENTRY_TITLE,
+    FLUX_DISCOVERY,
     IP_ADDRESS,
     MAC_ADDRESS,
+    _mock_config_entry_for_bulb,
+    _mocked_bulb,
     _mocked_switch,
     _patch_discovery,
     _patch_wifibulb,
@@ -18,7 +21,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_switch_reboot(hass: HomeAssistant) -> None:
+async def test_button_reboot(hass: HomeAssistant) -> None:
     """Test a smart plug can be rebooted."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -39,3 +42,21 @@ async def test_switch_reboot(hass: HomeAssistant) -> None:
         BUTTON_DOMAIN, "press", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     switch.async_reboot.assert_called_once()
+
+
+async def test_button_unpair_remotes(hass: HomeAssistant) -> None:
+    """Test that remotes can be unpaired."""
+    _mock_config_entry_for_bulb(hass)
+    bulb = _mocked_bulb()
+    bulb.discovery = FLUX_DISCOVERY
+    with _patch_discovery(device=FLUX_DISCOVERY), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "button.bulb_rgbcw_ddeeff_unpair_remotes"
+    assert hass.states.get(entity_id)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN, "press", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_unpair_remotes.assert_called_once()

--- a/tests/components/flux_led/test_sensor.py
+++ b/tests/components/flux_led/test_sensor.py
@@ -1,0 +1,25 @@
+"""Tests for flux_led sensor platform."""
+from homeassistant.components import flux_led
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import (
+    FLUX_DISCOVERY,
+    _mock_config_entry_for_bulb,
+    _mocked_bulb,
+    _patch_discovery,
+    _patch_wifibulb,
+)
+
+
+async def test_paired_remotes_sensor(hass: HomeAssistant) -> None:
+    """Test that the paired remotes sensor has the correct value."""
+    _mock_config_entry_for_bulb(hass)
+    bulb = _mocked_bulb()
+    bulb.discovery = FLUX_DISCOVERY
+    with _patch_discovery(device=FLUX_DISCOVERY), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "sensor.bulb_rgbcw_ddeeff_paired_remotes"
+    assert hass.states.get(entity_id).state == "2"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for managing 2.4G remotes in flux_led

The remote config can now be changed to : Open, Paired Only, Disabled

A button can be used to unpair all remotes which will change the config to Open so all remotes can be used.

Note that the number platform is not used as its not possible to add paired remotes as this requires turning off the device and pressing a button on the remote for 3 seconds within the first 15s of the device booting to pair.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21090

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
