### PR TITLE
Fix august locks failing to lock/unlock

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -247,11 +247,29 @@ class AugustData(AugustSubscriberMixin):
             device_id,
         )
 
+    async def async_lock_async(self, device_id):
+        """Lock the device but do not wait for a response since it will come via pubnub."""
+        return await self._async_call_api_op_requires_bridge(
+            device_id,
+            self._api.async_lock_async,
+            self._august_gateway.access_token,
+            device_id,
+        )
+
     async def async_unlock(self, device_id):
         """Unlock the device."""
         return await self._async_call_api_op_requires_bridge(
             device_id,
             self._api.async_unlock_return_activities,
+            self._august_gateway.access_token,
+            device_id,
+        )
+
+    async def async_unlock_async(self, device_id):
+        """Unlock the device but do not wait for a response since it will come via pubnub."""
+        return await self._async_call_api_op_requires_bridge(
+            device_id,
+            self._api.async_unlock_async,
             self._august_gateway.access_token,
             device_id,
         )

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -48,10 +48,16 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
 
     async def async_lock(self, **kwargs):
         """Lock the device."""
+        if self._data.activity_stream.pubnub.connected:
+            await self._data.async_lock_async(self._device_id)
+            return
         await self._call_lock_operation(self._data.async_lock)
 
     async def async_unlock(self, **kwargs):
         """Unlock the device."""
+        if self._data.activity_stream.pubnub.connected:
+            await self._data.async_unlock_async(self._device_id)
+            return
         await self._call_lock_operation(self._data.async_unlock)
 
     async def _call_lock_operation(self, lock_operation):

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.16"],
+  "requirements": ["yalexs==1.1.17"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -4,7 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "requirements": ["yalexs==1.1.17"],
   "codeowners": ["@bdraco"],
-  "config_flow": true,
   "dhcp": [
     {
       "hostname": "connect",
@@ -23,5 +22,6 @@
       "macaddress": "E076D0*"
     }
   ],
+  "config_flow": true,
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "requirements": ["yalexs==1.1.16"],
   "codeowners": ["@bdraco"],
+  "config_flow": true,
   "dhcp": [
     {
       "hostname": "connect",
@@ -22,6 +23,5 @@
       "macaddress": "E076D0*"
     }
   ],
-  "config_flow": true,
   "iot_class": "cloud_push"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2494,7 +2494,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.3.7
 
 # homeassistant.components.august
-yalexs==1.1.16
+yalexs==1.1.17
 
 # homeassistant.components.yeelight
 yeelight==0.7.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1513,7 +1513,7 @@ xmltodict==0.12.0
 yalesmartalarmclient==0.3.7
 
 # homeassistant.components.august
-yalexs==1.1.16
+yalexs==1.1.17
 
 # homeassistant.components.yeelight
 yeelight==0.7.8

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -2,8 +2,6 @@
 import json
 import os
 import time
-
-# from unittest.mock import AsyncMock
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from yalexs.activity import (
@@ -207,6 +205,8 @@ async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, 
             side_effect=api_call_side_effects["unlock_return_activities"]
         )
 
+    api_instance.async_unlock_async = AsyncMock()
+    api_instance.async_lock_async = AsyncMock()
     api_instance.async_get_user = AsyncMock(return_value={"UserID": "abc"})
 
     return await _mock_setup_august(hass, api_instance, pubnub)

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -154,6 +154,86 @@ async def test_one_lock_operation(hass):
     )
 
 
+async def test_one_lock_operation_pubnub_connected(hass):
+    """Test lock and unlock operations are async when pubnub is connected."""
+    lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
+    assert lock_one.pubsub_channel == "pubsub"
+
+    pubnub = AugustPubNub()
+    await _create_august_with_devices(hass, [lock_one], pubnub=pubnub)
+    pubnub.connected = True
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+    assert lock_online_with_doorsense_name.attributes.get("battery_level") == 92
+    assert (
+        lock_online_with_doorsense_name.attributes.get("friendly_name")
+        == "online_with_doorsense Name"
+    )
+
+    data = {ATTR_ENTITY_ID: "lock.online_with_doorsense_name"}
+    assert await hass.services.async_call(
+        LOCK_DOMAIN, SERVICE_UNLOCK, data, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=lock_one.pubsub_channel,
+            timetoken=(dt_util.utcnow().timestamp() + 1) * 10000000,
+            message={
+                "status": "kAugLockState_Unlocked",
+            },
+        ),
+    )
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_UNLOCKED
+
+    assert lock_online_with_doorsense_name.attributes.get("battery_level") == 92
+    assert (
+        lock_online_with_doorsense_name.attributes.get("friendly_name")
+        == "online_with_doorsense Name"
+    )
+
+    assert await hass.services.async_call(
+        LOCK_DOMAIN, SERVICE_LOCK, data, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=lock_one.pubsub_channel,
+            timetoken=(dt_util.utcnow().timestamp() + 2) * 10000000,
+            message={
+                "status": "kAugLockState_Locked",
+            },
+        ),
+    )
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+    # No activity means it will be unavailable until the activity feed has data
+    entity_registry = er.async_get(hass)
+    lock_operator_sensor = entity_registry.async_get(
+        "sensor.online_with_doorsense_name_operator"
+    )
+    assert lock_operator_sensor
+    assert (
+        hass.states.get("sensor.online_with_doorsense_name_operator").state
+        == STATE_UNKNOWN
+    )
+
+
 async def test_lock_jammed(hass):
     """Test lock gets jammed on unlock."""
 
@@ -273,6 +353,7 @@ async def test_lock_update_via_pubnub(hass):
     config_entry = await _create_august_with_devices(
         hass, [lock_one], activities=activities, pubnub=pubnub
     )
+    pubnub.connected = True
 
     lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The cloud api we were using waited for a response. August has not
being using the old api in their apps for a while and it appears that
the server timeouts were adjusted to be lower which makes the older
api unreliable. Since we have pubnub support, use the new async
api and let the responses come in via pubnub



Changelog for yalexs: https://github.com/bdraco/yalexs/compare/v1.1.16...v1.1.17

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63649
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
