### PR TITLE
Improve multi-device test coverage for greeneye_monitor

### DIFF
--- a/tests/components/greeneye_monitor/common.py
+++ b/tests/components/greeneye_monitor/common.py
@@ -128,6 +128,35 @@ SINGLE_MONITOR_CONFIG_VOLTAGE_SENSORS = make_single_monitor_config_with_sensors(
     }
 )
 
+MULTI_MONITOR_CONFIG = {
+    DOMAIN: {
+        CONF_PORT: 7513,
+        CONF_MONITORS: [
+            {
+                CONF_SERIAL_NUMBER: "00000001",
+                CONF_TEMPERATURE_SENSORS: {
+                    CONF_TEMPERATURE_UNIT: "C",
+                    CONF_SENSORS: [{CONF_NUMBER: 1, CONF_NAME: "unit_1_temp_1"}],
+                },
+            },
+            {
+                CONF_SERIAL_NUMBER: "00000002",
+                CONF_TEMPERATURE_SENSORS: {
+                    CONF_TEMPERATURE_UNIT: "F",
+                    CONF_SENSORS: [{CONF_NUMBER: 1, CONF_NAME: "unit_2_temp_1"}],
+                },
+            },
+            {
+                CONF_SERIAL_NUMBER: "00000003",
+                CONF_TEMPERATURE_SENSORS: {
+                    CONF_TEMPERATURE_UNIT: "C",
+                    CONF_SENSORS: [{CONF_NUMBER: 1, CONF_NAME: "unit_3_temp_1"}],
+                },
+            },
+        ],
+    }
+}
+
 
 async def setup_greeneye_monitor_component_with_config(
     hass: HomeAssistant, config: ConfigType

--- a/tests/components/greeneye_monitor/test_init.py
+++ b/tests/components/greeneye_monitor/test_init.py
@@ -6,23 +6,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from homeassistant.components.greeneye_monitor import (
-    CONF_MONITORS,
-    CONF_NUMBER,
-    CONF_SERIAL_NUMBER,
-    CONF_TEMPERATURE_SENSORS,
-    DOMAIN,
-)
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_PORT,
-    CONF_SENSORS,
-    CONF_TEMPERATURE_UNIT,
-)
+from homeassistant.components.greeneye_monitor import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import (
+    MULTI_MONITOR_CONFIG,
     SINGLE_MONITOR_CONFIG_NO_SENSORS,
     SINGLE_MONITOR_CONFIG_POWER_SENSORS,
     SINGLE_MONITOR_CONFIG_PULSE_COUNTERS,
@@ -155,35 +144,12 @@ async def test_multi_monitor_config(hass: HomeAssistant, monitors: AsyncMock) ->
     """Test that component setup registers entities from multiple monitors correctly."""
     assert await setup_greeneye_monitor_component_with_config(
         hass,
-        {
-            DOMAIN: {
-                CONF_PORT: 7513,
-                CONF_MONITORS: [
-                    {
-                        CONF_SERIAL_NUMBER: "00000001",
-                        CONF_TEMPERATURE_SENSORS: {
-                            CONF_TEMPERATURE_UNIT: "C",
-                            CONF_SENSORS: [
-                                {CONF_NUMBER: 1, CONF_NAME: "unit_1_temp_1"}
-                            ],
-                        },
-                    },
-                    {
-                        CONF_SERIAL_NUMBER: "00000002",
-                        CONF_TEMPERATURE_SENSORS: {
-                            CONF_TEMPERATURE_UNIT: "F",
-                            CONF_SENSORS: [
-                                {CONF_NUMBER: 1, CONF_NAME: "unit_2_temp_1"}
-                            ],
-                        },
-                    },
-                ],
-            }
-        },
+        MULTI_MONITOR_CONFIG,
     )
 
     assert_temperature_sensor_registered(hass, 1, 1, "unit_1_temp_1")
     assert_temperature_sensor_registered(hass, 2, 1, "unit_2_temp_1")
+    assert_temperature_sensor_registered(hass, 3, 1, "unit_3_temp_1")
 
 
 async def test_setup_and_shutdown(hass: HomeAssistant, monitors: AsyncMock) -> None:

--- a/tests/components/greeneye_monitor/test_sensor.py
+++ b/tests/components/greeneye_monitor/test_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_registry import (
 )
 
 from .common import (
+    MULTI_MONITOR_CONFIG,
     SINGLE_MONITOR_CONFIG_POWER_SENSORS,
     SINGLE_MONITOR_CONFIG_PULSE_COUNTERS,
     SINGLE_MONITOR_CONFIG_TEMPERATURE_SENSORS,
@@ -152,6 +153,17 @@ async def test_voltage_sensor(hass: HomeAssistant, monitors: AsyncMock) -> None:
     )
     connect_monitor(monitors, SINGLE_MONITOR_SERIAL_NUMBER)
     assert_sensor_state(hass, "sensor.voltage_1", "120.0")
+
+
+async def test_multi_monitor_sensors(hass: HomeAssistant, monitors: AsyncMock) -> None:
+    """Test that sensors still work when multiple monitors are registered."""
+    await setup_greeneye_monitor_component_with_config(hass, MULTI_MONITOR_CONFIG)
+    connect_monitor(monitors, 1)
+    connect_monitor(monitors, 2)
+    connect_monitor(monitors, 3)
+    assert_sensor_state(hass, "sensor.unit_1_temp_1", "32.0")
+    assert_sensor_state(hass, "sensor.unit_2_temp_1", "0.0")
+    assert_sensor_state(hass, "sensor.unit_3_temp_1", "32.0")
 
 
 def connect_monitor(monitors: AsyncMock, serial_number: int) -> MagicMock:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The tests for configurations with multiple devices were a little weak. They only tested two devices, and they didn't actually try to query any state from the entities afterwards. Addressing those shortcomings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
