### PR TITLE
Add DSMR config options for EasyMeter/Q3D

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -46,6 +46,8 @@ class DSMRConnection:
         self._equipment_identifier = obis_ref.EQUIPMENT_IDENTIFIER
         if dsmr_version == "5L":
             self._equipment_identifier = obis_ref.LUXEMBOURG_EQUIPMENT_IDENTIFIER
+        if dsmr_version == "Q3D":
+            self._equipment_identifier = obis_ref.Q3D_EQUIPMENT_IDENTIFIER
 
     def equipment_identifier(self) -> str | None:
         """Equipment identifier."""

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -35,7 +35,7 @@ DATA_TASK = "task"
 DEVICE_NAME_ENERGY = "Energy Meter"
 DEVICE_NAME_GAS = "Gas Meter"
 
-DSMR_VERSIONS = {"2.2", "4", "5", "5B", "5L", "5S"}
+DSMR_VERSIONS = {"2.2", "4", "5", "5B", "5L", "5S", "Q3D"}
 
 SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
@@ -244,7 +244,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_IMPORTED_TOTAL,
         name="Energy Consumption (total)",
-        dsmr_versions={"5", "5B", "5L", "5S"},
+        dsmr_versions={"5", "5B", "5L", "5S", "Q3D"},
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -252,7 +252,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_EXPORTED_TOTAL,
         name="Energy Production (total)",
-        dsmr_versions={"5L", "5S"},
+        dsmr_versions={"5L", "5S", "Q3D"},
         force_update=True,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,

--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -65,7 +65,9 @@ async def dsmr_connection_send_validate_fixture(hass):
             }
         if args[1] == "Q3D":
             protocol.telegram = {
-                P1_MESSAGE_TIMESTAMP: CosemObject([{"value": "12345678", "unit": ""}]),
+                Q3D_EQUIPMENT_IDENTIFIER: CosemObject(
+                    [{"value": "12345678", "unit": ""}]
+                ),
             }
 
         return (transport, protocol)

--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -8,6 +8,7 @@ from dsmr_parser.obis_references import (
     EQUIPMENT_IDENTIFIER_GAS,
     LUXEMBOURG_EQUIPMENT_IDENTIFIER,
     P1_MESSAGE_TIMESTAMP,
+    Q3D_EQUIPMENT_IDENTIFIER,
 )
 from dsmr_parser.objects import CosemObject
 import pytest

--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -63,6 +63,10 @@ async def dsmr_connection_send_validate_fixture(hass):
             protocol.telegram = {
                 P1_MESSAGE_TIMESTAMP: CosemObject([{"value": "12345678", "unit": ""}]),
             }
+        if args[1] == "Q3D":
+            protocol.telegram = {
+                P1_MESSAGE_TIMESTAMP: CosemObject([{"value": "12345678", "unit": ""}]),
+            }
 
         return (transport, protocol)
 

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -133,7 +133,7 @@ async def test_setup_Q3D(com_mock, hass, dsmr_connection_send_validate_fixture):
 
     assert result["type"] == "create_entry"
     assert result["title"] == port.device
-    assert result["data"] == {**entry_data, **SERIAL_DATA}
+    assert result["data"] == entry_data
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -100,6 +100,45 @@ async def test_setup_serial(com_mock, hass, dsmr_connection_send_validate_fixtur
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
+async def test_setup_5L(com_mock, hass, dsmr_connection_send_validate_fixture):
+    """Test we can setup serial."""
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"port": port.device, "dsmr_version": "5L"}
+        )
+
+    entry_data = {
+        "port": port.device,
+        "dsmr_version": "5L",
+        "serial_id": "12345678",
+        "serial_id_gas": "123456789",
+    }
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == port.device
+    assert result["data"] == entry_data
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_Q3D(com_mock, hass, dsmr_connection_send_validate_fixture):
     """Test we can setup serial."""
     port = com_port()
@@ -129,6 +168,8 @@ async def test_setup_Q3D(com_mock, hass, dsmr_connection_send_validate_fixture):
     entry_data = {
         "port": port.device,
         "dsmr_version": "Q3D",
+        "serial_id": "12345678",
+        "serial_id_gas": None,
     }
 
     assert result["type"] == "create_entry"

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -100,6 +100,43 @@ async def test_setup_serial(com_mock, hass, dsmr_connection_send_validate_fixtur
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
+async def test_setup_Q3D(com_mock, hass, dsmr_connection_send_validate_fixture):
+    """Test we can setup serial."""
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"port": port.device, "dsmr_version": "Q3D"}
+        )
+
+    entry_data = {
+        "port": port.device,
+        "dsmr_version": "Q3D",
+    }
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == port.device
+    assert result["data"] == {**entry_data, **SERIAL_DATA}
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_manual(
     com_mock, hass, dsmr_connection_send_validate_fixture
 ):

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -576,6 +576,80 @@ async def test_swedish_meter(hass, dsmr_connection_fixture):
     )
 
 
+async def test_easymeter(hass, dsmr_connection_fixture):
+    """Test if Q3D meter is correctly parsed."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    from dsmr_parser.obis_references import (
+        ELECTRICITY_EXPORTED_TOTAL,
+        ELECTRICITY_IMPORTED_TOTAL,
+    )
+    from dsmr_parser.objects import CosemObject
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "Q3D",
+        "precision": 4,
+        "reconnect_interval": 30,
+        "serial_id": None,
+        "serial_id_gas": None,
+    }
+    entry_options = {
+        "time_between_update": 0,
+    }
+
+    telegram = {
+        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
+            [{"value": Decimal(54184.6316), "unit": ENERGY_KILO_WATT_HOUR}]
+        ),
+        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
+            [{"value": Decimal(19981.1069), "unit": ENERGY_KILO_WATT_HOUR}]
+        ),
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr",
+        unique_id="/dev/ttyUSB0",
+        data=entry_data,
+        options=entry_options,
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to update
+    await asyncio.sleep(0)
+
+    power_tariff = hass.states.get("sensor.energy_consumption_total")
+    assert power_tariff.state == "54184.6316"
+    assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
+    assert power_tariff.attributes.get(ATTR_ICON) is None
+    assert (
+        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+    )
+
+    power_tariff = hass.states.get("sensor.energy_production_total")
+    assert power_tariff.state == "19981.1069"
+    assert (
+        power_tariff.attributes.get(ATTR_STATE_CLASS)
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert (
+        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+    )
+
+
 async def test_tcp(hass, dsmr_connection_fixture):
     """If proper config provided TCP connection should be made."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adding support dsmr EasyMeter Q3D
(re-submitting expired PR #60088, apologies)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21113 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
