### PR TITLE
Fix Netgear used method version

### DIFF
--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     DEFAULT_NAME,
     DOMAIN,
     MODELS_PORT80,
+    PORT80,
 )
 from .errors import CannotLoginException
 from .router import get_api
@@ -146,7 +147,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ) or discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(
                 model
             ):
-                updated_data[CONF_PORT] = 80
+                updated_data[CONF_PORT] = PORT80
 
         self.placeholders.update(updated_data)
         self.discovered = True

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -22,8 +22,8 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_NAME,
     DOMAIN,
-    MODELS_PORT80,
-    PORT80,
+    MODELS_PORT_80,
+    PORT_80,
 )
 from .errors import CannotLoginException
 from .router import get_api
@@ -141,13 +141,13 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured(updates=updated_data)
 
         updated_data[CONF_PORT] = DEFAULT_PORT
-        for model in MODELS_PORT80:
+        for model in MODELS_PORT_80:
             if discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(
                 model
             ) or discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(
                 model
             ):
-                updated_data[CONF_PORT] = PORT80
+                updated_data[CONF_PORT] = PORT_80
 
         self.placeholders.update(updated_data)
         self.discovered = True

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -22,8 +22,7 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_NAME,
     DOMAIN,
-    MODELS_V2,
-    ORBI_PORT,
+    MODELS_PORT80,
 )
 from .errors import CannotLoginException
 from .router import get_api
@@ -141,13 +140,13 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured(updates=updated_data)
 
         updated_data[CONF_PORT] = DEFAULT_PORT
-        for model in MODELS_V2:
+        for model in MODELS_PORT80:
             if discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(
                 model
             ) or discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(
                 model
             ):
-                updated_data[CONF_PORT] = ORBI_PORT
+                updated_data[CONF_PORT] = 80
 
         self.placeholders.update(updated_data)
         self.discovered = True

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -13,7 +13,7 @@ DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 
 # models using port 80 instead of 5000
-MODELS_PORT80 = [
+MODELS_PORT_80 = [
     "Orbi",
     "RBK",
     "RBR",
@@ -31,7 +31,7 @@ MODELS_PORT80 = [
     "SXR",
     "SXS",
 ]
-PORT80 = 80
+PORT_80 = 80
 # update method V2 models
 MODELS_V2 = [
     "Orbi",

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -13,7 +13,7 @@ DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 
 # update method V2 models
-MODELS_V2 = [
+MODELS_PORT80 = [
     "Orbi",
     "RBK",
     "RBR",
@@ -31,7 +31,23 @@ MODELS_V2 = [
     "SXR",
     "SXS",
 ]
-ORBI_PORT = 80
+MODELS_V2 = [
+    "Orbi",
+    "RBK",
+    "RBR",
+    "RBS",
+    "RBW",
+    "LBK",
+    "LBR",
+    "CBK",
+    "CBR",
+    "SRC",
+    "SRK",
+    "SRS",
+    "SXK",
+    "SXR",
+    "SXS",
+]
 
 # Icons
 DEVICE_ICONS = {

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -12,7 +12,7 @@ CONF_CONSIDER_HOME = "consider_home"
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 
-# update method V2 models
+# models using port 80 instead of 5000
 MODELS_PORT80 = [
     "Orbi",
     "RBK",
@@ -31,6 +31,8 @@ MODELS_PORT80 = [
     "SXR",
     "SXS",
 ]
+PORT80 = 80
+# update method V2 models
 MODELS_V2 = [
     "Orbi",
     "RBK",

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -151,7 +151,10 @@ class NetgearRouter:
 
         if self.method_version == 2:
             if not self._api.get_attached_devices_2():
-                _LOGGER.error("Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2.", self.model)
+                _LOGGER.error(
+                    "Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2.",
+                    self.model,
+                )
                 self.method_version = 1
 
     async def async_setup(self) -> None:

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -152,7 +152,7 @@ class NetgearRouter:
         if self.method_version == 2:
             if not self._api.get_attached_devices_2():
                 _LOGGER.error(
-                    "Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2.",
+                    "Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2",
                     self.model,
                 )
                 self.method_version = 1

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -151,6 +151,7 @@ class NetgearRouter:
 
         if self.method_version == 2:
             if not self._api.get_attached_devices_2():
+                _LOGGER.error("Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2.", self.model)
                 self.method_version = 1
 
     async def async_setup(self) -> None:

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -149,6 +149,10 @@ class NetgearRouter:
             if self.model.startswith(model):
                 self.method_version = 2
 
+        if self.method_version == 2:
+            if not self._api.get_attached_devices_2():
+                self.method_version = 1
+
     async def async_setup(self) -> None:
         """Set up a Netgear router."""
         await self.hass.async_add_executor_job(self._setup)

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
-from homeassistant.components.netgear.const import CONF_CONSIDER_HOME, DOMAIN, PORT80
+from homeassistant.components.netgear.const import CONF_CONSIDER_HOME, DOMAIN, PORT_80
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
@@ -252,7 +252,7 @@ async def test_ssdp(hass, service):
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
-    assert result["data"].get(CONF_PORT) == PORT80
+    assert result["data"].get(CONF_PORT) == PORT_80
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == DEFAULT_USER
     assert result["data"][CONF_PASSWORD] == PASSWORD

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
-from homeassistant.components.netgear.const import CONF_CONSIDER_HOME, DOMAIN, ORBI_PORT
+from homeassistant.components.netgear.const import CONF_CONSIDER_HOME, DOMAIN, PORT80
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
@@ -252,7 +252,7 @@ async def test_ssdp(hass, service):
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
-    assert result["data"].get(CONF_PORT) == ORBI_PORT
+    assert result["data"].get(CONF_PORT) == PORT80
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == DEFAULT_USER
     assert result["data"][CONF_PASSWORD] == PASSWORD


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apperently some of the Netgear Orbi routers do use port 80 for communication instead of the default port 5000, but do not support the newer get_attached_devices_2 method but instead need the lighter get_attached_devices method.

Therefore this PR adds a check if get_attached_devices_2 is indeed supported and otherwise falls back to the get_attached_devices method.
Besides the model list is now split up between models that use port 80 and models that need get_attached_devices_2.

Up to now the SRR60 model is the case that uses port 80 but needs get_attached_devices V1.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/63334
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
