### PR TITLE
Use Platform enum [mysensors]

### DIFF
--- a/homeassistant/components/mysensors/__init__.py
+++ b/homeassistant/components/mysensors/__init__.py
@@ -10,11 +10,9 @@ from mysensors import BaseAsyncGateway
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.mqtt import valid_publish_topic, valid_subscribe_topic
-from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_OPTIMISTIC
+from homeassistant.const import CONF_OPTIMISTIC, Platform
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -209,7 +207,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Allow loading device tracker platform via discovery
     # until refactor to config entry is done.
 
-    for platform in (DEVICE_TRACKER_DOMAIN, NOTIFY_DOMAIN):
+    for platform in (Platform.DEVICE_TRACKER, Platform.NOTIFY):
         load_discovery_platform = partial(
             async_load_platform,
             hass,
@@ -269,7 +267,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 @callback
 def setup_mysensors_platform(
     hass: HomeAssistant,
-    domain: str,  # hass platform name
+    domain: Platform,  # hass platform name
     discovery_info: DiscoveryInfo,
     device_class: type[MySensorsDevice] | dict[SensorType, type[MySensorsDevice]],
     device_args: (

--- a/homeassistant/components/mysensors/binary_sensor.py
+++ b/homeassistant/components/mysensors/binary_sensor.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 from homeassistant.components import mysensors
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES,
-    DOMAIN,
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_ON, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -41,7 +40,7 @@ async def async_setup_entry(
         """Discover and add a MySensors binary_sensor."""
         mysensors.setup_mysensors_platform(
             hass,
-            DOMAIN,
+            Platform.BINARY_SENSOR,
             discovery_info,
             MySensorsBinarySensor,
             async_add_entities=async_add_entities,
@@ -52,7 +51,7 @@ async def async_setup_entry(
         config_entry.entry_id,
         async_dispatcher_connect(
             hass,
-            MYSENSORS_DISCOVERY.format(config_entry.entry_id, DOMAIN),
+            MYSENSORS_DISCOVERY.format(config_entry.entry_id, Platform.BINARY_SENSOR),
             async_discover,
         ),
     )

--- a/homeassistant/components/mysensors/climate.py
+++ b/homeassistant/components/mysensors/climate.py
@@ -8,7 +8,6 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    DOMAIN,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
@@ -18,7 +17,12 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -54,7 +58,7 @@ async def async_setup_entry(
         """Discover and add a MySensors climate."""
         mysensors.setup_mysensors_platform(
             hass,
-            DOMAIN,
+            Platform.CLIMATE,
             discovery_info,
             MySensorsHVAC,
             async_add_entities=async_add_entities,
@@ -65,7 +69,7 @@ async def async_setup_entry(
         config_entry.entry_id,
         async_dispatcher_connect(
             hass,
-            MYSENSORS_DISCOVERY.format(config_entry.entry_id, DOMAIN),
+            MYSENSORS_DISCOVERY.format(config_entry.entry_id, Platform.CLIMATE),
             async_discover,
         ),
     )

--- a/homeassistant/components/mysensors/const.py
+++ b/homeassistant/components/mysensors/const.py
@@ -163,7 +163,7 @@ FLAT_PLATFORM_TYPES: dict[tuple[str, SensorType], set[ValueType]] = {
     for s_type_name, v_type_name in platform_types.items()
 }
 
-TYPE_TO_PLATFORMS: dict[SensorType, list[str]] = defaultdict(list)
+TYPE_TO_PLATFORMS: dict[SensorType, list[Platform]] = defaultdict(list)
 
 for platform, platform_types in PLATFORM_TYPES.items():
     for s_type_name in platform_types:

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -5,9 +5,9 @@ from enum import Enum, unique
 from typing import Any
 
 from homeassistant.components import mysensors
-from homeassistant.components.cover import ATTR_POSITION, DOMAIN, CoverEntity
+from homeassistant.components.cover import ATTR_POSITION, CoverEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -37,7 +37,7 @@ async def async_setup_entry(
         """Discover and add a MySensors cover."""
         mysensors.setup_mysensors_platform(
             hass,
-            DOMAIN,
+            Platform.COVER,
             discovery_info,
             MySensorsCover,
             async_add_entities=async_add_entities,
@@ -48,7 +48,7 @@ async def async_setup_entry(
         config_entry.entry_id,
         async_dispatcher_connect(
             hass,
-            MYSENSORS_DISCOVERY.format(config_entry.entry_id, DOMAIN),
+            MYSENSORS_DISCOVERY.format(config_entry.entry_id, Platform.COVER),
             async_discover,
         ),
     )

--- a/homeassistant/components/mysensors/device.py
+++ b/homeassistant/components/mysensors/device.py
@@ -8,7 +8,7 @@ from typing import Any
 from mysensors import BaseAsyncGateway, Sensor
 from mysensors.sensor import ChildSensor
 
-from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
@@ -209,7 +209,7 @@ class MySensorsDevice:
 
 
 def get_mysensors_devices(
-    hass: HomeAssistant, domain: str
+    hass: HomeAssistant, domain: Platform
 ) -> dict[DevId, MySensorsDevice]:
     """Return MySensors devices for a hass platform name."""
     if MYSENSORS_PLATFORM_DEVICES.format(domain) not in hass.data[DOMAIN]:

--- a/homeassistant/components/mysensors/device_tracker.py
+++ b/homeassistant/components/mysensors/device_tracker.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 
 from homeassistant.components import mysensors
-from homeassistant.components.device_tracker import DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import slugify
@@ -26,7 +26,7 @@ async def async_setup_scanner(
 
     new_devices = mysensors.setup_mysensors_platform(
         hass,
-        DOMAIN,
+        Platform.DEVICE_TRACKER,
         discovery_info,
         MySensorsDeviceScanner,
         device_args=(hass, async_see),

--- a/homeassistant/components/mysensors/handler.py
+++ b/homeassistant/components/mysensors/handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from mysensors import Message
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import decorator
@@ -66,7 +67,7 @@ async def handle_sketch_version(
 
 @callback
 def _handle_child_update(
-    hass: HomeAssistant, gateway_id: GatewayId, validated: dict[str, list[DevId]]
+    hass: HomeAssistant, gateway_id: GatewayId, validated: dict[Platform, list[DevId]]
 ) -> None:
     """Handle a child update."""
     signals: list[str] = []

--- a/homeassistant/components/mysensors/helpers.py
+++ b/homeassistant/components/mysensors/helpers.py
@@ -10,7 +10,7 @@ from mysensors import BaseAsyncGateway, Message
 from mysensors.sensor import ChildSensor
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -148,7 +148,9 @@ def invalid_msg(
     )
 
 
-def validate_set_msg(gateway_id: GatewayId, msg: Message) -> dict[str, list[DevId]]:
+def validate_set_msg(
+    gateway_id: GatewayId, msg: Message
+) -> dict[Platform, list[DevId]]:
     """Validate a set message."""
     if not validate_node(msg.gateway, msg.node_id):
         return {}
@@ -170,9 +172,9 @@ def validate_child(
     node_id: int,
     child: ChildSensor,
     value_type: int | None = None,
-) -> defaultdict[str, list[DevId]]:
+) -> defaultdict[Platform, list[DevId]]:
     """Validate a child. Returns a dict mapping hass platform names to list of DevId."""
-    validated: defaultdict[str, list[DevId]] = defaultdict(list)
+    validated: defaultdict[Platform, list[DevId]] = defaultdict(list)
     pres: type[IntEnum] = gateway.const.Presentation
     set_req: type[IntEnum] = gateway.const.SetReq
     child_type_name: SensorType | None = next(
@@ -186,7 +188,7 @@ def validate_child(
     value_type_names: set[ValueType] = {
         member.name for member in set_req if member.value in value_types
     }
-    platforms: list[str] = TYPE_TO_PLATFORMS.get(child_type_name, [])
+    platforms: list[Platform] = TYPE_TO_PLATFORMS.get(child_type_name, [])
     if not platforms:
         _LOGGER.warning("Child type %s is not supported", child.type)
         return validated

--- a/homeassistant/components/mysensors/light.py
+++ b/homeassistant/components/mysensors/light.py
@@ -11,11 +11,10 @@ from homeassistant.components.light import (
     COLOR_MODE_BRIGHTNESS,
     COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
-    DOMAIN,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -42,7 +41,7 @@ async def async_setup_entry(
         """Discover and add a MySensors light."""
         mysensors.setup_mysensors_platform(
             hass,
-            DOMAIN,
+            Platform.LIGHT,
             discovery_info,
             device_class_map,
             async_add_entities=async_add_entities,
@@ -53,7 +52,7 @@ async def async_setup_entry(
         config_entry.entry_id,
         async_dispatcher_connect(
             hass,
-            MYSENSORS_DISCOVERY.format(config_entry.entry_id, DOMAIN),
+            MYSENSORS_DISCOVERY.format(config_entry.entry_id, Platform.LIGHT),
             async_discover,
         ),
     )

--- a/homeassistant/components/mysensors/notify.py
+++ b/homeassistant/components/mysensors/notify.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components import mysensors
-from homeassistant.components.notify import ATTR_TARGET, DOMAIN, BaseNotificationService
+from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DevId, DiscoveryInfo
@@ -20,7 +21,7 @@ async def async_get_service(
         return None
 
     new_devices = mysensors.setup_mysensors_platform(
-        hass, DOMAIN, discovery_info, MySensorsNotificationDevice
+        hass, Platform.NOTIFY, discovery_info, MySensorsNotificationDevice
     )
     if not new_devices:
         return None
@@ -51,7 +52,7 @@ class MySensorsNotificationService(BaseNotificationService):
         self.devices: dict[
             DevId, MySensorsNotificationDevice
         ] = mysensors.get_mysensors_devices(
-            hass, DOMAIN
+            hass, Platform.NOTIFY
         )  # type: ignore[assignment]
 
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:

--- a/homeassistant/components/mysensors/sensor.py
+++ b/homeassistant/components/mysensors/sensor.py
@@ -7,7 +7,6 @@ from awesomeversion import AwesomeVersion
 
 from homeassistant.components import mysensors
 from homeassistant.components.sensor import (
-    DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -32,6 +31,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     VOLUME_CUBIC_METERS,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -197,7 +197,7 @@ async def async_setup_entry(
         """Discover and add a MySensors sensor."""
         mysensors.setup_mysensors_platform(
             hass,
-            DOMAIN,
+            Platform.SENSOR,
             discovery_info,
             MySensorsSensor,
             async_add_entities=async_add_entities,
@@ -208,7 +208,7 @@ async def async_setup_entry(
         config_entry.entry_id,
         async_dispatcher_connect(
             hass,
-            MYSENSORS_DISCOVERY.format(config_entry.entry_id, DOMAIN),
+            MYSENSORS_DISCOVERY.format(config_entry.entry_id, Platform.SENSOR),
             async_discover,
         ),
     )

--- a/homeassistant/components/mysensors/switch.py
+++ b/homeassistant/components/mysensors/switch.py
@@ -6,9 +6,9 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components import mysensors
-from homeassistant.components.switch import DOMAIN, SwitchEntity
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -57,7 +57,7 @@ async def async_setup_entry(
         """Discover and add a MySensors switch."""
         mysensors.setup_mysensors_platform(
             hass,
-            DOMAIN,
+            Platform.SWITCH,
             discovery_info,
             device_class_map,
             async_add_entities=async_add_entities,
@@ -67,7 +67,7 @@ async def async_setup_entry(
         """Set IR code as device state attribute."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         ir_code = service.data.get(ATTR_IR_CODE)
-        devices = mysensors.get_mysensors_devices(hass, DOMAIN)
+        devices = mysensors.get_mysensors_devices(hass, Platform.SWITCH)
 
         if entity_ids:
             _devices = [
@@ -99,7 +99,7 @@ async def async_setup_entry(
         config_entry.entry_id,
         async_dispatcher_connect(
             hass,
-            MYSENSORS_DISCOVERY.format(config_entry.entry_id, DOMAIN),
+            MYSENSORS_DISCOVERY.format(config_entry.entry_id, Platform.SWITCH),
             async_discover,
         ),
     )


### PR DESCRIPTION
## Proposed change
Replace `str` with `Platform` enum in `mysensors.setup_mysensors_platform` and subsequent function calls.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
