### PR TITLE
Remove warnings from compensation

### DIFF
--- a/homeassistant/components/compensation/__init__.py
+++ b/homeassistant/components/compensation/__init__.py
@@ -1,6 +1,5 @@
 """The Compensation integration."""
 import logging
-import warnings
 
 import numpy as np
 import voluptuous as vol
@@ -84,22 +83,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         # try to get valid coefficients for a polynomial
         coefficients = None
         with np.errstate(all="raise"):
-            with warnings.catch_warnings(record=True) as all_warnings:
-                warnings.simplefilter("always")
-                try:
-                    coefficients = np.polyfit(x_values, y_values, degree)
-                except FloatingPointError as error:
-                    _LOGGER.error(
-                        "Setup of %s encountered an error, %s",
-                        compensation,
-                        error,
-                    )
-                for warning in all_warnings:
-                    _LOGGER.warning(
-                        "Setup of %s encountered a warning, %s",
-                        compensation,
-                        str(warning.message).lower(),
-                    )
+            try:
+                coefficients = np.polyfit(x_values, y_values, degree)
+            except FloatingPointError as error:
+                _LOGGER.error(
+                    "Setup of %s encountered an error, %s",
+                    compensation,
+                    error,
+                )
 
         if coefficients is not None:
             data = {

--- a/tests/components/compensation/test_sensor.py
+++ b/tests/components/compensation/test_sensor.py
@@ -152,13 +152,6 @@ async def test_numpy_errors(hass, caplog):
             "test": {
                 "source": "sensor.uncompensated",
                 "data_points": [
-                    [1.0, 1.0],
-                    [1.0, 1.0],
-                ],
-            },
-            "test2": {
-                "source": "sensor.uncompensated2",
-                "data_points": [
                     [0.0, 1.0],
                     [0.0, 1.0],
                 ],
@@ -169,8 +162,6 @@ async def test_numpy_errors(hass, caplog):
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
-
-    assert "polyfit may be poorly conditioned" in caplog.text
 
     assert "invalid value encountered in true_divide" in caplog.text
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes 

Using warnings is not thread safe so it must be removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/61235
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
