### PR TITLE
Add UniFi Protect camera motion sensors and ThumbnailProxyView

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -33,6 +33,7 @@ from .const import (
     PLATFORMS,
 )
 from .data import ProtectData
+from .views import ThumbnailProxyView
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +82,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data_service
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    hass.http.register_view(ThumbnailProxyView(hass))
 
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     entry.async_on_unload(

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -9,11 +9,7 @@ from typing import Any
 from pyunifiprotect.data import NVR, Camera, Event, Light, Sensor
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_OCCUPANCY,
-    DEVICE_CLASS_PROBLEM,
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -56,7 +52,7 @@ CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key=_KEY_DOORBELL,
         name="Doorbell",
-        device_class=DEVICE_CLASS_OCCUPANCY,
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
         icon="mdi:doorbell-video",
         ufp_required_field="feature_flags.has_chime",
         ufp_value="is_ringing",
@@ -79,7 +75,7 @@ LIGHT_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key=_KEY_MOTION,
         name="Motion Detected",
-        device_class=DEVICE_CLASS_MOTION,
+        device_class=BinarySensorDeviceClass.MOTION,
         ufp_value="is_pir_motion_detected",
     ),
 )
@@ -88,20 +84,20 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key=_KEY_DOOR,
         name="Door",
-        device_class=DEVICE_CLASS_DOOR,
+        device_class=BinarySensorDeviceClass.DOOR,
         ufp_value="is_opened",
     ),
     ProtectBinaryEntityDescription(
         key=_KEY_BATTERY_LOW,
         name="Battery low",
-        device_class=DEVICE_CLASS_BATTERY,
+        device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="battery_status.is_low",
     ),
     ProtectBinaryEntityDescription(
         key=_KEY_MOTION,
         name="Motion Detected",
-        device_class=DEVICE_CLASS_MOTION,
+        device_class=BinarySensorDeviceClass.MOTION,
         ufp_value="is_motion_detected",
     ),
 )
@@ -110,7 +106,7 @@ MOTION_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key=_KEY_MOTION,
         name="Motion",
-        device_class=DEVICE_CLASS_MOTION,
+        device_class=BinarySensorDeviceClass.MOTION,
         ufp_value="is_motion_detected",
     ),
 )
@@ -120,7 +116,7 @@ DISK_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key=_KEY_DISK_HEALTH,
         name="Disk {index} Health",
-        device_class=DEVICE_CLASS_PROBLEM,
+        device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -6,6 +6,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "unifiprotect"
 
+ATTR_EVENT_SCORE = "event_score"
+ATTR_EVENT_THUMB = "event_thumbnail"
 ATTR_WIDTH = "width"
 ATTR_HEIGHT = "height"
 ATTR_FPS = "fps"

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -1,7 +1,7 @@
 """Base class for protect data."""
 from __future__ import annotations
 
-import collections
+from collections import deque
 from collections.abc import Generator, Iterable
 from datetime import timedelta
 import logging
@@ -43,7 +43,7 @@ class ProtectData:
         self._unsub_websocket: CALLBACK_TYPE | None = None
 
         self.last_update_success = False
-        self.access_tokens: dict[str, collections.deque] = {}
+        self.access_tokens: dict[str, deque] = {}
         self.api = protect
 
     @property
@@ -177,3 +177,10 @@ class ProtectData:
         _LOGGER.debug("Updating device: %s", device_id)
         for update_callback in self._subscriptions[device_id]:
             update_callback()
+
+    @callback
+    def async_get_or_create_access_tokens(self, entity_id: str) -> deque:
+        """Wrap access_tokens to automatically create underlying data structure if missing."""
+        if entity_id not in self.access_tokens:
+            self.access_tokens[entity_id] = deque([], 2)
+        return self.access_tokens[entity_id]

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -6,6 +6,9 @@
   "requirements": [
     "pyunifiprotect==1.5.3"
   ],
+  "dependencies": [
+    "http"
+  ],
   "codeowners": [
     "@briis",
     "@AngellusMortis",

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -9,8 +9,8 @@ from typing import Any
 from pyunifiprotect.data import NVR, Camera, Event
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 
-from homeassistant.components.binary_sensor import DEVICE_CLASS_OCCUPANCY
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
@@ -20,13 +20,6 @@ from homeassistant.const import (
     DATA_BYTES,
     DATA_RATE_BYTES_PER_SECOND,
     DATA_RATE_MEGABITS_PER_SECOND,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_SIGNAL_STRENGTH,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_TIMESTAMP,
-    DEVICE_CLASS_VOLTAGE,
     ELECTRIC_POTENTIAL_VOLT,
     LIGHT_LUX,
     PERCENTAGE,
@@ -51,6 +44,7 @@ from .utils import get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
 DETECTED_OBJECT_NONE = "none"
+DEVICE_CLASS_DETECTION = "unifiprotect__detection"
 
 
 @dataclass
@@ -96,7 +90,7 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_UPTIME,
         name="Uptime",
         icon="mdi:clock",
-        device_class=DEVICE_CLASS_TIMESTAMP,
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         ufp_value="up_since",
@@ -105,7 +99,7 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_BLE,
         name="Bluetooth Signal Strength",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -126,7 +120,7 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_WIFI,
         name="WiFi Signal Strength",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
@@ -139,7 +133,7 @@ CAMERA_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_OLDEST,
         name="Oldest Recording",
-        device_class=DEVICE_CLASS_TIMESTAMP,
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="stats.video.recording_start",
     ),
@@ -163,7 +157,7 @@ CAMERA_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_VOLTAGE,
         name="Voltage",
-        device_class=DEVICE_CLASS_VOLTAGE,
+        device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
@@ -201,7 +195,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_BATTERY,
         name="Battery Level",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=DEVICE_CLASS_BATTERY,
+        device_class=SensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="battery_status.percentage",
@@ -210,7 +204,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_LIGHT,
         name="Light Level",
         native_unit_of_measurement=LIGHT_LUX,
-        device_class=DEVICE_CLASS_ILLUMINANCE,
+        device_class=SensorDeviceClass.ILLUMINANCE,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.light.value",
     ),
@@ -218,7 +212,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_HUMIDITY,
         name="Humidity Level",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=DEVICE_CLASS_HUMIDITY,
+        device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.humidity.value",
     ),
@@ -226,7 +220,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_TEMP,
         name="Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.temperature.value",
     ),
@@ -237,7 +231,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_UPTIME,
         name="Uptime",
         icon="mdi:clock",
-        device_class=DEVICE_CLASS_TIMESTAMP,
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="up_since",
     ),
@@ -337,7 +331,7 @@ NVR_DISABLED_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         key=_KEY_CPU_TEMP,
         name="CPU Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
@@ -359,7 +353,7 @@ MOTION_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_OBJECT,
         name="Detected Object",
-        device_class=DEVICE_CLASS_OCCUPANCY,
+        device_class=DEVICE_CLASS_DETECTION,
     ),
 )
 

--- a/homeassistant/components/unifiprotect/views.py
+++ b/homeassistant/components/unifiprotect/views.py
@@ -1,0 +1,91 @@
+"""UniFi Protect Integration views."""
+from __future__ import annotations
+
+import collections
+from http import HTTPStatus
+import logging
+from typing import Any
+
+from aiohttp import web
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.exceptions import NvrError
+
+from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .data import ProtectData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _404(message: Any) -> web.Response:
+    _LOGGER.error("Error on load thumbnail: %s", message)
+    return web.Response(status=HTTPStatus.NOT_FOUND)
+
+
+class ThumbnailProxyView(HomeAssistantView):
+    """View to proxy event thumbnails from UniFi Protect."""
+
+    requires_auth = False
+    url = "/api/ufp/thumbnail/{event_id}"
+    name = "api:ufp_thumbnail"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize a thumbnail proxy view."""
+        self.hass = hass
+        self.data = hass.data[DOMAIN]
+
+    def _get_access_tokens(
+        self, entity_id: str
+    ) -> tuple[collections.deque, ProtectApiClient] | None:
+
+        entries: list[ProtectData] = list(self.data.values())
+        for entry in entries:
+            if entity_id in entry.access_tokens:
+                return entry.access_tokens[entity_id], entry.api
+        return None
+
+    async def get(self, request: web.Request, event_id: str) -> web.Response:
+        """Start a get request."""
+
+        entity_id: str | None = request.query.get("entity_id")
+        width: int | str | None = request.query.get("w")
+        height: int | str | None = request.query.get("h")
+        token: str | None = request.query.get("token")
+
+        if width is not None:
+            try:
+                width = int(width)
+            except ValueError:
+                return _404("Invalid width param")
+        if height is not None:
+            try:
+                height = int(height)
+            except ValueError:
+                return _404("Invalid height param")
+
+        access_tokens: list[str] = []
+        if entity_id is not None:
+            items = self._get_access_tokens(entity_id)
+            if items is None:
+                return _404(f"Could not find entity with entity_id {entity_id}")
+
+            access_tokens = list(items[0])
+            instance = items[1]
+
+        authenticated = request[KEY_AUTHENTICATED] or token in access_tokens
+        if not authenticated:
+            raise web.HTTPUnauthorized()
+
+        try:
+            thumbnail = await instance.get_event_thumbnail(
+                event_id, width=width, height=height
+            )
+        except NvrError as err:
+            return _404(err)
+
+        if thumbnail is None:
+            return _404("Event thumbnail not found")
+
+        return web.Response(body=thumbnail, content_type="image/jpeg")

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -37,6 +37,7 @@ class MockBootstrap:
     sensors: dict[str, Any]
     viewers: dict[str, Any]
     liveviews: dict[str, Any]
+    events: dict[str, Any]
 
     def reset_objects(self) -> None:
         """Reset all devices on bootstrap for tests."""
@@ -45,6 +46,7 @@ class MockBootstrap:
         self.sensors = {}
         self.viewers = {}
         self.liveviews = {}
+        self.events = {}
 
 
 @dataclass
@@ -83,7 +85,13 @@ def mock_old_nvr_fixture():
 def mock_bootstrap_fixture(mock_nvr: NVR):
     """Mock Bootstrap fixture."""
     return MockBootstrap(
-        nvr=mock_nvr, cameras={}, lights={}, sensors={}, viewers={}, liveviews={}
+        nvr=mock_nvr,
+        cameras={},
+        lights={},
+        sensors={},
+        viewers={},
+        liveviews={},
+        events={},
     )
 
 

--- a/tests/components/unifiprotect/test_views.py
+++ b/tests/components/unifiprotect/test_views.py
@@ -1,0 +1,236 @@
+"""Test UniFi Protect views."""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from pyunifiprotect.data import Camera, Event, EventType
+from pyunifiprotect.exceptions import NvrError
+
+from homeassistant.components.unifiprotect.binary_sensor import MOTION_SENSORS
+from homeassistant.components.unifiprotect.const import ATTR_EVENT_THUMB
+from homeassistant.components.unifiprotect.entity import TOKEN_CHANGE_INTERVAL
+from homeassistant.const import STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockEntityFixture, ids_from_device_description, time_changed
+
+
+@pytest.fixture(name="thumb_url")
+async def thumb_url_fixture(
+    hass: HomeAssistant,
+    mock_entry: MockEntityFixture,
+    mock_camera: Camera,
+    now: datetime,
+):
+    """Fixture for a single camera for testing the binary_sensor platform."""
+
+    # disable pydantic validation so mocking can happen
+    Camera.__config__.validate_assignment = False
+
+    camera_obj = mock_camera.copy(deep=True)
+    camera_obj._api = mock_entry.api
+    camera_obj.channels[0]._api = mock_entry.api
+    camera_obj.channels[1]._api = mock_entry.api
+    camera_obj.channels[2]._api = mock_entry.api
+    camera_obj.name = "Test Camera"
+    camera_obj.is_motion_detected = True
+
+    event = Event(
+        id="test_event_id",
+        type=EventType.MOTION,
+        start=now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=camera_obj.id,
+    )
+    camera_obj.last_motion_event_id = event.id
+
+    mock_entry.api.bootstrap.reset_objects()
+    mock_entry.api.bootstrap.nvr.system_info.storage.devices = []
+    mock_entry.api.bootstrap.cameras = {
+        camera_obj.id: camera_obj,
+    }
+    mock_entry.api.bootstrap.events = {event.id: event}
+
+    await hass.config_entries.async_setup(mock_entry.entry.entry_id)
+    await hass.async_block_till_done()
+
+    _, entity_id = ids_from_device_description(
+        Platform.BINARY_SENSOR, camera_obj, MOTION_SENSORS[0]
+    )
+
+    # make sure access tokens are generated
+    await time_changed(hass, 1)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_EVENT_THUMB].startswith(
+        f"/api/ufp/thumbnail/test_event_id?entity_id={entity_id}&token="
+    )
+
+    yield state.attributes[ATTR_EVENT_THUMB]
+
+    Camera.__config__.validate_assignment = True
+
+
+async def test_thumbnail_view_good(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url)
+    assert response.status == 200
+
+    mock_entry.api.get_event_thumbnail.assert_called_once_with(
+        "test_event_id", width=None, height=None
+    )
+
+
+async def test_thumbnail_view_good_args(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url + "&w=200&h=200")
+    assert response.status == 200
+
+    mock_entry.api.get_event_thumbnail.assert_called_once_with(
+        "test_event_id", width=200, height=200
+    )
+
+
+async def test_thumbnail_view_bad_width(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url + "&w=safds&h=200")
+    assert response.status == 404
+
+    assert not mock_entry.api.get_event_thumbnail.called
+
+
+async def test_thumbnail_view_bad_height(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url + "&w=200&h=asda")
+    assert response.status == 404
+
+    assert not mock_entry.api.get_event_thumbnail.called
+
+
+async def test_thumbnail_view_bad_entity_id(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    client = await hass_client_no_auth()
+
+    response = await client.get("/api/ufp/thumbnail/test_event_id?entity_id=sdfsfd")
+    assert response.status == 404
+
+    assert not mock_entry.api.get_event_thumbnail.called
+
+
+async def test_thumbnail_view_bad_access_token(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    client = await hass_client_no_auth()
+
+    thumb_url = thumb_url[:-1]
+
+    response = await client.get(thumb_url)
+    assert response.status == 401
+
+    assert not mock_entry.api.get_event_thumbnail.called
+
+
+async def test_thumbnail_view_upstream_error(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock(side_effect=NvrError)
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url)
+    assert response.status == 404
+
+
+async def test_thumbnail_view_no_thumb(
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock(return_value=None)
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url)
+    assert response.status == 404
+
+
+async def test_thumbnail_view_expired_access_token(
+    hass: HomeAssistant,
+    thumb_url: str,
+    hass_client_no_auth,
+    mock_entry: MockEntityFixture,
+):
+    """Test good result from thumbnail view."""
+
+    mock_entry.api.get_event_thumbnail = AsyncMock()
+
+    await time_changed(hass, TOKEN_CHANGE_INTERVAL.total_seconds())
+    await time_changed(hass, TOKEN_CHANGE_INTERVAL.total_seconds())
+
+    client = await hass_client_no_auth()
+
+    response = await client.get(thumb_url)
+    assert response.status == 401


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds camera motion sensor/binary_sensor entities. Entities have thumbnail attributes that are modeled directly after the `camera.entity_picture` attribute.

TODO for the rest of the UniFi Protect HACS migration after this PR:

* camera motion sensors + views & docs (this PR)
* `ufp_value` -> lambda refactor (ref: https://github.com/home-assistant/core/pull/63220#discussion_r777231482)
* global services & docs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21104

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
