### PR TITLE
Fix `ParamSpec` Callable return types

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
 import contextlib
 from datetime import datetime, timedelta
 import functools
@@ -73,7 +73,7 @@ _P = ParamSpec("_P")
 
 def catch_request_errors(
     func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Awaitable[_R | None]]:  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R | None]]:  # type: ignore[misc]
     """Catch UpnpError errors."""
 
     @functools.wraps(func)

--- a/homeassistant/components/evil_genius_labs/util.py
+++ b/homeassistant/components/evil_genius_labs/util.py
@@ -1,9 +1,9 @@
 """Utilities for Evil Genius Labs."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from typing_extensions import Concatenate, ParamSpec
 
@@ -16,7 +16,7 @@ _P = ParamSpec("_P")
 
 def update_when_done(
     func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Awaitable[_R]]:  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:  # type: ignore[misc]
     """Decorate function to trigger update when function is done."""
 
     @wraps(func)

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -1,8 +1,8 @@
 """Common code for tplink."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, TypeVar
 
 from kasa import SmartDevice
 from typing_extensions import Concatenate, ParamSpec
@@ -20,7 +20,7 @@ _P = ParamSpec("_P")
 
 def async_refresh_after(
     func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Awaitable[None]]:  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
     """Define a wrapper to refresh after."""
 
     async def _async_wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -1,7 +1,7 @@
 """Provide functionality to interact with the vlc telnet interface."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from datetime import datetime
 from functools import wraps
 from typing import Any, TypeVar
@@ -70,7 +70,7 @@ async def async_setup_entry(
 
 def catch_vlc_errors(
     func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Awaitable[None]]:  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
     """Catch VLC errors."""
 
     @wraps(func)

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
@@ -53,12 +53,12 @@ def get_addon_manager(hass: HomeAssistant) -> AddonManager:
 
 def api_error(
     error_message: str,
-) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]:
+) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Coroutine[Any, Any, _R]]]:
     """Handle HassioAPIError and raise a specific AddonError."""
 
     def handle_hassio_api_error(
         func: Callable[_P, Awaitable[_R]]
-    ) -> Callable[_P, Awaitable[_R]]:
+    ) -> Callable[_P, Coroutine[Any, Any, _R]]:
         """Handle a HassioAPIError."""
 
         async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:


### PR DESCRIPTION
## Proposed change
Some hopefully 🤞🏻 last changes to the `ParamSpec` typing. The Callable return type should be a `Coroutine` instead of `Awaitable`. Noticed these while testing a development branch from mypy that adds full support for `ParamSpec` and `Concatenate` in particular. With `Awaitable`, we would trigger incompatible overload errors since we override `Coroutines` from the base classes. The overriding methods thus also need to be a `Coroutines` too, which the wrapper functions already are. The typing just didn't reflect that.

Ref: #63148

```py
_P = ParamSpec("_P")
_R = TypeVar("_R")

def decorator(
    func: Callable[_P, Awaitable[_R]]  # Awaitable here is fine, as that's all we need
) -> Callable[_P, Coroutine[Any, Any, _R]]:  # Here Coroutine is necessary

    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
        return await func(*args, **kwargs)

    return wrapper


class Parent:
    async def func(self) -> None: ...

class Child(Parent):
    @decorator
    async def func(self) -> None: ...
```

/CC: @MartinHjelmare @frenck


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
