### PR TITLE
Use local constant in netgear_lte config schema

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -8,9 +8,6 @@ import attr
 import eternalegypt
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_MONITORED_CONDITIONS,
@@ -91,12 +88,12 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Required(CONF_HOST): cv.string,
                         vol.Required(CONF_PASSWORD): cv.string,
-                        vol.Optional(NOTIFY_DOMAIN, default={}): vol.All(
+                        vol.Optional(Platform.NOTIFY, default={}): vol.All(
                             cv.ensure_list, [NOTIFY_SCHEMA]
                         ),
-                        vol.Optional(SENSOR_DOMAIN, default={}): SENSOR_SCHEMA,
+                        vol.Optional(Platform.SENSOR, default={}): SENSOR_SCHEMA,
                         vol.Optional(
-                            BINARY_SENSOR_DOMAIN, default={}
+                            Platform.BINARY_SENSOR, default={}
                         ): BINARY_SENSOR_SCHEMA,
                     }
                 )
@@ -225,11 +222,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Load platforms for each modem
     for lte_conf in netgear_lte_config:
         # Notify
-        for notify_conf in lte_conf[NOTIFY_DOMAIN]:
+        for notify_conf in lte_conf[Platform.NOTIFY]:
             discovery_info = {
                 CONF_HOST: lte_conf[CONF_HOST],
                 CONF_NAME: notify_conf.get(CONF_NAME),
-                NOTIFY_DOMAIN: notify_conf,
+                Platform.NOTIFY: notify_conf,
             }
             hass.async_create_task(
                 discovery.async_load_platform(
@@ -238,8 +235,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
 
         # Sensor
-        sensor_conf = lte_conf.get(SENSOR_DOMAIN)
-        discovery_info = {CONF_HOST: lte_conf[CONF_HOST], SENSOR_DOMAIN: sensor_conf}
+        sensor_conf = lte_conf.get(Platform.SENSOR)
+        discovery_info = {CONF_HOST: lte_conf[CONF_HOST], Platform.SENSOR: sensor_conf}
         hass.async_create_task(
             discovery.async_load_platform(
                 hass, Platform.SENSOR, DOMAIN, discovery_info, config
@@ -247,10 +244,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
 
         # Binary Sensor
-        binary_sensor_conf = lte_conf.get(BINARY_SENSOR_DOMAIN)
+        binary_sensor_conf = lte_conf.get(Platform.BINARY_SENSOR)
         discovery_info = {
             CONF_HOST: lte_conf[CONF_HOST],
-            BINARY_SENSOR_DOMAIN: binary_sensor_conf,
+            Platform.BINARY_SENSOR: binary_sensor_conf,
         }
         hass.async_create_task(
             discovery.async_load_platform(

--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -2,6 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import Final
 
 import aiohttp
 import attr
@@ -34,6 +35,10 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=10)
 DISPATCHER_NETGEAR_LTE = "netgear_lte_update"
+
+CONF_NOTIFY: Final = "notify"
+CONF_BINARY_SENSOR: Final = "binary_sensor"
+CONF_SENSOR: Final = "sensor"
 
 DOMAIN = "netgear_lte"
 DATA_KEY = "netgear_lte"
@@ -88,12 +93,12 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Required(CONF_HOST): cv.string,
                         vol.Required(CONF_PASSWORD): cv.string,
-                        vol.Optional(Platform.NOTIFY, default={}): vol.All(
+                        vol.Optional(CONF_NOTIFY, default={}): vol.All(
                             cv.ensure_list, [NOTIFY_SCHEMA]
                         ),
-                        vol.Optional(Platform.SENSOR, default={}): SENSOR_SCHEMA,
+                        vol.Optional(CONF_SENSOR, default={}): SENSOR_SCHEMA,
                         vol.Optional(
-                            Platform.BINARY_SENSOR, default={}
+                            CONF_BINARY_SENSOR, default={}
                         ): BINARY_SENSOR_SCHEMA,
                     }
                 )
@@ -222,11 +227,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Load platforms for each modem
     for lte_conf in netgear_lte_config:
         # Notify
-        for notify_conf in lte_conf[Platform.NOTIFY]:
+        for notify_conf in lte_conf[CONF_NOTIFY]:
             discovery_info = {
                 CONF_HOST: lte_conf[CONF_HOST],
                 CONF_NAME: notify_conf.get(CONF_NAME),
-                Platform.NOTIFY: notify_conf,
+                CONF_NOTIFY: notify_conf,
             }
             hass.async_create_task(
                 discovery.async_load_platform(
@@ -235,8 +240,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
 
         # Sensor
-        sensor_conf = lte_conf.get(Platform.SENSOR)
-        discovery_info = {CONF_HOST: lte_conf[CONF_HOST], Platform.SENSOR: sensor_conf}
+        sensor_conf = lte_conf[CONF_SENSOR]
+        discovery_info = {CONF_HOST: lte_conf[CONF_HOST], CONF_SENSOR: sensor_conf}
         hass.async_create_task(
             discovery.async_load_platform(
                 hass, Platform.SENSOR, DOMAIN, discovery_info, config
@@ -244,10 +249,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
 
         # Binary Sensor
-        binary_sensor_conf = lte_conf.get(Platform.BINARY_SENSOR)
+        binary_sensor_conf = lte_conf[CONF_BINARY_SENSOR]
         discovery_info = {
             CONF_HOST: lte_conf[CONF_HOST],
-            Platform.BINARY_SENSOR: binary_sensor_conf,
+            CONF_BINARY_SENSOR: binary_sensor_conf,
         }
         hass.async_create_task(
             discovery.async_load_platform(

--- a/homeassistant/components/netgear_lte/binary_sensor.py
+++ b/homeassistant/components/netgear_lte/binary_sensor.py
@@ -1,8 +1,8 @@
 """Support for Netgear LTE binary sensors."""
-from homeassistant.components.binary_sensor import DOMAIN, BinarySensorEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.exceptions import PlatformNotReady
 
-from . import CONF_MONITORED_CONDITIONS, DATA_KEY, LTEEntity
+from . import CONF_BINARY_SENSOR, CONF_MONITORED_CONDITIONS, DATA_KEY, LTEEntity
 from .sensor_types import BINARY_SENSOR_CLASSES
 
 
@@ -16,7 +16,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info)
     if not modem_data or not modem_data.data:
         raise PlatformNotReady
 
-    binary_sensor_conf = discovery_info[DOMAIN]
+    binary_sensor_conf = discovery_info[CONF_BINARY_SENSOR]
     monitored_conditions = binary_sensor_conf[CONF_MONITORED_CONDITIONS]
 
     binary_sensors = []

--- a/homeassistant/components/netgear_lte/notify.py
+++ b/homeassistant/components/netgear_lte/notify.py
@@ -4,9 +4,9 @@ import logging
 import attr
 import eternalegypt
 
-from homeassistant.components.notify import ATTR_TARGET, DOMAIN, BaseNotificationService
+from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
 
-from . import CONF_RECIPIENT, DATA_KEY
+from . import CONF_NOTIFY, CONF_RECIPIENT, DATA_KEY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class NetgearNotifyService(BaseNotificationService):
             _LOGGER.error("Modem not ready")
             return
 
-        targets = kwargs.get(ATTR_TARGET, self.config[DOMAIN][CONF_RECIPIENT])
+        targets = kwargs.get(ATTR_TARGET, self.config[CONF_NOTIFY][CONF_RECIPIENT])
         if not targets:
             _LOGGER.warning("No recipients")
             return

--- a/homeassistant/components/netgear_lte/sensor.py
+++ b/homeassistant/components/netgear_lte/sensor.py
@@ -1,8 +1,8 @@
 """Support for Netgear LTE sensors."""
-from homeassistant.components.sensor import DOMAIN, SensorEntity
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.exceptions import PlatformNotReady
 
-from . import CONF_MONITORED_CONDITIONS, DATA_KEY, LTEEntity
+from . import CONF_MONITORED_CONDITIONS, CONF_SENSOR, DATA_KEY, LTEEntity
 from .sensor_types import SENSOR_SMS, SENSOR_SMS_TOTAL, SENSOR_UNITS, SENSOR_USAGE
 
 
@@ -16,7 +16,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info)
     if not modem_data or not modem_data.data:
         raise PlatformNotReady
 
-    sensor_conf = discovery_info[DOMAIN]
+    sensor_conf = discovery_info[CONF_SENSOR]
     monitored_conditions = sensor_conf[CONF_MONITORED_CONDITIONS]
 
     sensors = []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As a follow-up to https://github.com/home-assistant/core/pull/63577#issuecomment-1008283032, I think it might be nicer to use the ~Platform enum~ local constant than the Domain constant in some of the configuration schemas out there.
At this stage, this is a sample for validation and review.
cc @cdce8p / @frenck / @MartinHjelmare  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
