### PR TITLE
Change webOS Smart TV PyPi package to aiowebostv

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -194,9 +194,9 @@ async def async_control_connect(host: str, key: str | None) -> WebOsClient:
     client = WebOsClient(host, key)
     try:
         await client.connect()
-    except WebOsTvPairError as err:
+    except WebOsTvPairError:
         _LOGGER.warning("Connected to LG webOS TV %s but not paired", host)
-        raise WebOsTvPairError(err) from err
+        raise
 
     return client
 

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 import logging
 from typing import Any
 
-from bscpylgtv import PyLGTVPairException, WebOsClient
+from aiowebostv import WebOsClient, WebOsTvPairError
 import voluptuous as vol
 
 from homeassistant.components import notify as hass_notify
@@ -191,12 +191,12 @@ async def async_update_options(hass, config_entry):
 
 async def async_control_connect(host: str, key: str | None) -> WebOsClient:
     """LG Connection."""
-    client = await WebOsClient.create(host, client_key=key)
+    client = WebOsClient(host, key)
     try:
         await client.connect()
-    except PyLGTVPairException as err:
+    except WebOsTvPairError as err:
         _LOGGER.warning("Connected to LG webOS TV %s but not paired", host)
-        raise PyLGTVPairException(err) from err
+        raise WebOsTvPairError(err) from err
 
     return client
 
@@ -265,8 +265,8 @@ class WebOsClientWrapper:
 
     async def connect(self) -> None:
         """Attempt a connection, but fail gracefully if tv is off for example."""
-        self.client = await WebOsClient.create(self.host, client_key=self.client_key)
-        with suppress(*WEBOSTV_EXCEPTIONS, PyLGTVPairException):
+        self.client = WebOsClient(self.host, self.client_key)
+        with suppress(*WEBOSTV_EXCEPTIONS, WebOsTvPairError):
             await self.client.connect()
 
     async def shutdown(self) -> None:

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import urlparse
 
-from bscpylgtv import PyLGTVPairException
+from aiowebostv import WebOsTvPairError
 import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
@@ -93,7 +93,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         ):
             try:
                 client = await async_control_connect(self._host, None)
-            except PyLGTVPairException:
+            except WebOsTvPairError:
                 return self.async_abort(reason="error_pairing")
             except WEBOSTV_EXCEPTIONS:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,7 +1,7 @@
 """Constants used for LG webOS Smart TV."""
 import asyncio
 
-from bscpylgtv import PyLGTVCmdException
+from aiowebostv import WebOsTvCommandError
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 
 DOMAIN = "webostv"
@@ -29,7 +29,7 @@ WEBOSTV_EXCEPTIONS = (
     ConnectionClosed,
     ConnectionClosedOK,
     ConnectionRefusedError,
-    PyLGTVCmdException,
+    WebOsTvCommandError,
     asyncio.TimeoutError,
     asyncio.CancelledError,
 )

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -3,7 +3,7 @@
   "name": "LG webOS Smart TV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/webostv",
-  "requirements": ["bscpylgtv==0.2.8"],
+  "requirements": ["aiowebostv==0.1.1"],
   "codeowners": ["@bendavid"],
   "ssdp": [{
     "manufacturer": "LG Electronics.",

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -1,7 +1,7 @@
 """Support for LG WebOS TV notification service."""
 import logging
 
-from bscpylgtv import PyLGTVPairException
+from aiowebostv import WebOsTvPairError
 
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
 from homeassistant.const import CONF_ICON, CONF_NAME
@@ -18,7 +18,9 @@ async def async_get_service(hass, _config, discovery_info=None):
         return None
 
     name = discovery_info.get(CONF_NAME)
-    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][discovery_info[ATTR_CONFIG_ENTRY_ID]]
+    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
+        discovery_info[ATTR_CONFIG_ENTRY_ID]
+    ].client
 
     return LgWebOSNotificationService(client, name)
 
@@ -40,7 +42,7 @@ class LgWebOSNotificationService(BaseNotificationService):
             data = kwargs.get(ATTR_DATA)
             icon_path = data.get(CONF_ICON, "") if data else None
             await self._client.send_message(message, icon_path=icon_path)
-        except PyLGTVPairException:
+        except WebOsTvPairError:
             _LOGGER.error("Pairing with TV failed")
         except FileNotFoundError:
             _LOGGER.error("Icon %s not found", icon_path)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -268,6 +268,9 @@ aiovlc==0.1.0
 # homeassistant.components.watttime
 aiowatttime==0.1.1
 
+# homeassistant.components.webostv
+aiowebostv==0.1.1
+
 # homeassistant.components.yandex_transport
 aioymaps==1.2.2
 
@@ -446,9 +449,6 @@ brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0
-
-# homeassistant.components.webostv
-bscpylgtv==0.2.8
 
 # homeassistant.components.bluetooth_tracker
 bt_proximity==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -197,6 +197,9 @@ aiovlc==0.1.0
 # homeassistant.components.watttime
 aiowatttime==0.1.1
 
+# homeassistant.components.webostv
+aiowebostv==0.1.1
+
 # homeassistant.components.yandex_transport
 aioymaps==1.2.2
 
@@ -286,9 +289,6 @@ brunt==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0
-
-# homeassistant.components.webostv
-bscpylgtv==0.2.8
 
 # homeassistant.components.buienradar
 buienradar==1.0.5

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -18,7 +18,6 @@ def client_fixture():
     with patch(
         "homeassistant.components.webostv.WebOsClient", autospec=True
     ) as mock_client_class:
-        mock_client_class.create.return_value = mock_client_class.return_value
         client = mock_client_class.return_value
         client.software_info = {"device_id": "00:01:02:03:04:05"}
         client.system_info = {"modelName": "TVFAKE"}

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the WebOS Tv config flow."""
 from unittest.mock import Mock, patch
 
-from bscpylgtv import PyLGTVPairException
+from aiowebostv import WebOsTvPairError
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp
@@ -144,7 +144,7 @@ async def test_form_pairexception(hass, client):
         data=MOCK_YAML_CONFIG,
     )
 
-    client.connect = Mock(side_effect=PyLGTVPairException("error"))
+    client.connect = Mock(side_effect=WebOsTvPairError("error"))
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Change PyPi package to `aiowebostv`**

Last change to `bscpylgtv` did not work well due to owner not using home assistant and not enabling issues on his repository which made it hard to fix bugs found during testing. 

PR changes to package which is maintained by Home Assistant team: https://github.com/home-assistant-libs/aiowebostv 

Changes: https://github.com/home-assistant-libs/aiowebostv/commits/main
Additional changes from initial commit:
- Drop storage class (not used by integration)
- Drop picture settings and calibration functions  (not used by integration)

During testing I found a small bug in the notify component, to make the branch operational it is also included in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
