### PR TITLE
Warn on`time.sleep` in event loop

### DIFF
--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -1,5 +1,6 @@
 """Block I/O being done in asyncio."""
 from http.client import HTTPConnection
+import time
 
 from .util.async_ import protect_loop
 
@@ -8,6 +9,9 @@ def enable() -> None:
     """Enable the detection of I/O in the event loop."""
     # Prevent urllib3 and requests doing I/O in event loop
     HTTPConnection.putrequest = protect_loop(HTTPConnection.putrequest)  # type: ignore
+
+    # Prevent sleeping in event loop
+    time.sleep = protect_loop(time.sleep)
 
     # Currently disabled. pytz doing I/O when getting timezone.
     # Prevent files being opened inside the event loop

--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -1,4 +1,4 @@
-"""Block I/O being done in asyncio."""
+"""Block blocking calls being done in asyncio."""
 from http.client import HTTPConnection
 import time
 
@@ -6,7 +6,7 @@ from .util.async_ import protect_loop
 
 
 def enable() -> None:
-    """Enable the detection of I/O in the event loop."""
+    """Enable the detection of blocking calls in the event loop."""
     # Prevent urllib3 and requests doing I/O in event loop
     HTTPConnection.putrequest = protect_loop(HTTPConnection.putrequest)  # type: ignore
 

--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -10,8 +10,8 @@ def enable() -> None:
     # Prevent urllib3 and requests doing I/O in event loop
     HTTPConnection.putrequest = protect_loop(HTTPConnection.putrequest)  # type: ignore
 
-    # Prevent sleeping in event loop
-    time.sleep = protect_loop(time.sleep)
+    # Prevent sleeping in event loop. Non-strict since 2022.02
+    time.sleep = protect_loop(time.sleep, strict=False)
 
     # Currently disabled. pytz doing I/O when getting timezone.
     # Prevent files being opened inside the event loop

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -116,7 +116,8 @@ def check_loop(strict: bool = True) -> None:
     # Did not source from integration? Hard error.
     if found_frame is None:
         raise RuntimeError(
-            "Detected blocking call inside the event loop. This is causing stability issues. Please report issue"
+            "Detected blocking call inside the event loop. "
+            "This is causing stability issues. Please report issue"
         )
 
     start = index + len(path)
@@ -130,7 +131,8 @@ def check_loop(strict: bool = True) -> None:
         extra = ""
 
     _LOGGER.warning(
-        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue%s for %s doing blocking calls at %s, line %s: %s",
+        "Detected blocking call inside the event loop. This is causing stability issues. "
+        "Please report issue%s for %s doing blocking calls at %s, line %s: %s",
         extra,
         integration,
         found_frame.filename[index:],

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -116,7 +116,7 @@ def check_loop() -> None:
     # Did not source from integration? Hard error.
     if found_frame is None:
         raise RuntimeError(
-            "Detected I/O inside the event loop. This is causing stability issues. Please report issue"
+            "Detected blocking call inside the event loop. This is causing stability issues. Please report issue"
         )
 
     start = index + len(path)
@@ -130,7 +130,7 @@ def check_loop() -> None:
         extra = ""
 
     _LOGGER.warning(
-        "Detected I/O inside the event loop. This is causing stability issues. Please report issue%s for %s doing I/O at %s, line %s: %s",
+        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue%s for %s doing blocking calls at %s, line %s: %s",
         extra,
         integration,
         found_frame.filename[index:],
@@ -138,7 +138,7 @@ def check_loop() -> None:
         found_frame.line.strip(),
     )
     raise RuntimeError(
-        f"I/O must be done in the executor; Use `await hass.async_add_executor_job()` "
+        f"Blocking calls must be done in the executor; Use `await hass.async_add_executor_job()` "
         f"at {found_frame.filename[index:]}, line {found_frame.lineno}: {found_frame.line.strip()}"
     )
 

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -138,7 +138,8 @@ def check_loop() -> None:
         found_frame.line.strip(),
     )
     raise RuntimeError(
-        f"Blocking calls must be done in the executor; Use `await hass.async_add_executor_job()` "
+        "Blocking calls must be done in the executor or a separate thread; "
+        "Use `await hass.async_add_executor_job()` "
         f"at {found_frame.filename[index:]}, line {found_frame.lineno}: {found_frame.line.strip()}"
     )
 

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -77,7 +77,7 @@ async def test_check_loop_async():
 
 
 async def test_check_loop_async_integration(caplog):
-    """Test check_loop detects when called from event loop from integration context."""
+    """Test check_loop detects and raises when called from event loop from integration context."""
     with pytest.raises(RuntimeError), patch(
         "homeassistant.util.async_.extract_stack",
         return_value=[
@@ -100,7 +100,36 @@ async def test_check_loop_async_integration(caplog):
     ):
         hasync.check_loop()
     assert (
-        "Detected I/O inside the event loop. This is causing stability issues. Please report issue for hue doing I/O at homeassistant/components/hue/light.py, line 23: self.light.is_on"
+        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue for hue doing blocking calls at homeassistant/components/hue/light.py, line 23: self.light.is_on"
+        in caplog.text
+    )
+
+
+async def test_check_loop_async_integration_non_strict(caplog):
+    """Test check_loop detects when called from event loop from integration context."""
+    with patch(
+        "homeassistant.util.async_.extract_stack",
+        return_value=[
+            Mock(
+                filename="/home/paulus/homeassistant/core.py",
+                lineno="23",
+                line="do_something()",
+            ),
+            Mock(
+                filename="/home/paulus/homeassistant/components/hue/light.py",
+                lineno="23",
+                line="self.light.is_on",
+            ),
+            Mock(
+                filename="/home/paulus/aiohue/lights.py",
+                lineno="2",
+                line="something()",
+            ),
+        ],
+    ):
+        hasync.check_loop(strict=False)
+    assert (
+        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue for hue doing blocking calls at homeassistant/components/hue/light.py, line 23: self.light.is_on"
         in caplog.text
     )
 
@@ -129,7 +158,7 @@ async def test_check_loop_async_custom(caplog):
     ):
         hasync.check_loop()
     assert (
-        "Detected I/O inside the event loop. This is causing stability issues. Please report issue to the custom component author for hue doing I/O at custom_components/hue/light.py, line 23: self.light.is_on"
+        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue to the custom component author for hue doing blocking calls at custom_components/hue/light.py, line 23: self.light.is_on"
         in caplog.text
     )
 
@@ -137,16 +166,16 @@ async def test_check_loop_async_custom(caplog):
 def test_check_loop_sync(caplog):
     """Test check_loop does nothing when called from thread."""
     hasync.check_loop()
-    assert "Detected I/O inside the event loop" not in caplog.text
+    assert "Detected blocking call inside the event loop" not in caplog.text
 
 
 def test_protect_loop_sync():
     """Test protect_loop calls check_loop."""
-    calls = []
-    with patch("homeassistant.util.async_.check_loop") as mock_loop:
-        hasync.protect_loop(calls.append)(1)
-    assert len(mock_loop.mock_calls) == 1
-    assert calls == [1]
+    func = Mock()
+    with patch("homeassistant.util.async_.check_loop") as mock_check_loop:
+        hasync.protect_loop(func)(1, test=2)
+    mock_check_loop.assert_called_once_with(strict=True)
+    func.assert_called_once_with(1, test=2)
 
 
 async def test_gather_with_concurrency():

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -100,7 +100,9 @@ async def test_check_loop_async_integration(caplog):
     ):
         hasync.check_loop()
     assert (
-        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue for hue doing blocking calls at homeassistant/components/hue/light.py, line 23: self.light.is_on"
+        "Detected blocking call inside the event loop. This is causing stability issues. "
+        "Please report issue for hue doing blocking calls at "
+        "homeassistant/components/hue/light.py, line 23: self.light.is_on"
         in caplog.text
     )
 
@@ -129,7 +131,9 @@ async def test_check_loop_async_integration_non_strict(caplog):
     ):
         hasync.check_loop(strict=False)
     assert (
-        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue for hue doing blocking calls at homeassistant/components/hue/light.py, line 23: self.light.is_on"
+        "Detected blocking call inside the event loop. This is causing stability issues. "
+        "Please report issue for hue doing blocking calls at "
+        "homeassistant/components/hue/light.py, line 23: self.light.is_on"
         in caplog.text
     )
 
@@ -158,8 +162,9 @@ async def test_check_loop_async_custom(caplog):
     ):
         hasync.check_loop()
     assert (
-        "Detected blocking call inside the event loop. This is causing stability issues. Please report issue to the custom component author for hue doing blocking calls at custom_components/hue/light.py, line 23: self.light.is_on"
-        in caplog.text
+        "Detected blocking call inside the event loop. This is causing stability issues. "
+        "Please report issue to the custom component author for hue doing blocking calls "
+        "at custom_components/hue/light.py, line 23: self.light.is_on" in caplog.text
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Warn on`time.sleep` in event loop. A warning will now be logged for usage of `time.sleep` blocking the main event loop.

```
2022-01-09 23:32:57 WARNING (MainThread) [homeassistant.util.async_] Detected blocking call inside the event loop. This is causing stability issues. Please report issue for *component* doing blocking calls at homeassistant/components/*component*/...
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Warn on`time.sleep` in event loop.
With this change a warning will be logged for usage of `time.sleep` blocking the main event loop.

`2022-01-09 23:32:57 WARNING (MainThread) [homeassistant.util.async_] Detected blocking call inside the event loop. This is causing stability issues. Please report issue for *component* doing blocking calls at homeassistant/components/*component*/...`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
