### PR TITLE
Improve typing [helpers.entity_registry]

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -50,6 +50,14 @@ from .typing import UNDEFINED, UndefinedType
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
+# pylint: disable-next=fixme
+# TODO 3.9: Replace EntityRegistryUserDict with generic UserDict at runtime
+if TYPE_CHECKING:
+    EntityRegistryUserDict = UserDict[str, "RegistryEntry"]
+else:
+    EntityRegistryUserDict = UserDict
+
+
 PATH_REGISTRY = "entity_registry.yaml"
 DATA_REGISTRY = "entity_registry"
 EVENT_ENTITY_REGISTRY_UPDATED = "entity_registry_updated"
@@ -165,7 +173,7 @@ class EntityRegistryStore(storage.Store):
         return await _async_migrate(old_major_version, old_minor_version, old_data)
 
 
-class EntityRegistryItems(UserDict):
+class EntityRegistryItems(EntityRegistryUserDict):
     """Container for entity registry items, maps entity_id -> entry.
 
     Maintains two additional indexes:
@@ -196,10 +204,6 @@ class EntityRegistryItems(UserDict):
         self._index.__delitem__((entry.domain, entry.platform, entry.unique_id))
         super().__delitem__(key)
 
-    def __getitem__(self, key: str) -> RegistryEntry:
-        """Get an item."""
-        return cast(RegistryEntry, super().__getitem__(key))
-
     def get_entity_id(self, key: tuple[str, str, str]) -> str | None:
         """Get entity_id from (domain, platform, unique_id)."""
         return self._index.get(key)
@@ -212,10 +216,11 @@ class EntityRegistryItems(UserDict):
 class EntityRegistry:
     """Class to hold a registry of entities."""
 
+    entities: EntityRegistryItems
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the registry."""
         self.hass = hass
-        self.entities: EntityRegistryItems
         self._store = EntityRegistryStore(
             hass,
             STORAGE_VERSION_MAJOR,
@@ -230,13 +235,13 @@ class EntityRegistry:
     @callback
     def async_get_device_class_lookup(
         self, domain_device_classes: set[tuple[str, str | None]]
-    ) -> dict:
+    ) -> dict[str, dict[tuple[str, str | None], str]]:
         """Return a lookup of entity ids for devices which have matching entities.
 
         Entities must match a set of (domain, device_class) tuples.
         The result is indexed by device_id, then by the matching (domain, device_class)
         """
-        lookup: dict[str, dict[tuple[Any, Any], str]] = {}
+        lookup: dict[str, dict[tuple[str, str | None], str]] = {}
         for entity in self.entities.values():
             if not entity.device_id:
                 continue
@@ -483,8 +488,8 @@ class EntityRegistry:
         """Private facing update properties method."""
         old = self.entities[entity_id]
 
-        new_values = {}  # Dict with new key/value pairs
-        old_values = {}  # Dict with old key/value pairs
+        new_values: dict[str, Any] = {}  # Dict with new key/value pairs
+        old_values: dict[str, Any] = {}  # Dict with old key/value pairs
 
         if isinstance(disabled_by, str) and not isinstance(
             disabled_by, RegistryEntryDisabler
@@ -550,7 +555,11 @@ class EntityRegistry:
 
         self.async_schedule_save()
 
-        data = {"action": "update", "entity_id": entity_id, "changes": old_values}
+        data: dict[str, str | dict[str, Any]] = {
+            "action": "update",
+            "entity_id": entity_id,
+            "changes": old_values,
+        }
 
         if old.entity_id != entity_id:
             data["old_entity_id"] = old.entity_id
@@ -613,7 +622,7 @@ class EntityRegistry:
     @callback
     def _data_to_save(self) -> dict[str, Any]:
         """Return data of entity registry to store in a file."""
-        data = {}
+        data: dict[str, Any] = {}
 
         data["entities"] = [
             {
@@ -841,7 +850,7 @@ def async_setup_entity_restore(hass: HomeAssistant, registry: EntityRegistry) ->
 async def async_migrate_entries(
     hass: HomeAssistant,
     config_entry_id: str,
-    entry_callback: Callable[[RegistryEntry], dict | None],
+    entry_callback: Callable[[RegistryEntry], dict[str, Any] | None],
 ) -> None:
     """Migrator of unique IDs."""
     ent_reg = await async_get_registry(hass)

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
 # pylint: disable-next=fixme
 # TODO 3.9: Replace EntityRegistryUserDict with generic UserDict at runtime
 if TYPE_CHECKING:
+    # pylint: disable-next=unsubscriptable-object
     EntityRegistryUserDict = UserDict[str, "RegistryEntry"]
 else:
     EntityRegistryUserDict = UserDict

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -50,15 +50,6 @@ from .typing import UNDEFINED, UndefinedType
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
-# pylint: disable-next=fixme
-# TODO 3.9: Replace EntityRegistryUserDict with generic UserDict at runtime
-if TYPE_CHECKING:
-    # pylint: disable-next=unsubscriptable-object
-    EntityRegistryUserDict = UserDict[str, "RegistryEntry"]
-else:
-    EntityRegistryUserDict = UserDict
-
-
 PATH_REGISTRY = "entity_registry.yaml"
 DATA_REGISTRY = "entity_registry"
 EVENT_ENTITY_REGISTRY_UPDATED = "entity_registry_updated"
@@ -174,7 +165,7 @@ class EntityRegistryStore(storage.Store):
         return await _async_migrate(old_major_version, old_minor_version, old_data)
 
 
-class EntityRegistryItems(EntityRegistryUserDict):
+class EntityRegistryItems(UserDict[str, "RegistryEntry"]):
     """Container for entity registry items, maps entity_id -> entry.
 
     Maintains two additional indexes:


### PR DESCRIPTION
## Proposed change
Improve typing in the `helper.entity_registry` module. In particular add types for Generic `collections.UserDict`.

`UserDict` is only generic in `3.9+`. To type it nevertheless, I used the pattern from the mypy documentation.
https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
