### PR TITLE
Change greeneye_monitor data to be a dictionary

### DIFF
--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -33,7 +33,7 @@ from .const import (
     CONF_TEMPERATURE_SENSORS,
     CONF_TIME_UNIT,
     CONF_VOLTAGE_SENSORS,
-    DATA_GREENEYE_MONITOR,
+    DATA_MONITORS,
     DOMAIN,
     TEMPERATURE_UNIT_CELSIUS,
 )
@@ -117,7 +117,9 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: COMPONENT_SCHEMA}, extra=vol.ALLOW_EXTRA)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the GreenEye Monitor component."""
     monitors = greeneye.Monitors()
-    hass.data[DATA_GREENEYE_MONITOR] = monitors
+    hass.data[DOMAIN] = {
+        DATA_MONITORS: monitors,
+    }
 
     server_config = config[DOMAIN]
     await monitors.start_server(server_config[CONF_PORT])

--- a/homeassistant/components/greeneye_monitor/const.py
+++ b/homeassistant/components/greeneye_monitor/const.py
@@ -13,7 +13,7 @@ CONF_TEMPERATURE_SENSORS = "temperature_sensors"
 CONF_TIME_UNIT = "time_unit"
 CONF_VOLTAGE_SENSORS = "voltage"
 
-DATA_GREENEYE_MONITOR = "greeneye_monitor"
+DATA_MONITORS = "monitors"
 DOMAIN = "greeneye_monitor"
 
 SENSOR_TYPE_CURRENT = "current_sensor"

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -32,7 +32,8 @@ from .const import (
     CONF_TEMPERATURE_SENSORS,
     CONF_TIME_UNIT,
     CONF_VOLTAGE_SENSORS,
-    DATA_GREENEYE_MONITOR,
+    DATA_MONITORS,
+    DOMAIN,
 )
 
 DATA_PULSES = "pulses"
@@ -130,13 +131,13 @@ class GEMSensor(SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Wait for and connect to the sensor."""
-        monitors = self.hass.data[DATA_GREENEYE_MONITOR]
+        monitors = self.hass.data[DOMAIN][DATA_MONITORS]
 
         if not self._try_connect_to_monitor(monitors):
             monitors.add_listener(self._on_new_monitor)
 
     def _on_new_monitor(self, monitor: greeneye.monitor.Monitor) -> None:
-        monitors = self.hass.data[DATA_GREENEYE_MONITOR]
+        monitors = self.hass.data[DOMAIN][DATA_MONITORS]
         if self._try_connect_to_monitor(monitors):
             monitors.remove_listener(self._on_new_monitor)
 
@@ -145,7 +146,7 @@ class GEMSensor(SensorEntity):
         if self._sensor:
             self._sensor.remove_listener(self.async_write_ha_state)
         else:
-            monitors = self.hass.data[DATA_GREENEYE_MONITOR]
+            monitors = self.hass.data[DOMAIN][DATA_MONITORS]
             monitors.remove_listener(self._on_new_monitor)
 
     def _try_connect_to_monitor(self, monitors: greeneye.Monitors) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`greeneye_monitor` used to store its `Monitors` instance (the object provided by the API to manage GreenEye Monitor devices) directly in `hass`'s `data` dictionary. This PR adds another `dict` layer, so that future PRs can store more stuff in there.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
