### PR TITLE
Support Tuya strip lights with correct values for saturation and brightness

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -257,6 +257,14 @@ DEFAULT_COLOR_TYPE_DATA = ColorTypeData(
     v_type=IntegerTypeData(min=1, scale=0, max=255, step=1),
 )
 
+# Used for devices with "colour_data" key and 0-1000 range
+# Strip lights use 0-1000 but this is not documented in Tuya API docs
+DEFAULT_COLOR_TYPE_DATA_1000 = ColorTypeData(
+    h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
+    s_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
+    v_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
+)
+
 DEFAULT_COLOR_TYPE_DATA_V2 = ColorTypeData(
     h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
     s_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
@@ -445,6 +453,9 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                     self._brightness_type and self._brightness_type.max > 255
                 ):
                     self._color_data_type = DEFAULT_COLOR_TYPE_DATA_V2
+                #If device category is dd (Strip light) use 0-1000 range for colour_data key
+                if (self.device.category == "dd"):
+                    self._color_data_type = DEFAULT_COLOR_TYPE_DATA_1000
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -31,6 +31,28 @@ from .util import remap_value
 
 
 @dataclass
+class ColorTypeData:
+    """Color Type Data."""
+
+    h_type: IntegerTypeData
+    s_type: IntegerTypeData
+    v_type: IntegerTypeData
+
+
+DEFAULT_COLOR_TYPE_DATA = ColorTypeData(
+    h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
+    s_type=IntegerTypeData(min=1, scale=0, max=255, step=1),
+    v_type=IntegerTypeData(min=1, scale=0, max=255, step=1),
+)
+
+DEFAULT_COLOR_TYPE_DATA_V2 = ColorTypeData(
+    h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
+    s_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
+    v_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
+)
+
+
+@dataclass
 class TuyaLightEntityDescription(LightEntityDescription):
     """Describe an Tuya light entity."""
 
@@ -40,6 +62,7 @@ class TuyaLightEntityDescription(LightEntityDescription):
     color_data: DPCode | tuple[DPCode, ...] | None = None
     color_mode: DPCode | None = None
     color_temp: DPCode | tuple[DPCode, ...] | None = None
+    default_color_type: ColorTypeData = DEFAULT_COLOR_TYPE_DATA
 
 
 LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
@@ -63,6 +86,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
             color_data=DPCode.COLOUR_DATA,
+            default_color_type=DEFAULT_COLOR_TYPE_DATA_V2,
         ),
     ),
     # Light
@@ -243,28 +267,6 @@ LIGHTS["pc"] = LIGHTS["kg"]
 
 
 @dataclass
-class ColorTypeData:
-    """Color Type Data."""
-
-    h_type: IntegerTypeData
-    s_type: IntegerTypeData
-    v_type: IntegerTypeData
-
-
-DEFAULT_COLOR_TYPE_DATA = ColorTypeData(
-    h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
-    s_type=IntegerTypeData(min=1, scale=0, max=255, step=1),
-    v_type=IntegerTypeData(min=1, scale=0, max=255, step=1),
-)
-
-DEFAULT_COLOR_TYPE_DATA_V2 = ColorTypeData(
-    h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
-    s_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
-    v_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
-)
-
-
-@dataclass
 class ColorData:
     """Color Data."""
 
@@ -440,11 +442,10 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                 )
             else:
                 # If no type is found, use a default one
-                self._color_data_type = DEFAULT_COLOR_TYPE_DATA
-                #If device supports v2 API or category is dd (Strip light) use 0-1000 range for colour_data key
+                self._color_data_type = self.entity_description.default_color_type
                 if self._color_data_dpcode == DPCode.COLOUR_DATA_V2 or (
                     self._brightness_type and self._brightness_type.max > 255
-                ) or (self.device.category == "dd"):
+                ):
                     self._color_data_type = DEFAULT_COLOR_TYPE_DATA_V2
 
     @property

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -257,14 +257,6 @@ DEFAULT_COLOR_TYPE_DATA = ColorTypeData(
     v_type=IntegerTypeData(min=1, scale=0, max=255, step=1),
 )
 
-# Used for devices with "colour_data" key and 0-1000 range
-# Strip lights use 0-1000 but this is not documented in Tuya API docs
-DEFAULT_COLOR_TYPE_DATA_1000 = ColorTypeData(
-    h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
-    s_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
-    v_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
-)
-
 DEFAULT_COLOR_TYPE_DATA_V2 = ColorTypeData(
     h_type=IntegerTypeData(min=1, scale=0, max=360, step=1),
     s_type=IntegerTypeData(min=1, scale=0, max=1000, step=1),
@@ -449,13 +441,11 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             else:
                 # If no type is found, use a default one
                 self._color_data_type = DEFAULT_COLOR_TYPE_DATA
+                #If device supports v2 API or category is dd (Strip light) use 0-1000 range for colour_data key
                 if self._color_data_dpcode == DPCode.COLOUR_DATA_V2 or (
                     self._brightness_type and self._brightness_type.max > 255
-                ):
+                ) or (self.device.category == "dd"):
                     self._color_data_type = DEFAULT_COLOR_TYPE_DATA_V2
-                #If device category is dd (Strip light) use 0-1000 range for colour_data key
-                if (self.device.category == "dd"):
-                    self._color_data_type = DEFAULT_COLOR_TYPE_DATA_1000
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
This PR fixes https://github.com/home-assistant/core/issues/59030 by adding a new color data type DEFAULT_COLOR_TYPE_DATA_1000 using value range 0-1000 for colour_data key.
Strip lights (category code "dd") do not have a defined value range for colour_data key in the API docs (https://developer.tuya.com/en/docs/iot/f?id=Kaof81gv0qj9i), but Tuya app uses 0-1000 for strip lights.
Product category "light" (category code "dj") uses 0-255 range for colour_data and 0-1000 for colour_data_v2 so to keep support for this a new DEFAULT_COLOR_TYPE_DATA  with 0-1000 range is added

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
	- fixes #59030 
	- fixes #63260
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
