### PR TITLE
webOS TV check UUID for user added device

### DIFF
--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -98,7 +98,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except WEBOSTV_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
             else:
-                await self.async_set_unique_id(client.hello_info["deviceUUID"])
+                await self.async_set_unique_id(
+                    client.hello_info["deviceUUID"], raise_on_progress=False
+                )
                 self._abort_if_unique_id_configured({CONF_HOST: self._host})
                 data = {CONF_HOST: self._host, CONF_CLIENT_SECRET: client.client_key}
                 return self.async_create_entry(title=self._name, data=data)

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -98,6 +98,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except WEBOSTV_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
             else:
+                await self.async_set_unique_id(client.hello_info["deviceUUID"])
+                self._abort_if_unique_id_configured({CONF_HOST: self._host})
                 data = {CONF_HOST: self._host, CONF_CLIENT_SECRET: client.client_key}
                 return self.async_create_entry(title=self._name, data=data)
 

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -5,12 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/webostv",
   "requirements": ["aiowebostv==0.1.1"],
   "codeowners": ["@bendavid"],
-  "ssdp": [{
-    "manufacturer": "LG Electronics.",
-    "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
-  }, {
-    "manufacturer": "LG Electronics",
-    "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
-  }],
+  "ssdp": [{"st": "urn:lge-com:service:webos-second-screen:1"}],
   "iot_class": "local_polling"
 }

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -248,12 +248,7 @@ SSDP = {
     ],
     "webostv": [
         {
-            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
-            "manufacturer": "LG Electronics."
-        },
-        {
-            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
-            "manufacturer": "LG Electronics"
+            "st": "urn:lge-com:service:webos-second-screen:1"
         }
     ],
     "wemo": [

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -19,6 +19,7 @@ def client_fixture():
         "homeassistant.components.webostv.WebOsClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
+        client.hello_info = {"deviceUUID": "some-fake-uuid"}
         client.software_info = {"device_id": "00:01:02:03:04:05"}
         client.system_info = {"modelName": "TVFAKE"}
         client.client_key = "0123456789"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- When user add a device via config flow abort the flow if the `UUID` match a `UUID` with a device from SSDP discovery. 
- Change the filter used for SSDP discovery to `urn:lge-com:service:webos-second-screen:1`, the reason for this change is that to old filter returns a `UUID` that can't be queried from he TV. The filter `urn:lge-com:service:webos-second-screen:1` contains the same `UUID` that is in the TV hello message and it also identical to zeroconf so it will be possible to add zeroconf discovery in the future. 

Background for the `urn:lge-com:service:webos-second-screen:1`:
- https://gist.github.com/jlai/d49ccbea26e9b5da20a3
- https://github.com/msloth/lgtv.js


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
