### PR TITLE
Fix implicit reexport [dt_util]

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine, Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 import hashlib
 from types import ModuleType
 from typing import Any, Final, final
@@ -337,7 +337,7 @@ def async_setup_scanner_platform(
     # Initial scan of each mac we also tell about host name for config
     seen: Any = set()
 
-    async def async_device_tracker_scan(now: dt_util.dt.datetime | None) -> None:
+    async def async_device_tracker_scan(now: datetime | None) -> None:
         """Handle interval matches."""
         if update_lock.locked():
             LOGGER.warning(
@@ -578,7 +578,7 @@ class DeviceTracker:
             )
 
     @callback
-    def async_update_stale(self, now: dt_util.dt.datetime) -> None:
+    def async_update_stale(self, now: datetime) -> None:
         """Update stale devices.
 
         This method must be run in the event loop.
@@ -616,7 +616,7 @@ class Device(RestoreEntity):
     location_name: str | None = None
     gps: GPSType | None = None
     gps_accuracy: int = 0
-    last_seen: dt_util.dt.datetime | None = None
+    last_seen: datetime | None = None
     battery: int | None = None
     attributes: dict | None = None
 
@@ -744,7 +744,7 @@ class Device(RestoreEntity):
 
         await self.async_update()
 
-    def stale(self, now: dt_util.dt.datetime | None = None) -> bool:
+    def stale(self, now: datetime | None = None) -> bool:
         """Return if device state is stale.
 
         Async friendly.

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -5,7 +5,7 @@ import asyncio
 from collections import deque
 from collections.abc import Container, Generator
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, time as dt_time, timedelta
 import functools as ft
 import logging
 import re
@@ -687,8 +687,8 @@ def async_template_from_config(config: ConfigType) -> ConditionCheckerType:
 
 def time(
     hass: HomeAssistant,
-    before: dt_util.dt.time | str | None = None,
-    after: dt_util.dt.time | str | None = None,
+    before: dt_time | str | None = None,
+    after: dt_time | str | None = None,
     weekday: None | str | Container[str] = None,
 ) -> bool:
     """Test if local time condition matches.
@@ -702,12 +702,12 @@ def time(
     now_time = now.time()
 
     if after is None:
-        after = dt_util.dt.time(0)
+        after = dt_time(0)
     elif isinstance(after, str):
         if not (after_entity := hass.states.get(after)):
             raise ConditionErrorMessage("time", f"unknown 'after' entity {after}")
         if after_entity.domain == "input_datetime":
-            after = dt_util.dt.time(
+            after = dt_time(
                 after_entity.attributes.get("hour", 23),
                 after_entity.attributes.get("minute", 59),
                 after_entity.attributes.get("second", 59),
@@ -726,12 +726,12 @@ def time(
             return False
 
     if before is None:
-        before = dt_util.dt.time(23, 59, 59, 999999)
+        before = dt_time(23, 59, 59, 999999)
     elif isinstance(before, str):
         if not (before_entity := hass.states.get(before)):
             raise ConditionErrorMessage("time", f"unknown 'before' entity {before}")
         if before_entity.domain == "input_datetime":
-            before = dt_util.dt.time(
+            before = dt_time(
                 before_entity.attributes.get("hour", 23),
                 before_entity.attributes.get("minute", 59),
                 before_entity.attributes.get("second", 59),


### PR DESCRIPTION
## Proposed change
Part of #63820
Replace imports from `dt_util.dt` with `datetime`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
