### PR TITLE
Revert "Weather units: climacell (1.3/4)"

### DIFF
--- a/homeassistant/components/climacell/weather.py
+++ b/homeassistant/components/climacell/weather.py
@@ -31,8 +31,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_API_VERSION,
     CONF_NAME,
-    LENGTH_INCHES,
+    LENGTH_FEET,
+    LENGTH_KILOMETERS,
+    LENGTH_METERS,
     LENGTH_MILES,
+    PRESSURE_HPA,
     PRESSURE_INHG,
     SPEED_KILOMETERS_PER_HOUR,
     SPEED_MILES_PER_HOUR,
@@ -42,6 +45,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.sun import is_up
 from homeassistant.util import dt as dt_util
+from homeassistant.util.distance import convert as distance_convert
+from homeassistant.util.pressure import convert as pressure_convert
 from homeassistant.util.speed import convert as speed_convert
 
 from . import ClimaCellDataUpdateCoordinator, ClimaCellEntity
@@ -112,12 +117,6 @@ async def async_setup_entry(
 class BaseClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
     """Base ClimaCell weather entity."""
 
-    _attr_temperature_unit = TEMP_FAHRENHEIT
-    _attr_pressure_unit = PRESSURE_INHG
-    _attr_wind_speed_unit = SPEED_MILES_PER_HOUR
-    _attr_visibility_unit = LENGTH_MILES
-    _attr_precipitation_unit = LENGTH_INCHES
-
     def __init__(
         self,
         config_entry: ConfigEntry,
@@ -160,6 +159,21 @@ class BaseClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
             )
         else:
             translated_condition = self._translate_condition(condition, True)
+
+        if self.hass.config.units.is_metric:
+            if precipitation:
+                precipitation = round(
+                    distance_convert(precipitation / 12, LENGTH_FEET, LENGTH_METERS)
+                    * 1000,
+                    4,
+                )
+            if wind_speed:
+                wind_speed = round(
+                    speed_convert(
+                        wind_speed, SPEED_MILES_PER_HOUR, SPEED_KILOMETERS_PER_HOUR
+                    ),
+                    4,
+                )
 
         data = {
             ATTR_FORECAST_TIME: forecast_dt.isoformat(),
@@ -209,22 +223,54 @@ class BaseClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
 
     @property
     @abstractmethod
-    def pressure(self):
+    def _pressure(self):
         """Return the raw pressure."""
 
     @property
-    @abstractmethod
-    def wind_speed(self):
-        """Return the raw wind speed."""
+    def pressure(self):
+        """Return the pressure."""
+        if self.hass.config.units.is_metric and self._pressure:
+            return round(
+                pressure_convert(self._pressure, PRESSURE_INHG, PRESSURE_HPA), 4
+            )
+        return self._pressure
 
     @property
     @abstractmethod
-    def visibility(self):
+    def _wind_speed(self):
+        """Return the raw wind speed."""
+
+    @property
+    def wind_speed(self):
+        """Return the wind speed."""
+        if self.hass.config.units.is_metric and self._wind_speed:
+            return round(
+                speed_convert(
+                    self._wind_speed, SPEED_MILES_PER_HOUR, SPEED_KILOMETERS_PER_HOUR
+                ),
+                4,
+            )
+        return self._wind_speed
+
+    @property
+    @abstractmethod
+    def _visibility(self):
         """Return the raw visibility."""
+
+    @property
+    def visibility(self):
+        """Return the visibility."""
+        if self.hass.config.units.is_metric and self._visibility:
+            return round(
+                distance_convert(self._visibility, LENGTH_MILES, LENGTH_KILOMETERS), 4
+            )
+        return self._visibility
 
 
 class ClimaCellWeatherEntity(BaseClimaCellWeatherEntity):
     """Entity that talks to ClimaCell v4 API to retrieve weather data."""
+
+    _attr_temperature_unit = TEMP_FAHRENHEIT
 
     @staticmethod
     def _translate_condition(
@@ -247,7 +293,7 @@ class ClimaCellWeatherEntity(BaseClimaCellWeatherEntity):
         return self._get_current_property(CC_ATTR_TEMPERATURE)
 
     @property
-    def pressure(self):
+    def _pressure(self):
         """Return the raw pressure."""
         return self._get_current_property(CC_ATTR_PRESSURE)
 
@@ -275,7 +321,7 @@ class ClimaCellWeatherEntity(BaseClimaCellWeatherEntity):
         return PrecipitationType(precipitation_type).name.lower()
 
     @property
-    def wind_speed(self):
+    def _wind_speed(self):
         """Return the raw wind speed."""
         return self._get_current_property(CC_ATTR_WIND_SPEED)
 
@@ -298,7 +344,7 @@ class ClimaCellWeatherEntity(BaseClimaCellWeatherEntity):
         )
 
     @property
-    def visibility(self):
+    def _visibility(self):
         """Return the raw visibility."""
         return self._get_current_property(CC_ATTR_VISIBILITY)
 
@@ -372,6 +418,8 @@ class ClimaCellWeatherEntity(BaseClimaCellWeatherEntity):
 class ClimaCellV3WeatherEntity(BaseClimaCellWeatherEntity):
     """Entity that talks to ClimaCell v3 API to retrieve weather data."""
 
+    _attr_temperature_unit = TEMP_FAHRENHEIT
+
     @staticmethod
     def _translate_condition(
         condition: int | str | None, sun_is_up: bool = True
@@ -394,7 +442,7 @@ class ClimaCellV3WeatherEntity(BaseClimaCellWeatherEntity):
         )
 
     @property
-    def pressure(self):
+    def _pressure(self):
         """Return the raw pressure."""
         return self._get_cc_value(self.coordinator.data[CURRENT], CC_V3_ATTR_PRESSURE)
 
@@ -423,7 +471,7 @@ class ClimaCellV3WeatherEntity(BaseClimaCellWeatherEntity):
         )
 
     @property
-    def wind_speed(self):
+    def _wind_speed(self):
         """Return the raw wind speed."""
         return self._get_cc_value(self.coordinator.data[CURRENT], CC_V3_ATTR_WIND_SPEED)
 
@@ -448,7 +496,7 @@ class ClimaCellV3WeatherEntity(BaseClimaCellWeatherEntity):
         )
 
     @property
-    def visibility(self):
+    def _visibility(self):
         """Return the raw visibility."""
         return self._get_cc_value(self.coordinator.data[CURRENT], CC_V3_ATTR_VISIBILITY)
 

--- a/tests/components/climacell/test_weather.py
+++ b/tests/components/climacell/test_weather.py
@@ -41,12 +41,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
     DOMAIN as WEATHER_DOMAIN,
 )
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    ATTR_FRIENDLY_NAME,
-    PRESSURE_HPA,
-    SPEED_KILOMETERS_PER_HOUR,
-)
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.util import dt as dt_util
@@ -97,9 +92,6 @@ async def test_v3_weather(
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test v3 weather data."""
-    hass.config.units.wind_speed_unit = SPEED_KILOMETERS_PER_HOUR
-    hass.config.units.pressure_unit = PRESSURE_HPA
-
     weather_state = await _setup(hass, API_V3_ENTRY_DATA)
     assert weather_state.state == ATTR_CONDITION_SUNNY
     assert weather_state.attributes[ATTR_ATTRIBUTION] == ATTRIBUTION
@@ -107,7 +99,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_SUNNY,
             ATTR_FORECAST_TIME: "2021-03-07T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 7,
             ATTR_FORECAST_TEMP_LOW: -5,
@@ -115,7 +107,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-08T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 10,
             ATTR_FORECAST_TEMP_LOW: -4,
@@ -123,7 +115,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-09T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 19,
             ATTR_FORECAST_TEMP_LOW: 0,
@@ -131,7 +123,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-10T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 18,
             ATTR_FORECAST_TEMP_LOW: 3,
@@ -139,7 +131,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-11T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 5,
             ATTR_FORECAST_TEMP: 20,
             ATTR_FORECAST_TEMP_LOW: 9,
@@ -147,7 +139,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-12T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0.0457, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0.0457,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 25,
             ATTR_FORECAST_TEMP: 20,
             ATTR_FORECAST_TEMP_LOW: 12,
@@ -155,7 +147,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-13T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 25,
             ATTR_FORECAST_TEMP: 16,
             ATTR_FORECAST_TEMP_LOW: 7,
@@ -163,7 +155,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_RAINY,
             ATTR_FORECAST_TIME: "2021-03-14T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(1.0744, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 1.0744,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 75,
             ATTR_FORECAST_TEMP: 6,
             ATTR_FORECAST_TEMP_LOW: 3,
@@ -171,7 +163,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_SNOWY,
             ATTR_FORECAST_TIME: "2021-03-15T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(7.3050, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 7.3050,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 95,
             ATTR_FORECAST_TEMP: 1,
             ATTR_FORECAST_TEMP_LOW: 0,
@@ -179,7 +171,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-16T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0.0051, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0.0051,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 5,
             ATTR_FORECAST_TEMP: 6,
             ATTR_FORECAST_TEMP_LOW: -2,
@@ -187,7 +179,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-17T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 11,
             ATTR_FORECAST_TEMP_LOW: 1,
@@ -195,7 +187,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-18T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 5,
             ATTR_FORECAST_TEMP: 12,
             ATTR_FORECAST_TEMP_LOW: 6,
@@ -203,7 +195,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-19T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0.1778, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0.1778,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 45,
             ATTR_FORECAST_TEMP: 9,
             ATTR_FORECAST_TEMP_LOW: 5,
@@ -211,7 +203,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_RAINY,
             ATTR_FORECAST_TIME: "2021-03-20T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(1.2319, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 1.2319,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 55,
             ATTR_FORECAST_TEMP: 5,
             ATTR_FORECAST_TEMP_LOW: 3,
@@ -219,7 +211,7 @@ async def test_v3_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_CLOUDY,
             ATTR_FORECAST_TIME: "2021-03-21T00:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0.0432, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0.0432,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 20,
             ATTR_FORECAST_TEMP: 7,
             ATTR_FORECAST_TEMP_LOW: 1,
@@ -228,11 +220,11 @@ async def test_v3_weather(
     assert weather_state.attributes[ATTR_FRIENDLY_NAME] == "ClimaCell - Daily"
     assert weather_state.attributes[ATTR_WEATHER_HUMIDITY] == 24
     assert weather_state.attributes[ATTR_WEATHER_OZONE] == 52.625
-    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 1028.12
+    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 1028.1246
     assert weather_state.attributes[ATTR_WEATHER_TEMPERATURE] == 7
-    assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 9.99
+    assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 9.9940
     assert weather_state.attributes[ATTR_WEATHER_WIND_BEARING] == 320.31
-    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 14.63
+    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 14.6289
     assert weather_state.attributes[ATTR_CLOUD_COVER] == 100
     assert weather_state.attributes[ATTR_WIND_GUST] == 24.0758
     assert weather_state.attributes[ATTR_PRECIPITATION_TYPE] == "rain"
@@ -243,9 +235,6 @@ async def test_v4_weather(
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test v4 weather data."""
-    hass.config.units.wind_speed_unit = SPEED_KILOMETERS_PER_HOUR
-    hass.config.units.pressure_unit = PRESSURE_HPA
-
     weather_state = await _setup(hass, API_V4_ENTRY_DATA)
     assert weather_state.state == ATTR_CONDITION_SUNNY
     assert weather_state.attributes[ATTR_ATTRIBUTION] == ATTRIBUTION
@@ -253,152 +242,152 @@ async def test_v4_weather(
         {
             ATTR_FORECAST_CONDITION: ATTR_CONDITION_SUNNY,
             ATTR_FORECAST_TIME: "2021-03-07T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 8,
             ATTR_FORECAST_TEMP_LOW: -3,
             ATTR_FORECAST_WIND_BEARING: 239.6,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(15.2727, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 15.2727,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-08T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 10,
             ATTR_FORECAST_TEMP_LOW: -3,
             ATTR_FORECAST_WIND_BEARING: 262.82,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(11.6517, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 11.6517,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-09T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 19,
             ATTR_FORECAST_TEMP_LOW: 0,
             ATTR_FORECAST_WIND_BEARING: 229.3,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(11.3459, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 11.3459,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-10T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 18,
             ATTR_FORECAST_TEMP_LOW: 3,
             ATTR_FORECAST_WIND_BEARING: 149.91,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(17.1234, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 17.1234,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-11T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 19,
             ATTR_FORECAST_TEMP_LOW: 9,
             ATTR_FORECAST_WIND_BEARING: 210.45,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(25.2506, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 25.2506,
         },
         {
             ATTR_FORECAST_CONDITION: "rainy",
             ATTR_FORECAST_TIME: "2021-03-12T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0.1219, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0.1219,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 25,
             ATTR_FORECAST_TEMP: 20,
             ATTR_FORECAST_TEMP_LOW: 12,
             ATTR_FORECAST_WIND_BEARING: 217.98,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(19.7949, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 19.7949,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-13T11:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 25,
             ATTR_FORECAST_TEMP: 12,
             ATTR_FORECAST_TEMP_LOW: 6,
             ATTR_FORECAST_WIND_BEARING: 58.79,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(15.6428, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 15.6428,
         },
         {
             ATTR_FORECAST_CONDITION: "snowy",
             ATTR_FORECAST_TIME: "2021-03-14T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(23.9573, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 23.9573,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 95,
             ATTR_FORECAST_TEMP: 6,
             ATTR_FORECAST_TEMP_LOW: 1,
             ATTR_FORECAST_WIND_BEARING: 70.25,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(26.1518, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 26.1518,
         },
         {
             ATTR_FORECAST_CONDITION: "snowy",
             ATTR_FORECAST_TIME: "2021-03-15T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(1.4630, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 1.4630,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 55,
             ATTR_FORECAST_TEMP: 6,
             ATTR_FORECAST_TEMP_LOW: -1,
             ATTR_FORECAST_WIND_BEARING: 84.47,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(25.5725, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 25.5725,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-16T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 6,
             ATTR_FORECAST_TEMP_LOW: -2,
             ATTR_FORECAST_WIND_BEARING: 103.85,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(10.7987, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 10.7987,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-17T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 0,
             ATTR_FORECAST_TEMP: 11,
             ATTR_FORECAST_TEMP_LOW: 1,
             ATTR_FORECAST_WIND_BEARING: 145.41,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(11.6999, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 11.6999,
         },
         {
             ATTR_FORECAST_CONDITION: "cloudy",
             ATTR_FORECAST_TIME: "2021-03-18T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(0, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 0,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 10,
             ATTR_FORECAST_TEMP: 12,
             ATTR_FORECAST_TEMP_LOW: 5,
             ATTR_FORECAST_WIND_BEARING: 62.99,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(10.5895, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 10.5895,
         },
         {
             ATTR_FORECAST_CONDITION: "rainy",
             ATTR_FORECAST_TIME: "2021-03-19T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(2.9261, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 2.9261,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 55,
             ATTR_FORECAST_TEMP: 9,
             ATTR_FORECAST_TEMP_LOW: 4,
             ATTR_FORECAST_WIND_BEARING: 68.54,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(22.3860, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 22.3860,
         },
         {
             ATTR_FORECAST_CONDITION: "snowy",
             ATTR_FORECAST_TIME: "2021-03-20T10:00:00+00:00",
-            ATTR_FORECAST_PRECIPITATION: pytest.approx(1.2192, abs=0.01),
+            ATTR_FORECAST_PRECIPITATION: 1.2192,
             ATTR_FORECAST_PRECIPITATION_PROBABILITY: 33.3,
             ATTR_FORECAST_TEMP: 5,
             ATTR_FORECAST_TEMP_LOW: 2,
             ATTR_FORECAST_WIND_BEARING: 56.98,
-            ATTR_FORECAST_WIND_SPEED: pytest.approx(27.9221, abs=0.01),
+            ATTR_FORECAST_WIND_SPEED: 27.9221,
         },
     ]
     assert weather_state.attributes[ATTR_FRIENDLY_NAME] == "ClimaCell - Daily"
     assert weather_state.attributes[ATTR_WEATHER_HUMIDITY] == 23
     assert weather_state.attributes[ATTR_WEATHER_OZONE] == 46.53
-    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 1027.77
+    assert weather_state.attributes[ATTR_WEATHER_PRESSURE] == 1027.7691
     assert weather_state.attributes[ATTR_WEATHER_TEMPERATURE] == 7
-    assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 13.12
+    assert weather_state.attributes[ATTR_WEATHER_VISIBILITY] == 13.1162
     assert weather_state.attributes[ATTR_WEATHER_WIND_BEARING] == 315.14
-    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 15.02
+    assert weather_state.attributes[ATTR_WEATHER_WIND_SPEED] == 15.0152
     assert weather_state.attributes[ATTR_CLOUD_COVER] == 100
     assert weather_state.attributes[ATTR_WIND_GUST] == 20.3421
     assert weather_state.attributes[ATTR_PRECIPITATION_TYPE] == "rain"


### PR DESCRIPTION
Reverts home-assistant/core#61472

I'm suggesting to revert this case.

It is a massive breaking change and not tagged or documented as such.

Additionally, it makes the core configuration responsible for configuring units in this place, while the magnitude of those units should probably not be centralized.

Some more context is here as well: <https://github.com/home-assistant/architecture/discussions/682>

However, this merged PR already was merged and went ahead before that all was taken into consideration.

CC: @emontnemery @rianadon

PS: I want to add to this: I do think in general the idea of this change and the feature is correct. As a matter of fact, I hope to see something like this on a bigger scale (e.g., being able to change the scale of, or convert between units of measurements on maybe even entity level!). This is an important step forward for that.

However, currently, it relies on the core configuration as the sole determination for the units used. The latter should be discussed and crystallized more (with the future in mind) before we start making breaking changes.