### PR TITLE
Revert "Weather units: Buienradar (1.2/4)"

### DIFF
--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -37,16 +37,7 @@ from homeassistant.components.weather import (
     WeatherEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_NAME,
-    LENGTH_METERS,
-    LENGTH_MILLIMETERS,
-    PRESSURE_HPA,
-    SPEED_METERS_PER_SECOND,
-    TEMP_CELSIUS,
-)
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -121,10 +112,6 @@ class BrWeather(WeatherEntity):
     """Representation of a weather condition."""
 
     _attr_temperature_unit = TEMP_CELSIUS
-    _attr_pressure_unit = PRESSURE_HPA
-    _attr_visibility_unit = LENGTH_METERS
-    _attr_wind_speed_unit = SPEED_METERS_PER_SECOND
-    _attr_precipitation_unit = LENGTH_MILLIMETERS
 
     def __init__(self, data, config, coordinates):
         """Initialize the platform with a data instance and station name."""


### PR DESCRIPTION
Reverts home-assistant/core#61470

I'm suggesting to revert this case.

It is a massive breaking change and not tagged or documented as such.

Additionally, it makes the core configuration responsible for configuring units in this place, while the magnitude of those units should probably not be centralized.

Some more context is here as well: <https://github.com/home-assistant/architecture/discussions/682>

However, this merged PR already was merged and went ahead before that all was taken into consideration.

CC: @emontnemery @rianadon

PS: I want to add to this: I do think in general the idea of this change and the feature is correct. As a matter of fact, I hope to see something like this on a bigger scale (e.g., being able to change the scale of, or convert between units of measurements on maybe even entity level!). This is an important step forward for that.

However, currently, it relies on the core configuration as the sole determination for the units used. The latter should be discussed and crystallized more (with the future in mind) before we start making breaking changes.