### PR TITLE
Avoid locking the database for non-SQLite backends

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -78,7 +78,7 @@ from .util import (
     session_scope,
     setup_connection_for_dialect,
     validate_or_move_away_sqlite_database,
-    write_lock_db,
+    write_lock_db_sqlite,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -870,7 +870,7 @@ class Recorder(threading.Thread):
         def _async_set_database_locked(task: DatabaseLockTask):
             task.database_locked.set()
 
-        with write_lock_db(self):
+        with write_lock_db_sqlite(self):
             # Notify that lock is being held, wait until database can be used again.
             self.hass.add_job(_async_set_database_locked, task)
             while not task.database_unlock.wait(timeout=DB_LOCK_QUEUE_CHECK_TIMEOUT):
@@ -1057,6 +1057,10 @@ class Recorder(threading.Thread):
 
     async def lock_database(self) -> bool:
         """Lock database so it can be backed up safely."""
+        if self.engine.dialect.name != "sqlite":
+            _LOGGER.debug("Not a SQLite database, locking not necessary")
+            return True
+
         if self._database_lock_task:
             _LOGGER.warning("Database already locked")
             return False
@@ -1080,6 +1084,10 @@ class Recorder(threading.Thread):
 
         Returns true if database lock has been held throughout the process.
         """
+        if self.engine.dialect.name != "sqlite":
+            _LOGGER.debug("Not a SQLite database, locking not necessary")
+            return True
+
         if not self._database_lock_task:
             _LOGGER.warning("Database currently not locked")
             return False

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -1057,8 +1057,10 @@ class Recorder(threading.Thread):
 
     async def lock_database(self) -> bool:
         """Lock database so it can be backed up safely."""
-        if self.engine.dialect.name != "sqlite":
-            _LOGGER.debug("Not a SQLite database, locking not necessary")
+        if not self.engine or self.engine.dialect.name != "sqlite":
+            _LOGGER.debug(
+                "Not a SQLite database or not connected, locking not necessary"
+            )
             return True
 
         if self._database_lock_task:
@@ -1084,8 +1086,10 @@ class Recorder(threading.Thread):
 
         Returns true if database lock has been held throughout the process.
         """
-        if self.engine.dialect.name != "sqlite":
-            _LOGGER.debug("Not a SQLite database, locking not necessary")
+        if not self.engine or self.engine.dialect.name != "sqlite":
+            _LOGGER.debug(
+                "Not a SQLite database or not connected, unlocking not necessary"
+            )
             return True
 
         if not self._database_lock_task:

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -462,22 +462,21 @@ def perodic_db_cleanups(instance: Recorder):
 
 
 @contextmanager
-def write_lock_db(instance: Recorder):
+def write_lock_db_sqlite(instance: Recorder):
     """Lock database for writes."""
 
-    if instance.engine.dialect.name == "sqlite":
-        with instance.engine.connect() as connection:
-            # Execute sqlite to create a wal checkpoint
-            # This is optional but makes sure the backup is going to be minimal
-            connection.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
-            # Create write lock
-            _LOGGER.debug("Lock database")
-            connection.execute(text("BEGIN IMMEDIATE;"))
-            try:
-                yield
-            finally:
-                _LOGGER.debug("Unlock database")
-                connection.execute(text("END;"))
+    with instance.engine.connect() as connection:
+        # Execute sqlite to create a wal checkpoint
+        # This is optional but makes sure the backup is going to be minimal
+        connection.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+        # Create write lock
+        _LOGGER.debug("Lock database")
+        connection.execute(text("BEGIN IMMEDIATE;"))
+        try:
+            yield
+        finally:
+            _LOGGER.debug("Unlock database")
+            connection.execute(text("END;"))
 
 
 def async_migration_in_progress(hass: HomeAssistant) -> bool:

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1232,4 +1232,7 @@ async def test_database_lock_without_instance(hass):
 
     instance: Recorder = hass.data[DATA_INSTANCE]
     with patch.object(instance, "engine", None):
-        assert await instance.lock_database()
+        try:
+            assert await instance.lock_database()
+        finally:
+            assert instance.unlock_database()

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import datetime, timedelta
 import sqlite3
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -1204,12 +1205,31 @@ async def test_database_lock_timeout(hass):
     """Test locking database timeout when recorder stopped."""
     await async_init_recorder_component(hass)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
 
     instance: Recorder = hass.data[DATA_INSTANCE]
+
+    class BlockQueue(recorder.RecorderTask):
+        event: threading.Event = threading.Event()
+
+        def run(self, instance: Recorder) -> None:
+            self.event.wait()
+
+    block_task = BlockQueue()
+    instance.queue.put(block_task)
     with patch.object(recorder, "DB_LOCK_TIMEOUT", 0.1):
         try:
             with pytest.raises(TimeoutError):
                 await instance.lock_database()
         finally:
             instance.unlock_database()
+            block_task.event.set()
+
+
+async def test_database_lock_without_instance(hass):
+    """Test database lock doesn't fail if instance is not initialized."""
+    await async_init_recorder_component(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    with patch.object(instance, "engine", None):
+        assert await instance.lock_database()

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -570,7 +570,7 @@ async def test_write_lock_db(hass, tmp_path):
 
     instance = hass.data[DATA_INSTANCE]
 
-    with util.write_lock_db(instance):
+    with util.write_lock_db_sqlite(instance):
         # Database should be locked now, try writing SQL command
         with instance.engine.connect() as connection:
             with pytest.raises(OperationalError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we only have a lock implementation for SQLite. Just return
success for all other databases as they are not expected to store data
in the config directory and the caller can assume that a backup can
be safely taken.

This fixes `RuntimeError: generator didn't yield` errors when creating
a backup with the current Supervisor dev builds.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63650
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
