### PR TITLE
Remove deprecated async_get_scanner from fritz

### DIFF
--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -272,17 +272,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.hass.config_entries.async_reload(self._entry.entry_id)
         return self.async_abort(reason="reauth_successful")
 
-    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user(
-            {
-                CONF_HOST: import_config[CONF_HOST],
-                CONF_USERNAME: import_config[CONF_USERNAME],
-                CONF_PASSWORD: import_config.get(CONF_PASSWORD),
-                CONF_PORT: import_config.get(CONF_PORT, DEFAULT_PORT),
-            }
-        )
-
 
 class FritzBoxToolsOptionsFlowHandler(OptionsFlow):
     """Handle a option flow."""

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -4,17 +4,10 @@ from __future__ import annotations
 import datetime
 import logging
 
-import voluptuous as vol
-
-from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
-    SOURCE_TYPE_ROUTER,
-)
+from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -31,19 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 
 YAML_DEFAULT_HOST = "169.254.1.1"
 YAML_DEFAULT_USERNAME = "admin"
-
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_HOST),
-    cv.deprecated(CONF_USERNAME),
-    cv.deprecated(CONF_PASSWORD),
-    PARENT_PLATFORM_SCHEMA.extend(
-        {
-            vol.Optional(CONF_HOST, default=YAML_DEFAULT_HOST): cv.string,
-            vol.Optional(CONF_USERNAME, default=YAML_DEFAULT_USERNAME): cv.string,
-            vol.Optional(CONF_PASSWORD): cv.string,
-        }
-    ),
-)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -7,18 +7,16 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
     SOURCE_TYPE_ROUTER,
 )
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
 
 from .common import (
     FritzBoxTools,
@@ -46,27 +44,6 @@ PLATFORM_SCHEMA = vol.All(
         }
     ),
 )
-
-
-async def async_get_scanner(hass: HomeAssistant, config: ConfigType) -> None:
-    """Import legacy FRITZ!Box configuration."""
-    _LOGGER.debug("Import legacy FRITZ!Box configuration from YAML")
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config[DEVICE_TRACKER_DOMAIN],
-        )
-    )
-
-    _LOGGER.warning(
-        "Your Fritz configuration has been imported into the UI, "
-        "please remove it from configuration.yaml. "
-        "Loading Fritz via scanner setup is now deprecated"
-    )
-
-    return None
 
 
 async def async_setup_entry(

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -17,12 +17,7 @@ from homeassistant.components.fritz.const import (
     ERROR_UNKNOWN,
 )
 from homeassistant.components.ssdp import ATTR_UPNP_FRIENDLY_NAME, ATTR_UPNP_UDN
-from homeassistant.config_entries import (
-    SOURCE_IMPORT,
-    SOURCE_REAUTH,
-    SOURCE_SSDP,
-    SOURCE_USER,
-)
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -48,7 +43,6 @@ MOCK_DEVICE_INFO = {
     ATTR_HOST: MOCK_HOST,
     ATTR_NEW_SERIAL_NUMBER: MOCK_SERIAL_NUMBER,
 }
-MOCK_IMPORT_CONFIG = {CONF_HOST: MOCK_HOST, CONF_USERNAME: "username"}
 MOCK_SSDP_DATA = ssdp.SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
@@ -485,43 +479,6 @@ async def test_ssdp_exception(hass: HomeAssistant, mock_get_source_ip):
 
         assert result["type"] == RESULT_TYPE_FORM
         assert result["step_id"] == "confirm"
-
-
-async def test_import(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
-    """Test importing."""
-    with patch(
-        "homeassistant.components.fritz.common.FritzConnection",
-        side_effect=fc_class_mock,
-    ), patch("homeassistant.components.fritz.common.FritzStatus"), patch(
-        "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
-        return_value=MOCK_FIRMWARE_INFO,
-    ), patch(
-        "homeassistant.components.fritz.async_setup_entry"
-    ) as mock_setup_entry, patch(
-        "requests.get"
-    ) as mock_request_get, patch(
-        "requests.post"
-    ) as mock_request_post, patch(
-        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
-        return_value=MOCK_IP,
-    ):
-
-        mock_request_get.return_value.status_code = 200
-        mock_request_get.return_value.content = MOCK_REQUEST
-        mock_request_post.return_value.status_code = 200
-        mock_request_post.return_value.text = MOCK_REQUEST
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_IMPORT_CONFIG
-        )
-
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["data"][CONF_HOST] == "fake_host"
-        assert result["data"][CONF_PASSWORD] is None
-        assert result["data"][CONF_USERNAME] == "username"
-        await hass.async_block_till_done()
-
-    assert mock_setup_entry.called
 
 
 async def test_options_flow(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Your Fritz device tracker has been imported into the UI, please remove it from configuration.yaml.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up from #48287

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
