### PR TITLE
Remove deprecated async_get_scanner from keenetic_ndms2

### DIFF
--- a/homeassistant/components/keenetic_ndms2/config_flow.py
+++ b/homeassistant/components/keenetic_ndms2/config_flow.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_CONSIDER_HOME,
@@ -97,12 +96,6 @@ class KeeneticFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
-
-    async def async_step_import(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResult:
-        """Import a config entry."""
-        return await self.async_step_user(user_input)
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a discovered device."""

--- a/homeassistant/components/keenetic_ndms2/device_tracker.py
+++ b/homeassistant/components/keenetic_ndms2/device_tracker.py
@@ -1,7 +1,6 @@
 """Support for Keenetic routers as device tracker."""
 from __future__ import annotations
 
-from datetime import timedelta
 import logging
 
 from ndms2_client import Device
@@ -13,14 +12,8 @@ from homeassistant.components.device_tracker import (
     SOURCE_TYPE_ROUTER,
 )
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
@@ -29,12 +22,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from .const import (
-    CONF_CONSIDER_HOME,
-    CONF_INTERFACES,
     CONF_LEGACY_INTERFACE,
-    DEFAULT_CONSIDER_HOME,
     DEFAULT_INTERFACE,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_TELNET_PORT,
     DOMAIN,
     ROUTER,
@@ -52,46 +41,6 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_SCHEMA.extend(
         vol.Required(CONF_LEGACY_INTERFACE, default=DEFAULT_INTERFACE): cv.string,
     }
 )
-
-
-async def async_get_scanner(hass: HomeAssistant, config):
-    """Import legacy configuration from YAML."""
-
-    scanner_config = config[DEVICE_TRACKER_DOMAIN]
-    scan_interval: timedelta | None = scanner_config.get(CONF_SCAN_INTERVAL)
-    consider_home: timedelta | None = scanner_config.get(CONF_CONSIDER_HOME)
-
-    host: str = scanner_config[CONF_HOST]
-    hass.data[DOMAIN][f"imported_options_{host}"] = {
-        CONF_INTERFACES: [scanner_config[CONF_LEGACY_INTERFACE]],
-        CONF_SCAN_INTERVAL: int(scan_interval.total_seconds())
-        if scan_interval
-        else DEFAULT_SCAN_INTERVAL,
-        CONF_CONSIDER_HOME: int(consider_home.total_seconds())
-        if consider_home
-        else DEFAULT_CONSIDER_HOME,
-    }
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_HOST: scanner_config[CONF_HOST],
-                CONF_PORT: scanner_config[CONF_PORT],
-                CONF_USERNAME: scanner_config[CONF_USERNAME],
-                CONF_PASSWORD: scanner_config[CONF_PASSWORD],
-            },
-        )
-    )
-
-    _LOGGER.warning(
-        "Your Keenetic NDMS2 configuration has been imported into the UI, "
-        "please remove it from configuration.yaml. "
-        "Loading Keenetic NDMS2 via scanner setup is now deprecated"
-    )
-
-    return None
 
 
 async def async_setup_entry(

--- a/homeassistant/components/keenetic_ndms2/device_tracker.py
+++ b/homeassistant/components/keenetic_ndms2/device_tracker.py
@@ -4,43 +4,23 @@ from __future__ import annotations
 import logging
 
 from ndms2_client import Device
-import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
-    PLATFORM_SCHEMA as DEVICE_TRACKER_SCHEMA,
     SOURCE_TYPE_ROUTER,
 )
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import (
-    CONF_LEGACY_INTERFACE,
-    DEFAULT_INTERFACE,
-    DEFAULT_TELNET_PORT,
-    DOMAIN,
-    ROUTER,
-)
+from .const import DOMAIN, ROUTER
 from .router import KeeneticRouter
 
 _LOGGER = logging.getLogger(__name__)
-
-PLATFORM_SCHEMA = DEVICE_TRACKER_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PORT, default=DEFAULT_TELNET_PORT): cv.port,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_LEGACY_INTERFACE, default=DEFAULT_INTERFACE): cv.string,
-    }
-)
 
 
 async def async_setup_entry(

--- a/tests/components/keenetic_ndms2/test_config_flow.py
+++ b/tests/components/keenetic_ndms2/test_config_flow.py
@@ -69,25 +69,6 @@ async def test_flow_works(hass: HomeAssistant, connect) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_import_works(hass: HomeAssistant, connect) -> None:
-    """Test config flow."""
-
-    with patch(
-        "homeassistant.components.keenetic_ndms2.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            keenetic.DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_DATA,
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == MOCK_NAME
-    assert result["data"] == MOCK_DATA
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_options(hass: HomeAssistant) -> None:
     """Test updating options."""
     entry = MockConfigEntry(domain=keenetic.DOMAIN, data=MOCK_DATA)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Your Keenetic ndms2 device tracker has been imported into the UI, please remove it from configuration.yaml.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #38353

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
