### PR TITLE
Drop last_reset attribute for non 'total' sensors

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -308,15 +308,16 @@ class SensorEntity(Entity):
         """Return state attributes."""
         if last_reset := self.last_reset:
             if (
-                self.state_class == SensorStateClass.MEASUREMENT
+                self.state_class != SensorStateClass.TOTAL
                 and not self._last_reset_reported
             ):
                 self._last_reset_reported = True
                 report_issue = self._suggest_report_issue()
+                # This should raise in Home Assistant Core 2022.5
                 _LOGGER.warning(
                     "Entity %s (%s) with state_class %s has set last_reset. Setting "
                     "last_reset for entities with state_class other than 'total' is "
-                    "deprecated and will be removed from Home Assistant Core 2021.11. "
+                    "not supported. "
                     "Please update your configuration if state_class is manually "
                     "configured, otherwise %s",
                     self.entity_id,
@@ -325,7 +326,8 @@ class SensorEntity(Entity):
                     report_issue,
                 )
 
-            return {ATTR_LAST_RESET: last_reset.isoformat()}
+            if self.state_class == SensorStateClass.TOTAL:
+                return {ATTR_LAST_RESET: last_reset.isoformat()}
 
         return None
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -262,6 +262,7 @@ class SensorEntity(Entity):
         None  # Subclasses of SensorEntity should not set this
     )
     _last_reset_reported = False
+    _no_check_last_reset = False
     _temperature_conversion_reported = False
 
     # Temporary private attribute to track if deprecation has been logged.
@@ -310,6 +311,7 @@ class SensorEntity(Entity):
             if (
                 self.state_class != SensorStateClass.TOTAL
                 and not self._last_reset_reported
+                and not self._no_check_last_reset
             ):
                 self._last_reset_reported = True
                 report_issue = self._suggest_report_issue()
@@ -326,7 +328,7 @@ class SensorEntity(Entity):
                     report_issue,
                 )
 
-            if self.state_class == SensorStateClass.TOTAL:
+            if self.state_class == SensorStateClass.TOTAL or self._no_check_last_reset:
                 return {ATTR_LAST_RESET: last_reset.isoformat()}
 
         return None

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -262,7 +262,6 @@ class SensorEntity(Entity):
         None  # Subclasses of SensorEntity should not set this
     )
     _last_reset_reported = False
-    _no_check_last_reset = False
     _temperature_conversion_reported = False
 
     # Temporary private attribute to track if deprecation has been logged.
@@ -311,7 +310,6 @@ class SensorEntity(Entity):
             if (
                 self.state_class != SensorStateClass.TOTAL
                 and not self._last_reset_reported
-                and not self._no_check_last_reset
             ):
                 self._last_reset_reported = True
                 report_issue = self._suggest_report_issue()
@@ -328,7 +326,7 @@ class SensorEntity(Entity):
                     report_issue,
                 )
 
-            if self.state_class == SensorStateClass.TOTAL or self._no_check_last_reset:
+            if self.state_class == SensorStateClass.TOTAL:
                 return {ATTR_LAST_RESET: last_reset.isoformat()}
 
         return None

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -140,8 +140,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class UtilityMeterSensor(RestoreEntity, SensorEntity):
     """Representation of an utility meter sensor."""
 
-    _no_check_last_reset = True
-
     def __init__(
         self,
         parent_meter,
@@ -400,6 +398,9 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
             state_attr[ATTR_CRON_PATTERN] = self._cron_pattern
         if self._tariff is not None:
             state_attr[ATTR_TARIFF] = self._tariff
+        if last_reset := self._last_reset:
+            state_attr[ATTR_LAST_RESET] = last_reset.isoformat()
+
         return state_attr
 
     @property

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -398,6 +398,8 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
             state_attr[ATTR_CRON_PATTERN] = self._cron_pattern
         if self._tariff is not None:
             state_attr[ATTR_TARIFF] = self._tariff
+        # SensorEntity blocks last_reset for total_increasing sensor, add it as an extra
+        # attribute instead
         if last_reset := self._last_reset:
             state_attr[ATTR_LAST_RESET] = last_reset.isoformat()
 
@@ -407,8 +409,3 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return ICON
-
-    @property
-    def last_reset(self):
-        """Return the time when the sensor was last reset."""
-        return self._last_reset

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -140,6 +140,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class UtilityMeterSensor(RestoreEntity, SensorEntity):
     """Representation of an utility meter sensor."""
 
+    _no_check_last_reset = True
+
     def __init__(
         self,
         parent_meter,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -398,8 +398,11 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
             state_attr[ATTR_CRON_PATTERN] = self._cron_pattern
         if self._tariff is not None:
             state_attr[ATTR_TARIFF] = self._tariff
-        # SensorEntity blocks last_reset for total_increasing sensor, add it as an extra
-        # attribute instead
+        # last_reset in utility meter was used before last_reset was added for long term
+        # statistics in base sensor. base sensor only supports last reset
+        # sensors with state_class set to total.
+        # To avoid a breaking change we set last_reset directly
+        # in extra state attributes.
         if last_reset := self._last_reset:
             state_attr[ATTR_LAST_RESET] = last_reset.isoformat()
 

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -272,6 +272,7 @@ async def test_setting_sensor_last_reset_via_mqtt_message(hass, mqtt_mock, caplo
             sensor.DOMAIN: {
                 "platform": "mqtt",
                 "name": "test",
+                "state_class": "total",
                 "state_topic": "test-topic",
                 "unit_of_measurement": "fav unit",
                 "last_reset_topic": "last-reset-topic",
@@ -302,6 +303,7 @@ async def test_setting_sensor_bad_last_reset_via_mqtt_message(
             sensor.DOMAIN: {
                 "platform": "mqtt",
                 "name": "test",
+                "state_class": "total",
                 "state_topic": "test-topic",
                 "unit_of_measurement": "fav unit",
                 "last_reset_topic": "last-reset-topic",
@@ -327,6 +329,7 @@ async def test_setting_sensor_empty_last_reset_via_mqtt_message(
             sensor.DOMAIN: {
                 "platform": "mqtt",
                 "name": "test",
+                "state_class": "total",
                 "state_topic": "test-topic",
                 "unit_of_measurement": "fav unit",
                 "last_reset_topic": "last-reset-topic",
@@ -350,6 +353,7 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message(hass, mqtt_mock):
             sensor.DOMAIN: {
                 "platform": "mqtt",
                 "name": "test",
+                "state_class": "total",
                 "state_topic": "test-topic",
                 "unit_of_measurement": "fav unit",
                 "last_reset_topic": "last-reset-topic",
@@ -379,6 +383,7 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
                 **{
                     "platform": "mqtt",
                     "name": "test",
+                    "state_class": "total",
                     "state_topic": "test-topic",
                     "unit_of_measurement": "kWh",
                     "value_template": "{{ value_json.value | float / 60000 }}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking
The `last_reset` property is now ignored by sensors with `state_class` set to `measurement`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop last_reset attribute for non 'total' sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
