### PR TITLE
Use Platform enum in load_platform [tests]

### DIFF
--- a/tests/components/numato/test_binary_sensor.py
+++ b/tests/components/numato/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the numato binary_sensor platform."""
+from homeassistant.const import Platform
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -54,7 +55,9 @@ async def test_hass_binary_sensor_notification(hass, numato_fixture):
 async def test_binary_sensor_setup_without_discovery_info(hass, config, numato_fixture):
     """Test handling of empty discovery_info."""
     numato_fixture.discover()
-    await discovery.async_load_platform(hass, "binary_sensor", "numato", None, config)
+    await discovery.async_load_platform(
+        hass, Platform.BINARY_SENSOR, "numato", None, config
+    )
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id not in hass.states.async_entity_ids()
     await hass.async_block_till_done()  # wait for numato platform to be loaded

--- a/tests/components/numato/test_sensor.py
+++ b/tests/components/numato/test_sensor.py
@@ -1,5 +1,5 @@
 """Tests for the numato sensor platform."""
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -30,7 +30,7 @@ async def test_failing_sensor_update(hass, numato_fixture, monkeypatch):
 async def test_sensor_setup_without_discovery_info(hass, config, numato_fixture):
     """Test handling of empty discovery_info."""
     numato_fixture.discover()
-    await discovery.async_load_platform(hass, "sensor", "numato", None, config)
+    await discovery.async_load_platform(hass, Platform.SENSOR, "numato", None, config)
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id not in hass.states.async_entity_ids()
     await hass.async_block_till_done()  # wait for numato platform to be loaded

--- a/tests/components/numato/test_switch.py
+++ b/tests/components/numato/test_switch.py
@@ -1,6 +1,11 @@
 """Tests for the numato switch platform."""
 from homeassistant.components import switch
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
@@ -106,7 +111,7 @@ async def test_failing_hass_operations(hass, numato_fixture, monkeypatch):
 async def test_switch_setup_without_discovery_info(hass, config, numato_fixture):
     """Test handling of empty discovery_info."""
     numato_fixture.discover()
-    await discovery.async_load_platform(hass, "switch", "numato", None, config)
+    await discovery.async_load_platform(hass, Platform.SWITCH, "numato", None, config)
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id not in hass.states.async_entity_ids()
     await hass.async_block_till_done()  # wait for numato platform to be loaded

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -131,7 +131,7 @@ class TestHelpersDiscovery:
         def component_setup(hass, config):
             """Set up mock component."""
             discovery.load_platform(
-                hass, Platform.SWITCH, "test_circular", "disc", config
+                hass, Platform.SWITCH, "test_circular", {"key": "value"}, config
             )
             component_calls.append(1)
             return True

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import setup
+from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -129,7 +130,9 @@ class TestHelpersDiscovery:
 
         def component_setup(hass, config):
             """Set up mock component."""
-            discovery.load_platform(hass, "switch", "test_circular", "disc", config)
+            discovery.load_platform(
+                hass, Platform.SWITCH, "test_circular", "disc", config
+            )
             component_calls.append(1)
             return True
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Identified using regex `load_platform\(hass, [^P]`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
