### PR TITLE
Move `disallow-any-generics` to mypy.ini

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -2,7 +2,29 @@
 # If component is fully covered with type annotations, please add it here
 # to enable strict mypy checks.
 
+# Stict typing is enabled by default for core files.
+# Add it here to add 'disallow_any_generics'.
+# --- Only for core file! ---
+homeassistant.exceptions
 homeassistant.core
+homeassistant.loader
+homeassistant.requirements
+homeassistant.runner
+homeassistant.setup
+homeassistant.auth.auth_store
+homeassistant.auth.providers.*
+homeassistant.helpers.area_registry
+homeassistant.helpers.condition
+homeassistant.helpers.discovery
+homeassistant.helpers.entity_values
+homeassistant.helpers.reload
+homeassistant.helpers.script_variables
+homeassistant.helpers.translation
+homeassistant.util.color
+homeassistant.util.process
+homeassistant.util.unit_system
+
+# --- Add components below this line ---
 homeassistant.components
 homeassistant.components.abode.*
 homeassistant.components.acer_projector.*

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -22,8 +22,6 @@ from .permissions import system_policies
 from .permissions.models import PermissionLookup
 from .permissions.types import PolicyType
 
-# mypy: disallow-any-generics
-
 STORAGE_VERSION = 1
 STORAGE_KEY = "auth"
 GROUP_NAME_ADMIN = "Administrators"

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -22,8 +22,6 @@ from ..auth_store import AuthStore
 from ..const import MFA_SESSION_EXPIRATION
 from ..models import Credentials, RefreshToken, User, UserMeta
 
-# mypy: disallow-any-generics
-
 _LOGGER = logging.getLogger(__name__)
 DATA_REQS = "auth_prov_reqs_processed"
 

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -16,8 +16,6 @@ from homeassistant.exceptions import HomeAssistantError
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
-# mypy: disallow-any-generics
-
 CONF_ARGS = "args"
 CONF_META = "meta"
 

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -18,8 +18,6 @@ from homeassistant.exceptions import HomeAssistantError
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
-# mypy: disallow-any-generics
-
 STORAGE_VERSION = 1
 STORAGE_KEY = "auth_provider.homeassistant"
 

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -14,8 +14,6 @@ from homeassistant.exceptions import HomeAssistantError
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
-# mypy: disallow-any-generics
-
 USER_SCHEMA = vol.Schema(
     {
         vol.Required("username"): str,

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -19,8 +19,6 @@ import homeassistant.helpers.config_validation as cv
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from ..models import Credentials, UserMeta
 
-# mypy: disallow-any-generics
-
 AUTH_PROVIDER_TYPE = "legacy_api_password"
 CONF_API_PASSWORD = "api_password"
 

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -27,8 +27,6 @@ from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
 from .. import InvalidAuthError
 from ..models import Credentials, RefreshToken, UserMeta
 
-# mypy: disallow-any-generics
-
 IPAddress = Union[IPv4Address, IPv6Address]
 IPNetwork = Union[IPv4Network, IPv6Network]
 

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -9,8 +9,6 @@ import attr
 if TYPE_CHECKING:
     from .core import Context
 
-# mypy: disallow-any-generics
-
 
 class HomeAssistantError(Exception):
     """General Home Assistant exception occurred."""

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -14,8 +14,6 @@ from homeassistant.util import slugify
 from . import device_registry as dr, entity_registry as er
 from .typing import UNDEFINED, UndefinedType
 
-# mypy: disallow-any-generics
-
 DATA_REGISTRY = "area_registry"
 EVENT_AREA_REGISTRY_UPDATED = "area_registry_updated"
 STORAGE_KEY = "core.area_registry"

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -70,8 +70,6 @@ from .trace import (
 )
 from .typing import ConfigType, TemplateVarsType
 
-# mypy: disallow-any-generics
-
 ASYNC_FROM_CONFIG_FORMAT = "async_{}_from_config"
 FROM_CONFIG_FORMAT = "{}_from_config"
 VALIDATE_CONFIG_FORMAT = "{}_validate_config"

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -23,8 +23,6 @@ EVENT_LOAD_PLATFORM = "load_platform.{}"
 ATTR_PLATFORM = "platform"
 ATTR_DISCOVERED = "discovered"
 
-# mypy: disallow-any-generics
-
 
 class DiscoveryDict(TypedDict):
     """Discovery data."""

--- a/homeassistant/helpers/entity_values.py
+++ b/homeassistant/helpers/entity_values.py
@@ -8,8 +8,6 @@ from typing import Any
 
 from homeassistant.core import split_entity_id
 
-# mypy: disallow-any-generics
-
 
 class EntityValues:
     """Class to store entity id based values."""

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -17,8 +17,6 @@ from . import config_per_platform
 from .entity_platform import EntityPlatform, async_get_platforms
 from .typing import ConfigType
 
-# mypy: disallow-any-generics
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -8,8 +8,6 @@ from homeassistant.core import HomeAssistant, callback
 
 from . import template
 
-# mypy: disallow-any-generics
-
 
 class ScriptVariables:
     """Class to hold and render script variables."""

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -17,8 +17,6 @@ from homeassistant.loader import (
 from homeassistant.util.async_ import gather_with_concurrency
 from homeassistant.util.json import load_json
 
-# mypy: disallow-any-generics
-
 _LOGGER = logging.getLogger(__name__)
 
 TRANSLATION_LOAD_LOCK = "translation_load_lock"

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -34,8 +34,6 @@ from .util.async_ import gather_with_concurrency
 if TYPE_CHECKING:
     from .core import HomeAssistant
 
-# mypy: disallow-any-generics
-
 CALLABLE_T = TypeVar(  # pylint: disable=invalid-name
     "CALLABLE_T", bound=Callable[..., Any]
 )

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -13,8 +13,6 @@ from .helpers.typing import UNDEFINED, UndefinedType
 from .loader import Integration, IntegrationNotFound, async_get_integration
 from .util import package as pkg_util
 
-# mypy: disallow-any-generics
-
 PIP_TIMEOUT = 60  # The default is too low when the internet connection is satellite or high latency
 MAX_INSTALL_FAILURES = 3
 DATA_PIP_LOCK = "pip_lock"

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -14,8 +14,6 @@ from .helpers.frame import warn_use
 from .util.executor import InterruptibleThreadPoolExecutor
 from .util.thread import deadlock_safe_shutdown
 
-# mypy: disallow-any-generics
-
 #
 # Python 3.8 has significantly less workers by default
 # than Python 3.7.  In order to be consistent between

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -22,8 +22,6 @@ from .exceptions import HomeAssistantError
 from .helpers.typing import ConfigType
 from .util import dt as dt_util, ensure_unique_string
 
-# mypy: disallow-any-generics
-
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_COMPONENT = "component"

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -7,8 +7,6 @@ from typing import NamedTuple, cast
 
 import attr
 
-# mypy: disallow-any-generics
-
 
 class RGBColor(NamedTuple):
     """RGB hex values."""

--- a/homeassistant/util/process.py
+++ b/homeassistant/util/process.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
-# mypy: disallow-any-generics
-
 
 def kill_subprocess(process: subprocess.Popen[Any]) -> None:
     """Force kill a subprocess and wait for it to exit."""

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -40,8 +40,6 @@ from . import (
     volume as volume_util,
 )
 
-# mypy: disallow-any-generics
-
 LENGTH_UNITS = distance_util.VALID_UNITS
 
 MASS_UNITS: tuple[str, ...] = (MASS_POUNDS, MASS_OUNCES, MASS_KILOGRAMS, MASS_GRAMS)

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,7 +22,58 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.exceptions]
+disallow_any_generics = true
+
 [mypy-homeassistant.core]
+disallow_any_generics = true
+
+[mypy-homeassistant.loader]
+disallow_any_generics = true
+
+[mypy-homeassistant.requirements]
+disallow_any_generics = true
+
+[mypy-homeassistant.runner]
+disallow_any_generics = true
+
+[mypy-homeassistant.setup]
+disallow_any_generics = true
+
+[mypy-homeassistant.auth.auth_store]
+disallow_any_generics = true
+
+[mypy-homeassistant.auth.providers.*]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.area_registry]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.condition]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.discovery]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.entity_values]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.reload]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.script_variables]
+disallow_any_generics = true
+
+[mypy-homeassistant.helpers.translation]
+disallow_any_generics = true
+
+[mypy-homeassistant.util.color]
+disallow_any_generics = true
+
+[mypy-homeassistant.util.process]
+disallow_any_generics = true
+
+[mypy-homeassistant.util.unit_system]
 disallow_any_generics = true
 
 [mypy-homeassistant.components.*]


### PR DESCRIPTION
## Proposed change
Use new feature from `.strict-typing` added in #63244 to remove `# mypy: disallow-any-generics` comments from core files.

The comment is also used in some isolated `components` files. At the moment, I don't think it makes sense to update the `mypy_config` script to account for that. Maybe once all core files have been updated.
https://github.com/home-assistant/core/blob/d3da791168de63d7446ecdae0b6d6983cf039faa/homeassistant/components/binary_sensor/device_condition.py#L25

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
