### PR TITLE
Update typing - collections.abc (1)

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Optional, cast
 
 import jwt
 

--- a/homeassistant/auth/permissions/types.py
+++ b/homeassistant/auth/permissions/types.py
@@ -1,5 +1,6 @@
 """Common code for permissions."""
-from typing import Mapping, Union
+from collections.abc import Mapping
+from typing import Union
 
 # MyPy doesn't support recursion yet. So writing it out as far as we need.
 

--- a/homeassistant/auth/permissions/util.py
+++ b/homeassistant/auth/permissions/util.py
@@ -1,8 +1,9 @@
 """Helpers to deal with permissions."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, Optional, cast
+from typing import Optional, cast
 
 from .const import SUBCAT_ALL
 from .models import PermissionLookup

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextvars import ContextVar
 import dataclasses
 from enum import Enum
 import functools
 import logging
 from types import MappingProxyType, MethodType
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 import weakref
 
 from . import data_entry_flow, loader

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -7,7 +7,14 @@ of entities and react to changes.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Collection, Coroutine, Iterable, Mapping
+from collections.abc import (
+    Awaitable,
+    Callable,
+    Collection,
+    Coroutine,
+    Iterable,
+    Mapping,
+)
 import datetime
 import enum
 import functools
@@ -21,8 +28,6 @@ from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
     Generic,
     NamedTuple,
     Optional,

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from itertools import groupby
 import logging
-from typing import Any, Awaitable, Callable, Iterable, Optional, cast
+from typing import Any, Optional, cast
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from collections.abc import Container, Generator
+from collections.abc import Callable, Container, Generator
 from contextlib import contextmanager
 from datetime import datetime, time as dt_time, timedelta
 import functools as ft
 import logging
 import re
 import sys
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 from homeassistant.components import zone as zone_cmp
 from homeassistant.components.device_automation import (

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,10 +1,9 @@
 """Helpers for data entry flows for config entries."""
 from __future__ import annotations
 
-import asyncio  # pylint: disable=unused-import  # used in cast as string
 from collections.abc import Awaitable, Callable
 import logging
-from typing import Any, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp, mqtt, ssdp, zeroconf
@@ -12,6 +11,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from .typing import UNDEFINED, DiscoveryInfoType, UndefinedType
+
+if TYPE_CHECKING:
+    import asyncio
 
 DiscoveryFunctionType = Callable[[HomeAssistant], Union[Awaitable[bool], bool]]
 

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import asyncio  # pylint: disable=unused-import  # used in cast as string
+from collections.abc import Awaitable, Callable
 import logging
-from typing import Any, Awaitable, Callable, Union, cast
+from typing import Any, Union, cast
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp, mqtt, ssdp, zeroconf

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 import copy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import functools as ft
 import logging
 import time
-from typing import Any, Callable, Union, cast
+from typing import Any, Union, cast
 
 import attr
 from typing_extensions import Concatenate, ParamSpec

--- a/homeassistant/helpers/significant_change.py
+++ b/homeassistant/helpers/significant_change.py
@@ -28,8 +28,9 @@ The following cases will never be passed to your function:
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import MappingProxyType
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional, Union
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State, callback

--- a/homeassistant/helpers/singleton.py
+++ b/homeassistant/helpers/singleton.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import functools
-from typing import Callable, TypeVar, cast
+from typing import TypeVar, cast
 
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,6 +1,7 @@
 """Typing Helpers for Home Assistant."""
+from collections.abc import Mapping
 from enum import Enum
-from typing import Any, Mapping, Optional, Union
+from typing import Any, Optional, Union
 
 import homeassistant.core
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -7,6 +7,7 @@ documentation as possible to keep it understandable.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from contextlib import suppress
 import functools as ft
 import importlib
@@ -15,7 +16,7 @@ import logging
 import pathlib
 import sys
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, TypedDict, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 
 from awesomeversion import (
     AwesomeVersion,

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from functools import partial, wraps
 import inspect
 import logging
 import logging.handlers
 import queue
 import traceback
-from typing import Any, Awaitable, Callable, cast, overload
+from typing import Any, cast, overload
 
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.core import HomeAssistant, callback, is_callback

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -106,7 +106,7 @@ def log_exception(format_err: Callable[..., Any], *args: Any) -> None:
 
 
 @overload
-def catch_log_exception(  # type: ignore
+def catch_log_exception(  # type: ignore[misc]
     func: Callable[..., Awaitable[Any]], format_err: Callable[..., Any], *args: Any
 ) -> Callable[..., Awaitable[None]]:
     """Overload for Callables that return an Awaitable."""


### PR DESCRIPTION
## Proposed change
Part two of the PEP 585 typing updates.
Import abstract base classes from `collections.abc` instead of `typing`.

Once this round of updates is merged, the `deprecated-typing-alias` pylint check can be reenabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
