### PR TITLE
Add MyAir5 "myfan" support to Advantage Air

### DIFF
--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -49,7 +49,11 @@ AC_HVAC_MODES = [
     HVAC_MODE_DRY,
 ]
 
+MYAIR5 = "MyAir5"
+MYAIR5_FAN_AUTO = "autoAA"
+
 ADVANTAGE_AIR_FAN_MODES = {
+    MYAIR5_FAN_AUTO: FAN_AUTO,
     "auto": FAN_AUTO,
     "low": FAN_LOW,
     "medium": FAN_MEDIUM,
@@ -60,6 +64,7 @@ FAN_SPEEDS = {FAN_LOW: 30, FAN_MEDIUM: 60, FAN_HIGH: 100}
 
 ADVANTAGE_AIR_SERVICE_SET_MYZONE = "set_myzone"
 ZONE_HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_HEAT_COOL]
+
 
 PARALLEL_UPDATES = 0
 
@@ -151,9 +156,14 @@ class AdvantageAirAC(AdvantageAirClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode):
         """Set the Fan Mode."""
-        await self.async_change(
-            {self.ac_key: {"info": {"fan": HASS_FAN_MODES.get(fan_mode)}}}
-        )
+        mode = HASS_FAN_MODES.get(fan_mode)
+        # MyAir5 has a unique automatic fan mode branded "myfan" that reports as "autoAA"
+        if (
+            self.coordinator.data["system"]["sysType"] == MYAIR5
+            and fan_mode == FAN_AUTO
+        ):
+            mode = MYAIR5_FAN_AUTO
+        await self.async_change({self.ac_key: {"info": {"fan": mode}}})
 
     async def async_set_temperature(self, **kwargs):
         """Set the Temperature."""

--- a/tests/components/advantage_air/fixtures/getSystemData.json
+++ b/tests/components/advantage_air/fixtures/getSystemData.json
@@ -152,7 +152,7 @@
         "hasThingsLight": false,
         "name": "testname",
         "rid": "uniqueid",
-        "sysType": "e-zone",
+        "sysType": "MyAir5",
         "myAppRev": "testversion"
     }
 }

--- a/tests/components/advantage_air/test_climate.py
+++ b/tests/components/advantage_air/test_climate.py
@@ -6,6 +6,7 @@ from homeassistant.components.advantage_air.climate import (
     ADVANTAGE_AIR_SERVICE_SET_MYZONE,
     HASS_FAN_MODES,
     HASS_HVAC_MODES,
+    MYAIR5_FAN_AUTO,
 )
 from homeassistant.components.advantage_air.const import (
     ADVANTAGE_AIR_STATE_OFF,
@@ -16,6 +17,7 @@ from homeassistant.components.climate.const import (
     ATTR_FAN_MODE,
     ATTR_HVAC_MODE,
     DOMAIN as CLIMATE_DOMAIN,
+    FAN_AUTO,
     FAN_LOW,
     HVAC_MODE_FAN_ONLY,
     HVAC_MODE_OFF,
@@ -123,6 +125,21 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[-1][0] == "GET"
     assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"
 
+    # Test MyAir5 special case
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {ATTR_ENTITY_ID: [entity_id], ATTR_FAN_MODE: FAN_AUTO},
+        blocking=True,
+    )
+    assert len(aioclient_mock.mock_calls) == 11
+    assert aioclient_mock.mock_calls[-2][0] == "GET"
+    assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
+    data = loads(aioclient_mock.mock_calls[-2][1].query["json"])
+    assert data["ac1"]["info"]["fan"] == MYAIR5_FAN_AUTO
+    assert aioclient_mock.mock_calls[-1][0] == "GET"
+    assert aioclient_mock.mock_calls[-1][1].path == "/getSystemData"
+
     # Test Climate Zone Entity
     entity_id = "climate.zone_open_with_sensor"
     state = hass.states.get(entity_id)
@@ -142,7 +159,7 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
         {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVAC_MODE_FAN_ONLY},
         blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 11
+    assert len(aioclient_mock.mock_calls) == 13
     assert aioclient_mock.mock_calls[-2][0] == "GET"
     assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
     assert aioclient_mock.mock_calls[-1][0] == "GET"
@@ -154,7 +171,7 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
         {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVAC_MODE_OFF},
         blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 13
+    assert len(aioclient_mock.mock_calls) == 15
     assert aioclient_mock.mock_calls[-2][0] == "GET"
     assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
     assert aioclient_mock.mock_calls[-1][0] == "GET"
@@ -166,7 +183,7 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
         {ATTR_ENTITY_ID: [entity_id], ATTR_TEMPERATURE: 25},
         blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 15
+    assert len(aioclient_mock.mock_calls) == 17
     assert aioclient_mock.mock_calls[-2][0] == "GET"
     assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
     assert aioclient_mock.mock_calls[-1][0] == "GET"
@@ -179,7 +196,7 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
         {ATTR_ENTITY_ID: [entity_id]},
         blocking=True,
     )
-    assert len(aioclient_mock.mock_calls) == 17
+    assert len(aioclient_mock.mock_calls) == 19
     assert aioclient_mock.mock_calls[-2][0] == "GET"
     assert aioclient_mock.mock_calls[-2][1].path == "/setAircon"
     data = loads(aioclient_mock.mock_calls[-2][1].query["json"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MyAir 5 product uses a different value for its automatic fan mode "autoAA", so this PR adds support for this custom value when it detects a MyAir 5 system.

https://www.advantageair.com.au/wp-content/uploads/2019/10/MyComfort.pdf

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #62362
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
