### PR TITLE
Add support for changing the white strip type to flux_led

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Final, cast
 
 from flux_led import DeviceType
 from flux_led.aio import AIOWifiLedBulb
-from flux_led.const import ATTR_ID
+from flux_led.const import ATTR_ID, WhiteChannelType
 from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant.config_entries import ConfigEntry
@@ -23,6 +23,7 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    CONF_WHITE_CHANNEL_TYPE,
     DISCOVER_SCAN_TIMEOUT,
     DOMAIN,
     FLUX_LED_DISCOVERY,
@@ -56,6 +57,9 @@ PLATFORMS_BY_TYPE: Final = {
 }
 DISCOVERY_INTERVAL: Final = timedelta(minutes=15)
 REQUEST_REFRESH_DELAY: Final = 1.5
+NAME_TO_WHITE_CHANNEL_TYPE: Final = {
+    option.name.lower(): option for option in WhiteChannelType
+}
 
 
 @callback
@@ -95,6 +99,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device: AIOWifiLedBulb = async_wifi_bulb_for_host(host, discovery=discovery)
     signal = SIGNAL_STATE_UPDATED.format(device.ipaddr)
     device.discovery = discovery
+    if white_channel_type := entry.data.get(CONF_WHITE_CHANNEL_TYPE):
+        device.white_channel_channel_type = NAME_TO_WHITE_CHANNEL_TYPE[
+            white_channel_type
+        ]
 
     @callback
     def _async_state_changed(*_: Any) -> None:

--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -28,6 +28,7 @@ FLUX_COLOR_MODE_TO_HASS: Final = {
     FLUX_COLOR_MODE_CCT: COLOR_MODE_COLOR_TEMP,
 }
 
+MULTI_BRIGHTNESS_COLOR_MODES: Final = {COLOR_MODE_RGBWW, COLOR_MODE_RGBW}
 
 API: Final = "flux_api"
 
@@ -57,6 +58,8 @@ CONF_MINOR_VERSION: Final = "minor_version"
 CONF_REMOTE_ACCESS_ENABLED: Final = "remote_access_enabled"
 CONF_REMOTE_ACCESS_HOST: Final = "remote_access_host"
 CONF_REMOTE_ACCESS_PORT: Final = "remote_access_port"
+CONF_WHITE_CHANNEL_TYPE: Final = "white_channel_type"
+
 
 TRANSITION_GRADUAL: Final = "gradual"
 TRANSITION_JUMP: Final = "jump"

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -305,7 +305,7 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
             ):
                 # When switching to color temp from RGBWW or RGB&W mode,
                 # we do not want the overall brightness of the RGB channels
-                brightness = max(self.rgb_color)
+                brightness = max(self._device.rgb)
             await self._device.async_set_white_temp(color_temp_kelvin, brightness)
             return
         # Handle switch to RGB Color Mode

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -7,12 +7,7 @@ from typing import Any, Final
 
 from flux_led.const import MultiColorEffects
 from flux_led.protocol import MusicMode
-from flux_led.utils import (
-    color_temp_to_white_levels,
-    rgbcw_brightness,
-    rgbcw_to_rgbwc,
-    rgbw_brightness,
-)
+from flux_led.utils import rgbcw_brightness, rgbcw_to_rgbwc, rgbw_brightness
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -24,7 +19,6 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_WHITE,
-    COLOR_MODE_RGBWW,
     SUPPORT_EFFECT,
     SUPPORT_TRANSITION,
     LightEntity,
@@ -50,6 +44,7 @@ from .const import (
     CONF_TRANSITION,
     DEFAULT_EFFECT_SPEED,
     DOMAIN,
+    MULTI_BRIGHTNESS_COLOR_MODES,
     TRANSITION_GRADUAL,
     TRANSITION_JUMP,
     TRANSITION_STROBE,
@@ -203,9 +198,7 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
     ) -> None:
         """Initialize the light."""
         super().__init__(coordinator, unique_id, name, None)
-        self._attr_min_mireds = (
-            color_temperature_kelvin_to_mired(self._device.max_temp) + 1
-        )  # for rounding
+        self._attr_min_mireds = color_temperature_kelvin_to_mired(self._device.max_temp)
         self._attr_max_mireds = color_temperature_kelvin_to_mired(self._device.min_temp)
         self._attr_supported_color_modes = _hass_color_modes(self._device)
         custom_effects: list[str] = []
@@ -306,20 +299,15 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
         # Handle switch to CCT Color Mode
         if color_temp_mired := kwargs.get(ATTR_COLOR_TEMP):
             color_temp_kelvin = color_temperature_mired_to_kelvin(color_temp_mired)
-            if self.color_mode != COLOR_MODE_RGBWW:
-                await self._device.async_set_white_temp(color_temp_kelvin, brightness)
-                return
-
-            # When switching to color temp from RGBWW mode,
-            # we do not want the overall brightness, we only
-            # want the brightness of the white channels
-            brightness = kwargs.get(
-                ATTR_BRIGHTNESS, self._device.getWhiteTemperature()[1]
-            )
-            channels = color_temp_to_white_levels(color_temp_kelvin, brightness)
-            warm = channels.warm_white
-            cold = channels.cool_white
-            await self._device.async_set_levels(r=0, b=0, g=0, w=warm, w2=cold)
+            if (
+                ATTR_BRIGHTNESS not in kwargs
+                and self.color_mode in MULTI_BRIGHTNESS_COLOR_MODES
+            ):
+                # When switching to color temp from RGBWW or RGB&W mode,
+                # we do not want the overall brightness of any channel
+                # otherwise we may end up at 0
+                brightness = max(self.rgbww_color)
+            await self._device.async_set_white_temp(color_temp_kelvin, brightness)
             return
         # Handle switch to RGB Color Mode
         if rgb := kwargs.get(ATTR_RGB_COLOR):

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -304,9 +304,8 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
                 and self.color_mode in MULTI_BRIGHTNESS_COLOR_MODES
             ):
                 # When switching to color temp from RGBWW or RGB&W mode,
-                # we do not want the overall brightness of any channel
-                # otherwise we may end up at 0
-                brightness = max(self.rgbww_color)
+                # we do not want the overall brightness of the RGB channels
+                brightness = max(self.rgb_color)
             await self._device.async_set_white_temp(color_temp_kelvin, brightness)
             return
         # Handle switch to RGB Color Mode

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.27.45"],
+  "requirements": ["flux_led==0.28.0"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch", "@bdraco"],
   "iot_class": "local_push",

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.28.0"],
+  "requirements": ["flux_led==0.28.1"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch", "@bdraco"],
   "iot_class": "local_push",

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -230,9 +230,8 @@ class FluxWhiteChannelSelect(FluxConfigSelect):
         """Change the ic type."""
         entry = self.coordinator.entry
         hass = self.hass
-        config_entries = hass.config_entries
-        config_entries.async_update_entry(
+        hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_WHITE_CHANNEL_TYPE: option.lower()}
         )
         # reload since we need to reinit the device
-        hass.async_create_task(config_entries.async_reload(entry.entry_id))
+        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -219,7 +219,7 @@ class FluxWhiteChannelSelect(FluxConfigSelect):
 
     @property
     def current_option(self) -> str | None:
-        """Return the current operating mode."""
+        """Return the current white channel type."""
         return _human_readable_option(
             self.coordinator.entry.data.get(
                 CONF_WHITE_CHANNEL_TYPE, DEFAULT_WHITE_CHANNEL_TYPE.name

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.base_device import DeviceType
+from flux_led.const import DEFAULT_WHITE_CHANNEL_TYPE, WhiteChannelType
 from flux_led.protocol import PowerRestoreState, RemoteConfig
 
 from homeassistant import config_entries
@@ -12,9 +13,14 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import CONF_WHITE_CHANNEL_TYPE, DOMAIN, FLUX_COLOR_MODE_RGBW
 from .coordinator import FluxLedUpdateCoordinator
 from .entity import FluxBaseEntity, FluxEntity
+from .util import _human_readable_option
+
+NAME_TO_POWER_RESTORE_STATE = {
+    _human_readable_option(option.name): option for option in PowerRestoreState
+}
 
 
 async def async_setup_entry(
@@ -31,6 +37,7 @@ async def async_setup_entry(
         | FluxWiringsSelect
         | FluxICTypeSelect
         | FluxRemoteConfigSelect
+        | FluxWhiteChannelSelect
     ] = []
     name = entry.data[CONF_NAME]
     unique_id = entry.unique_id
@@ -57,13 +64,15 @@ async def async_setup_entry(
                 coordinator, unique_id, f"{name} Remote Config", "remote_config"
             )
         )
+    if FLUX_COLOR_MODE_RGBW in device.color_modes:
+        entities.append(
+            FluxWhiteChannelSelect(
+                coordinator, unique_id, f"{name} White Channel", "white_channel"
+            )
+        )
 
     if entities:
         async_add_entities(entities)
-
-
-def _human_readable_option(const_option: str) -> str:
-    return const_option.replace("_", " ").title()
 
 
 class FluxPowerStateSelect(FluxBaseEntity, SelectEntity):
@@ -82,10 +91,7 @@ class FluxPowerStateSelect(FluxBaseEntity, SelectEntity):
         self._attr_name = f"{entry.data[CONF_NAME]} Power Restored"
         if entry.unique_id:
             self._attr_unique_id = f"{entry.unique_id}_power_restored"
-        self._name_to_state = {
-            _human_readable_option(option.name): option for option in PowerRestoreState
-        }
-        self._attr_options = list(self._name_to_state)
+        self._attr_options = list(NAME_TO_POWER_RESTORE_STATE)
         self._async_set_current_option_from_device()
 
     @callback
@@ -98,7 +104,9 @@ class FluxPowerStateSelect(FluxBaseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the power state."""
-        await self._device.async_set_power_restore(channel1=self._name_to_state[option])
+        await self._device.async_set_power_restore(
+            channel1=NAME_TO_POWER_RESTORE_STATE[option]
+        )
         self._async_set_current_option_from_device()
         self.async_write_ha_state()
 
@@ -202,3 +210,29 @@ class FluxRemoteConfigSelect(FluxConfigSelect):
         """Change the remote config setting."""
         remote_config: RemoteConfig = self._name_to_state[option]
         await self._device.async_config_remotes(remote_config)
+
+
+class FluxWhiteChannelSelect(FluxConfigSelect):
+    """Representation of Flux white channel."""
+
+    _attr_options = [_human_readable_option(option.name) for option in WhiteChannelType]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current operating mode."""
+        return _human_readable_option(
+            self.coordinator.entry.data.get(
+                CONF_WHITE_CHANNEL_TYPE, DEFAULT_WHITE_CHANNEL_TYPE.name
+            )
+        )
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the ic type."""
+        entry = self.coordinator.entry
+        hass = self.hass
+        config_entries = hass.config_entries
+        config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_WHITE_CHANNEL_TYPE: option.lower()}
+        )
+        # reload since we need to reinit the device
+        hass.async_create_task(config_entries.async_reload(entry.entry_id))

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -227,7 +227,7 @@ class FluxWhiteChannelSelect(FluxConfigSelect):
         )
 
     async def async_select_option(self, option: str) -> None:
-        """Change the ic type."""
+        """Change the white channel type."""
         entry = self.coordinator.entry
         hass = self.hass
         hass.config_entries.async_update_entry(

--- a/homeassistant/components/flux_led/util.py
+++ b/homeassistant/components/flux_led/util.py
@@ -23,6 +23,10 @@ def format_as_flux_mac(mac: str | None) -> str | None:
     return None if mac is None else mac.replace(":", "").upper()
 
 
+def _human_readable_option(const_option: str) -> str:
+    return const_option.replace("_", " ").title()
+
+
 def _flux_color_mode_to_hass(
     flux_color_mode: str | None, flux_color_modes: set[str]
 ) -> str:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -681,7 +681,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.28.0
+flux_led==0.28.1
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -681,7 +681,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.27.45
+flux_led==0.28.0
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -424,7 +424,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.28.0
+flux_led==0.28.1
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -424,7 +424,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.27.45
+flux_led==0.28.0
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -12,6 +12,7 @@ from flux_led.aio import AIOWifiLedBulb
 from flux_led.const import (
     COLOR_MODE_CCT as FLUX_COLOR_MODE_CCT,
     COLOR_MODE_RGB as FLUX_COLOR_MODE_RGB,
+    WhiteChannelType,
 )
 from flux_led.models_db import MODEL_MAP
 from flux_led.protocol import (
@@ -105,6 +106,7 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.async_set_brightness = AsyncMock()
     bulb.async_set_device_config = AsyncMock()
     bulb.async_config_remotes = AsyncMock()
+    bulb.white_channel_channel_type = WhiteChannelType.WARM
     bulb.paired_remotes = 2
     bulb.pixels_per_segment = 300
     bulb.segments = 2

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -12,6 +12,7 @@ from flux_led.const import (
     COLOR_MODES_RGB_W as FLUX_COLOR_MODES_RGB_W,
     MODE_MUSIC,
     MultiColorEffects,
+    WhiteChannelType,
 )
 from flux_led.protocol import MusicMode
 import pytest
@@ -25,6 +26,7 @@ from homeassistant.components.flux_led.const import (
     CONF_EFFECT,
     CONF_SPEED_PCT,
     CONF_TRANSITION,
+    CONF_WHITE_CHANNEL_TYPE,
     DOMAIN,
     TRANSITION_JUMP,
 )
@@ -520,11 +522,15 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     bulb.async_set_brightness.reset_mock()
 
 
-async def test_rgbw_light(hass: HomeAssistant) -> None:
-    """Test an rgbw light."""
+async def test_rgbw_light_cold_white(hass: HomeAssistant) -> None:
+    """Test an rgbw light with a cold white channel."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        data={
+            CONF_HOST: IP_ADDRESS,
+            CONF_NAME: DEFAULT_ENTRY_TITLE,
+            CONF_WHITE_CHANNEL_TYPE: WhiteChannelType.COLD.name.lower(),
+        },
         unique_id=MAC_ADDRESS,
     )
     config_entry.add_to_hass(hass)
@@ -593,6 +599,148 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
     )
     bulb.async_set_levels.assert_called_with(255, 255, 255, 255)
     bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (255, 191, 178, 0)},
+        blocking=True,
+    )
+    bulb.async_set_levels.assert_called_with(255, 191, 178, 0)
+    bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
+        blocking=True,
+    )
+    bulb.async_set_effect.assert_called_once()
+    bulb.async_set_effect.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade", ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+    bulb.async_set_effect.assert_called_with("purple_fade", 50, 100)
+    bulb.async_set_effect.reset_mock()
+
+
+async def test_rgbw_light_warm_white(hass: HomeAssistant) -> None:
+    """Test an rgbw light with a warm white channel."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: IP_ADDRESS,
+            CONF_NAME: DEFAULT_ENTRY_TITLE,
+            CONF_WHITE_CHANNEL_TYPE: WhiteChannelType.WARM.name.lower(),
+        },
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.color_modes = {FLUX_COLOR_MODE_RGBW, FLUX_COLOR_MODE_CCT}
+    bulb.color_mode = FLUX_COLOR_MODE_RGBW
+    with _patch_discovery(), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.bulb_rgbcw_ddeeff"
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 128
+    assert attributes[ATTR_COLOR_MODE] == "rgbw"
+    assert attributes[ATTR_EFFECT_LIST] == bulb.effect_list
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgbw"]
+    assert attributes[ATTR_RGB_COLOR] == (255, 42, 42)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_turn_off.assert_called_once()
+    await async_mock_device_turn_off(hass, bulb)
+
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
+    bulb.is_on = True
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    bulb.async_set_brightness.assert_called_with(100)
+    bulb.async_set_brightness.reset_mock()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_RGBW_COLOR: (255, 255, 255, 255),
+            ATTR_BRIGHTNESS: 128,
+        },
+        blocking=True,
+    )
+    bulb.async_set_levels.assert_called_with(128, 128, 128, 128)
+    bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (255, 255, 255, 255)},
+        blocking=True,
+    )
+    bulb.async_set_levels.assert_called_with(255, 255, 255, 255)
+    bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (255, 191, 178, 0)},
+        blocking=True,
+    )
+    bulb.async_set_levels.assert_called_with(255, 191, 178, 0)
+    bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 154},
+        blocking=True,
+    )
+    bulb.async_set_white_temp.assert_called_with(6493, 255)
+    bulb.async_set_white_temp.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 154, ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+    bulb.async_set_white_temp.assert_called_with(6493, 255)
+    bulb.async_set_white_temp.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 290},
+        blocking=True,
+    )
+    bulb.async_set_white_temp.assert_called_with(3448, 255)
+    bulb.async_set_white_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -811,8 +959,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 154},
         blocking=True,
     )
-    bulb.async_set_levels.assert_called_with(r=0, b=0, g=0, w=0, w2=127)
-    bulb.async_set_levels.reset_mock()
+    bulb.async_set_white_temp.assert_called_with(6493, 255)
+    bulb.async_set_white_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -820,8 +968,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 154, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
-    bulb.async_set_levels.assert_called_with(r=0, b=0, g=0, w=0, w2=255)
-    bulb.async_set_levels.reset_mock()
+    bulb.async_set_white_temp.assert_called_with(6493, 255)
+    bulb.async_set_white_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -829,8 +977,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 290},
         blocking=True,
     )
-    bulb.async_set_levels.assert_called_with(r=0, b=0, g=0, w=102, w2=25)
-    bulb.async_set_levels.reset_mock()
+    bulb.async_set_white_temp.assert_called_with(3448, 255)
+    bulb.async_set_white_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- The strip white type can now be specified: Warm, Natural, or Cold

- This ensures the color temp values more accurately reflect the actual strip being used since we always assumed it was warm.

- The breaking change in the upstream lib allowed removal of additional code in `light.py` https://github.com/Danielhiversen/flux_led/compare/0.27.45...0.28.0

<img width="342" alt="Screen Shot 2022-01-11 at 13 06 25" src="https://user-images.githubusercontent.com/663432/149035478-2e5a643a-0a49-4563-ba33-94752916eaeb.png">
<img width="369" alt="Screen Shot 2022-01-11 at 13 06 20" src="https://user-images.githubusercontent.com/663432/149035482-078669bd-3075-4c3c-84a6-e21c1b808a8c.png">
<img width="317" alt="Screen Shot 2022-01-11 at 13 07 19" src="https://user-images.githubusercontent.com/663432/149035551-7515dc6d-15ca-4b7c-9861-b5d04e14f1e8.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
