### PR TITLE
Rework webOS Smart TV device trigger to custom trigger platform

### DIFF
--- a/homeassistant/components/webostv/device_trigger.py
+++ b/homeassistant/components/webostv/device_trigger.py
@@ -19,7 +19,8 @@ from homeassistant.helpers.typing import ConfigType
 from . import trigger
 from .const import DOMAIN
 from .helpers import (
-    async_get_client_wrapper_by_device_id,
+    async_get_client_wrapper_by_device_entry,
+    async_get_device_entry_by_device_id,
     async_is_device_config_entry_not_loaded,
 )
 from .triggers.turn_on import PLATFORM_TYPE as TURN_ON_PLATFORM_TYPE
@@ -47,7 +48,8 @@ async def async_validate_trigger_config(
     if config[CONF_TYPE] == TURN_ON_PLATFORM_TYPE:
         device_id = config[CONF_DEVICE_ID]
         try:
-            async_get_client_wrapper_by_device_id(hass, device_id)
+            device = async_get_device_entry_by_device_id(hass, device_id)
+            async_get_client_wrapper_by_device_entry(hass, device)
         except ValueError as err:
             raise InvalidDeviceAutomationConfig(err) from err
 

--- a/homeassistant/components/webostv/helpers.py
+++ b/homeassistant/components/webostv/helpers.py
@@ -1,0 +1,87 @@
+"""Helper functions for webOS Smart TV."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from . import WebOsClientWrapper
+from .const import DATA_CONFIG_ENTRY, DOMAIN
+
+
+@callback
+def async_get_device_entry_by_device_id(
+    hass: HomeAssistant, device_id: str
+) -> DeviceEntry:
+    """
+    Get Device Entry from Device Registry by device ID.
+
+    Raises ValueError if device ID is invalid.
+    """
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get(device_id)
+
+    if device is None:
+        raise ValueError(f"Device {device_id} is not a valid {DOMAIN} device.")
+
+    return device
+
+
+@callback
+def async_is_device_config_entry_not_loaded(
+    hass: HomeAssistant, device_id: str
+) -> bool:
+    """Return whether device's config entries are not loaded."""
+    device = async_get_device_entry_by_device_id(hass, device_id)
+    return any(
+        (entry := hass.config_entries.async_get_entry(entry_id))
+        and entry.state != ConfigEntryState.LOADED
+        for entry_id in device.config_entries
+    )
+
+
+@callback
+def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
+    """
+    Get device ID from an entity ID.
+
+    Raises ValueError if entity or device ID is invalid.
+    """
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(entity_id)
+
+    if (
+        entity_entry is None
+        or entity_entry.device_id is None
+        or entity_entry.platform != DOMAIN
+    ):
+        raise ValueError(f"Entity {entity_id} is not a valid {DOMAIN} entity.")
+
+    return entity_entry.device_id
+
+
+@callback
+def async_get_client_wrapper_by_device_id(
+    hass: HomeAssistant,
+    device_id: str,
+    device: DeviceEntry | None = None,
+) -> WebOsClientWrapper:
+    """
+    Get WebOsClientWrapper from Device Registry by device ID.
+
+    Raises ValueError if device ID is invalid.
+    """
+    if device is None:
+        device = async_get_device_entry_by_device_id(hass, device_id)
+
+    for config_entry_id in device.config_entries:
+        if wrapper := hass.data[DOMAIN][DATA_CONFIG_ENTRY].get(config_entry_id):
+            break
+
+    if not wrapper:
+        raise ValueError(
+            f"Device {device_id} is not from an existing {DOMAIN} config entry"
+        )
+
+    return wrapper

--- a/homeassistant/components/webostv/helpers.py
+++ b/homeassistant/components/webostv/helpers.py
@@ -62,26 +62,21 @@ def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> s
 
 
 @callback
-def async_get_client_wrapper_by_device_id(
-    hass: HomeAssistant,
-    device_id: str,
-    device: DeviceEntry | None = None,
+def async_get_client_wrapper_by_device_entry(
+    hass: HomeAssistant, device: DeviceEntry
 ) -> WebOsClientWrapper:
     """
-    Get WebOsClientWrapper from Device Registry by device ID.
+    Get WebOsClientWrapper from Device Registry by device entry.
 
-    Raises ValueError if device ID is invalid.
+    Raises ValueError if client wrapper is not found.
     """
-    if device is None:
-        device = async_get_device_entry_by_device_id(hass, device_id)
-
     for config_entry_id in device.config_entries:
         if wrapper := hass.data[DOMAIN][DATA_CONFIG_ENTRY].get(config_entry_id):
             break
 
     if not wrapper:
         raise ValueError(
-            f"Device {device_id} is not from an existing {DOMAIN} config entry"
+            f"Device {device.id} is not from an existing {DOMAIN} config entry"
         )
 
     return wrapper

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -41,7 +41,7 @@
   },
   "device_automation": {
     "trigger_type": {
-      "turn_on": "Device is requested to turn on"
+      "webostv.turn_on": "Device is requested to turn on"
     }
   }
 }

--- a/homeassistant/components/webostv/translations/en.json
+++ b/homeassistant/components/webostv/translations/en.json
@@ -41,7 +41,7 @@
   },
   "device_automation": {
     "trigger_type": {
-        "turn_on": "Device is requested to turn on"
+        "webostv.turn_on": "Device is requested to turn on"
     }
   }
 }

--- a/homeassistant/components/webostv/trigger.py
+++ b/homeassistant/components/webostv/trigger.py
@@ -1,0 +1,60 @@
+"""webOS Smart TV trigger dispatcher."""
+from __future__ import annotations
+
+from types import ModuleType
+from typing import cast
+
+from homeassistant.components.automation import (
+    AutomationActionType,
+    AutomationTriggerInfo,
+)
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .triggers import turn_on
+
+TRIGGERS = {
+    "turn_on": turn_on,
+}
+
+
+def _get_trigger_platform(config: ConfigType) -> ModuleType:
+    """Return trigger platform."""
+    platform_split = config[CONF_PLATFORM].split(".", maxsplit=1)
+    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:
+        raise ValueError(
+            f"Unknown webOS Smart TV trigger platform {config[CONF_PLATFORM]}"
+        )
+    return TRIGGERS[platform_split[1]]
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    platform = _get_trigger_platform(config)
+    if hasattr(platform, "async_validate_trigger_config"):
+        return cast(
+            ConfigType,
+            await getattr(platform, "async_validate_trigger_config")(hass, config),
+        )
+    assert hasattr(platform, "TRIGGER_SCHEMA")
+    return cast(ConfigType, getattr(platform, "TRIGGER_SCHEMA")(config))
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: AutomationTriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach trigger of specified platform."""
+    platform = _get_trigger_platform(config)
+    assert hasattr(platform, "async_attach_trigger")
+    return cast(
+        CALLBACK_TYPE,
+        await getattr(platform, "async_attach_trigger")(
+            hass, config, action, automation_info
+        ),
+    )

--- a/homeassistant/components/webostv/triggers/__init__.py
+++ b/homeassistant/components/webostv/triggers/__init__.py
@@ -1,0 +1,1 @@
+"""webOS Smart TV triggers."""

--- a/homeassistant/components/webostv/triggers/__init__.py
+++ b/homeassistant/components/webostv/triggers/__init__.py
@@ -1,1 +1,12 @@
 """webOS Smart TV triggers."""
+from __future__ import annotations
+
+from typing import Protocol
+
+import voluptuous as vol
+
+
+class TriggersPlatformModule(Protocol):
+    """Protocol type for the triggers platform."""
+
+    TRIGGER_SCHEMA: vol.Schema

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -1,0 +1,91 @@
+"""webOS Smart TV device turn on trigger."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.automation import (
+    AutomationActionType,
+    AutomationTriggerInfo,
+)
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, CONF_PLATFORM
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from ..const import DOMAIN
+from ..helpers import (
+    async_get_client_wrapper_by_device_id,
+    async_get_device_entry_by_device_id,
+    async_get_device_id_from_entity_id,
+)
+
+# Platform type should be <DOMAIN>.<SUBMODULE_NAME>
+PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
+
+TRIGGER_TYPE_TURN_ON = "turn_on"
+
+TRIGGER_SCHEMA = vol.All(
+    cv.TRIGGER_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_PLATFORM): PLATFORM_TYPE,
+            vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+        },
+    ),
+    cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
+)
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: AutomationTriggerInfo,
+    *,
+    platform_type: str = PLATFORM_TYPE,
+) -> CALLBACK_TYPE | None:
+    """Attach a trigger."""
+    device_ids = set()
+    if ATTR_DEVICE_ID in config:
+        device_ids.update(config.get(ATTR_DEVICE_ID, []))
+
+    if ATTR_ENTITY_ID in config:
+        device_ids.update(
+            {
+                async_get_device_id_from_entity_id(hass, entity_id)
+                for entity_id in config.get(ATTR_ENTITY_ID, [])
+            }
+        )
+
+    trigger_data = automation_info["trigger_data"]
+
+    unsubs = []
+
+    for device_id in device_ids:
+        device = async_get_device_entry_by_device_id(hass, device_id)
+        device_name = device.name_by_user or device.name
+
+        variables = {
+            **trigger_data,
+            CONF_PLATFORM: platform_type,
+            ATTR_DEVICE_ID: device_id,
+            "description": f"webostv turn on trigger for {device_name}",
+        }
+
+        if (
+            wrapper := async_get_client_wrapper_by_device_id(hass, device_id, device)
+        ) is None:
+            raise ValueError(
+                f"Device {device_id} is not from an existing {DOMAIN} config entry"
+            )
+
+        unsubs.append(wrapper.turn_on.async_attach(action, {"trigger": variables}))
+
+    @callback
+    def async_remove() -> None:
+        """Remove state listeners async."""
+        for unsub in unsubs:
+            unsub()
+        unsubs.clear()
+
+    return async_remove

--- a/homeassistant/components/webostv/triggers/turn_on.py
+++ b/homeassistant/components/webostv/triggers/turn_on.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from ..const import DOMAIN
 from ..helpers import (
-    async_get_client_wrapper_by_device_id,
+    async_get_client_wrapper_by_device_entry,
     async_get_device_entry_by_device_id,
     async_get_device_id_from_entity_id,
 )
@@ -72,14 +72,11 @@ async def async_attach_trigger(
             "description": f"webostv turn on trigger for {device_name}",
         }
 
-        if (
-            wrapper := async_get_client_wrapper_by_device_id(hass, device_id, device)
-        ) is None:
-            raise ValueError(
-                f"Device {device_id} is not from an existing {DOMAIN} config entry"
-            )
+        client_wrapper = async_get_client_wrapper_by_device_entry(hass, device)
 
-        unsubs.append(wrapper.turn_on.async_attach(action, {"trigger": variables}))
+        unsubs.append(
+            client_wrapper.turn_on.async_attach(action, {"trigger": variables})
+        )
 
     @callback
     def async_remove() -> None:

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -19,7 +19,7 @@ async def test_get_triggers(hass, client):
     turn_on_trigger = {
         "platform": "device",
         "domain": DOMAIN,
-        "type": "turn_on",
+        "type": "webostv.turn_on",
         "device_id": device.id,
     }
 
@@ -44,7 +44,7 @@ async def test_if_fires_on_turn_on_request(hass, calls, client):
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": device.id,
-                        "type": "turn_on",
+                        "type": "webostv.turn_on",
                     },
                     "action": {
                         "service": "test.automation",
@@ -53,8 +53,21 @@ async def test_if_fires_on_turn_on_request(hass, calls, client):
                             "id": "{{ trigger.id }}",
                         },
                     },
-                }
-            ]
+                },
+                {
+                    "trigger": {
+                        "platform": "webostv.turn_on",
+                        "entity_id": ENTITY_ID,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": ENTITY_ID,
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                },
+            ],
         },
     )
 
@@ -66,9 +79,11 @@ async def test_if_fires_on_turn_on_request(hass, calls, client):
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data["some"] == device.id
     assert calls[0].data["id"] == 0
+    assert calls[1].data["some"] == ENTITY_ID
+    assert calls[1].data["id"] == 0
 
 
 async def test_get_triggers_for_invalid_device_id(hass, caplog):
@@ -85,7 +100,7 @@ async def test_get_triggers_for_invalid_device_id(hass, caplog):
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "invalid_device_id",
-                        "type": "turn_on",
+                        "type": "webostv.turn_on",
                     },
                     "action": {
                         "service": "test.automation",
@@ -101,6 +116,6 @@ async def test_get_triggers_for_invalid_device_id(hass, caplog):
     await hass.async_block_till_done()
 
     assert (
-        "Invalid config for [automation]: Device not found: invalid_device_id"
+        "Invalid config for [automation]: Device invalid_device_id is not a valid webostv device"
         in caplog.text
     )

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -1,0 +1,120 @@
+"""The tests for WebOS TV automation triggers."""
+from homeassistant.components import automation
+from homeassistant.components.webostv import DOMAIN
+from homeassistant.helpers.device_registry import async_get as get_dev_reg
+from homeassistant.setup import async_setup_component
+
+from . import ENTITY_ID, setup_webostv
+
+
+async def test_webostv_turn_on_trigger_device_id(hass, calls, client):
+    """Test for turn_on triggers by device_id firing."""
+    await setup_webostv(hass, "fake-uuid")
+
+    device_reg = get_dev_reg(hass)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, "fake-uuid")})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "webostv.turn_on",
+                        "device_id": device.id,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": device.id,
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    await hass.services.async_call(
+        "media_player",
+        "turn_on",
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == device.id
+    assert calls[0].data["id"] == 0
+
+
+async def test_webostv_turn_on_trigger_entity_id(hass, calls, client):
+    """Test for turn_on triggers by entity_id firing."""
+    await setup_webostv(hass, "fake-uuid")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "webostv.turn_on",
+                        "entity_id": ENTITY_ID,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": ENTITY_ID,
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    await hass.services.async_call(
+        "media_player",
+        "turn_on",
+        {"entity_id": ENTITY_ID},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == ENTITY_ID
+    assert calls[0].data["id"] == 0
+
+
+async def test_wrong_trigger_platform_type(hass, caplog, client):
+    """Test wrong trigger platform type."""
+    await setup_webostv(hass, "fake-uuid")
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "webostv.wrong_type",
+                        "entity_id": ENTITY_ID,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": ENTITY_ID,
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    assert (
+        "ValueError: Unknown webOS Smart TV trigger platform webostv.wrong_type"
+        in caplog.text
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently our device triggers does not originate from a fired event, as requested here https://github.com/home-assistant/core/pull/62620#discussion_r774168643 the device trigger is reworked to use custom trigger platform.

Example YAML:
```yaml
automation 1:
  trigger:
    - platform: webostv.turn_on
      entity_id: media_player.lg_webos_smart_tv
  action:
    - service: logbook.log
      data:
        message: test turn on
        name: test action
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
