### PR TITLE
Enable package camera by default for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -40,9 +40,7 @@ def get_camera_channels(
 
         is_default = True
         for channel in camera.channels:
-            # G4 Doorbell Pro as a 4th camera channel for package camera,
-            # it is _always_ named "Package Camera"
-            if channel.name == "Package Camera":
+            if channel.is_package:
                 yield camera, channel, True
             elif channel.is_rtsp_enabled:
                 yield camera, channel, is_default
@@ -73,11 +71,11 @@ async def async_setup_entry(
                 channel,
                 is_default,
                 True,
-                disable_stream or channel.fps <= 2,
+                disable_stream or channel.is_package,
             )
         )
 
-        if channel.is_rtsp_enabled and channel.fps > 2:
+        if channel.is_rtsp_enabled and not channel.is_package:
             entities.append(
                 ProtectCamera(
                     data,

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -40,14 +40,13 @@ def get_camera_channels(
 
         is_default = True
         for channel in camera.channels:
-            if channel.is_rtsp_enabled:
-                # G4 Doorbell Pro as a 4th camera channel for package camera,
-                # it is _always_ named "Package Camera"
-                if channel.name == "Package Camera":
-                    yield camera, channel, True
-                else:
-                    yield camera, channel, is_default
-                    is_default = False
+            # G4 Doorbell Pro as a 4th camera channel for package camera,
+            # it is _always_ named "Package Camera"
+            if channel.name == "Package Camera":
+                yield camera, channel, True
+            elif channel.is_rtsp_enabled:
+                yield camera, channel, is_default
+                is_default = False
 
         # no RTSP enabled use first channel with no stream
         if is_default:

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "requirements": [
-    "pyunifiprotect==1.6.1"
+    "pyunifiprotect==1.6.2"
   ],
   "dependencies": [
     "http"

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -48,7 +48,7 @@ INFRARED_MODES = [
 
 CHIME_TYPES = [
     {"id": ChimeType.NONE.value, "name": "None"},
-    {"id": ChimeType.MECHINCAL.value, "name": "Mechanical"},
+    {"id": ChimeType.MECHANICAL.value, "name": "Mechanical"},
     {"id": ChimeType.DIGITAL.value, "name": "Digital"},
 ]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2015,7 +2015,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==1.6.1
+pyunifiprotect==1.6.2
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==21.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1240,7 +1240,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==1.6.1
+pyunifiprotect==1.6.2
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==21.11.0

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -272,6 +272,7 @@ async def test_basic_setup(
     camera_package.channels[1].is_rtsp_enabled = False
     camera_package.channels[2].is_rtsp_enabled = False
     package_channel = camera_package.channels[0].copy(deep=True)
+    package_channel.is_rtsp_enabled = False
     package_channel.name = "Package Camera"
     package_channel.id = 3
     package_channel.fps = 2

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -259,16 +259,36 @@ async def test_basic_setup(
     camera_no_channels.channels[1].is_rtsp_enabled = False
     camera_no_channels.channels[2].is_rtsp_enabled = False
 
+    camera_package = mock_camera.copy(deep=True)
+    camera_package._api = mock_entry.api
+    camera_package.channels[0]._api = mock_entry.api
+    camera_package.channels[1]._api = mock_entry.api
+    camera_package.channels[2]._api = mock_entry.api
+    camera_package.name = "Test Camera 5"
+    camera_package.id = "test_package"
+    camera_package.channels[0].is_rtsp_enabled = True
+    camera_package.channels[0].name = "High"
+    camera_package.channels[0].rtsp_alias = "test_high_alias"
+    camera_package.channels[1].is_rtsp_enabled = False
+    camera_package.channels[2].is_rtsp_enabled = False
+    package_channel = camera_package.channels[0].copy(deep=True)
+    package_channel.name = "Package Camera"
+    package_channel.id = 3
+    package_channel.fps = 2
+    package_channel.rtsp_alias = "test_package_alias"
+    camera_package.channels.append(package_channel)
+
     mock_entry.api.bootstrap.cameras = {
         camera_high_only.id: camera_high_only,
         camera_medium_only.id: camera_medium_only,
         camera_all_channels.id: camera_all_channels,
         camera_no_channels.id: camera_no_channels,
+        camera_package.id: camera_package,
     }
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)
     await hass.async_block_till_done()
 
-    assert_entity_counts(hass, Platform.CAMERA, 11, 4)
+    assert_entity_counts(hass, Platform.CAMERA, 14, 6)
 
     # test camera 1
     entity_id = validate_default_camera_entity(hass, camera_high_only, 0)
@@ -314,6 +334,19 @@ async def test_basic_setup(
     entity_id = validate_default_camera_entity(hass, camera_no_channels, 0)
     await validate_no_stream_camera_state(
         hass, camera_no_channels, 0, entity_id, features=0
+    )
+
+    # test camera 5
+    entity_id = validate_default_camera_entity(hass, camera_package, 0)
+    await validate_rtsps_camera_state(hass, camera_package, 0, entity_id)
+
+    entity_id = validate_rtsp_camera_entity(hass, camera_package, 0)
+    await enable_entity(hass, mock_entry.entry.entry_id, entity_id)
+    await validate_rtsp_camera_state(hass, camera_package, 0, entity_id)
+
+    entity_id = validate_default_camera_entity(hass, camera_package, 3)
+    await validate_no_stream_camera_state(
+        hass, camera_package, 3, entity_id, features=0
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

HACS integration is complete, this is the first "new" feature for the UniFi Protect integration. 

This enables the Package Camera on the new G4 Doorbell Pro by default. It was already being added to HA previously due to a camera entity being added for all channels.

The package camera also has streaming forcibly disabled since the stream is only 2 FPS (causes a ton of buffering since there is not enough frames for a full HLS segment).

Changelog for version bump: https://github.com/briis/pyunifiprotect/releases/tag/v1.6.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21163

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
