### PR TITLE
Add Chime Type select for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -82,18 +82,6 @@ CAMERA_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (
         ufp_value="isp_settings.zoom_position",
         ufp_set_method="set_camera_zoom",
     ),
-    ProtectNumberEntityDescription(
-        key="duration",
-        name="Chime Duration",
-        icon="mdi:camera-timer",
-        entity_category=EntityCategory.CONFIG,
-        ufp_min=0,
-        ufp_max=10000,
-        ufp_step=100,
-        ufp_required_field="feature_flags.has_chime",
-        ufp_value="chime_duration",
-        ufp_set_method="set_chime_duration",
-    ),
 )
 
 LIGHT_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -48,7 +48,7 @@ INFRARED_MODES = [
 
 CHIME_TYPES = [
     {"id": ChimeType.NONE.value, "name": "None"},
-    {"id": ChimeType.MECHINCAL.value, "name": "Mechincal"},
+    {"id": ChimeType.MECHINCAL.value, "name": "Mechanical"},
     {"id": ChimeType.DIGITAL.value, "name": "Digital"},
 ]
 

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -19,6 +19,7 @@ from pyunifiprotect.data import (
     RecordingMode,
     Viewer,
 )
+from pyunifiprotect.data.types import ChimeType
 import voluptuous as vol
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -43,6 +44,12 @@ INFRARED_MODES = [
     {"id": IRLEDMode.ON.value, "name": "Always Enable"},
     {"id": IRLEDMode.AUTO_NO_LED.value, "name": "Auto (Filter Only, no LED's)"},
     {"id": IRLEDMode.OFF.value, "name": "Always Disable"},
+]
+
+CHIME_TYPES = [
+    {"id": ChimeType.NONE.value, "name": "None"},
+    {"id": ChimeType.MECHINCAL.value, "name": "Mechincal"},
+    {"id": ChimeType.DIGITAL.value, "name": "Digital"},
 ]
 
 LIGHT_MODE_MOTION = "On Motion - Always"
@@ -211,6 +218,17 @@ CAMERA_SELECTS: tuple[ProtectSelectEntityDescription, ...] = (
         ufp_value_fn=_get_doorbell_current,
         ufp_options_callable=_get_doorbell_options,
         ufp_set_method_fn=_set_doorbell_message,
+    ),
+    ProtectSelectEntityDescription(
+        key="chime_type",
+        name="Chime Type",
+        icon="mdi:bell",
+        entity_category=EntityCategory.CONFIG,
+        ufp_required_field="feature_flags.has_chime",
+        ufp_options=CHIME_TYPES,
+        ufp_enum_type=ChimeType,
+        ufp_value="chime_type",
+        ufp_set_method="set_chime_type",
     ),
 )
 

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -70,7 +70,6 @@ async def camera_fixture(
     camera_obj.channels[1]._api = mock_entry.api
     camera_obj.channels[2]._api = mock_entry.api
     camera_obj.name = "Test Camera"
-    camera_obj.feature_flags.has_chime = True
     camera_obj.feature_flags.can_optical_zoom = True
     camera_obj.feature_flags.has_mic = True
     # has_wdr is an the inverse of has HDR
@@ -78,7 +77,6 @@ async def camera_fixture(
     camera_obj.isp_settings.wdr = 0
     camera_obj.mic_volume = 0
     camera_obj.isp_settings.zoom_position = 0
-    camera_obj.chime_duration = 0
 
     mock_entry.api.bootstrap.reset_objects()
     mock_entry.api.bootstrap.cameras = {
@@ -88,7 +86,7 @@ async def camera_fixture(
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)
     await hass.async_block_till_done()
 
-    assert_entity_counts(hass, Platform.NUMBER, 4, 4)
+    assert_entity_counts(hass, Platform.NUMBER, 3, 3)
 
     yield camera_obj
 
@@ -152,7 +150,6 @@ async def test_number_setup_camera_none(
     camera_obj.channels[1]._api = mock_entry.api
     camera_obj.channels[2]._api = mock_entry.api
     camera_obj.name = "Test Camera"
-    camera_obj.feature_flags.has_chime = False
     camera_obj.feature_flags.can_optical_zoom = False
     camera_obj.feature_flags.has_mic = False
     # has_wdr is an the inverse of has HDR
@@ -217,7 +214,7 @@ async def test_number_light_sensitivity(hass: HomeAssistant, light: Light):
 
 
 async def test_number_light_duration(hass: HomeAssistant, light: Light):
-    """Test chime duration number entity for lights."""
+    """Test auto-shutoff duration number entity for lights."""
 
     description = LIGHT_NUMBERS[1]
 

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -93,9 +93,11 @@ async def camera_fixture(
     camera_obj.channels[2]._api = mock_entry.api
     camera_obj.name = "Test Camera"
     camera_obj.feature_flags.has_lcd_screen = True
+    camera_obj.feature_flags.has_chime = True
     camera_obj.recording_settings.mode = RecordingMode.ALWAYS
     camera_obj.isp_settings.ir_led_mode = IRLEDMode.AUTO
     camera_obj.lcd_message = None
+    camera_obj.chime_duration = 0
 
     mock_entry.api.bootstrap.reset_objects()
     mock_entry.api.bootstrap.cameras = {
@@ -105,7 +107,7 @@ async def camera_fixture(
     await hass.config_entries.async_setup(mock_entry.entry.entry_id)
     await hass.async_block_till_done()
 
-    assert_entity_counts(hass, Platform.SELECT, 3, 3)
+    assert_entity_counts(hass, Platform.SELECT, 4, 4)
 
     yield camera_obj
 
@@ -140,7 +142,7 @@ async def light_fixture(
     await hass.config_entries.async_reload(mock_entry.entry.entry_id)
     await hass.async_block_till_done()
 
-    assert_entity_counts(hass, Platform.SELECT, 5, 5)
+    assert_entity_counts(hass, Platform.SELECT, 6, 6)
 
     yield light_obj
 
@@ -163,6 +165,7 @@ async def camera_none_fixture(
     camera_obj.channels[2]._api = mock_entry.api
     camera_obj.name = "Test Camera"
     camera_obj.feature_flags.has_lcd_screen = False
+    camera_obj.feature_flags.has_chime = False
     camera_obj.recording_settings.mode = RecordingMode.ALWAYS
     camera_obj.isp_settings.ir_led_mode = IRLEDMode.AUTO
 
@@ -235,7 +238,7 @@ async def test_select_setup_camera_all(
     """Test select entity setup for camera devices (all features)."""
 
     entity_registry = er.async_get(hass)
-    expected_values = ("Always", "Auto", "Default Message (Welcome)")
+    expected_values = ("Always", "Auto", "Default Message (Welcome)", "None")
 
     for index, description in enumerate(CAMERA_SELECTS):
         unique_id, entity_id = ids_from_device_description(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Replaces the "Chime Duration" number entity with a "Chime Type" select entity. UniFi Protect only uses 3 values for Chime Duration: 0, 300, and 1000. These map directly to the values None, Mechanical and Digital inside of the UniFi Protect UI.

Setting the value to other values may have unintended side-effects and we should stop allowing it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21166

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
