### PR TITLE
Add switch entity to Overkiz integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -823,6 +823,7 @@ omit =
     homeassistant/components/overkiz/scene.py
     homeassistant/components/overkiz/select.py
     homeassistant/components/overkiz/sensor.py
+    homeassistant/components/overkiz/switch.py
     homeassistant/components/ovo_energy/__init__.py
     homeassistant/components/ovo_energy/const.py
     homeassistant/components/ovo_energy/sensor.py

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -39,5 +39,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIClass.LIGHT: Platform.LIGHT,
     UIClass.ON_OFF: Platform.SWITCH,
+    UIWidget.RTD_INDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
+    UIWidget.RTD_OUTDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIClass.SWIMMING_POOL: Platform.SWITCH,
 }

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -25,6 +25,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SCENE,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 IGNORED_OVERKIZ_DEVICES: list[UIClass | UIWidget] = [
@@ -35,5 +36,8 @@ IGNORED_OVERKIZ_DEVICES: list[UIClass | UIWidget] = [
 # Used to map the Somfy widget and ui_class to the Home Assistant platform
 OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIClass.DOOR_LOCK: Platform.LOCK,
+    UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIClass.LIGHT: Platform.LIGHT,
+    UIClass.ON_OFF: Platform.SWITCH,
+    UIClass.SWIMMING_POOL: Platform.SWITCH,
 }

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -96,8 +96,10 @@ class OverkizDescriptiveEntity(OverkizEntity):
         """Initialize the device."""
         super().__init__(device_url, coordinator)
         self.entity_description = description
-        self._attr_name = f"{super().name} {self.entity_description.name}"
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
+
+        if self.entity_description.name:
+            self._attr_name = f"{super().name} {self.entity_description.name}"
 
 
 # Used by translations of state and select sensors

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -49,6 +49,7 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
         is_on=lambda select_state: (
             select_state(OverkizState.IO_FORCE_HEATING) == OverkizCommandParam.ON
         ),
+        icon="mdi:water-boiler",
     ),
     OverkizSwitchDescription(
         key=UIClass.ON_OFF,
@@ -66,6 +67,7 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
         is_on=lambda select_state: (
             select_state(OverkizState.CORE_ON_OFF) == OverkizCommandParam.ON
         ),
+        icon="mdi:pool",
     ),
     OverkizSwitchDescription(
         key=UIWidget.RTD_INDOOR_SIREN,

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Awaitable
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.enums.ui import UIClass, UIWidget
@@ -27,8 +27,8 @@ from .entity import OverkizDescriptiveEntity
 class OverkizSwitchDescriptionMixin:
     """Define an entity description mixin for number entities."""
 
-    turn_on: Callable[[Callable], None]
-    turn_off: Callable[[Callable], None]
+    turn_on: Callable[[Callable], Awaitable[None]]
+    turn_off: Callable[[Callable], Awaitable[None]]
     is_on: Callable[[Callable], bool]
 
 
@@ -66,6 +66,24 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
         is_on=lambda select_state: (
             select_state(OverkizState.CORE_ON_OFF) == OverkizCommandParam.ON
         ),
+    ),
+    OverkizSwitchDescription(
+        key=UIWidget.RTD_INDOOR_SIREN,
+        turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
+        is_on=lambda select_state: (
+            select_state(OverkizState.CORE_ON_OFF) == OverkizCommandParam.ON
+        ),
+        icon="mdi:bell",
+    ),
+    OverkizSwitchDescription(
+        key=UIWidget.RTD_OUTDOOR_SIREN,
+        turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
+        is_on=lambda select_state: (
+            select_state(OverkizState.CORE_ON_OFF) == OverkizCommandParam.ON
+        ),
+        icon="mdi:bell",
     ),
 ]
 

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.enums.ui import UIClass, UIWidget
+from pyoverkiz.types import StateType as OverkizStateType
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -19,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
-from .const import DOMAIN, OverkizStateType
+from .const import DOMAIN
 from .entity import OverkizDescriptiveEntity
 
 
@@ -89,6 +90,10 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
     ),
 ]
 
+SUPPORTED_DEVICES = {
+    description.key: description for description in SWITCH_DESCRIPTIONS
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -99,12 +104,8 @@ async def async_setup_entry(
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
     entities: list[OverkizSwitch] = []
 
-    supported_devices = {
-        description.key: description for description in SWITCH_DESCRIPTIONS
-    }
-
     for device in data.platforms[Platform.SWITCH]:
-        if description := supported_devices.get(device.widget) or supported_devices.get(
+        if description := SUPPORTED_DEVICES.get(device.widget) or SUPPORTED_DEVICES.get(
             device.ui_class
         ):
             entities.append(

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -1,0 +1,117 @@
+"""Support for Overkiz switches."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+from pyoverkiz.enums.ui import UIClass, UIWidget
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HomeAssistantOverkizData
+from .const import DOMAIN
+from .entity import OverkizDescriptiveEntity
+
+
+@dataclass
+class OverkizSwitchDescriptionMixin:
+    """Define an entity description mixin for number entities."""
+
+    turn_on: Callable[[Callable], None]
+    turn_off: Callable[[Callable], None]
+    is_on: Callable[[Callable], bool]
+
+
+@dataclass
+class OverkizSwitchDescription(SwitchEntityDescription, OverkizSwitchDescriptionMixin):
+    """Class to describe an Overkiz number."""
+
+
+SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
+    OverkizSwitchDescription(
+        key=UIWidget.DOMESTIC_HOT_WATER_TANK,
+        turn_on=lambda execute_command: execute_command(
+            OverkizCommand.SET_FORCE_HEATING, OverkizCommandParam.ON
+        ),
+        turn_off=lambda execute_command: execute_command(
+            OverkizCommand.SET_FORCE_HEATING, OverkizCommandParam.OFF
+        ),
+        is_on=lambda select_state: (
+            select_state(OverkizState.IO_FORCE_HEATING) == OverkizCommandParam.ON
+        ),
+    ),
+    OverkizSwitchDescription(
+        key=UIClass.ON_OFF,
+        turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
+        is_on=lambda select_state: (
+            select_state(OverkizState.CORE_ON_OFF) == OverkizCommandParam.ON
+        ),
+        device_class=SwitchDeviceClass.OUTLET,
+    ),
+    OverkizSwitchDescription(
+        key=UIClass.SWIMMING_POOL,
+        turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
+        is_on=lambda select_state: (
+            select_state(OverkizState.CORE_ON_OFF) == OverkizCommandParam.ON
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up the Overkiz switch from a config entry."""
+    data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
+    entities: list[OverkizSwitch] = []
+
+    key_supported_devices = {
+        description.key: description for description in SWITCH_DESCRIPTIONS
+    }
+
+    for device in data.platforms[Platform.SWITCH]:
+        if description := key_supported_devices.get(
+            device.widget
+        ) or key_supported_devices.get(device.ui_class):
+            entities.append(
+                OverkizSwitch(
+                    device.device_url,
+                    data.coordinator,
+                    description,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class OverkizSwitch(OverkizDescriptiveEntity, SwitchEntity):
+    """Representation an Overkiz Switch."""
+
+    entity_description: OverkizSwitchDescription
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self.entity_description.is_on(self.executor.select_state)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.entity_description.turn_on(self.executor.async_execute_command)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.entity_description.turn_off(self.executor.async_execute_command)

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -119,7 +119,7 @@ async def async_setup_entry(
 
 
 class OverkizSwitch(OverkizDescriptiveEntity, SwitchEntity):
-    """Representation an Overkiz Switch."""
+    """Representation of an Overkiz Switch."""
 
     entity_description: OverkizSwitchDescription
 

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
-from .const import DOMAIN
+from .const import DOMAIN, OverkizStateType
 from .entity import OverkizDescriptiveEntity
 
 
@@ -27,9 +27,9 @@ from .entity import OverkizDescriptiveEntity
 class OverkizSwitchDescriptionMixin:
     """Define an entity description mixin for switch entities."""
 
-    turn_on: Callable[[Callable], Awaitable[None]]
-    turn_off: Callable[[Callable], Awaitable[None]]
-    is_on: Callable[[Callable], bool]
+    turn_on: Callable[[Callable[..., Awaitable[None]]], Awaitable[None]]
+    turn_off: Callable[[Callable[..., Awaitable[None]]], Awaitable[None]]
+    is_on: Callable[[Callable[[str], OverkizStateType]], bool]
 
 
 @dataclass
@@ -92,7 +92,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
     """Set up the Overkiz switch from a config entry."""
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
     entities: list[OverkizSwitch] = []

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -1,9 +1,9 @@
 """Support for Overkiz switches."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Awaitable
+from typing import Any
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.enums.ui import UIClass, UIWidget

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -79,14 +79,14 @@ async def async_setup_entry(
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
     entities: list[OverkizSwitch] = []
 
-    key_supported_devices = {
+    supported_devices = {
         description.key: description for description in SWITCH_DESCRIPTIONS
     }
 
     for device in data.platforms[Platform.SWITCH]:
-        if description := key_supported_devices.get(
-            device.widget
-        ) or key_supported_devices.get(device.ui_class):
+        if description := supported_devices.get(device.widget) or supported_devices.get(
+            device.ui_class
+        ):
             entities.append(
                 OverkizSwitch(
                     device.device_url,

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -25,7 +25,7 @@ from .entity import OverkizDescriptiveEntity
 
 @dataclass
 class OverkizSwitchDescriptionMixin:
-    """Define an entity description mixin for number entities."""
+    """Define an entity description mixin for switch entities."""
 
     turn_on: Callable[[Callable], Awaitable[None]]
     turn_off: Callable[[Callable], Awaitable[None]]
@@ -34,7 +34,7 @@ class OverkizSwitchDescriptionMixin:
 
 @dataclass
 class OverkizSwitchDescription(SwitchEntityDescription, OverkizSwitchDescriptionMixin):
-    """Class to describe an Overkiz number."""
+    """Class to describe an Overkiz switch."""
 
 
 SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [


### PR DESCRIPTION
## Proposed change
The `switch` platform for Overkiz. The difference compared to other platforms is that we don't check here for the state key, but check for device ui_class or widget. This is because we want to describe which devices have which switches, instead of enabling them for all devices with that available state. (since this will be duplicate functionality with climate etc.)

The `SWITCH_DESCRIPTIONS` use lambda's where quite some span more than a single line, however I think in this situation it is better for readability to keep them like this, instead of moving all of them to separate functions. Happy to hear other opinions.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21167

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
