### PR TITLE
Fix changed port on Netgear R7000

### DIFF
--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -22,7 +22,9 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_NAME,
     DOMAIN,
+    MODELS_PORT_5555,
     MODELS_PORT_80,
+    PORT_5555,
     PORT_80,
 )
 from .errors import CannotLoginException
@@ -126,15 +128,16 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         device_url = urlparse(discovery_info.ssdp_location)
         if device_url.hostname:
             updated_data[CONF_HOST] = device_url.hostname
-        if device_url.scheme == "https":
-            updated_data[CONF_SSL] = True
-        else:
-            updated_data[CONF_SSL] = False
 
         _LOGGER.debug("Netgear ssdp discovery info: %s", discovery_info)
 
         await self.async_set_unique_id(discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL])
         self._abort_if_unique_id_configured(updates=updated_data)
+
+        if device_url.scheme == "https":
+            updated_data[CONF_SSL] = True
+        else:
+            updated_data[CONF_SSL] = False
 
         updated_data[CONF_PORT] = DEFAULT_PORT
         for model in MODELS_PORT_80:
@@ -144,6 +147,14 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 model
             ):
                 updated_data[CONF_PORT] = PORT_80
+        for model in MODELS_PORT_5555:
+            if discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(
+                model
+            ) or discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(
+                model
+            ):
+                updated_data[CONF_PORT] = PORT_5555
+                updated_data[CONF_SSL] = True
 
         self.placeholders.update(updated_data)
         self.discovered = True

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -22,10 +22,10 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_NAME,
     DOMAIN,
-    MODELS_PORT_5555,
     MODELS_PORT_80,
-    PORT_5555,
+    MODELS_PORT_5555,
     PORT_80,
+    PORT_5555,
 )
 from .errors import CannotLoginException
 from .router import get_api

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -32,6 +32,10 @@ MODELS_PORT_80 = [
     "SXS",
 ]
 PORT_80 = 80
+MODELS_PORT_5555 = [
+    "R7000",
+]
+PORT_5555 = 5555
 # update method V2 models
 MODELS_V2 = [
     "Orbi",

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 from tests.common import MockConfigEntry
 
 URL = "http://routerlogin.net"
+URL_SSL = "https://routerlogin.net"
 SERIAL = "5ER1AL0000001"
 
 ROUTER_INFOS = {
@@ -49,6 +50,7 @@ ROUTER_INFOS = {
     "DeviceModeCapability": "0;1",
 }
 TITLE = f"{ROUTER_INFOS['ModelName']} - {ROUTER_INFOS['DeviceName']}"
+TITLE_INCOMPLETE = ROUTER_INFOS["ModelName"]
 
 HOST = "10.0.0.1"
 SERIAL_2 = "5ER1AL0000002"
@@ -67,6 +69,18 @@ def mock_controller_service():
         "homeassistant.components.netgear.async_setup_entry", return_value=True
     ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
         service_mock.return_value.get_info = Mock(return_value=ROUTER_INFOS)
+        yield service_mock
+
+
+@pytest.fixture(name="service_incomplete")
+def mock_controller_service_incomplete():
+    """Mock a successful service."""
+    router_infos = ROUTER_INFOS.copy()
+    router_infos.pop("DeviceName")
+    with patch(
+        "homeassistant.components.netgear.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
+        service_mock.return_value.get_info = Mock(return_value=router_infos)
         yield service_mock
 
 
@@ -101,6 +115,59 @@ async def test_user(hass, service):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
+    assert result["data"].get(CONF_HOST) == HOST
+    assert result["data"].get(CONF_PORT) == PORT
+    assert result["data"].get(CONF_SSL) == SSL
+    assert result["data"].get(CONF_USERNAME) == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+
+
+async def test_user_connect_error(hass, service_failed):
+    """Test user step with connection failure."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # Have to provide all config
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_SSL: SSL,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "config"}
+
+
+async def test_user_incomplete_info(hass, service_incomplete):
+    """Test user step with incomplete device info."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # Have to provide all config
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_SSL: SSL,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["result"].unique_id == SERIAL
+    assert result["title"] == TITLE_INCOMPLETE
     assert result["data"].get(CONF_HOST) == HOST
     assert result["data"].get(CONF_PORT) == PORT
     assert result["data"].get(CONF_SSL) == SSL
@@ -197,10 +264,10 @@ async def test_ssdp_port_5555(hass, service):
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location=SSDP_URL,
+            ssdp_location=SSDP_URL_SLL,
             upnp={
                 ssdp.ATTR_UPNP_MODEL_NUMBER: MODELS_PORT_5555[0],
-                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
+                ssdp.ATTR_UPNP_PRESENTATION_URL: URL_SSL,
                 ssdp.ATTR_UPNP_SERIAL: SERIAL,
             },
         ),

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -10,8 +10,8 @@ from homeassistant.components.netgear.const import (
     CONF_CONSIDER_HOME,
     DOMAIN,
     MODELS_PORT_5555,
-    PORT_5555,
     PORT_80,
+    PORT_5555,
 )
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import (
@@ -216,7 +216,7 @@ async def test_ssdp_port_5555(hass, service):
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
     assert result["data"].get(CONF_PORT) == PORT_5555
-    assert result["data"].get(CONF_SSL) == True
+    assert result["data"].get(CONF_SSL) is True
     assert result["data"].get(CONF_USERNAME) == DEFAULT_USER
     assert result["data"][CONF_PASSWORD] == PASSWORD
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
On the latest firmware of the Netgear R7000 Nighthawk router (One of the most popular) the SOAP API on port 5000 was closed and does not work anymore.

Fortunately the same SOAP API is still active/was moved to port 5555 where SSL is required.

This PR ensures that SSDP discovery does not wrongfully overwrite the need for SSL and also makes sure the correct port and SSL setting is used for the Netgear R7000.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/63956 https://github.com/home-assistant/home-assistant.io/issues/21204
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
