### PR TITLE
Ensure flux_led is reloaded when the ICtype is changed

### DIFF
--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -137,6 +137,10 @@ class FluxICTypeSelect(FluxConfigSelect):
     async def async_select_option(self, option: str) -> None:
         """Change the ic type."""
         await self._device.async_set_device_config(ic_type=option)
+        # reload since we need to reinit the device
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self.coordinator.entry.entry_id)
+        )
 
 
 class FluxWiringsSelect(FluxConfigSelect):

--- a/tests/components/flux_led/test_select.py
+++ b/tests/components/flux_led/test_select.py
@@ -115,6 +115,7 @@ async def test_select_addressable_strip_config(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: ic_type_entity_id, ATTR_OPTION: "UCS1618"},
             blocking=True,
         )
+        await hass.async_block_till_done()
     bulb.async_set_device_config.assert_called_once_with(ic_type="UCS1618")
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/flux_led/test_select.py
+++ b/tests/components/flux_led/test_select.py
@@ -105,13 +105,18 @@ async def test_select_addressable_strip_config(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: ic_type_entity_id, ATTR_OPTION: "INVALID"},
             blocking=True,
         )
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        "select_option",
-        {ATTR_ENTITY_ID: ic_type_entity_id, ATTR_OPTION: "UCS1618"},
-        blocking=True,
-    )
+
+    with patch(
+        "homeassistant.components.flux_led.async_setup_entry"
+    ) as mock_setup_entry:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            "select_option",
+            {ATTR_ENTITY_ID: ic_type_entity_id, ATTR_OPTION: "UCS1618"},
+            blocking=True,
+        )
     bulb.async_set_device_config.assert_called_once_with(ic_type="UCS1618")
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_select_mutable_0x25_strip_config(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure flux_led is reloaded when the ICtype is changed

- When changing the ICtype the color modes can change
  from RGB to RGBW and back. We need to reload in this
  case

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
