### PR TITLE
Freebox integration RfDomus and IOHomeControl/RTS adapters integration

### DIFF
--- a/homeassistant/components/freebox/binary_sensor.py
+++ b/homeassistant/components/freebox/binary_sensor.py
@@ -1,0 +1,169 @@
+"""Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN, HOME_NODES_BINARY_SENSORS
+from .router import FreeboxRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up the binary_sensors."""
+    router = hass.data[DOMAIN][entry.unique_id]
+    entities = []
+
+    _LOGGER.info(
+        "%s - %s - %s home node(s)", router.name, router.mac, len(router.home_nodes)
+    )
+
+    for home_node in router.home_nodes.values():
+        for endpoint in home_node.get("show_endpoints"):
+            if endpoint["ep_type"] == "signal":
+                if endpoint["name"] == "cover":
+                    entities.append(
+                        FreeboxHomeNodeBinarySensor(
+                            router,
+                            home_node,
+                            endpoint,
+                            HOME_NODES_BINARY_SENSORS[endpoint["name"]],
+                        )
+                    )
+                elif endpoint["name"] == "trigger":
+                    if home_node["category"] == "pir":
+                        entities.append(
+                            FreeboxHomeNodeBinarySensor(
+                                router,
+                                home_node,
+                                endpoint,
+                                HOME_NODES_BINARY_SENSORS["motion"],
+                            )
+                        )
+                    elif home_node["category"] == "dws":
+                        entities.append(
+                            FreeboxHomeNodeBinarySensor(
+                                router,
+                                home_node,
+                                endpoint,
+                                HOME_NODES_BINARY_SENSORS["opening"],
+                            )
+                        )
+
+    async_add_entities(entities, True)
+
+
+class FreeboxBinarySensor(BinarySensorEntity):
+    """Representation of a Freebox binary_sensors."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        description: BinarySensorEntityDescription,
+        unik: Any,
+    ) -> None:
+        """Initialize a Freebox binary_sensors."""
+        self.entity_description = description
+        self._router = router
+        self._unik = unik
+        self._attr_unique_id = f"{router.mac} {description.name} {unik}"
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the Freebox binary_sensors."""
+        state = self._router.sensors[self.entity_description.key]
+        self._attr_is_on = state
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return self._router.device_info
+
+    @callback
+    def async_on_demand_update(self):
+        """Update state."""
+        self.async_update_state()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self.async_update_state()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_sensor_update,
+                self.async_on_demand_update,
+            )
+        )
+
+
+class FreeboxHomeNodeBinarySensor(FreeboxBinarySensor):
+    """Representation of a Freebox Home node sensor."""
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        home_node: dict[str, Any],
+        endpoint: dict[str, Any],
+        description: BinarySensorEntityDescription,
+    ) -> None:
+        """Initialize a Freebox Home node sensor."""
+        super().__init__(router, description, f"{home_node['id']} {endpoint['id']}")
+        self._home_node = home_node
+        self._endpoint = endpoint
+        self._attr_name = f"{home_node['label']} {description.name}"
+        self._unique_id = f"{self._router.mac} {description.key} {self._home_node['id']} {endpoint['id']}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        fw_version = None
+        if "props" in self._home_node:
+            props = self._home_node["props"]
+            if "FwVersion" in props:
+                fw_version = props["FwVersion"]
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._home_node["id"])},
+            model=f'{self._home_node["category"]}',
+            name=f"{self._home_node['label']}",
+            sw_version=fw_version,
+            via_device=(
+                DOMAIN,
+                self._router.mac,
+            ),
+            vendor_name="Freebox SAS",
+            manufacturer="Freebox SAS",
+        )
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the Freebox Home node sensor."""
+        value = None
+
+        current_home_node = self._router.home_nodes.get(self._home_node.get("id"))
+        if current_home_node.get("show_endpoints"):
+            for end_point in current_home_node["show_endpoints"]:
+                if self._endpoint["id"] == end_point["id"]:
+                    value = (
+                        not end_point["value"]
+                        if end_point["name"] == "trigger"
+                        else end_point["value"]
+                    )
+                    break
+
+        self._attr_is_on = value

--- a/homeassistant/components/freebox/camera.py
+++ b/homeassistant/components/freebox/camera.py
@@ -1,0 +1,117 @@
+"""Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.camera import DEFAULT_CONTENT_TYPE
+from homeassistant.components.generic.camera import (
+    CONF_CONTENT_TYPE,
+    CONF_FRAMERATE,
+    CONF_LIMIT_REFETCH_TO_URL_CHANGE,
+    CONF_NAME,
+    CONF_STILL_IMAGE_URL,
+    CONF_STREAM_SOURCE,
+    CONF_VERIFY_SSL,
+    GenericCamera,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import template
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+from .router import FreeboxRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up the camera."""
+    router = hass.data[DOMAIN][entry.unique_id]
+    entities = []
+
+    _LOGGER.info(
+        "%s - %s - %s home node(s)", router.name, router.mac, len(router.home_nodes)
+    )
+    for home_node in router.home_nodes.values():
+        if home_node["category"] == "camera":
+            entities.append(
+                FreeboxHomeNodeCamera(
+                    hass,
+                    router,
+                    home_node,
+                )
+            )
+
+    async_add_entities(entities, True)
+
+
+class FreeBoxCamera(GenericCamera):
+    """Representation of a Freebox camera."""
+
+    def __init__(self, hass, router, home_node):
+        """Initialize as a subclass of GenericCamera."""
+        props = home_node["props"]
+        config = {
+            CONF_NAME: "camera",
+            CONF_STREAM_SOURCE: template.Template(
+                f'http://{props["Login"]}:{props["Pass"]}@{props["Ip"]}/img/stream.m3u8'
+            ),
+            CONF_STILL_IMAGE_URL: template.Template(
+                f'http://{props["Login"]}:{props["Pass"]}@{props["Ip"]}/img/snapshot.cgi?size=4&quality=1'
+            ),
+            CONF_VERIFY_SSL: True,
+            CONF_LIMIT_REFETCH_TO_URL_CHANGE: False,
+            CONF_FRAMERATE: 2,
+            CONF_CONTENT_TYPE: DEFAULT_CONTENT_TYPE,
+        }
+        super().__init__(hass, config)
+        self._router = router
+        self._home_node = home_node
+        self._attr_unique_id = f"{router.mac} camera {home_node['id']}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return self._router.device_info
+
+
+class FreeboxHomeNodeCamera(FreeBoxCamera):
+    """Representation of a Freebox Home node camera."""
+
+    def __init__(
+        self,
+        hass: Any,
+        router: FreeboxRouter,
+        home_node: dict[str, Any],
+    ) -> None:
+        """Initialize a Freebox Home node camera."""
+        super().__init__(hass, router, home_node)
+        self._home_node = home_node
+        self._attr_name = f"{home_node['label']}"
+        self._unique_id = f"{self._router.mac} camera {self._home_node['id']}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        fw_version = None
+        if "props" in self._home_node:
+            props = self._home_node["props"]
+            if "FwVersion" in props:
+                fw_version = props["FwVersion"]
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._home_node["id"])},
+            model=f'{self._home_node["category"]}',
+            name=f"{self._home_node['label']}",
+            sw_version=fw_version,
+            via_device=(
+                DOMAIN,
+                self._router.mac,
+            ),
+            vendor_name="Freebox SAS",
+            manufacturer="Freebox SAS",
+        )

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -24,6 +24,8 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize Freebox config flow."""
         self._host = None
         self._port = None
+        self._enable_device_trackers = True
+        self._enable_home_devices = False
 
     def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
@@ -37,6 +39,12 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
                     vol.Required(CONF_PORT, default=user_input.get(CONF_PORT, "")): int,
+                    vol.Required(
+                        "enable_device_trackers", default=self._enable_device_trackers
+                    ): bool,
+                    vol.Required(
+                        "enable_home_devices", default=self._enable_home_devices
+                    ): bool,
                 }
             ),
             errors=errors or {},
@@ -51,6 +59,8 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._host = user_input[CONF_HOST]
         self._port = user_input[CONF_PORT]
+        self._enable_device_trackers = user_input["enable_device_trackers"]
+        self._enable_home_devices = user_input["enable_home_devices"]
 
         # Check if already configured
         await self.async_set_unique_id(self._host)
@@ -84,7 +94,12 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             return self.async_create_entry(
                 title=self._host,
-                data={CONF_HOST: self._host, CONF_PORT: self._port},
+                data={
+                    CONF_HOST: self._host,
+                    CONF_PORT: self._port,
+                    "enable_device_trackers": self._enable_device_trackers,
+                    "enable_home_devices": self._enable_home_devices,
+                },
             )
 
         except AuthorizationError as error:

--- a/homeassistant/components/freebox/const.py
+++ b/homeassistant/components/freebox/const.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 
 import socket
 
-from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription,
+)
+from homeassistant.components.cover import CoverDeviceClass, CoverEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.const import DATA_RATE_KILOBYTES_PER_SECOND, PERCENTAGE, Platform
 
 DOMAIN = "freebox"
@@ -12,12 +21,19 @@ SERVICE_REBOOT = "reboot"
 APP_DESC = {
     "app_id": "hass",
     "app_name": "Home Assistant",
-    "app_version": "0.106",
+    "app_version": "0.109",
     "device_name": socket.gethostname(),
 }
 API_VERSION = "v6"
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.COVER,
+    Platform.CAMERA,
+]
 
 DEFAULT_DEVICE_NAME = "Unknown device"
 
@@ -25,7 +41,7 @@ DEFAULT_DEVICE_NAME = "Unknown device"
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
 
-
+# Sensors
 CONNECTION_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="rate_down",
@@ -53,11 +69,82 @@ CALL_SENSORS: tuple[SensorEntityDescription, ...] = (
 DISK_PARTITION_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="partition_free_space",
-        name="free space",
+        name="Free space",
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:harddisk",
     ),
 )
+
+HOME_NODE_BATTERY_SENSOR: SensorEntityDescription = SensorEntityDescription(
+    key="battery",
+    name="Battery",
+    entity_category="diagnostic",
+    device_class=SensorDeviceClass.BATTERY,
+    state_class=SensorStateClass.MEASUREMENT,
+    unit_of_measurement=PERCENTAGE,
+)
+
+HOME_NODE_REMOTE_BUTTON_SENSOR: SensorEntityDescription = SensorEntityDescription(
+    key="pushed",
+    name="Last action",
+)
+
+HOME_NODES_SENSORS: dict[str, SensorEntityDescription] = {
+    "battery": HOME_NODE_BATTERY_SENSOR,
+    "pushed": HOME_NODE_REMOTE_BUTTON_SENSOR,
+}
+
+# Binary Sensors
+HOME_NODE_COVER_BINARY_SENSOR: BinarySensorEntityDescription = (
+    BinarySensorEntityDescription(
+        key="cover",
+        name="Cover",
+        entity_category="diagnostic",
+        device_class=BinarySensorDeviceClass.OPENING,
+    )
+)
+
+HOME_NODE_MOTION_BINARY_SENSOR: BinarySensorEntityDescription = (
+    BinarySensorEntityDescription(
+        key="motion",
+        name="Motion",
+        device_class=BinarySensorDeviceClass.MOTION,
+    )
+)
+
+HOME_NODE_OPENING_BINARY_SENSOR: BinarySensorEntityDescription = (
+    BinarySensorEntityDescription(
+        key="opening",
+        name="Status",
+        device_class=BinarySensorDeviceClass.OPENING,
+    )
+)
+
+HOME_NODES_BINARY_SENSORS: dict[str, BinarySensorEntityDescription] = {
+    "cover": HOME_NODE_COVER_BINARY_SENSOR,
+    "opening": HOME_NODE_OPENING_BINARY_SENSOR,
+    "motion": HOME_NODE_MOTION_BINARY_SENSOR,
+}
+
+# Cover
+HOME_NODE_SHUTTER_COVER: CoverEntityDescription = CoverEntityDescription(
+    key="shutter",
+    name="Shutter",
+    device_class=CoverDeviceClass.SHUTTER,
+)
+
+HOME_NODES_COVERS: dict[str, CoverEntityDescription] = {
+    "shutter": HOME_NODE_SHUTTER_COVER,
+}
+
+# Alarm
+HOME_NODES_ALARM_REMOTE_KEY: list[str] = [
+    "Alarm 1 ON",
+    "Alarm OFF",
+    "Alarm 2 ON",
+    "Not used",
+]
+
 
 # Icons
 DEVICE_ICONS = {

--- a/homeassistant/components/freebox/cover.py
+++ b/homeassistant/components/freebox/cover.py
@@ -1,0 +1,222 @@
+"""Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from freebox_api.exceptions import InsufficientPermissionsError
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
+    CoverEntity,
+    CoverEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN, HOME_NODES_COVERS
+from .router import FreeboxRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up the covers."""
+    router = hass.data[DOMAIN][entry.unique_id]
+    entities = []
+
+    _LOGGER.info(
+        "%s - %s - %s home node(s)", router.name, router.mac, len(router.home_nodes)
+    )
+
+    for home_node in router.home_nodes.values():
+        if home_node["category"] == "shutter":
+            entities.append(
+                FreeboxHomeNodeCover(
+                    router,
+                    home_node,
+                    HOME_NODES_COVERS["shutter"],
+                )
+            )
+
+    async_add_entities(entities, True)
+
+
+class FreeboxCover(CoverEntity):
+    """Representation of a Freebox cover."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        description: CoverEntityDescription,
+        unik: Any,
+    ) -> None:
+        """Initialize a Freebox cover."""
+        self.entity_description = description
+        self._router = router
+        self._unik = unik
+        self._attr_unique_id = f"{router.mac} {description.name} {unik}"
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the Freebox cover."""
+        # state = self._router.sensors[self.entity_description.key]
+        # self._attr = state
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return self._router.device_info
+
+    @callback
+    def async_on_demand_update(self):
+        """Update state."""
+        self.async_update_state()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self.async_update_state()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_sensor_update,
+                self.async_on_demand_update,
+            )
+        )
+
+
+class FreeboxHomeNodeCover(FreeboxCover):
+    """Representation of a Freebox Home node cover."""
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        home_node: dict[str, Any],
+        description: CoverEntityDescription,
+    ) -> None:
+        """Initialize a Freebox Home node sensor."""
+        super().__init__(router, description, home_node["id"])
+        self._home_node = home_node
+        self._attr_name = f"{home_node['label']} {description.name}"
+        self._unique_id = (
+            f"{self._router.mac} {description.key} {self._home_node['id']}"
+        )
+        self._attr_supported_features = (
+            SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
+        )
+
+        self._position = None
+        # Discover for set/get endpoints
+        for endpoint in home_node.get("show_endpoints"):
+            if endpoint["name"] == "position_set":
+                if endpoint["ep_type"] == "signal":
+                    self._get_endpoint_id = endpoint["id"]
+                elif endpoint["ep_type"] == "slot":
+                    self._set_endpoint_id = endpoint["id"]
+            elif endpoint["name"] == "stop" and endpoint["ep_type"] == "slot":
+                self._stop_endpoint_id = endpoint["id"]
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        fw_version = None
+        if "props" in self._home_node:
+            props = self._home_node["props"]
+            if "FwVersion" in props:
+                fw_version = props["FwVersion"]
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._home_node["id"])},
+            model=f'{self._home_node["category"]}',
+            name=f"{self._home_node['label']}",
+            sw_version=fw_version,
+            via_device=(
+                DOMAIN,
+                self._router.mac,
+            ),
+            vendor_name="Freebox SAS",
+            manufacturer="Freebox SAS",
+        )
+
+    @callback
+    def async_update_state(self) -> None:
+        """Refresh position and state."""
+        current_home_node = self._router.home_nodes.get(self._home_node.get("id"))
+        if current_home_node.get("show_endpoints"):
+            for end_point in current_home_node["show_endpoints"]:
+                if end_point["id"] == self._get_endpoint_id:
+                    self._position = 100 - end_point["value"]
+        return self._position == 0
+
+    @property
+    def current_cover_position(self):
+        """Return if the current cover position."""
+        return self._position
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._position == 0
+
+    async def set_position(self, position):
+        """Set the cover position from 0 (closed) to 100 (open)."""
+        value_position = {"value": (100 - position)}
+        try:
+            await self._router.api.home.set_home_endpoint_value(
+                self._home_node["id"], self._set_endpoint_id, value_position
+            )
+        except InsufficientPermissionsError:
+            _LOGGER.warning(
+                "Home Assistant does not have permissions to modify the Freebox settings. Please refer to documentation"
+            )
+
+    async def get_position(self):
+        """Get the cover position from 0 (closed) to 100 (open)."""
+        try:
+            ret = await self._router.api.home.get_home_endpoint_value(
+                self._home_node["id"], self._get_endpoint_id
+            )
+            self._position = 100 - ret["value"]
+        except InsufficientPermissionsError:
+            _LOGGER.warning(
+                "Home Assistant does not have permissions to modify the Freebox settings. Please refer to documentation"
+            )
+        print(f"get_position -> {self._position}")
+        return self._position
+
+    async def async_close_cover(self, **kwargs):
+        """Close cover."""
+        await self.set_position(0)
+        self.async_write_ha_state()
+
+    async def async_open_cover(self, **kwargs):
+        """Open cover."""
+        await self.set_position(100)
+        self.async_write_ha_state()
+
+    async def async_set_cover_position(self, **kwargs):
+        """Set cover position."""
+        await self.set_position(kwargs.get(ATTR_POSITION))
+        self.async_write_ha_state()
+
+    async def async_stop_cover(self, **kwargs):
+        """Stop the current cover move."""
+        try:
+            await self._router.api.home.set_home_endpoint_value(
+                self._home_node["id"], self._stop_endpoint_id, {"value": True}
+            )
+        except InsufficientPermissionsError:
+            _LOGGER.warning(
+                "Home Assistant does not have permissions to modify the Freebox settings. Please refer to documentation"
+            )

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -17,7 +17,14 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import CALL_SENSORS, CONNECTION_SENSORS, DISK_PARTITION_SENSORS, DOMAIN
+from .const import (
+    CALL_SENSORS,
+    CONNECTION_SENSORS,
+    DISK_PARTITION_SENSORS,
+    DOMAIN,
+    HOME_NODES_ALARM_REMOTE_KEY,
+    HOME_NODES_SENSORS,
+)
 from .router import FreeboxRouter
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,24 +52,47 @@ async def async_setup_entry(
                 native_unit_of_measurement=TEMP_CELSIUS,
                 device_class=SensorDeviceClass.TEMPERATURE,
             ),
+            router.mac,
         )
         for sensor_name in router.sensors_temperature
     ]
 
     entities.extend(
-        [FreeboxSensor(router, description) for description in CONNECTION_SENSORS]
+        [
+            FreeboxSensor(router, description, router.mac)
+            for description in CONNECTION_SENSORS
+        ]
     )
     entities.extend(
         [FreeboxCallSensor(router, description) for description in CALL_SENSORS]
     )
 
-    _LOGGER.debug("%s - %s - %s disk(s)", router.name, router.mac, len(router.disks))
+    _LOGGER.info("%s - %s - %s disk(s)", router.name, router.mac, len(router.disks))
     entities.extend(
         FreeboxDiskSensor(router, disk, partition, description)
         for disk in router.disks.values()
         for partition in disk["partitions"]
         for description in DISK_PARTITION_SENSORS
     )
+
+    _LOGGER.info(
+        "%s - %s - %s home node(s)", router.name, router.mac, len(router.home_nodes)
+    )
+
+    for home_node in router.home_nodes.values():
+        for endpoint in home_node.get("show_endpoints"):
+            if (
+                endpoint["ep_type"] == "signal"
+                and endpoint["name"] in HOME_NODES_SENSORS.keys()
+            ):
+                entities.append(
+                    FreeboxHomeNodeSensor(
+                        router,
+                        home_node,
+                        endpoint,
+                        HOME_NODES_SENSORS[endpoint["name"]],
+                    )
+                )
 
     async_add_entities(entities, True)
 
@@ -73,12 +103,13 @@ class FreeboxSensor(SensorEntity):
     _attr_should_poll = False
 
     def __init__(
-        self, router: FreeboxRouter, description: SensorEntityDescription
+        self, router: FreeboxRouter, description: SensorEntityDescription, unik: Any
     ) -> None:
         """Initialize a Freebox sensor."""
         self.entity_description = description
         self._router = router
-        self._attr_unique_id = f"{router.mac} {description.name}"
+        self._unik = unik
+        self._attr_unique_id = f"{router.mac} {description.name} {unik}"
 
     @callback
     def async_update_state(self) -> None:
@@ -119,7 +150,7 @@ class FreeboxCallSensor(FreeboxSensor):
         self, router: FreeboxRouter, description: SensorEntityDescription
     ) -> None:
         """Initialize a Freebox call sensor."""
-        super().__init__(router, description)
+        super().__init__(router, description, router.mac)
         self._call_list_for_type = []
 
     @callback
@@ -155,7 +186,7 @@ class FreeboxDiskSensor(FreeboxSensor):
         description: SensorEntityDescription,
     ) -> None:
         """Initialize a Freebox disk sensor."""
-        super().__init__(router, description)
+        super().__init__(router, description, f"{disk['id']} {partition['id']}")
         self._disk = disk
         self._partition = partition
         self._attr_name = f"{partition['label']} {description.name}"
@@ -173,14 +204,78 @@ class FreeboxDiskSensor(FreeboxSensor):
                 DOMAIN,
                 self._router.mac,
             ),
+            vendor_name="Freebox SAS",
+            manufacturer="Freebox SAS",
         )
 
     @callback
     def async_update_state(self) -> None:
         """Update the Freebox disk sensor."""
         value = None
-        if self._partition.get("total_bytes"):
-            value = round(
-                self._partition["free_bytes"] * 100 / self._partition["total_bytes"], 2
-            )
+        current_disk = self._router.disks.get(self._disk.get("id"))
+        for partition in current_disk["partitions"]:
+            if self._partition["id"] == partition["id"]:
+                value = round(
+                    partition["free_bytes"] * 100 / partition["total_bytes"], 2
+                )
+        self._attr_native_value = value
+
+
+class FreeboxHomeNodeSensor(FreeboxSensor):
+    """Representation of a Freebox Home node sensor."""
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        home_node: dict[str, Any],
+        endpoint: dict[str, Any],
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize a Freebox Home node sensor."""
+        super().__init__(router, description, f"{home_node['id']} {endpoint['id']}")
+        self._home_node = home_node
+        self._endpoint = endpoint
+        self._attr_name = f"{home_node['label']} {description.name}"
+        self._unique_id = f"{self._router.mac} {description.key} {self._home_node['id']} {endpoint['id']}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        fw_version = None
+        if "props" in self._home_node:
+            props = self._home_node["props"]
+            if "FwVersion" in props:
+                fw_version = props["FwVersion"]
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._home_node["id"])},
+            model=f'{self._home_node["category"]}',
+            name=f"{self._home_node['label']}",
+            sw_version=fw_version,
+            via_device=(
+                DOMAIN,
+                self._router.mac,
+            ),
+            vendor_name="Freebox SAS",
+            manufacturer="Freebox SAS",
+        )
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the Freebox Home node sensor."""
+        value = None
+
+        current_home_node = self._router.home_nodes.get(self._home_node.get("id"))
+        if current_home_node.get("show_endpoints"):
+            for end_point in current_home_node["show_endpoints"]:
+                if self._endpoint["id"] == end_point["id"]:
+                    if self._endpoint["name"] == "pushed":
+                        if len(end_point.get("history")) > 0:
+                            # Get the latest button pushed as pool mode is a mess
+                            value = end_point.get("history")[-1].get("value")
+                            value = HOME_NODES_ALARM_REMOTE_KEY[int(value) - 1]
+                    else:
+                        value = end_point["value"]
+                    break
+
         self._attr_native_value = value

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from freebox_api.exceptions import InsufficientPermissionsError
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -22,7 +24,180 @@ async def async_setup_entry(
 ) -> None:
     """Set up the switch."""
     router = hass.data[DOMAIN][entry.unique_id]
-    async_add_entities([FreeboxWifiSwitch(router)], True)
+
+    entities = []
+
+    entities.append(FreeboxWifiSwitch(router))
+
+    _LOGGER.info(
+        "%s - %s - %s home node(s)", router.name, router.mac, len(router.home_nodes)
+    )
+
+    for home_node in router.home_nodes.values():
+        if home_node["category"] != "shutter":
+            for endpoint in home_node.get("show_endpoints"):
+                if endpoint["ep_type"] == "slot" and endpoint["value_type"] == "bool":
+                    entities.append(
+                        FreeboxHomeNodeSwitch(
+                            router,
+                            home_node,
+                            endpoint,
+                            endpoint["name"],
+                        )
+                    )
+
+    async_add_entities(entities, True)
+
+
+class FreeboxSwitch(SwitchEntity):
+    """Representation of a Freebox switch."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        endpoint_name: str,
+        unik: Any,
+    ) -> None:
+        """Initialize a Freebox binary_sensors."""
+        self.entity_description = SwitchEntityDescription(
+            key="switch", name=endpoint_name
+        )
+        self._router = router
+        self._unik = unik
+        self._attr_unique_id = f"{router.mac} {endpoint_name} {unik}"
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the Freebox binary_sensors."""
+        # state = self._router.sensors[self.entity_description.key]
+        # self._attr_is_on = state
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return self._router.device_info
+
+    @callback
+    def async_on_demand_update(self):
+        """Update state."""
+        self.async_update_state()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self.async_update_state()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_sensor_update,
+                self.async_on_demand_update,
+            )
+        )
+
+
+class FreeboxHomeNodeSwitch(FreeboxSwitch):
+    """Representation of a Freebox Home node switch."""
+
+    def __init__(
+        self,
+        router: FreeboxRouter,
+        home_node: dict[str, Any],
+        endpoint: dict[str, Any],
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize a Freebox Home node switch."""
+        super().__init__(router, description, f"{home_node['id']} {endpoint['id']}")
+        self._home_node = home_node
+        self._endpoint = endpoint
+        self._attr_name = f"{home_node['label']} {endpoint['name']}"
+        self._unique_id = f"{self._router.mac} {endpoint['name']} {self._home_node['id']} {endpoint['id']}"
+        self._enabled = None
+        self._get_endpoint_id = None
+
+        # Discover for get endpoint
+        for endpoint_candidate in home_node.get("show_endpoints"):
+            if (
+                endpoint_candidate["name"] == endpoint["name"]
+                and endpoint_candidate["ep_type"] == "signal"
+            ):
+                self._get_endpoint_id = endpoint_candidate["id"]
+                break
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        fw_version = None
+        if "props" in self._home_node:
+            props = self._home_node["props"]
+            if "FwVersion" in props:
+                fw_version = props["FwVersion"]
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._home_node["id"])},
+            model=f'{self._home_node["category"]}',
+            name=f"{self._home_node['label']}",
+            sw_version=fw_version,
+            via_device=(
+                DOMAIN,
+                self._router.mac,
+            ),
+            vendor_name="Freebox SAS",
+            manufacturer="Freebox SAS",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return self._enabled
+
+    @callback
+    def async_update_state(self) -> None:
+        """Update the Freebox Home node switch."""
+        current_home_node = self._router.home_nodes.get(self._home_node.get("id"))
+        if current_home_node.get("show_endpoints"):
+            for end_point in current_home_node["show_endpoints"]:
+                if self._get_endpoint_id == end_point["id"]:
+                    self._enabled = end_point["value"]
+                    break
+        self._attr_is_on = self._enabled
+
+    async def _async_set_state(self, enabled: bool):
+        """Turn the switch on or off."""
+        value_enabled = {"value": enabled}
+        try:
+            await self._router.api.home.set_home_endpoint_value(
+                self._home_node["id"], self._endpoint["id"], value_enabled
+            )
+            self._enabled = enabled
+        except InsufficientPermissionsError:
+            _LOGGER.warning(
+                "Home Assistant does not have permissions to modify the Freebox settings. Please refer to documentation"
+            )
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self._async_set_state(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self._async_set_state(False)
+        self.async_write_ha_state()
+
+    async def async_update(self):
+        """Get switch status and update it."""
+        try:
+            ret = await self._router.api.home.get_home_endpoint_value(
+                self._home_node["id"], self._get_endpoint_id
+            )
+            self._enabled = ret["value"]
+        except InsufficientPermissionsError:
+            _LOGGER.warning(
+                "Home Assistant does not have permissions to modify the Freebox settings. Please refer to documentation"
+            )
+        return self._enabled
 
 
 class FreeboxWifiSwitch(SwitchEntity):

--- a/homeassistant/components/freebox/translations/en.json
+++ b/homeassistant/components/freebox/translations/en.json
@@ -16,7 +16,9 @@
             "user": {
                 "data": {
                     "host": "Host",
-                    "port": "Port"
+                    "port": "Port",
+                    "enable_device_trackers": "LAN device tracker",
+                    "enable_home_devices": "IOHomeControl/RTS (ex: Velux) and DomusRf (Alarm)"
                 },
                 "title": "Freebox"
             }

--- a/homeassistant/components/freebox/translations/fr.json
+++ b/homeassistant/components/freebox/translations/fr.json
@@ -16,9 +16,12 @@
             "user": {
                 "data": {
                     "host": "H\u00f4te",
-                    "port": "Port"
+                    "port": "Port",
+                    "enable_device_trackers": "Suivi périphériques connectés sur le LAN",
+                    "enable_home_devices": "Delta (V7) : Suivi de la Maison -> réseaux IOHomeControl/RTS (Ex: Velux) et DomusRf (module Alarme si installé)."
                 },
-                "title": "Freebox"
+                "title": "Freebox",
+                "description": "Aller sur http://mafreebox.freebox.fr/api_version et rentrer la valeur de 'api_domain' dans Hôte et 'https_port' dans Port. Avec la Freebox Delta (V7), cochez l'option 'Suivi de la maison' pour retrouver tous vos périphériques connectés sur tous les réseaux"
             }
         }
     }


### PR DESCRIPTION
## Proposed change
  This PR extends the actual Freebox component.
  French operator FreeBox V7 (Delta) embeds:
- RfDomus adapter, also called "Module alarme". It is a ZigBee fork with a master authentication key with an RFID sensor. It is a mesh 868MHz (without router devices except the Freebox module itself!) network which It supports:
  - PIR devices (Battery sensor, cover binary_sensor, motion binary_sensor, alarm zone switches)
  - Door opening devices (Battery sensor, cover binary_sensor, opening, alarm zone switches)
  - Camera device (WLAN connected, setting switches)
  - Remote control device (Battery sensor, last_button sensor)
  - Alarm device ((Battery sensor and setting switches)
- IOHomeControl adapter (bi-directional)
  - Cover devices (Somfy, Velux,...)
- RTS adapter  (mono-directional)
  - Cover devices (Somfy, Velux,...)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X]  New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [X] 🥈 Silver
- [X] 🥇 Gold (partial)
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
