### PR TITLE
Improve UniFi Protect Smart Sensor support

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -103,7 +103,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="alarm_sound",
         name="Alarm Sound Detected",
-        device_class=BinarySensorDeviceClass.PROBLEM,
+        device_class=BinarySensorDeviceClass.SOUND,
         ufp_value="is_alarm_detected",
         ufp_last_trip_value="alarm_triggered_at",
         ufp_enabled="is_alarm_sensor_enabled",
@@ -111,7 +111,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="tampering",
         name="Tampering Detected",
-        device_class=BinarySensorDeviceClass.PROBLEM,
+        device_class=BinarySensorDeviceClass.TAMPER,
         ufp_value="is_tampering_detected",
         ufp_last_trip_value="tampering_detected_at",
     ),

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -108,14 +108,6 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
         ufp_enabled="is_motion_sensor_enabled",
     ),
     ProtectBinaryEntityDescription(
-        key="alarm_sound",
-        name="Alarm Sound Detected",
-        device_class=BinarySensorDeviceClass.SOUND,
-        ufp_value="is_alarm_detected",
-        ufp_last_trip_value="alarm_triggered_at",
-        ufp_enabled="is_alarm_sensor_enabled",
-    ),
-    ProtectBinaryEntityDescription(
         key="tampering",
         name="Tampering Detected",
         device_class=BinarySensorDeviceClass.TAMPER,

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -5,8 +5,7 @@ from copy import copy
 from dataclasses import dataclass
 import logging
 
-from pyunifiprotect.data import NVR, Camera, Event, Light, Sensor
-from pyunifiprotect.data.types import MountType
+from pyunifiprotect.data import NVR, Camera, Event, Light, MountType, Sensor
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -42,6 +42,13 @@ class ProtectBinaryEntityDescription(
     ufp_last_trip_value: str | None = None
 
 
+MOUNT_DEVICE_CLASS_MAP = {
+    MountType.GARAGE: BinarySensorDeviceClass.GARAGE_DOOR,
+    MountType.WINDOW: BinarySensorDeviceClass.WINDOW,
+    MountType.DOOR: BinarySensorDeviceClass.DOOR,
+}
+
+
 CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="doorbell",
@@ -217,14 +224,9 @@ class ProtectDeviceBinarySensor(ProtectDeviceEntity, BinarySensorEntity):
 
         # UP Sense can be any of the 3 contact sensor device classes
         if self.entity_description.key == _KEY_DOOR and isinstance(self.device, Sensor):
-            if self.device.mount_type == MountType.WINDOW:
-                self.entity_description.device_class = BinarySensorDeviceClass.WINDOW
-            elif self.device.mount_type == MountType.GARAGE:
-                self.entity_description.device_class = (
-                    BinarySensorDeviceClass.GARAGE_DOOR
-                )
-            else:
-                self.entity_description.device_class = BinarySensorDeviceClass.DOOR
+            self.entity_description.device_class = MOUNT_DEVICE_CLASS_MAP.get(
+                self.device.mount_type, BinarySensorDeviceClass.DOOR
+            )
 
 
 class ProtectDiskBinarySensor(ProtectNVREntity, BinarySensorEntity):

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -7,9 +7,14 @@ import logging
 from typing import Any
 
 from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import Bootstrap, ModelType, WSSubscriptionMessage
+from pyunifiprotect.data import (
+    Bootstrap,
+    Event,
+    Liveview,
+    ModelType,
+    WSSubscriptionMessage,
+)
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel, ProtectDeviceModel
-from pyunifiprotect.data.nvr import Liveview
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -115,6 +120,14 @@ class ProtectData:
                 for camera in self.api.bootstrap.cameras.values():
                     if camera.feature_flags.has_lcd_screen:
                         self.async_signal_device_id_update(camera.id)
+        # trigger updates for camera that the event references
+        elif isinstance(message.new_obj, Event):
+            if message.new_obj.camera is not None:
+                self.async_signal_device_id_update(message.new_obj.camera.id)
+            elif message.new_obj.light is not None:
+                self.async_signal_device_id_update(message.new_obj.light.id)
+            elif message.new_obj.sensor is not None:
+                self.async_signal_device_id_update(message.new_obj.sensor.id)
         # alert user viewport needs restart so voice clients can get new options
         elif len(self.api.bootstrap.viewers) > 0 and isinstance(
             message.new_obj, Liveview

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -149,9 +149,19 @@ class ProtectDeviceEntity(Entity):
             devices = getattr(self.data.api.bootstrap, f"{self.device.model.value}s")
             self.device = devices[self.device.id]
 
-        self._attr_available = (
+        is_connected = (
             self.data.last_update_success and self.device.state == StateType.CONNECTED
         )
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description is not None
+            and hasattr(self.entity_description, "get_ufp_enabled")
+        ):
+            assert isinstance(self.entity_description, ProtectRequiredKeysMixin)
+            is_connected = is_connected and self.entity_description.get_ufp_enabled(
+                self.device
+            )
+        self._attr_available = is_connected
 
     @callback
     def _async_updated_event(self) -> None:

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "requirements": [
-    "pyunifiprotect==1.6.2"
+    "pyunifiprotect==1.6.3"
   ],
   "dependencies": [
     "http"

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -23,7 +23,6 @@ class ProtectRequiredKeysMixin:
     ufp_value: str | None = None
     ufp_value_fn: Callable[[ProtectAdoptableDeviceModel | NVR], Any] | None = None
     ufp_enabled: str | None = None
-    ufp_enabled_fn: Callable[[ProtectAdoptableDeviceModel | NVR], bool] | None = None
 
     def get_ufp_value(self, obj: ProtectAdoptableDeviceModel | NVR) -> Any:
         """Return value from UniFi Protect device."""

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -22,6 +22,8 @@ class ProtectRequiredKeysMixin:
     ufp_required_field: str | None = None
     ufp_value: str | None = None
     ufp_value_fn: Callable[[ProtectAdoptableDeviceModel | NVR], Any] | None = None
+    ufp_enabled: str | None = None
+    ufp_enabled_fn: Callable[[ProtectAdoptableDeviceModel | NVR], bool] | None = None
 
     def get_ufp_value(self, obj: ProtectAdoptableDeviceModel | NVR) -> Any:
         """Return value from UniFi Protect device."""
@@ -34,6 +36,12 @@ class ProtectRequiredKeysMixin:
         raise RuntimeError(  # pragma: no cover
             "`ufp_value` or `ufp_value_fn` is required"
         )
+
+    def get_ufp_enabled(self, obj: ProtectAdoptableDeviceModel | NVR) -> bool:
+        """Return value from UniFi Protect device."""
+        if self.ufp_enabled is not None:
+            return bool(get_nested_attr(obj, self.ufp_enabled))
+        return True
 
 
 @dataclass

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -111,6 +111,21 @@ LIGHT_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (
     ),
 )
 
+SENSE_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (
+    ProtectNumberEntityDescription(
+        key="sensitivity",
+        name="Motion Sensitivity",
+        icon="mdi:walk",
+        entity_category=EntityCategory.CONFIG,
+        ufp_min=0,
+        ufp_max=100,
+        ufp_step=1,
+        ufp_required_field=None,
+        ufp_value="motion_settings.sensitivity",
+        ufp_set_method="set_motion_sensitivity",
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -124,6 +139,7 @@ async def async_setup_entry(
         ProtectNumbers,
         camera_descs=CAMERA_NUMBERS,
         light_descs=LIGHT_NUMBERS,
+        sense_descs=SENSE_NUMBERS,
     )
 
     async_add_entities(entities)

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -210,6 +210,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ILLUMINANCE,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.light.value",
+        ufp_enabled="is_light_sensor_enabled",
     ),
     ProtectSensorEntityDescription(
         key="humidity_level",
@@ -218,6 +219,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.humidity.value",
+        ufp_enabled="is_humidity_sensor_enabled",
     ),
     ProtectSensorEntityDescription(
         key="temperature_level",
@@ -226,6 +228,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.temperature.value",
+        ufp_enabled="is_temperature_sensor_enabled",
     ),
 )
 

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pyunifiprotect.data import NVR, Camera, Event
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
+from pyunifiprotect.data.devices import Sensor
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -42,7 +43,7 @@ from .entity import (
 from .models import ProtectRequiredKeysMixin
 
 _LOGGER = logging.getLogger(__name__)
-DETECTED_OBJECT_NONE = "none"
+OBJECT_TYPE_NONE = "none"
 DEVICE_CLASS_DETECTION = "unifiprotect__detection"
 
 
@@ -86,6 +87,19 @@ def _get_nvr_memory(obj: Any) -> float | None:
     if memory.available is None or memory.total is None:
         return None
     return (1 - memory.available / memory.total) * 100
+
+
+def _get_alarm_sound(obj: ProtectAdoptableDeviceModel | NVR) -> str:
+    assert isinstance(obj, Sensor)
+
+    alarm_type = OBJECT_TYPE_NONE
+    if (
+        obj.is_alarm_detected
+        and obj.last_alarm_event is not None
+        and obj.last_alarm_event.metadata is not None
+    ):
+        alarm_type = obj.last_alarm_event.metadata.alarm_type or OBJECT_TYPE_NONE
+    return alarm_type.lower()
 
 
 ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
@@ -229,6 +243,12 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.temperature.value",
         ufp_enabled="is_temperature_sensor_enabled",
+    ),
+    ProtectSensorEntityDescription(
+        key="alarm_sound",
+        name="Alarm Sound Detected",
+        ufp_value_fn=_get_alarm_sound,
+        ufp_enabled="is_alarm_sensor_enabled",
     ),
 )
 
@@ -482,6 +502,6 @@ class ProtectEventSensor(ProtectDeviceSensor, EventThumbnailMixin):
         # do not call ProtectDeviceSensor method since we want event to get value here
         EventThumbnailMixin._async_update_device_from_protect(self)
         if self._event is None:
-            self._attr_native_value = DETECTED_OBJECT_NONE
+            self._attr_native_value = OBJECT_TYPE_NONE
         else:
             self._attr_native_value = self._event.smart_detect_types[0].value

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -152,6 +152,56 @@ CAMERA_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ),
 )
 
+SENSE_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
+    ProtectSwitchEntityDescription(
+        key="status_light",
+        name="Status Light On",
+        icon="mdi:led-on",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="led_settings.is_enabled",
+        ufp_set_method="set_status_light",
+    ),
+    ProtectSwitchEntityDescription(
+        key="motion",
+        name="Motion Detection",
+        icon="mdi:walk",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="motion_settings.is_enabled",
+        ufp_set_method="set_motion_status",
+    ),
+    ProtectSwitchEntityDescription(
+        key="temperature",
+        name="Temperature Sensor",
+        icon="mdi:thermometer",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="temperature_settings.is_enabled",
+        ufp_set_method="set_temperature_status",
+    ),
+    ProtectSwitchEntityDescription(
+        key="humidity",
+        name="Humidity Sensor",
+        icon="mdi:water-percent",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="humidity_settings.is_enabled",
+        ufp_set_method="set_humidity_status",
+    ),
+    ProtectSwitchEntityDescription(
+        key="light",
+        name="Light Sensor",
+        icon="mdi:brightness-5",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="light_settings.is_enabled",
+        ufp_set_method="set_light_status",
+    ),
+    ProtectSwitchEntityDescription(
+        key="alarm",
+        name="Alarm Sound Detection",
+        entity_category=EntityCategory.CONFIG,
+        ufp_value="alarm_settings.is_enabled",
+        ufp_set_method="set_alarm_status",
+    ),
+)
+
 
 LIGHT_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ProtectSwitchEntityDescription(
@@ -178,6 +228,7 @@ async def async_setup_entry(
         all_descs=ALL_DEVICES_SWITCHES,
         camera_descs=CAMERA_SWITCHES,
         light_descs=LIGHT_SWITCHES,
+        sense_descs=SENSE_SWITCHES,
     )
     async_add_entities(entities)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2015,7 +2015,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==1.6.2
+pyunifiprotect==1.6.3
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==21.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1240,7 +1240,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==1.6.2
+pyunifiprotect==1.6.3
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==21.11.0

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -7,8 +7,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Event, EventType, Light, Sensor
-from pyunifiprotect.data.types import MountType
+from pyunifiprotect.data import Camera, Event, EventType, Light, MountType, Sensor
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.unifiprotect.binary_sensor import (

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 from pyunifiprotect.data import NVR, Camera, Event, Sensor
 from pyunifiprotect.data.base import WifiConnectionState, WiredConnectionState
+from pyunifiprotect.data.nvr import EventMetadata
 from pyunifiprotect.data.types import EventType, SmartDetectObjectType
 
 from homeassistant.components.unifiprotect.const import (
@@ -19,13 +20,18 @@ from homeassistant.components.unifiprotect.sensor import (
     ALL_DEVICES_SENSORS,
     CAMERA_DISABLED_SENSORS,
     CAMERA_SENSORS,
-    DETECTED_OBJECT_NONE,
     MOTION_SENSORS,
     NVR_DISABLED_SENSORS,
     NVR_SENSORS,
+    OBJECT_TYPE_NONE,
     SENSE_SENSORS,
 )
-from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNKNOWN, Platform
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -53,6 +59,10 @@ async def sensor_fixture(
     sensor_obj._api = mock_entry.api
     sensor_obj.name = "Test Sensor"
     sensor_obj.battery_status.percentage = 10.0
+    sensor_obj.light_settings.is_enabled = True
+    sensor_obj.humidity_settings.is_enabled = True
+    sensor_obj.temperature_settings.is_enabled = True
+    sensor_obj.alarm_settings.is_enabled = True
     sensor_obj.stats.light.value = 10.0
     sensor_obj.stats.humidity.value = 10.0
     sensor_obj.stats.temperature.value = 10.0
@@ -68,7 +78,46 @@ async def sensor_fixture(
     await hass.async_block_till_done()
 
     # 2 from all, 4 from sense, 12 NVR
-    assert_entity_counts(hass, Platform.SENSOR, 18, 13)
+    assert_entity_counts(hass, Platform.SENSOR, 19, 14)
+
+    yield sensor_obj
+
+    Sensor.__config__.validate_assignment = True
+
+
+@pytest.fixture(name="sensor_none")
+async def sensor_none_fixture(
+    hass: HomeAssistant,
+    mock_entry: MockEntityFixture,
+    mock_sensor: Sensor,
+    now: datetime,
+):
+    """Fixture for a single sensor for testing the sensor platform."""
+
+    # disable pydantic validation so mocking can happen
+    Sensor.__config__.validate_assignment = False
+
+    sensor_obj = mock_sensor.copy(deep=True)
+    sensor_obj._api = mock_entry.api
+    sensor_obj.name = "Test Sensor"
+    sensor_obj.battery_status.percentage = 10.0
+    sensor_obj.light_settings.is_enabled = False
+    sensor_obj.humidity_settings.is_enabled = False
+    sensor_obj.temperature_settings.is_enabled = False
+    sensor_obj.alarm_settings.is_enabled = False
+    sensor_obj.up_since = now
+    sensor_obj.bluetooth_connection_state.signal_strength = -50.0
+
+    mock_entry.api.bootstrap.reset_objects()
+    mock_entry.api.bootstrap.sensors = {
+        sensor_obj.id: sensor_obj,
+    }
+
+    await hass.config_entries.async_setup(mock_entry.entry.entry_id)
+    await hass.async_block_till_done()
+
+    # 2 from all, 4 from sense, 12 NVR
+    assert_entity_counts(hass, Platform.SENSOR, 19, 14)
 
     yield sensor_obj
 
@@ -131,7 +180,7 @@ async def test_sensor_setup_sensor(
 
     entity_registry = er.async_get(hass)
 
-    expected_values = ("10", "10.0", "10.0", "10.0")
+    expected_values = ("10", "10.0", "10.0", "10.0", "none")
     for index, description in enumerate(SENSE_SENSORS):
         unique_id, entity_id = ids_from_device_description(
             Platform.SENSOR, sensor, description
@@ -162,6 +211,35 @@ async def test_sensor_setup_sensor(
     assert state
     assert state.state == "-50"
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+
+
+async def test_sensor_setup_sensor_none(
+    hass: HomeAssistant, mock_entry: MockEntityFixture, sensor_none: Sensor
+):
+    """Test sensor entity setup for sensor devices with no sensors enabled."""
+
+    entity_registry = er.async_get(hass)
+
+    expected_values = (
+        "10",
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+        STATE_UNAVAILABLE,
+    )
+    for index, description in enumerate(SENSE_SENSORS):
+        unique_id, entity_id = ids_from_device_description(
+            Platform.SENSOR, sensor_none, description
+        )
+
+        entity = entity_registry.async_get(entity_id)
+        assert entity
+        assert entity.unique_id == unique_id
+
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state == expected_values[index]
+        assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
 
 async def test_sensor_setup_nvr(
@@ -403,7 +481,7 @@ async def test_sensor_setup_camera(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == DETECTED_OBJECT_NONE
+    assert state.state == OBJECT_TYPE_NONE
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
     assert state.attributes[ATTR_EVENT_SCORE] == 0
 
@@ -426,6 +504,7 @@ async def test_sensor_update_motion(
         smart_detect_types=[SmartDetectObjectType.PERSON],
         smart_detect_event_ids=[],
         camera_id=camera.id,
+        api=mock_entry.api,
     )
 
     new_bootstrap = copy(mock_entry.api.bootstrap)
@@ -435,7 +514,7 @@ async def test_sensor_update_motion(
 
     mock_msg = Mock()
     mock_msg.changed_data = {}
-    mock_msg.new_obj = new_camera
+    mock_msg.new_obj = event
 
     new_bootstrap.cameras = {new_camera.id: new_camera}
     new_bootstrap.events = {event.id: event}
@@ -448,3 +527,45 @@ async def test_sensor_update_motion(
     assert state.state == SmartDetectObjectType.PERSON.value
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
     assert state.attributes[ATTR_EVENT_SCORE] == 100
+
+
+async def test_sensor_update_alarm(
+    hass: HomeAssistant, mock_entry: MockEntityFixture, sensor: Sensor, now: datetime
+):
+    """Test sensor motion entity."""
+
+    _, entity_id = ids_from_device_description(
+        Platform.SENSOR, sensor, SENSE_SENSORS[4]
+    )
+
+    event_metadata = EventMetadata(sensor_id=sensor.id, alarm_type="smoke")
+    event = Event(
+        id="test_event_id",
+        type=EventType.SENSOR_ALARM,
+        start=now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        metadata=event_metadata,
+        api=mock_entry.api,
+    )
+
+    new_bootstrap = copy(mock_entry.api.bootstrap)
+    new_sensor = sensor.copy()
+    new_sensor.set_alarm_timeout()
+    new_sensor.last_alarm_event_id = event.id
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+
+    new_bootstrap.sensors = {new_sensor.id: new_sensor}
+    new_bootstrap.events = {event.id: event}
+    mock_entry.api.bootstrap = new_bootstrap
+    mock_entry.api.ws_subscription(mock_msg)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "smoke"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds missing sensor entities for the Smart Sensor device, all except the leak sensor since the leak accessory has not been released yet. New entities:

* Alarm Sound and Tampering binary sensors
* Motion Sensitivity number
* Mount Type and Paired Camera selects
* Status Light switch
* Configuration switches for various sensors:
    * Motion Detection switch
    * Temperature Sensor switch
    * Humidity Sensor switch
    * Light Sensor switch
    * Alarm Sound Detection switch

The UniFi Protect Smart Sensor is a bit different than other devices. The sensors it provides is based on how you configure it. After a lot of discussion, we felt like the best way to handle this is just mark the sensors not configured as unavailable. Since they can be enabled via the switch entities provided, that seemed like the best solution instead of adding/removing them or enabling/disabling them, both of which requires a config entry reload.

Changelog for pyunifiprotect bump: https://github.com/briis/pyunifiprotect/releases/tag/v1.6.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21171

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
