### PR TITLE
Remove attributes from vizio state when they don't make sense

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -145,6 +145,7 @@ class VizioDevice(MediaPlayerEntity):
         self._volume_step = config_entry.options[CONF_VOLUME_STEP]
         self._current_input = None
         self._current_app_config = None
+        self._app_name = None
         self._available_inputs = []
         self._available_apps = []
         self._all_apps = apps_coordinator.data if apps_coordinator else None
@@ -208,7 +209,7 @@ class VizioDevice(MediaPlayerEntity):
             self._attr_volume_level = None
             self._attr_is_volume_muted = None
             self._current_input = None
-            self._attr_app_name = None
+            self._app_name = None
             self._current_app_config = None
             self._attr_sound_mode = None
             return
@@ -264,13 +265,13 @@ class VizioDevice(MediaPlayerEntity):
             log_api_exception=False
         )
 
-        self._attr_app_name = find_app_name(
+        self._app_name = find_app_name(
             self._current_app_config,
             [APP_HOME, *self._all_apps, *self._additional_app_configs],
         )
 
-        if self._attr_app_name == NO_APP_RUNNING:
-            self._attr_app_name = None
+        if self._app_name == NO_APP_RUNNING:
+            self._app_name = None
 
     def _get_additional_app_names(self) -> list[dict[str, Any]]:
         """Return list of additional apps that were included in configuration.yaml."""
@@ -336,8 +337,8 @@ class VizioDevice(MediaPlayerEntity):
     @property
     def source(self) -> str | None:
         """Return current input of the device."""
-        if self._attr_app_name is not None and self._current_input in INPUT_APPS:
-            return self._attr_app_name
+        if self._app_name is not None and self._current_input in INPUT_APPS:
+            return self._app_name
 
         return self._current_input
 
@@ -366,8 +367,8 @@ class VizioDevice(MediaPlayerEntity):
     @property
     def app_name(self) -> str | None:
         """Return the name of the current app."""
-        if self.source == self._attr_app_name:
-            return super().app_name
+        if self.source == self._app_name:
+            return self._app_name
 
         return None
 

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -216,6 +216,22 @@ def vizio_update_with_apps_fixture(vizio_update: pytest.fixture):
         yield
 
 
+@pytest.fixture(name="vizio_update_with_apps_on_input")
+def vizio_update_with_apps_on_input_fixture(vizio_update: pytest.fixture):
+    """Mock valid updates to vizio device that supports apps but is on a TV input."""
+    with patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_inputs_list",
+        return_value=get_mock_inputs(INPUT_LIST_WITH_APPS),
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_input",
+        return_value=CURRENT_INPUT,
+    ), patch(
+        "homeassistant.components.vizio.media_player.VizioAsync.get_current_app_config",
+        return_value=AppConfig("unknown", 1, "app"),
+    ):
+        yield
+
+
 @pytest.fixture(name="vizio_hostname_check")
 def vizio_hostname_check():
     """Mock vizio hostname resolution."""

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -751,3 +751,19 @@ async def test_apps_update(
                 sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
                 apps = list(set(sources) - set(INPUT_LIST))
                 assert len(apps) == len(APP_LIST)
+
+
+async def test_vizio_update_with_apps_on_input(
+    hass: HomeAssistant, vizio_connect, vizio_update_with_apps_on_input
+) -> None:
+    """Test a vizio TV with apps that is on a TV input."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=vol.Schema(VIZIO_SCHEMA)(MOCK_USER_VALID_TV_CONFIG),
+        unique_id=UNIQUE_ID,
+    )
+    await _add_config_entry_to_hass(hass, config_entry)
+    attr = _get_attr_and_assert_base_attr(hass, DEVICE_CLASS_TV, STATE_ON)
+    # App name and app ID should not be in the attributes
+    assert "app_name" not in attr
+    assert "app_id" not in attr


### PR DESCRIPTION
## Breaking change
If an integrated `vizio` TV supports apps and the source is currently a non-app input (e.g. HDMI-1), the `app_id` and `app_name` attributes will no longer be in the media player entity's state. When the TV is using an app, the `app_name` will still always be visible and the `app_id` will continue to only be shown if the app is not recognized.

## Proposed change
When a `vizio` media player is not on an app (it's on a regular TV input), there is no reason to show the app name and app ID as attributes. This PR addresses that.

Also did a little code clean up to reduce some lines.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63859
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
