### PR TITLE
Ensure august status is current when integration loads

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -140,6 +140,11 @@ class AugustData(AugustSubscriberMixin):
         pubnub.subscribe(self.async_pubnub_message)
         self._pubnub_unsub = async_create_pubnub(user_data["UserID"], pubnub)
 
+        if self._locks_by_id:
+            await asyncio.gather(
+                *[self.async_status_async(lock_id) for lock_id in self._locks_by_id]
+            )
+
     @callback
     def async_pubnub_message(self, device_id, date_time, message):
         """Process a pubnub message."""
@@ -243,6 +248,15 @@ class AugustData(AugustSubscriberMixin):
         return await self._async_call_api_op_requires_bridge(
             device_id,
             self._api.async_lock_return_activities,
+            self._august_gateway.access_token,
+            device_id,
+        )
+
+    async def async_status_async(self, device_id):
+        """Request status of the the device but do not wait for a response since it will come via pubnub."""
+        return await self._async_call_api_op_requires_bridge(
+            device_id,
+            self._api.async_status_async,
             self._august_gateway.access_token,
             device_id,
         )

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.17"],
+  "requirements": ["yalexs==1.1.18"],
   "codeowners": ["@bdraco"],
   "dhcp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2503,7 +2503,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.3.7
 
 # homeassistant.components.august
-yalexs==1.1.17
+yalexs==1.1.18
 
 # homeassistant.components.yeelight
 yeelight==0.7.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1525,7 +1525,7 @@ xmltodict==0.12.0
 yalesmartalarmclient==0.3.7
 
 # homeassistant.components.august
-yalexs==1.1.17
+yalexs==1.1.18
 
 # homeassistant.components.yeelight
 yeelight==0.7.8

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -167,6 +167,8 @@ async def _create_august_with_devices(  # noqa: C901
     )
 
     if device_data["locks"]:
+        # Ensure we sync status when the integration is loaded if there
+        # are any locks
         assert api_instance.async_status_async.mock_calls
 
     return entry

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -162,9 +162,14 @@ async def _create_august_with_devices(  # noqa: C901
             "unlock_return_activities"
         ] = unlock_return_activities_side_effect
 
-    return await _mock_setup_august_with_api_side_effects(
+    api_instance, entry = await _mock_setup_august_with_api_side_effects(
         hass, api_call_side_effects, pubnub
     )
+
+    if device_data["locks"]:
+        assert api_instance.async_status_async.mock_calls
+
+    return entry
 
 
 async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, pubnub):
@@ -210,7 +215,7 @@ async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, 
     api_instance.async_status_async = AsyncMock()
     api_instance.async_get_user = AsyncMock(return_value={"UserID": "abc"})
 
-    return await _mock_setup_august(hass, api_instance, pubnub)
+    return api_instance, await _mock_setup_august(hass, api_instance, pubnub)
 
 
 def _mock_august_authentication(token_text, token_timestamp, state):

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -207,6 +207,7 @@ async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, 
 
     api_instance.async_unlock_async = AsyncMock()
     api_instance.async_lock_async = AsyncMock()
+    api_instance.async_status_async = AsyncMock()
     api_instance.async_get_user = AsyncMock(return_value={"UserID": "abc"})
 
     return await _mock_setup_august(hass, api_instance, pubnub)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure august status is current when integration loads

Since there may be no pubnub subscribers, the status
may be stale at startup. We now query for the query status
from the lock when the integration is loaded.

Changelog: https://github.com/bdraco/yalexs/compare/v1.1.17...v1.1.18

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
