### PR TITLE
Simplify Overkiz coordinator (step 2) and address feedback

### DIFF
--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -101,7 +101,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
     async def _get_devices(self) -> dict[str, Device]:
         """Fetch devices."""
-        _LOGGER.debug("Fetching all devices and state via /setup/devices.")
+        _LOGGER.debug("Fetching all devices and state via /setup/devices")
         return {d.device_url: d for d in await self.client.get_devices(refresh=True)}
 
     def _places_to_area(self, place: Place) -> dict[str, str]:

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -101,11 +101,11 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
     async def _get_devices(self) -> dict[str, Device]:
         """Fetch devices."""
-        _LOGGER.debug("Fetching all devices and state via /setup/devices")
+        _LOGGER.debug("Fetching all devices and state via /setup/devices.")
         return {d.device_url: d for d in await self.client.get_devices(refresh=True)}
 
     def _places_to_area(self, place: Place) -> dict[str, str]:
-        """Convert places with sub_places to a flat dictionary."""
+        """Convert places with sub_places to a flat dictionary [placeoid, label])."""
         areas = {}
         if isinstance(place, Place):
             areas[place.oid] = place.label
@@ -124,7 +124,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
     @EVENT_HANDLERS.register((EventName.DEVICE_UNAVAILABLE, EventName.DEVICE_DISABLED))
     async def on_device_unavailable_disabled(self, event: Event) -> None:
-        """Handle device unavailable / dispabled event."""
+        """Handle device unavailable / disabled event."""
         if event.device_url:
             self.devices[event.device_url].available = False
 

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -126,13 +126,25 @@ async def on_device_available(
         coordinator.devices[event.device_url].available = True
 
 
-@EVENT_HANDLERS.register((EventName.DEVICE_UNAVAILABLE, EventName.DEVICE_DISABLED))
+@EVENT_HANDLERS.register(EventName.DEVICE_UNAVAILABLE)
+@EVENT_HANDLERS.register(EventName.DEVICE_DISABLED)
 async def on_device_unavailable_disabled(
     coordinator: OverkizDataUpdateCoordinator, event: Event
 ) -> None:
     """Handle device unavailable / disabled event."""
     if event.device_url:
         coordinator.devices[event.device_url].available = False
+
+
+@EVENT_HANDLERS.register(EventName.DEVICE_CREATED)
+@EVENT_HANDLERS.register(EventName.DEVICE_UPDATED)
+async def on_device_created_updated(
+    coordinator: OverkizDataUpdateCoordinator, event: Event
+) -> None:
+    """Handle device unavailable / disabled event."""
+    coordinator.hass.async_create_task(
+        coordinator.hass.config_entries.async_reload(coordinator._config_entry_id)
+    )
 
 
 @EVENT_HANDLERS.register(EventName.DEVICE_STATE_CHANGED)

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -136,12 +136,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
         for state in event.device_states:
             device = self.devices[event.device_url]
-
-            if (device_state := device.states[state.name]) is None:
-                device_state = state
-                device.states[state.name] = device_state
-
-            device_state.value = state.value
+            device.states[state.name] = state
 
     @EVENT_HANDLERS.register(EventName.DEVICE_REMOVED)
     async def on_device_removed(self, event: Event) -> None:

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -60,7 +60,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         )
         self.executions: dict[str, dict[str, str]] = {}
         self.areas = self._places_to_area(places)
-        self._config_entry_id = config_entry_id
+        self.config_entry_id = config_entry_id
 
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Overkiz data via event listener."""
@@ -143,7 +143,7 @@ async def on_device_created_updated(
 ) -> None:
     """Handle device unavailable / disabled event."""
     coordinator.hass.async_create_task(
-        coordinator.hass.config_entries.async_reload(coordinator._config_entry_id)
+        coordinator.hass.config_entries.async_reload(coordinator.config_entry_id)
     )
 
 


### PR DESCRIPTION
## Proposed change
As mentioned in review feedback https://github.com/home-assistant/core/pull/62640#discussion_r776268780, the coordinator is too complex and hard to read. In previous PR we removed some parts, in this PR we will implement the `Registry()` helper as suggested.

Not sure if this is the right way with passing `self`, however we need access to our data coordinator class variables 

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
