### PR TITLE
Remove constant DEFAULT_CONFIG from alexa tests

### DIFF
--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -55,7 +55,9 @@ class MockConfig(config.AbstractConfig):
         """Accept a grant."""
 
 
-DEFAULT_CONFIG = MockConfig(None)
+def get_default_config():
+    """Return a MockConfig instance."""
+    return MockConfig(None)
 
 
 def get_new_request(namespace, name, endpoint=None):
@@ -104,7 +106,9 @@ async def assert_request_calls_service(
     domain, service_name = service.split(".")
     calls = async_mock_service(hass, domain, service_name)
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    msg = await smart_home.async_handle_message(
+        hass, get_default_config(), request, context
+    )
     await hass.async_block_till_done()
 
     assert len(calls) == 1
@@ -128,7 +132,7 @@ async def assert_request_fails(
     domain, service_name = service_not_called.split(".")
     call = async_mock_service(hass, domain, service_name)
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert not call
@@ -187,7 +191,7 @@ async def reported_properties(hass, endpoint):
     assertions about the properties.
     """
     request = get_new_request("Alexa", "ReportState", endpoint)
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
     return ReportedProperties(msg["context"]["properties"])
 

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -29,9 +29,9 @@ from homeassistant.const import (
 )
 
 from . import (
-    DEFAULT_CONFIG,
     assert_request_calls_service,
     assert_request_fails,
+    get_default_config,
     get_new_request,
     reported_properties,
 )
@@ -56,7 +56,7 @@ async def test_api_adjust_brightness(hass, result, adjust):
 
     call_light = async_mock_service(hass, "light", "turn_on")
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg
@@ -86,7 +86,7 @@ async def test_api_set_color_rgb(hass):
 
     call_light = async_mock_service(hass, "light", "turn_on")
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg
@@ -112,7 +112,7 @@ async def test_api_set_color_temperature(hass):
 
     call_light = async_mock_service(hass, "light", "turn_on")
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg
@@ -140,7 +140,7 @@ async def test_api_decrease_color_temp(hass, result, initial):
 
     call_light = async_mock_service(hass, "light", "turn_on")
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg
@@ -168,7 +168,7 @@ async def test_api_increase_color_temp(hass, result, initial):
 
     call_light = async_mock_service(hass, "light", "turn_on")
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg

--- a/tests/components/alexa/test_entities.py
+++ b/tests/components/alexa/test_entities.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from homeassistant.components.alexa import smart_home
 from homeassistant.const import __version__
 
-from . import DEFAULT_CONFIG, get_new_request
+from . import get_default_config, get_new_request
 
 
 async def test_unsupported_domain(hass):
@@ -13,7 +13,7 @@ async def test_unsupported_domain(hass):
 
     hass.states.async_set("woz.boop", "on", {"friendly_name": "Boop Woz"})
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
 
     assert "event" in msg
     msg = msg["event"]
@@ -27,7 +27,7 @@ async def test_serialize_discovery(hass):
 
     hass.states.async_set("switch.bla", "on", {"friendly_name": "Boop Woz"})
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
 
     assert "event" in msg
     msg = msg["event"]
@@ -51,7 +51,7 @@ async def test_serialize_discovery_recovers(hass, caplog):
         "homeassistant.components.alexa.capabilities.AlexaPowerController.serialize_discovery",
         side_effect=TypeError,
     ):
-        msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+        msg = await smart_home.async_handle_message(hass, get_default_config(), request)
 
     assert "event" in msg
     msg = msg["event"]

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -31,13 +31,13 @@ from homeassistant.helpers import entityfilter
 from homeassistant.setup import async_setup_component
 
 from . import (
-    DEFAULT_CONFIG,
     MockConfig,
     ReportedProperties,
     assert_power_controller_works,
     assert_request_calls_service,
     assert_request_fails,
     assert_scene_controller_works,
+    get_default_config,
     get_new_request,
     reported_properties,
 )
@@ -121,7 +121,7 @@ async def test_wrong_version(hass):
     msg["directive"]["header"]["payloadVersion"] = "2"
 
     with pytest.raises(AssertionError):
-        await smart_home.async_handle_message(hass, DEFAULT_CONFIG, msg)
+        await smart_home.async_handle_message(hass, get_default_config(), msg)
 
 
 async def discovery_test(device, hass, expected_endpoints=1):
@@ -131,7 +131,7 @@ async def discovery_test(device, hass, expected_endpoints=1):
     # setup test devices
     hass.states.async_set(*device)
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
 
     assert "event" in msg
     msg = msg["event"]
@@ -2308,7 +2308,7 @@ async def test_api_entity_not_exists(hass):
 
     call_switch = async_mock_service(hass, "switch", "turn_on")
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg
@@ -2323,7 +2323,7 @@ async def test_api_entity_not_exists(hass):
 async def test_api_function_not_implemented(hass):
     """Test api call that is not implemented to us."""
     request = get_new_request("Alexa.HAHAAH", "Sweet")
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
 
     assert "event" in msg
     msg = msg["event"]
@@ -2347,7 +2347,7 @@ async def test_api_accept_grant(hass):
     }
 
     # setup test devices
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+    msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
 
     assert "event" in msg
@@ -2400,7 +2400,7 @@ async def test_logging_request(hass, events):
     """Test that we log requests."""
     context = Context()
     request = get_new_request("Alexa.Discovery", "Discover")
-    await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    await smart_home.async_handle_message(hass, get_default_config(), request, context)
 
     # To trigger event listener
     await hass.async_block_till_done()
@@ -2420,7 +2420,7 @@ async def test_logging_request_with_entity(hass, events):
     """Test that we log requests."""
     context = Context()
     request = get_new_request("Alexa.PowerController", "TurnOn", "switch#xy")
-    await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    await smart_home.async_handle_message(hass, get_default_config(), request, context)
 
     # To trigger event listener
     await hass.async_block_till_done()
@@ -2446,7 +2446,7 @@ async def test_disabled(hass):
     call_switch = async_mock_service(hass, "switch", "turn_on")
 
     msg = await smart_home.async_handle_message(
-        hass, DEFAULT_CONFIG, request, enabled=False
+        hass, get_default_config(), request, enabled=False
     )
     await hass.async_block_till_done()
 
@@ -2629,7 +2629,9 @@ async def test_range_unsupported_domain(hass):
     request["directive"]["payload"] = {"rangeValue": 1}
     request["directive"]["header"]["instance"] = "switch.speed"
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    msg = await smart_home.async_handle_message(
+        hass, get_default_config(), request, context
+    )
 
     assert "event" in msg
     msg = msg["event"]
@@ -2648,7 +2650,9 @@ async def test_mode_unsupported_domain(hass):
     request["directive"]["payload"] = {"mode": "testMode"}
     request["directive"]["header"]["instance"] = "switch.direction"
 
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    msg = await smart_home.async_handle_message(
+        hass, get_default_config(), request, context
+    )
 
     assert "event" in msg
     msg = msg["event"]
@@ -3388,7 +3392,9 @@ async def test_media_player_eq_bands_not_supported(hass):
         "Alexa.EqualizerController", "SetBands", "media_player#test_bands"
     )
     request["directive"]["payload"] = {"bands": [{"name": "BASS", "value": -2}]}
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    msg = await smart_home.async_handle_message(
+        hass, get_default_config(), request, context
+    )
 
     assert "event" in msg
     msg = msg["event"]
@@ -3403,7 +3409,9 @@ async def test_media_player_eq_bands_not_supported(hass):
     request["directive"]["payload"] = {
         "bands": [{"name": "BASS", "levelDelta": 3, "levelDirection": "UP"}]
     }
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    msg = await smart_home.async_handle_message(
+        hass, get_default_config(), request, context
+    )
 
     assert "event" in msg
     msg = msg["event"]
@@ -3418,7 +3426,9 @@ async def test_media_player_eq_bands_not_supported(hass):
     request["directive"]["payload"] = {
         "bands": [{"name": "BASS", "levelDelta": 3, "levelDirection": "UP"}]
     }
-    msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request, context)
+    msg = await smart_home.async_handle_message(
+        hass, get_default_config(), request, context
+    )
 
     assert "event" in msg
     msg = msg["event"]
@@ -3918,7 +3928,7 @@ async def test_initialize_camera_stream(hass, mock_camera, mock_stream):
         "homeassistant.components.demo.camera.DemoCamera.stream_source",
         return_value="rtsp://example.local",
     ):
-        msg = await smart_home.async_handle_message(hass, DEFAULT_CONFIG, request)
+        msg = await smart_home.async_handle_message(hass, get_default_config(), request)
         await hass.async_block_till_done()
 
     assert "event" in msg

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from homeassistant import core
 from homeassistant.components.alexa import state_report
 
-from . import DEFAULT_CONFIG, TEST_URL
+from . import TEST_URL, get_default_config
 
 
 async def test_report_state(hass, aioclient_mock):
@@ -17,7 +17,7 @@ async def test_report_state(hass, aioclient_mock):
         {"friendly_name": "Test Contact Sensor", "device_class": "door"},
     )
 
-    await state_report.async_enable_proactive_mode(hass, DEFAULT_CONFIG)
+    await state_report.async_enable_proactive_mode(hass, get_default_config())
 
     hass.states.async_set(
         "binary_sensor.test_contact",
@@ -58,7 +58,7 @@ async def test_report_state_instance(hass, aioclient_mock):
         },
     )
 
-    await state_report.async_enable_proactive_mode(hass, DEFAULT_CONFIG)
+    await state_report.async_enable_proactive_mode(hass, get_default_config())
 
     hass.states.async_set(
         "fan.test_fan",
@@ -127,7 +127,9 @@ async def test_send_add_or_update_message(hass, aioclient_mock):
         "binary_sensor.non_existing",  # Supported, but does not exist
         "zwave.bla",  # Unsupported
     ]
-    await state_report.async_send_add_or_update_message(hass, DEFAULT_CONFIG, entities)
+    await state_report.async_send_add_or_update_message(
+        hass, get_default_config(), entities
+    )
 
     assert len(aioclient_mock.mock_calls) == 1
     call = aioclient_mock.mock_calls
@@ -153,7 +155,7 @@ async def test_send_delete_message(hass, aioclient_mock):
     )
 
     await state_report.async_send_delete_message(
-        hass, DEFAULT_CONFIG, ["binary_sensor.test_contact", "zwave.bla"]
+        hass, get_default_config(), ["binary_sensor.test_contact", "zwave.bla"]
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -179,7 +181,7 @@ async def test_doorbell_event(hass, aioclient_mock):
         {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
     )
 
-    await state_report.async_enable_proactive_mode(hass, DEFAULT_CONFIG)
+    await state_report.async_enable_proactive_mode(hass, get_default_config())
 
     hass.states.async_set(
         "binary_sensor.test_doorbell",
@@ -219,7 +221,8 @@ async def test_doorbell_event(hass, aioclient_mock):
 async def test_proactive_mode_filter_states(hass, aioclient_mock):
     """Test all the cases that filter states."""
     aioclient_mock.post(TEST_URL, text="", status=202)
-    await state_report.async_enable_proactive_mode(hass, DEFAULT_CONFIG)
+    config = get_default_config()
+    await state_report.async_enable_proactive_mode(hass, config)
 
     # First state should report
     hass.states.async_set(
@@ -270,7 +273,7 @@ async def test_proactive_mode_filter_states(hass, aioclient_mock):
         "off",
         {"friendly_name": "Test Contact Sensor", "device_class": "door"},
     )
-    with patch.object(DEFAULT_CONFIG, "should_expose", return_value=False):
+    with patch.object(config, "should_expose", return_value=False):
         await hass.async_block_till_done()
         await hass.async_block_till_done()
     assert len(aioclient_mock.mock_calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove constant DEFAULT_CONFIG from Alexa tests, and instead create a new instance in each test.

This prevents tests from influencing each other

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
