### PR TITLE
Add SimpliSafe account ID to reauth UI dialog

### DIFF
--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -1,7 +1,15 @@
 {
   "config": {
     "step": {
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The credentials for account **{user_id}** are no longer valid and the integration must be reconfigured.\n\n[%key:component::simplisafe::config::step::user::description%]",
+        "data": {
+          "auth_code": "[%key:component::simplisafe::config::step::user::data::auth_code%]"
+        }
+      },
       "user": {
+        "title": "Fill in your information",
         "description": "SimpliSafe authenticates with Home Assistant via the SimpliSafe web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation]({docs_url}) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below.",
         "data": {
           "auth_code": "Authorization Code"

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -12,33 +12,19 @@
             "unknown": "Unexpected error"
         },
         "step": {
-            "input_auth_code": {
+            "reauth_confirm": {
                 "data": {
                     "auth_code": "Authorization Code"
                 },
-                "description": "Input the authorization code from the SimpliSafe web app URL:",
-                "title": "Finish Authorization"
-            },
-            "mfa": {
-                "description": "Check your email for a link from SimpliSafe. After verifying the link, return here to complete the installation of the integration.",
-                "title": "SimpliSafe Multi-Factor Authentication"
-            },
-            "reauth_confirm": {
-                "data": {
-                    "password": "Password"
-                },
-                "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
+                "description": "The credentials for account **{user_id}** are no longer valid and the integration must be reconfigured.\n\nSimpliSafe authenticates with Home Assistant via the SimpliSafe web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation]({docs_url}) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below.",
                 "title": "Reauthenticate Integration"
             },
             "user": {
                 "data": {
-                    "auth_code": "Authorization Code",
-                    "code": "Code (used in Home Assistant UI)",
-                    "password": "Password",
-                    "username": "Email"
+                    "auth_code": "Authorization Code"
                 },
                 "description": "SimpliSafe authenticates with Home Assistant via the SimpliSafe web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation]({docs_url}) before starting.\n\n1. Click [here]({url}) to open the SimpliSafe web app and input your credentials.\n\n2. When the login process is complete, return here and input the authorization code below.",
-                "title": "Fill in your information."
+                "title": "Fill in your information"
             }
         }
     },

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -120,7 +120,7 @@ async def test_step_reauth_old_format(hass, mock_async_from_auth):
         context={"source": SOURCE_REAUTH},
         data={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
     )
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reauth_confirm"
 
     with patch(
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
@@ -152,7 +152,7 @@ async def test_step_reauth_new_format(hass, mock_async_from_auth):
         context={"source": SOURCE_REAUTH},
         data={CONF_USER_ID: "12345", CONF_TOKEN: "token123"},
     )
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reauth_confirm"
 
     with patch(
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
@@ -184,7 +184,7 @@ async def test_step_reauth_wrong_account(hass, api, mock_async_from_auth):
         context={"source": SOURCE_REAUTH},
         data={CONF_USER_ID: "12345", CONF_TOKEN: "token123"},
     )
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reauth_confirm"
 
     # Simulate the next auth call returning a different user ID than the one we've
     # identified as this entry's unique ID:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SimpliSafe uses the same messaging for the `user` and `reauth` config flows; because of this, users with multiple SimpliSafe accounts aren't able to tell which account they are reauth-ing. This PR updates the messaging of the `reauth` flow to include the account ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/64007
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
