### PR TITLE
Remove Windows workarounds from wake_on_lan

### DIFF
--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import platform
 import subprocess as sp
 
 import voluptuous as vol
@@ -158,24 +157,14 @@ class WolSwitch(SwitchEntity):
 
     def update(self):
         """Check if device is on and update the state. Only called if assumed state is false."""
-        if platform.system().lower() == "windows":
-            ping_cmd = [
-                "ping",
-                "-n",
-                "1",
-                "-w",
-                str(DEFAULT_PING_TIMEOUT * 1000),
-                str(self._host),
-            ]
-        else:
-            ping_cmd = [
-                "ping",
-                "-c",
-                "1",
-                "-W",
-                str(DEFAULT_PING_TIMEOUT),
-                str(self._host),
-            ]
+        ping_cmd = [
+            "ping",
+            "-c",
+            "1",
+            "-W",
+            str(DEFAULT_PING_TIMEOUT),
+            str(self._host),
+        ]
 
         status = sp.call(ping_cmd, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
         self._state = not bool(status)

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -1,5 +1,4 @@
 """The tests for the wake on lan switch platform."""
-import platform
 import subprocess
 from unittest.mock import patch
 
@@ -64,38 +63,6 @@ async def test_valid_hostname(hass):
 
         state = hass.states.get("switch.wake_on_lan")
         assert state.state == STATE_ON
-
-
-async def test_valid_hostname_windows(hass):
-    """Test with valid hostname on windows."""
-    assert await async_setup_component(
-        hass,
-        switch.DOMAIN,
-        {
-            "switch": {
-                "platform": "wake_on_lan",
-                "mac": "00-01-02-03-04-05",
-                "host": "validhostname",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("switch.wake_on_lan")
-    assert state.state == STATE_OFF
-
-    with patch.object(subprocess, "call", return_value=0), patch.object(
-        platform, "system", return_value="Windows"
-    ):
-        await hass.services.async_call(
-            switch.DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.wake_on_lan"},
-            blocking=True,
-        )
-
-    state = hass.states.get("switch.wake_on_lan")
-    assert state.state == STATE_ON
 
 
 async def test_broadcast_config_ip_and_port(hass, mock_send_magic_packet):
@@ -243,38 +210,6 @@ async def test_off_script(hass):
         state = hass.states.get("switch.wake_on_lan")
         assert state.state == STATE_OFF
         assert len(calls) == 1
-
-
-async def test_invalid_hostname_windows(hass):
-    """Test with invalid hostname on windows."""
-
-    assert await async_setup_component(
-        hass,
-        switch.DOMAIN,
-        {
-            "switch": {
-                "platform": "wake_on_lan",
-                "mac": "00-01-02-03-04-05",
-                "host": "invalidhostname",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("switch.wake_on_lan")
-    assert state.state == STATE_OFF
-
-    with patch.object(subprocess, "call", return_value=2):
-
-        await hass.services.async_call(
-            switch.DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.wake_on_lan"},
-            blocking=True,
-        )
-
-        state = hass.states.get("switch.wake_on_lan")
-        assert state.state == STATE_OFF
 
 
 async def test_no_hostname_state(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove Windows workarounds from the `wake_on_lan` integration, Windows is not a supported platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
