### PR TITLE
Allow browsing favorites in Sonos media browser

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -43,6 +43,7 @@ SONOS_GENRE = "genres"
 SONOS_ALBUM_ARTIST = "album_artists"
 SONOS_TRACKS = "tracks"
 SONOS_COMPOSER = "composers"
+SONOS_RADIO = "radio"
 
 SONOS_STATE_PLAYING = "PLAYING"
 SONOS_STATE_TRANSITIONING = "TRANSITIONING"
@@ -76,6 +77,7 @@ SONOS_TO_MEDIA_CLASSES = {
     "object.container.playlistContainer.sameArtist": MEDIA_CLASS_ARTIST,
     "object.container.playlistContainer": MEDIA_CLASS_PLAYLIST,
     "object.item.audioItem.musicTrack": MEDIA_CLASS_TRACK,
+    "object.item.audioItem.audioBroadcast": MEDIA_CLASS_GENRE,
 }
 
 SONOS_TO_MEDIA_TYPES = {
@@ -120,6 +122,7 @@ SONOS_TYPES_MAPPING = {
     "object.container.playlistContainer.sameArtist": SONOS_ARTIST,
     "object.container.playlistContainer": SONOS_PLAYLISTS,
     "object.item.audioItem.musicTrack": SONOS_TRACKS,
+    "object.item.audioItem.audioBroadcast": SONOS_RADIO,
 }
 
 LIBRARY_TITLES_MAPPING = {

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -33,7 +33,7 @@ class SonosFavorites(SonosHouseholdCoordinator):
         favorites = self._favorites.copy()
         return iter(favorites)
 
-    def lookup_by_item_id(self, item_id: str) -> DidlFavorite:
+    def lookup_by_item_id(self, item_id: str) -> DidlFavorite | None:
         """Return the favorite object with the provided item_id."""
         return next((fav for fav in self._favorites if fav.item_id == item_id), None)
 

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -33,6 +33,10 @@ class SonosFavorites(SonosHouseholdCoordinator):
         favorites = self._favorites.copy()
         return iter(favorites)
 
+    def lookup_by_item_id(self, item_id: str) -> DidlFavorite:
+        """Return the favorite object with the provided item_id."""
+        return next((fav for fav in self._favorites if fav.item_id == item_id), None)
+
     async def async_update_entities(
         self, soco: SoCo, update_id: int | None = None
     ) -> None:

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -198,7 +198,7 @@ def favorites_payload(favorites):
     children = []
 
     group_types = {fav.reference.item_class for fav in favorites}
-    for group_type in group_types:
+    for group_type in sorted(group_types):
         media_content_type = SONOS_TYPES_MAPPING[group_type]
         children.append(
             BrowseMedia(

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -6,6 +6,7 @@ import urllib.parse
 from homeassistant.components.media_player import BrowseMedia
 from homeassistant.components.media_player.const import (
     MEDIA_CLASS_DIRECTORY,
+    MEDIA_CLASS_TRACK,
     MEDIA_TYPE_ALBUM,
 )
 from homeassistant.components.media_player.errors import BrowseError
@@ -120,6 +121,46 @@ def item_payload(item, get_thumbnail_url=None):
     )
 
 
+def root_payload(media_library):
+    """Return root payload for Sonos."""
+    children = [
+        BrowseMedia(
+            title="Favorites",
+            media_class=MEDIA_CLASS_DIRECTORY,
+            media_content_id="",
+            media_content_type="favorites",
+            can_play=False,
+            can_expand=True,
+        )
+    ]
+
+    if media_library.browse_by_idstring(
+        "tracks",
+        "",
+        max_items=1,
+    ):
+        children.append(
+            BrowseMedia(
+                title="Music Library",
+                media_class=MEDIA_CLASS_DIRECTORY,
+                media_content_id="",
+                media_content_type="library",
+                can_play=False,
+                can_expand=True,
+            )
+        )
+
+    return BrowseMedia(
+        title="Sonos",
+        media_class=MEDIA_CLASS_DIRECTORY,
+        media_content_id="library",
+        media_content_type="library",
+        can_play=False,
+        can_expand=True,
+        children=children,
+    )
+
+
 def library_payload(media_library, get_thumbnail_url=None):
     """
     Create response payload to describe contents of a specific library.
@@ -143,6 +184,36 @@ def library_payload(media_library, get_thumbnail_url=None):
         media_class=MEDIA_CLASS_DIRECTORY,
         media_content_id="library",
         media_content_type="library",
+        can_play=False,
+        can_expand=True,
+        children=children,
+    )
+
+
+def favorites_payload(favorites, get_thumbnail_url=None):
+    """
+    Create response payload to describe contents of a specific library.
+
+    Used by async_browse_media.
+    """
+    children = []
+    for item in favorites:
+        children.append(
+            BrowseMedia(
+                title=item.title,
+                media_class=MEDIA_CLASS_TRACK,
+                media_content_id=item.title,
+                media_content_type="favorite",
+                can_play=True,
+                can_expand=False,
+            )
+        )
+
+    return BrowseMedia(
+        title="Favorites",
+        media_class=MEDIA_CLASS_DIRECTORY,
+        media_content_id="",
+        media_content_type="favorites",
         can_play=False,
         can_expand=True,
         children=children,

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -519,6 +519,8 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         """
         if media_type == "favorite_item_id":
             favorite = self.speaker.favorites.lookup_by_item_id(media_id)
+            if favorite is None:
+                raise ValueError(f"Missing favorite for media_id: {media_id}")
             self._play_favorite(favorite)
             return
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -675,9 +675,12 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 media_image_id,
             )
 
-        if media_content_type is None:
+        if media_content_type in [None, "root"]:
             return await self.hass.async_add_executor_job(
-                media_browser.root_payload, self.media.library
+                media_browser.root_payload,
+                self.media.library,
+                self.speaker.favorites,
+                _get_thumbnail_url,
             )
 
         if media_content_type == "library":

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -517,10 +517,6 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
         If ATTR_MEDIA_ENQUEUE is True, add `media_id` to the queue.
         """
-        if media_type == "favorite":
-            self._play_favorite_by_name(media_id)
-            return
-
         if media_type == "favorite_item_id":
             favorite = self.speaker.favorites.lookup_by_item_id(media_id)
             self._play_favorite(favorite)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow browsing Sonos favorites in the media browser.

![image](https://user-images.githubusercontent.com/1444314/149406840-e9099ba2-1244-456d-b3c9-b1215c5dd41c.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
