### PR TITLE
Add switch platform to HomeWizard Energy

### DIFF
--- a/homeassistant/components/homewizard/__init__.py
+++ b/homeassistant/components/homewizard/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .const import COORDINATOR, DOMAIN, PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .coordinator import HWEnergyDeviceUpdateCoordinator as Coordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,9 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Finalize
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        COORDINATOR: coordinator,
-    }
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     for component in PLATFORMS:
         hass.async_create_task(
@@ -64,6 +62,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         config_data = hass.data[DOMAIN].pop(entry.entry_id)
-        await config_data[COORDINATOR].api.close()
+        await config_data.api.close()
 
     return unload_ok

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -7,11 +7,12 @@ from typing import TypedDict
 # Set up.
 from aiohwenergy.device import Device
 
+from homeassistant.const import Platform
 from homeassistant.helpers.typing import StateType
 
 DOMAIN = "homewizard"
 COORDINATOR = "coordinator"
-PLATFORMS = ["sensor", "switch"]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 
 # Platform config.
 CONF_SERIAL = "serial"

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.typing import StateType
 
 DOMAIN = "homewizard"
 COORDINATOR = "coordinator"
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "switch"]
 
 # Platform config.
 CONF_SERIAL = "serial"

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -11,7 +11,6 @@ from homeassistant.const import Platform
 from homeassistant.helpers.typing import StateType
 
 DOMAIN = "homewizard"
-COORDINATOR = "coordinator"
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 
 # Platform config.

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -15,9 +15,7 @@ from .const import DOMAIN, UPDATE_INTERVAL, DeviceResponseEntry
 _LOGGER = logging.getLogger(__name__)
 
 
-class HWEnergyDeviceUpdateCoordinator(
-    DataUpdateCoordinator[aiohwenergy.HomeWizardEnergy]
-):
+class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]):
     """Gather data for the energy device."""
 
     api: aiohwenergy

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]):
     """Gather data for the energy device."""
 
-    api: aiohwenergy
+    api: aiohwenergy.HomeWizardEnergy
 
     def __init__(
         self,

--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -5,7 +5,7 @@
   "codeowners": ["@DCSBL"],
   "dependencies": [],
   "requirements": [
-    "aiohwenergy==0.6.0"
+    "aiohwenergy==0.7.0"
   ],
   "zeroconf": ["_hwenergy._tcp.local."],
   "config_flow": true,

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import COORDINATOR, DOMAIN, DeviceResponseEntry
+from .const import DOMAIN, DeviceResponseEntry
 from .coordinator import HWEnergyDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,9 +130,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Initialize sensors."""
-    coordinator: HWEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator: HWEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities = []
     if coordinator.api.data is not None:

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import COORDINATOR, DOMAIN, DeviceResponseEntry
+from .const import COORDINATOR, DOMAIN
 from .coordinator import HWEnergyDeviceUpdateCoordinator
 
 
@@ -26,21 +26,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches."""
 
-    coordinator: HWEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        COORDINATOR
-    ]
-
-    if coordinator.api.state:
+    if hass.data[DOMAIN][entry.entry_id][COORDINATOR].api.state:
         async_add_entities(
             [
-                HWEnergyMainSwitchEntity(coordinator, entry),
-                HWEnergySwitchLockEntity(coordinator, entry),
+                HWEnergyMainSwitchEntity(
+                    hass.data[DOMAIN][entry.entry_id][COORDINATOR], entry
+                ),
+                HWEnergySwitchLockEntity(
+                    hass.data[DOMAIN][entry.entry_id][COORDINATOR], entry
+                ),
             ]
         )
 
 
-class HWEnergySwitchEntity(CoordinatorEntity[DeviceResponseEntry], SwitchEntity):
+class HWEnergySwitchEntity(CoordinatorEntity, SwitchEntity):
     """Representation switchable entity."""
+
+    coordinator: HWEnergyDeviceUpdateCoordinator
 
     def __init__(
         self,
@@ -62,15 +64,10 @@ class HWEnergySwitchEntity(CoordinatorEntity[DeviceResponseEntry], SwitchEntity)
         return {
             "name": self.entry.title,
             "manufacturer": "HomeWizard",
-            "sw_version": self.data["device"].firmware_version,
-            "model": self.data["device"].product_type,
-            "identifiers": {(DOMAIN, self.data["device"].serial)},
+            "sw_version": self.coordinator.data["device"].firmware_version,
+            "model": self.coordinator.data["device"].product_type,
+            "identifiers": {(DOMAIN, self.coordinator.data["device"].serial)},
         }
-
-    @property
-    def data(self) -> DeviceResponseEntry:
-        """Return data from DataUpdateCoordinator."""
-        return self.coordinator.data
 
 
 class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -69,7 +69,7 @@ class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):
         super().__init__(coordinator, entry, "power_on")
 
         # Config attributes
-        self._attr_name = entry.title
+        self._attr_name = f"{entry.title} Switch"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -3,14 +3,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.switch import (
-    DEVICE_CLASS_OUTLET,
-    DEVICE_CLASS_SWITCH,
-    SwitchEntity,
-)
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -113,6 +109,7 @@ class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
 
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_entity_category = EntityCategory.CONFIG
+
     def __init__(
         self, coordinator: HWEnergyDeviceUpdateCoordinator, entry: ConfigEntry
     ) -> None:

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
         COORDINATOR
     ]
 
-    if coordinator.api.state is not None:
+    if coordinator.api.state:
         async_add_entities(
             [
                 HWEnergyMainSwitchEntity(coordinator, entry),

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -76,6 +76,8 @@ class HWEnergySwitchEntity(CoordinatorEntity[DeviceResponseEntry], SwitchEntity)
 class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):
     """Representation of the main power switch."""
 
+    _attr_device_class = SwitchDeviceClass.OUTLET
+
     def __init__(
         self, coordinator: HWEnergyDeviceUpdateCoordinator, entry: ConfigEntry
     ) -> None:
@@ -84,7 +86,6 @@ class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):
 
         # Config attributes
         self._attr_name = entry.title
-        self._attr_device_class = DEVICE_CLASS_OUTLET
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -119,6 +120,8 @@ class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
     It disables any method that can turn of the relay.
     """
 
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_entity_category = EntityCategory.CONFIG
     def __init__(
         self, coordinator: HWEnergyDeviceUpdateCoordinator, entry: ConfigEntry
     ) -> None:
@@ -127,9 +130,6 @@ class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
 
         # Config attributes
         self._attr_name = f"{entry.title} Switch Lock"
-        self._attr_entity_category = ENTITY_CATEGORY_CONFIG
-        self._attr_device_class = DEVICE_CLASS_SWITCH
-        self._attr_icon = "mdi:lock"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch-lock on."""

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -55,7 +55,6 @@ class HWEnergySwitchEntity(CoordinatorEntity, SwitchEntity):
         self.entry = entry
 
         # Config attributes
-        self.api = coordinator.api
         self._attr_unique_id = f"{entry.unique_id}_{key}"
 
     @property
@@ -85,12 +84,12 @@ class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self.api.state.set(power_on=True)
+        await self.coordinator.api.state.set(power_on=True)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self.api.state.set(power_on=False)
+        await self.coordinator.api.state.set(power_on=False)
         await self.coordinator.async_refresh()
 
     @property
@@ -100,12 +99,12 @@ class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):
 
         This switch becomes unavailable when switch_lock is enabled.
         """
-        return super().available and not self.api.state.switch_lock
+        return super().available and not self.coordinator.api.state.switch_lock
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        return bool(self.api.state.power_on)
+        return bool(self.coordinator.api.state.power_on)
 
 
 class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
@@ -130,15 +129,15 @@ class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch-lock on."""
-        await self.api.state.set(switch_lock=True)
+        await self.coordinator.api.state.set(switch_lock=True)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn switch-lock off."""
-        await self.api.state.set(switch_lock=False)
+        await self.coordinator.api.state.set(switch_lock=False)
         await self.coordinator.async_refresh()
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        return bool(self.api.state.switch_lock)
+        return bool(self.coordinator.api.state.switch_lock)

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -1,0 +1,147 @@
+"""Creates Homewizard Energy switch entities."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import (
+    DEVICE_CLASS_OUTLET,
+    DEVICE_CLASS_SWITCH,
+    SwitchEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import COORDINATOR, DOMAIN, DeviceResponseEntry
+from .coordinator import HWEnergyDeviceUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches."""
+
+    coordinator: HWEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
+        COORDINATOR
+    ]
+
+    if coordinator.api.state is not None:
+        async_add_entities(
+            [
+                HWEnergyMainSwitchEntity(coordinator, entry),
+                HWEnergySwitchLockEntity(coordinator, entry),
+            ]
+        )
+
+
+class HWEnergySwitchEntity(CoordinatorEntity[DeviceResponseEntry], SwitchEntity):
+    """Representation switchable entity."""
+
+    def __init__(
+        self,
+        coordinator: HWEnergyDeviceUpdateCoordinator,
+        entry: ConfigEntry,
+        key: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self.entry = entry
+
+        # Config attributes
+        self.api = coordinator.api
+        self._attr_unique_id = f"{entry.unique_id}_{key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information about the device."""
+        return {
+            "name": self.entry.title,
+            "manufacturer": "HomeWizard",
+            "sw_version": self.data["device"].firmware_version,
+            "model": self.data["device"].product_type,
+            "identifiers": {(DOMAIN, self.data["device"].serial)},
+        }
+
+    @property
+    def data(self) -> DeviceResponseEntry:
+        """Return data from DataUpdateCoordinator."""
+        return self.coordinator.data
+
+
+class HWEnergyMainSwitchEntity(HWEnergySwitchEntity):
+    """Representation of the main power switch."""
+
+    def __init__(
+        self, coordinator: HWEnergyDeviceUpdateCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, entry, "power_on")
+
+        # Config attributes
+        self._attr_name = entry.title
+        self._attr_device_class = DEVICE_CLASS_OUTLET
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self.api.state.set(power_on=True)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self.api.state.set(power_on=False)
+        await self.coordinator.async_refresh()
+
+    @property
+    def available(self) -> bool:
+        """
+        Return availability of power_on.
+
+        This switch becomes unavailable when switch_lock is enabled.
+        """
+        return super().available and not self.api.state.switch_lock
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        return bool(self.api.state.power_on)
+
+
+class HWEnergySwitchLockEntity(HWEnergySwitchEntity):
+    """
+    Representation of the switch-lock configuration.
+
+    Switch-lock is a feature that forces the relay in 'on' state.
+    It disables any method that can turn of the relay.
+    """
+
+    def __init__(
+        self, coordinator: HWEnergyDeviceUpdateCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, entry, "switch_lock")
+
+        # Config attributes
+        self._attr_name = f"{entry.title} Switch Lock"
+        self._attr_entity_category = ENTITY_CATEGORY_CONFIG
+        self._attr_device_class = DEVICE_CLASS_SWITCH
+        self._attr_icon = "mdi:lock"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn switch-lock on."""
+        await self.api.state.set(switch_lock=True)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn switch-lock off."""
+        await self.api.state.set(switch_lock=False)
+        await self.coordinator.async_refresh()
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        return bool(self.api.state.switch_lock)

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -11,7 +11,6 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -56,11 +55,7 @@ class HWEnergySwitchEntity(CoordinatorEntity, SwitchEntity):
 
         # Config attributes
         self._attr_unique_id = f"{entry.unique_id}_{key}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about the device."""
-        return {
+        self._attr_device_info = {
             "name": self.entry.title,
             "manufacturer": "HomeWizard",
             "sw_version": self.coordinator.data["device"].firmware_version,

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -44,16 +44,13 @@ class HWEnergySwitchEntity(CoordinatorEntity, SwitchEntity):
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
-        self.entry = entry
-
-        # Config attributes
         self._attr_unique_id = f"{entry.unique_id}_{key}"
         self._attr_device_info = {
-            "name": self.entry.title,
+            "name": entry.title,
             "manufacturer": "HomeWizard",
-            "sw_version": self.coordinator.data["device"].firmware_version,
-            "model": self.coordinator.data["device"].product_type,
-            "identifiers": {(DOMAIN, self.coordinator.data["device"].serial)},
+            "sw_version": coordinator.data["device"].firmware_version,
+            "model": coordinator.data["device"].product_type,
+            "identifiers": {(DOMAIN, coordinator.data["device"].serial)},
         }
 
 

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import COORDINATOR, DOMAIN
+from .const import DOMAIN
 from .coordinator import HWEnergyDeviceUpdateCoordinator
 
 
@@ -20,16 +20,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switches."""
+    coordinator: HWEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    if hass.data[DOMAIN][entry.entry_id][COORDINATOR].api.state:
+    if coordinator.api.state:
         async_add_entities(
             [
-                HWEnergyMainSwitchEntity(
-                    hass.data[DOMAIN][entry.entry_id][COORDINATOR], entry
-                ),
-                HWEnergySwitchLockEntity(
-                    hass.data[DOMAIN][entry.entry_id][COORDINATOR], entry
-                ),
+                HWEnergyMainSwitchEntity(coordinator, entry),
+                HWEnergySwitchLockEntity(coordinator, entry),
             ]
         )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -194,7 +194,7 @@ aiohttp_cors==0.7.0
 aiohue==3.0.11
 
 # homeassistant.components.homewizard
-aiohwenergy==0.6.0
+aiohwenergy==0.7.0
 
 # homeassistant.components.imap
 aioimaplib==0.9.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -141,7 +141,7 @@ aiohttp_cors==0.7.0
 aiohue==3.0.11
 
 # homeassistant.components.homewizard
-aiohwenergy==0.6.0
+aiohwenergy==0.7.0
 
 # homeassistant.components.apache_kafka
 aiokafka==0.6.0

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -95,7 +95,7 @@ async def test_switch_loads_entities(hass, mock_config_entry_data, mock_config_e
         == "Product Name (aabbccddeeff) Switch Lock"
     )
     assert state_switch_lock.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_SWITCH
-    assert state_switch_lock.attributes.get(ATTR_ICON) == "mdi:lock"
+    assert ATTR_ICON not in state_switch_lock.attributes
 
 
 async def test_switch_power_on_off(hass, mock_config_entry_data, mock_config_entry):

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -37,7 +37,7 @@ async def test_switch_entity_not_loaded_when_not_available(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    state_power_on = hass.states.get("sensor.product_name_aabbccddeeff")
+    state_power_on = hass.states.get("sensor.product_name_aabbccddeeff_switch")
     state_switch_lock = hass.states.get("sensor.product_name_aabbccddeeff_switch_lock")
 
     assert state_power_on is None
@@ -66,8 +66,10 @@ async def test_switch_loads_entities(hass, mock_config_entry_data, mock_config_e
 
     entity_registry = er.async_get(hass)
 
-    state_power_on = hass.states.get("switch.product_name_aabbccddeeff")
-    entry_power_on = entity_registry.async_get("switch.product_name_aabbccddeeff")
+    state_power_on = hass.states.get("switch.product_name_aabbccddeeff_switch")
+    entry_power_on = entity_registry.async_get(
+        "switch.product_name_aabbccddeeff_switch"
+    )
     assert state_power_on
     assert entry_power_on
     assert entry_power_on.unique_id == "aabbccddeeff_power_on"
@@ -75,7 +77,7 @@ async def test_switch_loads_entities(hass, mock_config_entry_data, mock_config_e
     assert state_power_on.state == STATE_OFF
     assert (
         state_power_on.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Product Name (aabbccddeeff)"
+        == "Product Name (aabbccddeeff) Switch"
     )
     assert state_power_on.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_OUTLET
     assert ATTR_ICON not in state_power_on.attributes
@@ -122,30 +124,38 @@ async def test_switch_power_on_off(hass, mock_config_entry_data, mock_config_ent
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_OFF
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch").state
+            == STATE_OFF
+        )
 
         # Turn power_on on
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_ON,
-            {"entity_id": "switch.product_name_aabbccddeeff"},
+            {"entity_id": "switch.product_name_aabbccddeeff_switch"},
             blocking=True,
         )
 
         await hass.async_block_till_done()
         assert len(api.state.set.mock_calls) == 1
-        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_ON
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch").state == STATE_ON
+        )
 
         # Turn power_on off
         await hass.services.async_call(
             switch.DOMAIN,
             SERVICE_TURN_OFF,
-            {"entity_id": "switch.product_name_aabbccddeeff"},
+            {"entity_id": "switch.product_name_aabbccddeeff_switch"},
             blocking=True,
         )
 
         await hass.async_block_till_done()
-        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_OFF
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch").state
+            == STATE_OFF
+        )
         assert len(api.state.set.mock_calls) == 2
 
 
@@ -237,7 +247,9 @@ async def test_switch_lock_sets_power_on_unavailable(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_ON
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch").state == STATE_ON
+        )
         assert (
             hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
             == STATE_OFF
@@ -254,7 +266,7 @@ async def test_switch_lock_sets_power_on_unavailable(
         await hass.async_block_till_done()
         assert len(api.state.set.mock_calls) == 1
         assert (
-            hass.states.get("switch.product_name_aabbccddeeff").state
+            hass.states.get("switch.product_name_aabbccddeeff_switch").state
             == STATE_UNAVAILABLE
         )
         assert (
@@ -271,7 +283,9 @@ async def test_switch_lock_sets_power_on_unavailable(
         )
 
         await hass.async_block_till_done()
-        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_ON
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch").state == STATE_ON
+        )
         assert (
             hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
             == STATE_OFF

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -1,0 +1,279 @@
+"""Test the update coordinator for HomeWizard."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components import switch
+from homeassistant.components.switch import DEVICE_CLASS_OUTLET, DEVICE_CLASS_SWITCH
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.helpers import entity_registry as er
+
+from .generator import get_mock_device
+
+
+async def test_switch_entity_not_loaded_when_not_available(
+    hass, mock_config_entry_data, mock_config_entry
+):
+    """Test entity loads smr version."""
+
+    api = get_mock_device()
+
+    with patch(
+        "aiohwenergy.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state_power_on = hass.states.get("sensor.product_name_aabbccddeeff")
+    state_switch_lock = hass.states.get("sensor.product_name_aabbccddeeff_switch_lock")
+
+    assert state_power_on is None
+    assert state_switch_lock is None
+
+
+async def test_switch_loads_entities(hass, mock_config_entry_data, mock_config_entry):
+    """Test entity loads smr version."""
+
+    api = get_mock_device()
+    api.state = AsyncMock()
+
+    api.state.power_on = False
+    api.state.switch_lock = False
+
+    with patch(
+        "aiohwenergy.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+
+    state_power_on = hass.states.get("switch.product_name_aabbccddeeff")
+    entry_power_on = entity_registry.async_get("switch.product_name_aabbccddeeff")
+    assert state_power_on
+    assert entry_power_on
+    assert entry_power_on.unique_id == "aabbccddeeff_power_on"
+    assert not entry_power_on.disabled
+    assert state_power_on.state == STATE_OFF
+    assert (
+        state_power_on.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Product Name (aabbccddeeff)"
+    )
+    assert state_power_on.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_OUTLET
+    assert ATTR_ICON not in state_power_on.attributes
+
+    state_switch_lock = hass.states.get("switch.product_name_aabbccddeeff_switch_lock")
+    entry_switch_lock = entity_registry.async_get(
+        "switch.product_name_aabbccddeeff_switch_lock"
+    )
+
+    assert state_switch_lock
+    assert entry_switch_lock
+    assert entry_switch_lock.unique_id == "aabbccddeeff_switch_lock"
+    assert not entry_switch_lock.disabled
+    assert state_switch_lock.state == STATE_OFF
+    assert (
+        state_switch_lock.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Product Name (aabbccddeeff) Switch Lock"
+    )
+    assert state_switch_lock.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_SWITCH
+    assert state_switch_lock.attributes.get(ATTR_ICON) == "mdi:lock"
+
+
+async def test_switch_power_on_off(hass, mock_config_entry_data, mock_config_entry):
+    """Test entity turns switch on and off."""
+
+    api = get_mock_device()
+    api.state = AsyncMock()
+    api.state.power_on = False
+    api.state.switch_lock = False
+
+    def set_power_on(power_on):
+        api.state.power_on = power_on
+
+    api.state.set = AsyncMock(side_effect=set_power_on)
+
+    with patch(
+        "aiohwenergy.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_OFF
+
+        # Turn power_on on
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {"entity_id": "switch.product_name_aabbccddeeff"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert len(api.state.set.mock_calls) == 1
+        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_ON
+
+        # Turn power_on off
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {"entity_id": "switch.product_name_aabbccddeeff"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_OFF
+        assert len(api.state.set.mock_calls) == 2
+
+
+async def test_switch_lock_power_on_off(
+    hass, mock_config_entry_data, mock_config_entry
+):
+    """Test entity turns switch on and off."""
+
+    api = get_mock_device()
+    api.state = AsyncMock()
+    api.state.power_on = False
+    api.state.switch_lock = False
+
+    def set_switch_lock(switch_lock):
+        api.state.switch_lock = switch_lock
+
+    api.state.set = AsyncMock(side_effect=set_switch_lock)
+
+    with patch(
+        "aiohwenergy.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
+            == STATE_OFF
+        )
+
+        # Turn power_on on
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {"entity_id": "switch.product_name_aabbccddeeff_switch_lock"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert len(api.state.set.mock_calls) == 1
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
+            == STATE_ON
+        )
+
+        # Turn power_on off
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {"entity_id": "switch.product_name_aabbccddeeff_switch_lock"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
+            == STATE_OFF
+        )
+        assert len(api.state.set.mock_calls) == 2
+
+
+async def test_switch_lock_sets_power_on_unavailable(
+    hass, mock_config_entry_data, mock_config_entry
+):
+    """Test entity turns switch on and off."""
+
+    api = get_mock_device()
+    api.state = AsyncMock()
+    api.state.power_on = True
+    api.state.switch_lock = False
+
+    def set_switch_lock(switch_lock):
+        api.state.switch_lock = switch_lock
+
+    api.state.set = AsyncMock(side_effect=set_switch_lock)
+
+    with patch(
+        "aiohwenergy.HomeWizardEnergy",
+        return_value=api,
+    ):
+        entry = mock_config_entry
+        entry.data = mock_config_entry_data
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_ON
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
+            == STATE_OFF
+        )
+
+        # Turn power_on on
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_ON,
+            {"entity_id": "switch.product_name_aabbccddeeff_switch_lock"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert len(api.state.set.mock_calls) == 1
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff").state
+            == STATE_UNAVAILABLE
+        )
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
+            == STATE_ON
+        )
+
+        # Turn power_on off
+        await hass.services.async_call(
+            switch.DOMAIN,
+            SERVICE_TURN_OFF,
+            {"entity_id": "switch.product_name_aabbccddeeff_switch_lock"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+        assert hass.states.get("switch.product_name_aabbccddeeff").state == STATE_ON
+        assert (
+            hass.states.get("switch.product_name_aabbccddeeff_switch_lock").state
+            == STATE_OFF
+        )
+        assert len(api.state.set.mock_calls) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add switch platform to HomeWizard Energy to support Energy Socket outlet.

**Bumped depenceny**
https://github.com/DCSBL/aiohwenergy/compare/0.6.0...0.7.0
- Fixed error handling while setting state (like 'power_on' or 'switch_lock')

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21183

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
