### PR TITLE
Run scheduled workflows only in the home-assistant organization

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   init:
     name: Initialize build
+    if: github.repository_owner == 'home-assistant'
     runs-on: ubuntu-latest
     outputs:
       architectures: ${{ steps.info.outputs.architectures }}
@@ -62,7 +63,7 @@ jobs:
     name: Build PyPi package
     needs: init
     runs-on: ubuntu-latest
-    if: needs.init.outputs.publish == 'true'
+    if: github.repository_owner == 'home-assistant' && needs.init.outputs.publish == 'true'
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2.4.0
@@ -88,6 +89,7 @@ jobs:
 
   build_base:
     name: Build ${{ matrix.arch }} base core image
+    if: github.repository_owner == 'home-assistant'
     needs: init
     runs-on: ubuntu-latest
     strategy:
@@ -143,6 +145,7 @@ jobs:
 
   build_machine:
     name: Build ${{ matrix.machine }} machine core image
+    if: github.repository_owner == 'home-assistant'
     needs: ["init", "build_base"]
     runs-on: ubuntu-latest
     strategy:
@@ -206,6 +209,7 @@ jobs:
 
   publish_ha:
     name: Publish version files
+    if: github.repository_owner == 'home-assistant'
     needs: ["init", "build_machine"]
     runs-on: ubuntu-latest
     steps:
@@ -238,6 +242,7 @@ jobs:
 
   publish_container:
     name: Publish meta container
+    if: github.repository_owner == 'home-assistant'
     needs: ["init", "build_base"]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lock:
+    if: github.repository_owner == 'home-assistant'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   upload:
     name: Upload
-    if: secrets.LOKALISE_TOKEN != null
+    if: github.repository_owner == 'home-assistant'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -36,7 +36,7 @@ jobs:
   download:
     name: Download
     needs: upload
-    if: secrets.LOKALISE_TOKEN != null && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: github.repository_owner == 'home-assistant' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   upload:
     name: Upload
+    if: secrets.LOKALISE_TOKEN != null
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -35,7 +36,7 @@ jobs:
   download:
     name: Download
     needs: upload
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: secrets.LOKALISE_TOKEN != null && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   init:
     name: Initialize wheels builder
+    if: github.repository_owner == 'home-assistant'
     runs-on: ubuntu-latest
     outputs:
       architectures: ${{ steps.info.outputs.architectures }}
@@ -62,6 +63,7 @@ jobs:
 
   core:
     name: Build wheels with ${{ matrix.tag }} (${{ matrix.arch }}) for core
+    if: github.repository_owner == 'home-assistant'
     needs: init
     runs-on: ubuntu-latest
     strategy:
@@ -102,6 +104,7 @@ jobs:
 
   integrations:
     name: Build wheels with ${{ matrix.tag }} (${{ matrix.arch }}) for integrations
+    if: github.repository_owner == 'home-assistant'
     needs: init
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Proposed change

Only run the build, lock, translation and wheels workflows in GitHub Actions if the organization is `home-assistant`.

I'm not that familiar with GitHub Actioins in general, but my interpretation is that whenever someone forks the main repo, actions will begin to run according to the schedules defined in the `.github/workflows` folder. I was made aware of this because once I forked the repo, I started getting several mails per day about failed workflow runs.

The translation workflow requires a Lokalise API key configured as a secret to run successfully, so it will never work by default outside the main repo.

At least some of the other workflows fail because of a similar reason, some kind of secret token is missing in forks, but I'm not sure if that's the case for all of them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
