### PR TITLE
Add new sensors with translations to Overkiz, and fix minor bugs

### DIFF
--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommandParam, OverkizState
 from pyoverkiz.types import StateType as OverkizStateType
@@ -99,6 +100,16 @@ BINARY_SENSOR_DESCRIPTIONS: list[OverkizBinarySensorDescription] = [
         name="Vibration",
         device_class=BinarySensorDeviceClass.VIBRATION,
         value_fn=lambda state: state == OverkizCommandParam.DETECTED,
+    ),
+    # DomesticHotWaterProduction/WaterHeatingSystem
+    OverkizBinarySensorDescription(
+        key=OverkizState.IO_OPERATING_MODE_CAPABILITIES,
+        name="Energy Demand Status",
+        device_class=BinarySensorDeviceClass.HEAT,
+        value_fn=lambda state: cast(dict, state).get(
+            OverkizCommandParam.ENERGY_DEMAND_STATUS
+        )
+        == 1,
     ),
 ]
 

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -39,6 +39,13 @@ BUTTON_DESCRIPTIONS: list[ButtonEntityDescription] = [
         icon="mdi:human-greeting-variant",
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    # RTDIndoorSiren / RTDOutdoorSiren
+    ButtonEntityDescription(key="dingDong", name="Ding Dong", icon="mdi:bell-ring"),
+    ButtonEntityDescription(key="bip", name="Bip", icon="mdi:bell-ring"),
+    ButtonEntityDescription(
+        key="fastBipSequence", name="Fast Bip Sequence", icon="mdi:bell-ring"
+    ),
+    ButtonEntityDescription(key="ring", name="Ring", icon="mdi:bell-ring"),
 ]
 
 

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -37,3 +37,16 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIClass.DOOR_LOCK: Platform.LOCK,
     UIClass.LIGHT: Platform.LIGHT,
 }
+
+# Map Overkiz camelCase to Home Assistant snake_case
+OVERKIZ_STATE_TO_TRANSLATION: dict[str, str] = {
+    "externalGateway": "external_gateway",
+    "localUser": "local_user",
+    "lowBattery": "low_battery",
+    "LSC": "lsc",
+    "maintenanceRequired": "maintenance_required",
+    "noDefect": "no_defect",
+    "SAAC": "saac",
+    "SFC": "sfc",
+    "UPS": "ups",
+}

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -105,5 +105,10 @@ class OverkizDescriptiveEntity(OverkizEntity):
 class OverkizDeviceClass(StrEnum):
     """Device class for Overkiz specific devices."""
 
-    OPEN_CLOSED_PEDESTRIAN = "overkiz__open_closed_pedestrian"
+    BATTERY = "overkiz__battery"
+    DISCRETE_RSSI_LEVEL = "overkiz__discrete_rssi_level"
     MEMORIZED_SIMPLE_VOLUME = "overkiz__memorized_simple_volume"
+    OPEN_CLOSED_PEDESTRIAN = "overkiz__open_closed_pedestrian"
+    PRIORITY_LOCK_ORIGINATOR = "overkiz__priority_lock_originator"
+    SENSOR_DEFECT = "overkiz__sensor_defect"
+    SENSOR_ROOM = "overkiz__sensor_room"

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -59,21 +59,19 @@ class OverkizEntity(CoordinatorEntity):
         )
 
         model = (
-            str(
-                self.executor.select_state(
-                    OverkizState.CORE_MODEL,
-                    OverkizState.CORE_PRODUCT_MODEL_NAME,
-                    OverkizState.IO_MODEL,
-                ),
+            self.executor.select_state(
+                OverkizState.CORE_MODEL,
+                OverkizState.CORE_PRODUCT_MODEL_NAME,
+                OverkizState.IO_MODEL,
             )
-            or self.device.widget
+            or self.device.widget.value
         )
 
         return DeviceInfo(
             identifiers={(DOMAIN, self.executor.base_device_url)},
             name=self.device.label,
             manufacturer=str(manufacturer),
-            model=model,
+            model=str(model),
             sw_version=str(
                 self.executor.select_attribute(OverkizAttribute.CORE_FIRMWARE_REVISION)
             ),

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -53,12 +53,14 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        native_value=lambda value: int(str(value).strip("%")),
     ),
     OverkizSensorDescription(
         key=OverkizState.CORE_BATTERY,
         name="Battery",
         native_value=lambda value: str(value).capitalize(),
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:battery",
     ),
     OverkizSensorDescription(
         key=OverkizState.CORE_RSSI_LEVEL,

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -321,7 +321,9 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         device_class=OverkizDeviceClass.PRIORITY_LOCK_ORIGINATOR,
         icon="mdi:lock",
         entity_registry_enabled_default=False,
-        native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(str(value), value),
+        native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(
+            str(value), cast(str, value)
+        ),
     ),
     OverkizSensorDescription(
         key=OverkizState.CORE_PRIORITY_LOCK_TIMER,
@@ -344,7 +346,9 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=OverkizDeviceClass.SENSOR_DEFECT,
-        native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(str(value), value),
+        native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(
+            str(value), cast(str, value)
+        ),
     ),
     # DomesticHotWaterProduction/WaterHeatingSystem
     OverkizSensorDescription(

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -33,9 +33,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import HomeAssistantOverkizData
-from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
+from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES, OVERKIZ_STATE_TO_TRANSLATION
 from .coordinator import OverkizDataUpdateCoordinator
-from .entity import OverkizDescriptiveEntity, OverkizEntity
+from .entity import OverkizDescriptiveEntity, OverkizDeviceClass, OverkizEntity
 
 
 @dataclass
@@ -58,9 +58,9 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
     OverkizSensorDescription(
         key=OverkizState.CORE_BATTERY,
         name="Battery",
-        native_value=lambda value: str(value).capitalize(),
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:battery",
+        device_class=OverkizDeviceClass.BATTERY,
     ),
     OverkizSensorDescription(
         key=OverkizState.CORE_RSSI_LEVEL,
@@ -311,15 +311,17 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
     OverkizSensorDescription(
         key=OverkizState.IO_SENSOR_ROOM,
         name="Sensor Room",
-        native_value=lambda value: str(value).capitalize(),
-        entity_registry_enabled_default=False,
+        device_class=OverkizDeviceClass.SENSOR_ROOM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:spray-bottle",
     ),
     OverkizSensorDescription(
         key=OverkizState.IO_PRIORITY_LOCK_ORIGINATOR,
         name="Priority Lock Originator",
-        native_value=lambda value: str(value).capitalize(),
+        device_class=OverkizDeviceClass.PRIORITY_LOCK_ORIGINATOR,
         icon="mdi:lock",
         entity_registry_enabled_default=False,
+        native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(str(value), value),
     ),
     OverkizSensorDescription(
         key=OverkizState.CORE_PRIORITY_LOCK_TIMER,
@@ -332,8 +334,17 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         key=OverkizState.CORE_DISCRETE_RSSI_LEVEL,
         name="Discrete RSSI Level",
         entity_registry_enabled_default=False,
-        native_value=lambda value: str(value).capitalize(),
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=OverkizDeviceClass.DISCRETE_RSSI_LEVEL,
+        icon="mdi:wifi",
+    ),
+    OverkizSensorDescription(
+        key=OverkizState.CORE_SENSOR_DEFECT,
+        name="Sensor Defect",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=OverkizDeviceClass.SENSOR_DEFECT,
+        native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(str(value), value),
     ),
     # DomesticHotWaterProduction/WaterHeatingSystem
     OverkizSensorDescription(

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -322,7 +322,7 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         icon="mdi:lock",
         entity_registry_enabled_default=False,
         native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(
-            str(value), cast(str, value)
+            cast(str, value), cast(str, value)
         ),
     ),
     OverkizSensorDescription(
@@ -347,7 +347,7 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=OverkizDeviceClass.SENSOR_DEFECT,
         native_value=lambda value: OVERKIZ_STATE_TO_TRANSLATION.get(
-            str(value), cast(str, value)
+            cast(str, value), cast(str, value)
         ),
     ),
     # DomesticHotWaterProduction/WaterHeatingSystem

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -15,7 +15,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "server_in_maintenance": "Server is down for maintenance",
-      "too_many_requests": "Too many requests, try again later.",
+      "too_many_requests": "Too many requests, try again later",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/overkiz/strings.sensor.json
+++ b/homeassistant/components/overkiz/strings.sensor.json
@@ -1,0 +1,41 @@
+{
+  "state": {
+    "overkiz__battery": {
+      "full": "Full",
+      "low": "Low",
+      "normal": "Normal",
+      "verylow": "Very low"
+    },
+    "overkiz__discrete_rssi_level": {
+      "good": "Good",
+      "low": "Low",
+      "normal": "Normal",
+      "verylow": "Very low"
+    },
+    "overkiz__priority_lock_originator": {
+      "lsc": "LSC",
+      "saac": "SAAC",
+      "sfc": "SFC",
+      "ups": "UPS",
+      "external_gateway": "External gateway",
+      "local_user": "Local user",
+      "myself": "Myself",
+      "rain": "Rain",
+      "security": "Security",
+      "temperature": "Temperature",
+      "timer": "Timer",
+      "user": "User",
+      "wind": "Wind"
+    },
+    "overkiz__sensor_room": {
+      "clean": "Clean",
+      "dirty": "Dirty"
+    },
+    "overkiz__sensor_defect": {
+      "dead": "Dead",
+      "low_battery": "Low battery",
+      "maintenance_required": "Maintenance required",
+      "no_defect": "No defect"
+    }
+  }
+}

--- a/homeassistant/components/overkiz/translations/en.json
+++ b/homeassistant/components/overkiz/translations/en.json
@@ -7,7 +7,7 @@
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
             "server_in_maintenance": "Server is down for maintenance",
-            "too_many_requests": "Too many requests, try again later.",
+            "too_many_requests": "Too many requests, try again later",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/homeassistant/components/overkiz/translations/sensor.en.json
+++ b/homeassistant/components/overkiz/translations/sensor.en.json
@@ -1,0 +1,41 @@
+{
+    "state": {
+        "overkiz__battery": {
+            "full": "Full",
+            "low": "Low",
+            "normal": "Normal",
+            "verylow": "Very low"
+        },
+        "overkiz__discrete_rssi_level": {
+            "good": "Good",
+            "low": "Low",
+            "normal": "Normal",
+            "verylow": "Very low"
+        },
+        "overkiz__priority_lock_originator": {
+            "external_gateway": "External gateway",
+            "local_user": "Local user",
+            "lsc": "LSC",
+            "myself": "Myself",
+            "rain": "Rain",
+            "saac": "SAAC",
+            "security": "Security",
+            "sfc": "SFC",
+            "temperature": "Temperature",
+            "timer": "Timer",
+            "ups": "UPS",
+            "user": "User",
+            "wind": "Wind"
+        },
+        "overkiz__sensor_defect": {
+            "dead": "Dead",
+            "low_battery": "Low battery",
+            "maintenance_required": "Maintenance required",
+            "no_defect": "No defect"
+        },
+        "overkiz__sensor_room": {
+            "clean": "Clean",
+            "dirty": "Dirty"
+        }
+    }
+}


### PR DESCRIPTION
## Proposed change

If this is too big, I can split it up in multiple PR's, however since most of them are relatively small fixes I decided to couple them to not make a load of PR's. Would be good to have at least the bugs fixed.

- Add missing buttons from custom component
- Add missing sensors from custom component
- Add missing binary sensor from custom component (left out due to typing issues before)
- Translate sensors and use keys by default, instead of capitalizing them
- Fix bug in device info 'model' where a Enum could be stringified
- Fix bug in battery sensor where output was apparently a string (100 %) instead of int
- Remove extra dot from translations

This will fix and finish all current platforms that are in `dev` for now, so that it is ready for next core release. 

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
