### PR TITLE
Fix flux_led turn on when brightness is zero on newer devices

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -249,6 +249,10 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
     async def _async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified or all lights on."""
         if self._device.requires_turn_on or not kwargs:
+            if not self.brightness:
+                await self._device.async_set_brightness(
+                    self._async_brightness(**kwargs)
+                )
             if not self.is_on:
                 await self._device.async_turn_on()
             if not kwargs:
@@ -281,13 +285,11 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
         """Determine brightness from kwargs or current value."""
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is None:
             brightness = self.brightness
-        if not brightness:
-            # If the brightness was previously 0, the light
-            # will not turn on unless brightness is at least 1
-            # If the device was on and brightness was not
-            # set, it means it was masked by an effect
-            brightness = 255 if self.is_on else 1
-        return brightness
+        # If the brightness was previously 0, the light
+        # will not turn on unless brightness is at least 1
+        # If the device was on and brightness was not
+        # set, it means it was masked by an effect
+        return min(1, brightness)
 
     async def _async_set_mode(self, **kwargs: Any) -> None:
         """Set an effect or color mode."""

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -55,6 +55,7 @@ from .util import (
     _effect_brightness,
     _flux_color_mode_to_hass,
     _hass_color_modes,
+    _min_rgb_brightness,
     _min_rgbw_brightness,
     _min_rgbwc_brightness,
     _str_to_multi_color_effect,
@@ -312,6 +313,8 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
             return
         # Handle switch to RGB Color Mode
         if rgb := kwargs.get(ATTR_RGB_COLOR):
+            if not self._device.requires_turn_on:
+                rgb = _min_rgb_brightness(rgb)
             red, green, blue = rgb
             await self._device.async_set_levels(red, green, blue, brightness=brightness)
             return
@@ -321,16 +324,16 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
                 rgbw = rgbw_brightness(rgbw, brightness)
             if not self._device.requires_turn_on:
                 rgbw = _min_rgbw_brightness(rgbw)
-            _LOGGER.warning("RGBW: %s", rgbw)
             await self._device.async_set_levels(*rgbw)
             return
         # Handle switch to RGBWW Color Mode
         if rgbcw := kwargs.get(ATTR_RGBWW_COLOR):
             if ATTR_BRIGHTNESS in kwargs:
                 rgbcw = rgbcw_brightness(kwargs[ATTR_RGBWW_COLOR], brightness)
+            rgbwc = rgbcw_to_rgbwc(rgbcw)
             if not self._device.requires_turn_on:
-                rgbcw = _min_rgbwc_brightness(rgbcw_to_rgbwc(rgbcw))
-            await self._device.async_set_levels(*rgbcw)
+                rgbwc = _min_rgbwc_brightness(rgbwc)
+            await self._device.async_set_levels(*rgbwc)
             return
         if (white := kwargs.get(ATTR_WHITE)) is not None:
             await self._device.async_set_levels(w=white)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -287,6 +287,10 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
             brightness = self.brightness
         # If the brightness was previously 0, the light
         # will not turn on unless brightness is at least 1
+        #
+        # We previously had a problem with the brightness
+        # sometimes reporting as 0 when an effect was in progress,
+        # however this has since been resolved in the upstream library
         return max(1, brightness)
 
     async def _async_set_mode(self, **kwargs: Any) -> None:

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -319,15 +319,18 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
         if rgbw := kwargs.get(ATTR_RGBW_COLOR):
             if ATTR_BRIGHTNESS in kwargs:
                 rgbw = rgbw_brightness(rgbw, brightness)
-            await self._device.async_set_levels(*_min_rgbw_brightness(rgbw))
+            if not self._device.requires_turn_on:
+                rgbw = _min_rgbw_brightness(rgbw)
+            _LOGGER.warning("RGBW: %s", rgbw)
+            await self._device.async_set_levels(*rgbw)
             return
         # Handle switch to RGBWW Color Mode
         if rgbcw := kwargs.get(ATTR_RGBWW_COLOR):
             if ATTR_BRIGHTNESS in kwargs:
                 rgbcw = rgbcw_brightness(kwargs[ATTR_RGBWW_COLOR], brightness)
-            await self._device.async_set_levels(
-                *_min_rgbwc_brightness(rgbcw_to_rgbwc(rgbcw))
-            )
+            if not self._device.requires_turn_on:
+                rgbcw = _min_rgbwc_brightness(rgbcw_to_rgbwc(rgbcw))
+            await self._device.async_set_levels(*rgbcw)
             return
         if (white := kwargs.get(ATTR_WHITE)) is not None:
             await self._device.async_set_levels(w=white)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -287,9 +287,7 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
             brightness = self.brightness
         # If the brightness was previously 0, the light
         # will not turn on unless brightness is at least 1
-        # If the device was on and brightness was not
-        # set, it means it was masked by an effect
-        return min(1, brightness)
+        return max(1, brightness)
 
     async def _async_set_mode(self, **kwargs: Any) -> None:
         """Set an effect or color mode."""

--- a/homeassistant/components/flux_led/util.py
+++ b/homeassistant/components/flux_led/util.py
@@ -54,6 +54,13 @@ def _str_to_multi_color_effect(effect_str: str) -> MultiColorEffects:
     assert False  # pragma: no cover
 
 
+def _min_rgb_brightness(rgb: tuple[int, int, int]) -> tuple[int, int, int]:
+    """Ensure the RGB value will not turn off the device from a turn on command."""
+    if all(byte == 0 for byte in rgb):
+        return (1, 1, 1)
+    return rgb
+
+
 def _min_rgbw_brightness(rgbw: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
     """Ensure the RGBW value will not turn off the device from a turn on command."""
     if all(byte == 0 for byte in rgbw):

--- a/homeassistant/components/flux_led/util.py
+++ b/homeassistant/components/flux_led/util.py
@@ -52,3 +52,19 @@ def _str_to_multi_color_effect(effect_str: str) -> MultiColorEffects:
             return effect
     # unreachable due to schema validation
     assert False  # pragma: no cover
+
+
+def _min_rgbw_brightness(rgbw: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
+    """Ensure the RGBW value will not turn off the device from a turn on command."""
+    if all(byte == 0 for byte in rgbw):
+        return (1, 1, 1, 0)
+    return rgbw
+
+
+def _min_rgbwc_brightness(
+    rgbwc: tuple[int, int, int, int, int]
+) -> tuple[int, int, int, int, int]:
+    """Ensure the RGBWC value will not turn off the device from a turn on command."""
+    if all(byte == 0 for byte in rgbwc):
+        return (1, 1, 1, 0, 0)
+    return rgbwc

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -48,6 +48,9 @@ from homeassistant.components.light import (
     ATTR_RGBWW_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_WHITE,
+    COLOR_MODE_RGB,
+    COLOR_MODE_RGBW,
+    COLOR_MODE_RGBWW,
     DOMAIN as LIGHT_DOMAIN,
 )
 from homeassistant.const import (
@@ -258,7 +261,6 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
     # so we need to make sure its at least 1 and that we
     # call it before the turn on command since the device
     # does not support auto on
-    bulb.async_set_brightness.assert_called_with(1)
     bulb.async_set_levels.assert_called_with(10, 10, 30, brightness=1)
     bulb.async_set_levels.reset_mock()
 
@@ -314,9 +316,9 @@ async def test_rgb_light_auto_on(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "rgb"
+    assert attributes[ATTR_COLOR_MODE] == COLOR_MODE_RGB
     assert attributes[ATTR_EFFECT_LIST] == bulb.effect_list
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [COLOR_MODE_RGB]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -338,6 +340,19 @@ async def test_rgb_light_auto_on(hass: HomeAssistant) -> None:
     # it has to be at least 1 or the bulb won't turn on
     bulb.async_turn_on.assert_not_called()
     bulb.async_set_levels.assert_called_with(10, 10, 30, brightness=1)
+    bulb.async_set_levels.reset_mock()
+    bulb.async_turn_on.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: (0, 0, 0)},
+        blocking=True,
+    )
+    # If the bulb is off and we are using existing brightness
+    # it has to be at least 1 or the bulb won't turn on
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_levels.assert_called_with(1, 1, 1, brightness=1)
     bulb.async_set_levels.reset_mock()
     bulb.async_turn_on.reset_mock()
 
@@ -383,6 +398,236 @@ async def test_rgb_light_auto_on(hass: HomeAssistant) -> None:
     )
     bulb.async_turn_on.assert_not_called()
     bulb.async_set_levels.assert_called_with(255, 191, 178, brightness=128)
+    bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_effect.assert_called_once()
+    bulb.async_set_effect.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_effect.assert_called_with("purple_fade", 50, 50)
+    bulb.async_set_effect.reset_mock()
+
+
+async def test_rgbw_light_auto_on(hass: HomeAssistant) -> None:
+    """Test an rgbw light that does not need the turn on command sent."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.requires_turn_on = False
+    bulb.raw_state = bulb.raw_state._replace(model_num=0x33)  # RGB only model
+    bulb.color_modes = {FLUX_COLOR_MODE_RGBW}
+    bulb.color_mode = FLUX_COLOR_MODE_RGBW
+    with _patch_discovery(), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.bulb_rgbcw_ddeeff"
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 128
+    assert attributes[ATTR_COLOR_MODE] == COLOR_MODE_RGBW
+    assert attributes[ATTR_EFFECT_LIST] == bulb.effect_list
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [COLOR_MODE_RGBW]
+    assert attributes[ATTR_HS_COLOR] == (0.0, 83.529)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_turn_off.assert_called_once()
+
+    await async_mock_device_turn_off(hass, bulb)
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    bulb.brightness = 0
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (10, 10, 30, 0)},
+        blocking=True,
+    )
+    # If the bulb is off and we are using existing brightness
+    # it has to be at least 1 or the bulb won't turn on
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_levels.assert_called_with(10, 10, 30, 0)
+    bulb.async_set_levels.reset_mock()
+    bulb.async_turn_on.reset_mock()
+
+    # Should still be called with no kwargs
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_turn_on.assert_called_once()
+    await async_mock_device_turn_on(hass, bulb)
+    assert hass.states.get(entity_id).state == STATE_ON
+    bulb.async_turn_on.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_brightness.assert_called_with(100)
+    bulb.async_set_brightness.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (0, 0, 0, 0)},
+        blocking=True,
+    )
+    # If the bulb is on and we are using existing brightness
+    # and brightness was 0 we need to set it to at least 1
+    # or the device may not turn on
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_brightness.assert_not_called()
+    bulb.async_set_levels.assert_called_with(1, 1, 1, 0)
+    bulb.async_set_levels.reset_mock()
+
+    bulb.brightness = 128
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_levels.assert_called_with(110, 19, 0, 255)
+    bulb.async_set_levels.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_effect.assert_called_once()
+    bulb.async_set_effect.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_effect.assert_called_with("purple_fade", 50, 50)
+    bulb.async_set_effect.reset_mock()
+
+
+async def test_rgbww_light_auto_on(hass: HomeAssistant) -> None:
+    """Test an rgbww light that does not need the turn on command sent."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.requires_turn_on = False
+    bulb.raw_state = bulb.raw_state._replace(model_num=0x33)  # RGB only model
+    bulb.color_modes = {FLUX_COLOR_MODE_RGBWW}
+    bulb.color_mode = FLUX_COLOR_MODE_RGBWW
+    with _patch_discovery(), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.bulb_rgbcw_ddeeff"
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 128
+    assert attributes[ATTR_COLOR_MODE] == COLOR_MODE_RGBWW
+    assert attributes[ATTR_EFFECT_LIST] == bulb.effect_list
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [COLOR_MODE_RGBWW]
+    assert attributes[ATTR_HS_COLOR] == (3.237, 94.51)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_turn_off.assert_called_once()
+
+    await async_mock_device_turn_off(hass, bulb)
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    bulb.brightness = 0
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBWW_COLOR: (10, 10, 30, 0, 0)},
+        blocking=True,
+    )
+    # If the bulb is off and we are using existing brightness
+    # it has to be at least 1 or the bulb won't turn on
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_levels.assert_called_with(10, 10, 30, 0, 0)
+    bulb.async_set_levels.reset_mock()
+    bulb.async_turn_on.reset_mock()
+
+    # Should still be called with no kwargs
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.async_turn_on.assert_called_once()
+    await async_mock_device_turn_on(hass, bulb)
+    assert hass.states.get(entity_id).state == STATE_ON
+    bulb.async_turn_on.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_brightness.assert_called_with(100)
+    bulb.async_set_brightness.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBWW_COLOR: (0, 0, 0, 0, 0)},
+        blocking=True,
+    )
+    # If the bulb is on and we are using existing brightness
+    # and brightness was 0 we need to set it to at least 1
+    # or the device may not turn on
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_brightness.assert_not_called()
+    bulb.async_set_levels.assert_called_with(1, 1, 1, 0, 0)
+    bulb.async_set_levels.reset_mock()
+
+    bulb.brightness = 128
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
+        blocking=True,
+    )
+    bulb.async_turn_on.assert_not_called()
+    bulb.async_set_levels.assert_called_with(14, 0, 30, 255, 255)
     bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -254,9 +254,12 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
         blocking=True,
     )
     # If the bulb is on and we are using existing brightness
-    # and brightness was 0 it means we could not read it because
-    # an effect is in progress so we use 255
-    bulb.async_set_levels.assert_called_with(10, 10, 30, brightness=255)
+    # and brightness was 0 older devices will not be able to turn on
+    # so we need to make sure its at least 1 and that we
+    # call it before the turn on command since the device
+    # does not support auto on
+    bulb.async_set_brightness.assert_called_with(1)
+    bulb.async_set_levels.assert_called_with(10, 10, 30, brightness=1)
     bulb.async_set_levels.reset_mock()
 
     bulb.brightness = 128
@@ -364,10 +367,11 @@ async def test_rgb_light_auto_on(hass: HomeAssistant) -> None:
         blocking=True,
     )
     # If the bulb is on and we are using existing brightness
-    # and brightness was 0 it means we could not read it because
-    # an effect is in progress so we use 255
+    # and brightness was 0 we need to set it to at least 1
+    # or the device may not turn on
     bulb.async_turn_on.assert_not_called()
-    bulb.async_set_levels.assert_called_with(10, 10, 30, brightness=255)
+    bulb.async_set_brightness.assert_not_called()
+    bulb.async_set_levels.assert_called_with(10, 10, 30, brightness=1)
     bulb.async_set_levels.reset_mock()
 
     bulb.brightness = 128


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The older devices can have a brightness of 0 and still be in an on state. The newer
devices will turn off with a brightness of 0.

We now prevent the device from getting into this state since it won't be able
to be turned back on once it happens.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
