### PR TITLE
Guard for timeout errors during wled discovery

### DIFF
--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure the WLED integration."""
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import voluptuous as vol
@@ -74,7 +75,7 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
         self.discovered_host = discovery_info.host
         try:
             self.discovered_device = await self._async_get_device(discovery_info.host)
-        except WLEDConnectionError:
+        except (WLEDConnectionError, asyncio.TimeoutError):
             return self.async_abort(reason="cannot_connect")
 
         await self.async_set_unique_id(self.discovered_device.info.mac_address)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Noticed this in my dev environment. My device got discovered and then didn't respond I guess.

Catches

```
2022-01-14 10:55:17 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/helpers/discovery_flow.py", line 74, in _async_process_pending_flows
    await gather_with_concurrency(
  File "/Users/paulus/dev/hass/core/homeassistant/util/async_.py", line 174, in gather_with_concurrency
    return await gather(
  File "/Users/paulus/dev/hass/core/homeassistant/util/async_.py", line 172, in sem_task
    return await task
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 203, in async_init
    flow, result = await task
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 230, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data, init_done)
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 325, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/Users/paulus/dev/hass/core/homeassistant/components/wled/config_flow.py", line 76, in async_step_zeroconf
    self.discovered_device = await self._async_get_device(discovery_info.host)
  File "/Users/paulus/dev/hass/core/homeassistant/components/wled/config_flow.py", line 112, in _async_get_device
    return await wled.update()
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/backoff/_async.py", line 133, in retry
    ret = await target(*args, **kwargs)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/wled/wled.py", line 234, in update
    if not (data := await self.request("/json")):
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/backoff/_async.py", line 133, in retry
    ret = await target(*args, **kwargs)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/wled/wled.py", line 203, in request
    response_data = await response.json()
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 1098, in json
    await self.read()
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 1036, in read
    self._body = await self.content.read()
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/streams.py", line 375, in read
    block = await self.readany()
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/streams.py", line 397, in readany
    await self._wait("readany")
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/streams.py", line 304, in _wait
    await waiter
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/helpers.py", line 721, in __exit__
    raise asyncio.TimeoutError from None
asyncio.exceptions.TimeoutError
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
