### PR TITLE
Add Volumio repeat support

### DIFF
--- a/homeassistant/components/volumio/manifest.json
+++ b/homeassistant/components/volumio/manifest.json
@@ -5,6 +5,6 @@
   "codeowners": ["@OnFreund"],
   "config_flow": true,
   "zeroconf": ["_Volumio._tcp.local."],
-  "requirements": ["pyvolumio==0.1.3"],
+  "requirements": ["pyvolumio==0.1.5"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -9,6 +9,8 @@ import json
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
+    REPEAT_MODE_ALL,
+    REPEAT_MODE_OFF,
     SUPPORT_BROWSE_MEDIA,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
@@ -16,6 +18,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_REPEAT_SET,
     SUPPORT_SEEK,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_SHUFFLE_SET,
@@ -52,6 +55,7 @@ SUPPORT_VOLUMIO = (
     | SUPPORT_PLAY_MEDIA
     | SUPPORT_VOLUME_STEP
     | SUPPORT_SELECT_SOURCE
+    | SUPPORT_REPEAT_SET
     | SUPPORT_SHUFFLE_SET
     | SUPPORT_CLEAR_PLAYLIST
     | SUPPORT_BROWSE_MEDIA
@@ -183,6 +187,13 @@ class Volumio(MediaPlayerEntity):
         return self._state.get("random", False)
 
     @property
+    def repeat(self):
+        """Return current repeat mode."""
+        if self._state.get("repeat", None):
+            return REPEAT_MODE_ALL
+        return REPEAT_MODE_OFF
+
+    @property
     def source_list(self):
         """Return the list of available input sources."""
         return self._playlists
@@ -242,6 +253,13 @@ class Volumio(MediaPlayerEntity):
     async def async_set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""
         await self._volumio.set_shuffle(shuffle)
+
+    async def async_set_repeat(self, repeat):
+        """Set repeat mode."""
+        if repeat == REPEAT_MODE_OFF:
+            await self._volumio.repeatAll("false")
+        else:
+            await self._volumio.repeatAll("true")
 
     async def async_select_source(self, source):
         """Choose an available playlist and play it."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2039,7 +2039,7 @@ pyvizio==0.1.57
 pyvlx==0.2.19
 
 # homeassistant.components.volumio
-pyvolumio==0.1.3
+pyvolumio==0.1.5
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1255,7 +1255,7 @@ pyvesync==1.4.2
 pyvizio==0.1.57
 
 # homeassistant.components.volumio
-pyvolumio==0.1.3
+pyvolumio==0.1.5
 
 # homeassistant.components.html5
 pywebpush==1.9.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the repeat command to Volumio. It supports `Repeat All` and `Repeat Off`.

The Volumio REST API does not support `Repeat One`. https://github.com/volumio/Volumio2/issues/2121

This integration uses PyVolumio as a dependency and this has been bumped from 0.1.3 to 0.1.5 in this PR. The diff between them is available here https://github.com/OnFreund/PyVolumio/compare/v0.1.3...v0.1.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51592
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
