### PR TITLE
Add test cases for Tradfri fan platform

### DIFF
--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -67,6 +67,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         """Initialize a switch."""
         super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
+        self._refresh(device, write_ha=False)
 
     @property
     def supported_features(self) -> int:
@@ -171,6 +172,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
     def _refresh(self, device: Command, write_ha: bool = True) -> None:
         """Refresh the purifier data."""
         # Caching of air purifier control and purifier object
+        self._device = device
         self._device_control = device.air_purifier_control
         self._device_data = device.air_purifier_control.air_purifiers[0]
         super()._refresh(device, write_ha=write_ha)

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -172,7 +172,6 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
     def _refresh(self, device: Command, write_ha: bool = True) -> None:
         """Refresh the purifier data."""
         # Caching of air purifier control and purifier object
-        self._device = device
         self._device_control = device.air_purifier_control
         self._device_data = device.air_purifier_control.air_purifiers[0]
         super()._refresh(device, write_ha=write_ha)

--- a/tests/components/tradfri/test_fan.py
+++ b/tests/components/tradfri/test_fan.py
@@ -1,0 +1,162 @@
+"""Tradfri fan (recognised as air purifiers in the IKEA ecosystem) platform tests."""
+
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+import pytest
+from pytradfri.device import Device
+from pytradfri.device.air_purifier import AirPurifier
+from pytradfri.device.air_purifier_control import AirPurifierControl
+
+from .common import setup_integration
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(request):
+    """Set up patches for pytradfri methods."""
+    with patch(
+        "pytradfri.device.AirPurifierControl.raw",
+        new_callable=PropertyMock,
+        return_value=[{"mock": "mock"}],
+    ), patch(
+        "pytradfri.device.AirPurifierControl.air_purifiers",
+    ):
+        yield
+
+
+def mock_fan(test_features=None, test_state=None, device_number=0):
+    """Mock a tradfri fan/air purifier."""
+    if test_features is None:
+        test_features = {}
+    if test_state is None:
+        test_state = {}
+    mock_fan_data = Mock(**test_state)
+
+    dev_info_mock = MagicMock()
+    dev_info_mock.manufacturer = "manufacturer"
+    dev_info_mock.model_number = "model"
+    dev_info_mock.firmware_version = "1.2.3"
+    _mock_fan = Mock(
+        id=f"mock-fan-id-{device_number}",
+        reachable=True,
+        observe=Mock(),
+        device_info=dev_info_mock,
+        has_light_control=False,
+        has_socket_control=False,
+        has_blind_control=False,
+        has_signal_repeater_control=False,
+        has_air_purifier_control=True,
+    )
+    _mock_fan.name = f"tradfri_fan_{device_number}"
+    air_purifier_control = AirPurifierControl(_mock_fan)
+
+    # Store the initial state.
+    setattr(air_purifier_control, "air_purifiers", [mock_fan_data])
+    _mock_fan.air_purifier_control = air_purifier_control
+    return _mock_fan
+
+
+async def test_fan(hass, mock_gateway, mock_api_factory):
+    """Test that fans are correctly added."""
+    state = {
+        "fan_speed": 10,
+    }
+
+    mock_gateway.mock_devices.append(mock_fan(test_state=state))
+    await setup_integration(hass)
+
+    fan_1 = hass.states.get("fan.tradfri_fan_0")
+    assert fan_1 is not None
+    assert fan_1.state == "on"
+    assert fan_1.attributes["percentage"] == 18
+    assert fan_1.attributes["preset_modes"] == ["Auto"]
+    assert fan_1.attributes["supported_features"] == 9
+
+
+async def test_fan_observed(hass, mock_gateway, mock_api_factory):
+    """Test that fans are correctly observed."""
+    state = {
+        "fan_speed": 10,
+    }
+
+    fan = mock_fan(test_state=state)
+    mock_gateway.mock_devices.append(fan)
+    await setup_integration(hass)
+    assert len(fan.observe.mock_calls) > 0
+
+
+async def test_fan_available(hass, mock_gateway, mock_api_factory):
+    """Test fan available property."""
+
+    fan = mock_fan(test_state={"fan_speed": 10}, device_number=1)
+    fan.reachable = True
+
+    fan2 = mock_fan(test_state={"fan_speed": 10}, device_number=2)
+    fan2.reachable = False
+
+    mock_gateway.mock_devices.append(fan)
+    mock_gateway.mock_devices.append(fan2)
+    await setup_integration(hass)
+
+    assert hass.states.get("fan.tradfri_fan_1").state == "on"
+    assert hass.states.get("fan.tradfri_fan_2").state == "unavailable"
+
+
+@pytest.mark.parametrize(
+    "test_data, expected_result",
+    [
+        (
+            {"percentage": 50},
+            "on",
+        ),
+        ({"percentage": 0}, "off"),
+    ],
+)
+async def test_set_percentage(
+    hass,
+    mock_gateway,
+    mock_api_factory,
+    test_data,
+    expected_result,
+):
+    """Test setting speed of a fan."""
+    # Note pytradfri style, not hass. Values not really important.
+    initial_state = {"percentage": 10, "fan_speed": 3}
+
+    # Setup the gateway with a mock fan.
+    fan = mock_fan(test_state=initial_state, device_number=0)
+    mock_gateway.mock_devices.append(fan)
+    await setup_integration(hass)
+
+    # Use the turn_on service call to change the fan state.
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": "fan.tradfri_fan_0", **test_data},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Check that the fan is observed.
+    mock_func = fan.observe
+    assert len(mock_func.mock_calls) > 0
+    _, callkwargs = mock_func.call_args
+    assert "callback" in callkwargs
+    # Callback function to refresh fan state.
+    callback = callkwargs["callback"]
+
+    responses = mock_gateway.mock_responses
+    mock_gateway_response = responses[0]
+
+    # A KeyError is raised if we don't add the 5908 response code
+    mock_gateway_response["15025"][0].update({"5908": 10})
+
+    # Use the callback function to update the fan state.
+    dev = Device(mock_gateway_response)
+    fan_data = AirPurifier(dev, 0)
+    fan.air_purifier_control.air_purifiers[0] = fan_data
+    callback(fan)
+    await hass.async_block_till_done()
+
+    # Check that the state is correct.
+    state = hass.states.get("fan.tradfri_fan_0")
+    assert state.state == expected_result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR continues the work from #64072 and adds tests for the `fan` platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
