### PR TITLE
Bump google-nest-sdm to 1.5.0 and add nest mp4 clip transcoding to animated gif

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -1,12 +1,15 @@
 """Support for Nest devices."""
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
+import asyncio
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 import logging
 
 from aiohttp import web
+from google_nest_sdm.camera_traits import CameraClipPreviewTrait
+from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage
 from google_nest_sdm.event_media import Media
 from google_nest_sdm.exceptions import (
@@ -57,7 +60,11 @@ from .const import (
 )
 from .events import EVENT_NAME_MAP, NEST_EVENT
 from .legacy import async_setup_legacy, async_setup_legacy_entry
-from .media_source import async_get_media_event_store, get_media_source_devices
+from .media_source import (
+    async_get_media_event_store,
+    async_get_transcoder,
+    get_media_source_devices,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -234,6 +241,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     subscriber.cache_policy.fetch = True
     # Use disk backed event media store
     subscriber.cache_policy.store = await async_get_media_event_store(hass, subscriber)
+    subscriber.cache_policy.transcoder = await async_get_transcoder(hass)
 
     async def async_config_reload() -> None:
         await hass.config_entries.async_reload(entry.entry_id)
@@ -333,9 +341,7 @@ class NestEventViewBase(HomeAssistantView, ABC):
                 f"No Nest Device found for '{device_id}'", HTTPStatus.NOT_FOUND
             )
         try:
-            media = await nest_device.event_media_manager.get_media_from_token(
-                event_token
-            )
+            media = await self.load_media(nest_device, event_token)
         except DecodeException as err:
             raise HomeAssistantError(
                 "Even token was invalid: %s" % event_token
@@ -348,8 +354,13 @@ class NestEventViewBase(HomeAssistantView, ABC):
             )
         return await self.handle_media(media)
 
-    async def handle_media(self, media: Media) -> web.StreamResponse:
+    @abstractmethod
+    async def load_media(self, nest_device: Device, event_token: str) -> Media | None:
         """Load the specified media."""
+
+    @abstractmethod
+    async def handle_media(self, media: Media) -> web.StreamResponse:
+        """Process the specified media."""
 
     def _json_error(self, message: str, status: HTTPStatus) -> web.StreamResponse:
         """Return a json error message with additional logging."""
@@ -367,8 +378,12 @@ class NestEventMediaView(NestEventViewBase):
     url = "/api/nest/event_media/{device_id}/{event_token}"
     name = "api:nest:event_media"
 
+    async def load_media(self, nest_device: Device, event_token: str) -> Media | None:
+        """Load the specified media."""
+        return await nest_device.event_media_manager.get_media_from_token(event_token)
+
     async def handle_media(self, media: Media) -> web.StreamResponse:
-        """Start a GET request."""
+        """Process the specified media."""
         return web.Response(body=media.contents, content_type=media.content_type)
 
 
@@ -377,15 +392,38 @@ class NestEventMediaThumbnailView(NestEventViewBase):
 
     This is primarily used to render media for events for MediaSource. The media type
     depends on the specific device e.g. an image, or a movie clip preview.
+
+    mp4 clips are transcoded and thumbnailed by the SDM transcoder. jpgs are thumbnailed
+    from the original in this view.
     """
 
     url = "/api/nest/event_media/{device_id}/{event_token}/thumbnail"
     name = "api:nest:event_media"
 
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize NestEventMediaThumbnailView."""
+        super().__init__(hass)
+        self._lock = asyncio.Lock()
+        self.hass = hass
+
+    async def load_media(self, nest_device: Device, event_token: str) -> Media | None:
+        """Load the specified media."""
+        if CameraClipPreviewTrait.NAME in nest_device.traits:
+            async with self._lock:  # Only one transcode subprocess at a time
+                return (
+                    await nest_device.event_media_manager.get_clip_thumbnail_from_token(
+                        event_token
+                    )
+                )
+        return await nest_device.event_media_manager.get_media_from_token(event_token)
+
     async def handle_media(self, media: Media) -> web.StreamResponse:
         """Start a GET request."""
-        image = Image(media.event_image_type.content_type, media.contents)
-        contents = img_util.scale_jpeg_camera_image(
-            image, THUMBNAIL_SIZE_PX, THUMBNAIL_SIZE_PX
-        )
-        return web.Response(body=contents, content_type=media.content_type)
+        contents = media.contents
+        content_type = media.content_type
+        if content_type == "image/jpeg":
+            image = Image(media.event_image_type.content_type, contents)
+            contents = img_util.scale_jpeg_camera_image(
+                image, THUMBNAIL_SIZE_PX, THUMBNAIL_SIZE_PX
+            )
+        return web.Response(body=contents, content_type=content_type)

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "dependencies": ["ffmpeg", "http", "media_source"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
-  "requirements": ["python-nest==4.1.0", "google-nest-sdm==1.4.0"],
+  "requirements": ["python-nest==4.1.0", "google-nest-sdm==1.5.0"],
   "codeowners": ["@allenporter"],
   "quality_scale": "platinum",
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -764,7 +764,7 @@ google-cloud-pubsub==2.9.0
 google-cloud-texttospeech==0.4.0
 
 # homeassistant.components.nest
-google-nest-sdm==1.4.0
+google-nest-sdm==1.5.0
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -489,7 +489,7 @@ google-api-python-client==1.6.4
 google-cloud-pubsub==2.9.0
 
 # homeassistant.components.nest
-google-nest-sdm==1.4.0
+google-nest-sdm==1.5.0
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -7,11 +7,15 @@ as media in the media source.
 from collections.abc import Generator
 import datetime
 from http import HTTPStatus
+import io
+from typing import Generator
 from unittest.mock import patch
 
 import aiohttp
+import av
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage
+import numpy as np
 import pytest
 
 from homeassistant.components import media_source
@@ -73,6 +77,51 @@ GENERATE_IMAGE_URL_RESPONSE = {
 IMAGE_BYTES_FROM_EVENT = b"test url image bytes"
 IMAGE_AUTHORIZATION_HEADERS = {"Authorization": "Basic g.0.eventToken"}
 NEST_EVENT = "nest_event"
+
+
+def frame_image_data(frame_i, total_frames):
+    """Generate image content for a frame of a video."""
+    img = np.empty((480, 320, 3))
+    img[:, :, 0] = 0.5 + 0.5 * np.sin(2 * np.pi * (0 / 3 + frame_i / total_frames))
+    img[:, :, 1] = 0.5 + 0.5 * np.sin(2 * np.pi * (1 / 3 + frame_i / total_frames))
+    img[:, :, 2] = 0.5 + 0.5 * np.sin(2 * np.pi * (2 / 3 + frame_i / total_frames))
+
+    img = np.round(255 * img).astype(np.uint8)
+    img = np.clip(img, 0, 255)
+    return img
+
+
+@pytest.fixture
+def mp4() -> io.BytesIO:
+    """Generate test mp4 clip."""
+
+    total_frames = 10
+    fps = 10
+    output = io.BytesIO()
+    output.name = "test.mp4"
+    container = av.open(output, mode="w", format="mp4")
+
+    stream = container.add_stream("libx264", rate=fps)
+    stream.width = 480
+    stream.height = 320
+    stream.pix_fmt = "yuv420p"
+    #    stream.options.update({"g": str(fps), "keyint_min": str(fps)})
+
+    for frame_i in range(total_frames):
+        img = frame_image_data(frame_i, total_frames)
+        frame = av.VideoFrame.from_ndarray(img, format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+
+    # Flush stream
+    for packet in stream.encode():
+        container.mux(packet)
+
+    # Close the file
+    container.close()
+    output.seek(0)
+
+    return output
 
 
 async def async_setup_devices(hass, auth, device_type, traits={}, events=[]):
@@ -685,7 +734,7 @@ async def test_resolve_invalid_event_id(hass, auth):
     assert media.mime_type == "image/jpeg"
 
 
-async def test_camera_event_clip_preview(hass, auth, hass_client):
+async def test_camera_event_clip_preview(hass, auth, hass_client, mp4):
     """Test an event for a battery camera video clip."""
     subscriber = await async_setup_devices(
         hass, auth, CAMERA_DEVICE_TYPE, BATTERY_CAMERA_TRAITS
@@ -695,7 +744,7 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
     received_events = async_capture_events(hass, NEST_EVENT)
 
     auth.responses = [
-        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+        aiohttp.web.Response(body=mp4.getvalue()),
     ]
     event_timestamp = dt_util.now()
     await subscriber.async_receive_event(
@@ -730,8 +779,10 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
     assert browse.identifier == device.id
     assert browse.title == "Front: Recent Events"
     assert browse.can_expand
-    # No thumbnail support for mp4 clips yet
-    assert browse.thumbnail is None
+    assert (
+        browse.thumbnail
+        == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
+    )
     # The device expands recent events
     assert len(browse.children) == 1
     assert browse.children[0].domain == DOMAIN
@@ -742,7 +793,10 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
     assert len(browse.children[0].children) == 0
     assert browse.children[0].can_play
     # No thumbnail support for mp4 clips yet
-    assert browse.children[0].thumbnail is None
+    assert (
+        browse.children[0].thumbnail
+        == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
+    )
 
     # Verify received event and media ids match
     assert browse.children[0].identifier == f"{device.id}/{event_identifier}"
@@ -769,7 +823,14 @@ async def test_camera_event_clip_preview(hass, auth, hass_client):
     response = await client.get(media.url)
     assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
     contents = await response.read()
-    assert contents == IMAGE_BYTES_FROM_EVENT
+    assert contents == mp4.getvalue()
+
+    # Verify thumbnail for mp4 clip
+    response = await client.get(
+        f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
+    )
+    assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
+    await response.read()  # Animated gif format not tested
 
 
 async def test_event_media_render_invalid_device_id(hass, auth, hass_client):
@@ -1336,15 +1397,8 @@ async def test_camera_image_resize(hass, auth, hass_client):
         == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
     )
 
-    auth.responses = [
-        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
-        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
-    ]
-
     client = await hass_client()
-    response = await client.get(
-        f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}?width=175&height=175"
-    )
+    response = await client.get(browse.thumbnail)
     assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
     contents = await response.read()
     assert contents == IMAGE_BYTES_FROM_EVENT

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -1327,6 +1327,7 @@ async def test_camera_image_resize(hass, auth, hass_client):
         hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}/{event_identifier}"
     )
     assert browse.domain == DOMAIN
+    assert browse.identifier == f"{device.id}/{event_identifier}"
     assert "Person" in browse.title
     assert not browse.can_expand
     assert not browse.children
@@ -1335,8 +1336,15 @@ async def test_camera_image_resize(hass, auth, hass_client):
         == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
     )
 
+    auth.responses = [
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+
     client = await hass_client()
-    response = await client.get(browse.thumbnail)
+    response = await client.get(
+        f"/api/nest/event_media/{device.id}/{EVENT_SESSION_ID}?width=175&height=175"
+    )
     assert response.status == HTTPStatus.OK, "Response not matched: %s" % response
     contents = await response.read()
     assert contents == IMAGE_BYTES_FROM_EVENT

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -8,7 +8,6 @@ from collections.abc import Generator
 import datetime
 from http import HTTPStatus
 import io
-from typing import Generator
 from unittest.mock import patch
 
 import aiohttp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Transcode nest mp4 clips to animated gifs so they can be rendered as thumbnails in the media player and used for mobile notifications for android which doesn't support mp4 video.

The `ffmpeg` component is used to provide the ffmpeg binary to the sdm library, which handles the transcoding. Transcoding is handled on demand when rendering the grid, with a limit of one transcode item at a time to throttle load.

The ffmpeg work is similar to the haffmpeg library, though it reads and writes directly to files in the media store. Gifs are also slowed a little bit so the 10 frames are spread out at the same speed as shown in the Nest or Google Home app, and they are looped.

https://github.com/allenporter/python-google-nest-sdm/compare/1.4.0...1.5.0 - contains transcoding feature.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
