### PR TITLE
Add test cases for Tradfri switch platform

### DIFF
--- a/homeassistant/components/tradfri/switch.py
+++ b/homeassistant/components/tradfri/switch.py
@@ -43,6 +43,7 @@ class TradfriSwitch(TradfriBaseDevice, SwitchEntity):
         """Initialize a switch."""
         super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
+        self._refresh(device, write_ha=False)
 
     def _refresh(self, device: Command, write_ha: bool = True) -> None:
         """Refresh the switch data."""

--- a/tests/components/tradfri/test_switch.py
+++ b/tests/components/tradfri/test_switch.py
@@ -56,7 +56,7 @@ def mock_switch(test_features=None, test_state=None, device_number=0):
 
 
 async def test_switch(hass, mock_gateway, mock_api_factory):
-    """Test that fans are correctly added."""
+    """Test that switches are correctly added."""
     state = {
         "state": True,
     }
@@ -64,9 +64,9 @@ async def test_switch(hass, mock_gateway, mock_api_factory):
     mock_gateway.mock_devices.append(mock_switch(test_state=state))
     await setup_integration(hass)
 
-    fan_1 = hass.states.get("switch.tradfri_switch_0")
-    assert fan_1 is not None
-    assert fan_1.state == "on"
+    switch_1 = hass.states.get("switch.tradfri_switch_0")
+    assert switch_1 is not None
+    assert switch_1.state == "on"
 
 
 async def test_switch_observed(hass, mock_gateway, mock_api_factory):
@@ -126,7 +126,7 @@ async def test_turn_on_off(
     mock_gateway.mock_devices.append(switch)
     await setup_integration(hass)
 
-    # Use the turn_on service call to change the fan state.
+    # Use the turn_on/turn_off service call to change the switch state.
     await hass.services.async_call(
         "switch",
         test_data,
@@ -137,18 +137,18 @@ async def test_turn_on_off(
     )
     await hass.async_block_till_done()
 
-    # Check that the fan is observed.
+    # Check that the switch is observed.
     mock_func = switch.observe
     assert len(mock_func.mock_calls) > 0
     _, callkwargs = mock_func.call_args
     assert "callback" in callkwargs
-    # Callback function to refresh fan state.
+    # Callback function to refresh switch state.
     callback = callkwargs["callback"]
 
     responses = mock_gateway.mock_responses
     mock_gateway_response = responses[0]
 
-    # Use the callback function to update the fan state.
+    # Use the callback function to update the switch state.
     dev = Device(mock_gateway_response)
     switch_data = Socket(dev, 0)
     switch.socket_control.sockets[0] = switch_data

--- a/tests/components/tradfri/test_switch.py
+++ b/tests/components/tradfri/test_switch.py
@@ -29,7 +29,7 @@ def mock_switch(test_features=None, test_state=None, device_number=0):
         test_features = {}
     if test_state is None:
         test_state = {}
-    mock_fan_data = Mock(**test_state)
+    mock_switch_data = Mock(**test_state)
 
     dev_info_mock = MagicMock()
     dev_info_mock.manufacturer = "manufacturer"
@@ -50,7 +50,7 @@ def mock_switch(test_features=None, test_state=None, device_number=0):
     socket_control = SocketControl(_mock_switch)
 
     # Store the initial state.
-    setattr(socket_control, "sockets", [mock_fan_data])
+    setattr(socket_control, "sockets", [mock_switch_data])
     _mock_switch.socket_control = socket_control
     return _mock_switch
 

--- a/tests/components/tradfri/test_switch.py
+++ b/tests/components/tradfri/test_switch.py
@@ -1,0 +1,160 @@
+"""Tradfri switch (recognised as sockets in the IKEA ecosystem) platform tests."""
+
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+import pytest
+from pytradfri.device import Device
+from pytradfri.device.socket import Socket
+from pytradfri.device.socket_control import SocketControl
+
+from .common import setup_integration
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(request):
+    """Set up patches for pytradfri methods."""
+    with patch(
+        "pytradfri.device.SocketControl.raw",
+        new_callable=PropertyMock,
+        return_value=[{"mock": "mock"}],
+    ), patch(
+        "pytradfri.device.SocketControl.sockets",
+    ):
+        yield
+
+
+def mock_switch(test_features=None, test_state=None, device_number=0):
+    """Mock a tradfri switch/socket."""
+    if test_features is None:
+        test_features = {}
+    if test_state is None:
+        test_state = {}
+    mock_fan_data = Mock(**test_state)
+
+    dev_info_mock = MagicMock()
+    dev_info_mock.manufacturer = "manufacturer"
+    dev_info_mock.model_number = "model"
+    dev_info_mock.firmware_version = "1.2.3"
+    _mock_switch = Mock(
+        id=f"mock-switch-id-{device_number}",
+        reachable=True,
+        observe=Mock(),
+        device_info=dev_info_mock,
+        has_light_control=False,
+        has_socket_control=True,
+        has_blind_control=False,
+        has_signal_repeater_control=False,
+        has_air_purifier_control=False,
+    )
+    _mock_switch.name = f"tradfri_switch_{device_number}"
+    socket_control = SocketControl(_mock_switch)
+
+    # Store the initial state.
+    setattr(socket_control, "sockets", [mock_fan_data])
+    _mock_switch.socket_control = socket_control
+    return _mock_switch
+
+
+async def test_switch(hass, mock_gateway, mock_api_factory):
+    """Test that fans are correctly added."""
+    state = {
+        "state": True,
+    }
+
+    mock_gateway.mock_devices.append(mock_switch(test_state=state))
+    await setup_integration(hass)
+
+    fan_1 = hass.states.get("switch.tradfri_switch_0")
+    assert fan_1 is not None
+    assert fan_1.state == "on"
+
+
+async def test_switch_observed(hass, mock_gateway, mock_api_factory):
+    """Test that switches are correctly observed."""
+    state = {
+        "state": True,
+    }
+
+    switch = mock_switch(test_state=state)
+    mock_gateway.mock_devices.append(switch)
+    await setup_integration(hass)
+    assert len(switch.observe.mock_calls) > 0
+
+
+async def test_switch_available(hass, mock_gateway, mock_api_factory):
+    """Test switch available property."""
+
+    switch = mock_switch(test_state={"state": True}, device_number=1)
+    switch.reachable = True
+
+    switch2 = mock_switch(test_state={"state": True}, device_number=2)
+    switch2.reachable = False
+
+    mock_gateway.mock_devices.append(switch)
+    mock_gateway.mock_devices.append(switch2)
+    await setup_integration(hass)
+
+    assert hass.states.get("switch.tradfri_switch_1").state == "on"
+    assert hass.states.get("switch.tradfri_switch_2").state == "unavailable"
+
+
+@pytest.mark.parametrize(
+    "test_data, expected_result",
+    [
+        (
+            "turn_on",
+            "on",
+        ),
+        ("turn_off", "off"),
+    ],
+)
+async def test_turn_on_off(
+    hass,
+    mock_gateway,
+    mock_api_factory,
+    test_data,
+    expected_result,
+):
+    """Test turning switch on/off."""
+    # Note pytradfri style, not hass. Values not really important.
+    initial_state = {
+        "state": True,
+    }
+
+    # Setup the gateway with a mock switch.
+    switch = mock_switch(test_state=initial_state, device_number=0)
+    mock_gateway.mock_devices.append(switch)
+    await setup_integration(hass)
+
+    # Use the turn_on service call to change the fan state.
+    await hass.services.async_call(
+        "switch",
+        test_data,
+        {
+            "entity_id": "switch.tradfri_switch_0",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Check that the fan is observed.
+    mock_func = switch.observe
+    assert len(mock_func.mock_calls) > 0
+    _, callkwargs = mock_func.call_args
+    assert "callback" in callkwargs
+    # Callback function to refresh fan state.
+    callback = callkwargs["callback"]
+
+    responses = mock_gateway.mock_responses
+    mock_gateway_response = responses[0]
+
+    # Use the callback function to update the fan state.
+    dev = Device(mock_gateway_response)
+    switch_data = Socket(dev, 0)
+    switch.socket_control.sockets[0] = switch_data
+    callback(switch)
+    await hass.async_block_till_done()
+
+    # Check that the state is correct.
+    state = hass.states.get("switch.tradfri_switch_0")
+    assert state.state == expected_result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR continues the work from #64135 and adds tests for the `switch` platform.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
