### PR TITLE
Netgear try all ports

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -1,6 +1,6 @@
 """Support for Netgear routers."""
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -17,6 +17,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await router.async_setup()
     except CannotLoginException as ex:
         raise ConfigEntryNotReady from ex
+
+    port = entry.data.get(CONF_PORT)
+    ssl = entry.data.get(CONF_SSL)
+    if port != router.port or ssl != router.ssl:
+        hass.config_entries.async_update_entry(entry, data={CONF_PORT: router.port, CONF_SSL: router.ssl})
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = router

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -21,7 +21,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     port = entry.data.get(CONF_PORT)
     ssl = entry.data.get(CONF_SSL)
     if port != router.port or ssl != router.ssl:
-        hass.config_entries.async_update_entry(entry, data={CONF_PORT: router.port, CONF_SSL: router.ssl})
+        hass.config_entries.async_update_entry(
+            entry, data={CONF_PORT: router.port, CONF_SSL: router.ssl}
+        )
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = router

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -1,4 +1,6 @@
 """Support for Netgear routers."""
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.core import HomeAssistant
@@ -8,6 +10,8 @@ from homeassistant.helpers import device_registry as dr
 from .const import DOMAIN, PLATFORMS
 from .errors import CannotLoginException
 from .router import NetgearRouter
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -21,8 +25,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     port = entry.data.get(CONF_PORT)
     ssl = entry.data.get(CONF_SSL)
     if port != router.port or ssl != router.ssl:
-        hass.config_entries.async_update_entry(
-            entry, data={CONF_PORT: router.port, CONF_SSL: router.ssl}
+        data = entry.data.copy()
+        data[CONF_PORT] = router.port
+        data[CONF_SSL] = router.ssl
+        hass.config_entries.async_update_entry(entry, data=data)
+        _LOGGER.warning(
+            "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), this schould only occur after a firmware update.",
+            port,
+            ssl,
+            router.port,
+            router.ssl,
         )
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data[CONF_PORT] = router.port
         data[CONF_SSL] = router.ssl
         hass.config_entries.async_update_entry(entry, data=data)
-        _LOGGER.warning(
+        _LOGGER.info(
             "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), this should only occur after a firmware update",
             port,
             ssl,

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data[CONF_SSL] = router.ssl
         hass.config_entries.async_update_entry(entry, data=data)
         _LOGGER.warning(
-            "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), this schould only occur after a firmware update.",
+            "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), this should only occur after a firmware update.",
             port,
             ssl,
             router.port,

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data[CONF_SSL] = router.ssl
         hass.config_entries.async_update_entry(entry, data=data)
         _LOGGER.warning(
-            "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), this should only occur after a firmware update.",
+            "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), this should only occur after a firmware update",
             port,
             ssl,
             router.port,

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -38,9 +38,7 @@ def _discovery_schema_with_defaults(discovery_info):
 
 
 def _user_schema_with_defaults(user_input):
-    user_schema = {
-        vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str
-    }
+    user_schema = {vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str}
     user_schema.update(_ordered_shared_schema(user_input))
 
     return vol.Schema(user_schema)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -196,8 +196,8 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_USERNAME: username,
             CONF_PASSWORD: password,
             CONF_HOST: host,
-            CONF_PORT: port,
-            CONF_SSL: ssl,
+            CONF_PORT: api.port,
+            CONF_SSL: api.ssl,
         }
 
         if info.get("ModelName") is not None and info.get("DeviceName") is not None:

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -39,9 +39,7 @@ def _discovery_schema_with_defaults(discovery_info):
 
 def _user_schema_with_defaults(user_input):
     user_schema = {
-        vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
-        vol.Optional(CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)): int,
-        vol.Optional(CONF_SSL, default=user_input.get(CONF_SSL, False)): bool,
+        vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str
     }
     user_schema.update(_ordered_shared_schema(user_input))
 
@@ -169,8 +167,8 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_setup_form()
 
         host = user_input.get(CONF_HOST, self.placeholders[CONF_HOST])
-        port = user_input.get(CONF_PORT, self.placeholders[CONF_PORT])
-        ssl = user_input.get(CONF_SSL, self.placeholders[CONF_SSL])
+        port = self.placeholders[CONF_PORT]
+        ssl = self.placeholders[CONF_SSL]
         username = user_input.get(CONF_USERNAME, self.placeholders[CONF_USERNAME])
         password = user_input[CONF_PASSWORD]
         if not username:

--- a/homeassistant/components/netgear/manifest.json
+++ b/homeassistant/components/netgear/manifest.json
@@ -2,7 +2,7 @@
   "domain": "netgear",
   "name": "NETGEAR",
   "documentation": "https://www.home-assistant.io/integrations/netgear",
-  "requirements": ["pynetgear==0.8.0"],
+  "requirements": ["pynetgear==0.9.0"],
   "codeowners": ["@hacf-fr", "@Quentame", "@starkillerOG"],
   "iot_class": "local_polling",
   "config_flow": true,

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -52,7 +52,7 @@ def get_api(
     """Get the Netgear API and login to it."""
     api: Netgear = Netgear(password, host, username, port, ssl)
 
-    if not api.login():
+    if not api.login_try_port():
         raise CannotLoginException
 
     return api

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -244,6 +244,16 @@ class NetgearRouter:
         """Event specific per Netgear entry to signal updates in devices."""
         return f"{DOMAIN}-{self._host}-device-update"
 
+    @property
+    def port(self) -> int:
+        """Port used by the API."""
+        return self._api.port
+
+    @property
+    def ssl(self) -> bool:
+        """SSL used by the API."""
+        return self._api.ssl
+
 
 class NetgearDeviceEntity(Entity):
     """Base class for a device connected to a Netgear router."""

--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -5,8 +5,6 @@
         "description": "Default host: {host}\nDefault port: {port}\nDefault username: {username}",
         "data": {
           "host": "[%key:common::config_flow::data::host%] (Optional)",
-          "port": "[%key:common::config_flow::data::port%] (Optional)",
-          "ssl": "[%key:common::config_flow::data::ssl%]",
           "username": "[%key:common::config_flow::data::username%] (Optional)",
           "password": "[%key:common::config_flow::data::password%]"
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1690,7 +1690,7 @@ pymyq==3.1.4
 pymysensors==0.22.1
 
 # homeassistant.components.netgear
-pynetgear==0.8.0
+pynetgear==0.9.0
 
 # homeassistant.components.netio
 pynetio==0.1.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1059,7 +1059,7 @@ pymyq==3.1.4
 pymysensors==0.22.1
 
 # homeassistant.components.netgear
-pynetgear==0.8.0
+pynetgear==0.9.0
 
 # homeassistant.components.nina
 pynina==0.1.4

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -106,8 +106,6 @@ async def test_user(hass, service):
         result["flow_id"],
         {
             CONF_HOST: HOST,
-            CONF_PORT: PORT,
-            CONF_SSL: SSL,
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
         },
@@ -135,8 +133,6 @@ async def test_user_connect_error(hass, service_failed):
         result["flow_id"],
         {
             CONF_HOST: HOST,
-            CONF_PORT: PORT,
-            CONF_SSL: SSL,
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
         },
@@ -159,8 +155,6 @@ async def test_user_incomplete_info(hass, service_incomplete):
         result["flow_id"],
         {
             CONF_HOST: HOST,
-            CONF_PORT: PORT,
-            CONF_SSL: SSL,
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
         },

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -69,6 +69,20 @@ def mock_controller_service():
         "homeassistant.components.netgear.async_setup_entry", return_value=True
     ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
         service_mock.return_value.get_info = Mock(return_value=ROUTER_INFOS)
+        service_mock.return_value.port = 80
+        service_mock.return_value.ssl = False
+        yield service_mock
+
+
+@pytest.fixture(name="service_5555")
+def mock_controller_service_5555():
+    """Mock a successful service."""
+    with patch(
+        "homeassistant.components.netgear.async_setup_entry", return_value=True
+    ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
+        service_mock.return_value.get_info = Mock(return_value=ROUTER_INFOS)
+        service_mock.return_value.port = 5555
+        service_mock.return_value.ssl = True
         yield service_mock
 
 
@@ -81,6 +95,8 @@ def mock_controller_service_incomplete():
         "homeassistant.components.netgear.async_setup_entry", return_value=True
     ), patch("homeassistant.components.netgear.router.Netgear") as service_mock:
         service_mock.return_value.get_info = Mock(return_value=router_infos)
+        service_mock.return_value.port = 80
+        service_mock.return_value.ssl = False
         yield service_mock
 
 
@@ -88,7 +104,7 @@ def mock_controller_service_incomplete():
 def mock_controller_service_failed():
     """Mock a failed service."""
     with patch("homeassistant.components.netgear.router.Netgear") as service_mock:
-        service_mock.return_value.login = Mock(return_value=None)
+        service_mock.return_value.login_try_port = Mock(return_value=None)
         service_mock.return_value.get_info = Mock(return_value=None)
         yield service_mock
 
@@ -250,7 +266,7 @@ async def test_ssdp(hass, service):
     assert result["data"][CONF_PASSWORD] == PASSWORD
 
 
-async def test_ssdp_port_5555(hass, service):
+async def test_ssdp_port_5555(hass, service_5555):
     """Test ssdp step with port 5555."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During config_flow and setup, try all known Netgear ports (5555 and 433 with SSL and 5000 and 80 without SSL).
The port and SSL option given in the config_entry will be the first one that will be attempted, if that fails the other 3 will be tried, if all fail ConfigEntryNotReady will be raised.

On a succesfull connection, the port and SSL will be updated in the config_entry (if they have changed).

This process was recomended by the director of software engineering from Netgear.
According to him that schould work with all Netgear routers and across firmware upgrades.

Motivation for this change is that on the most recent firmware of the popular Netgear R7000 router the port has changed from 5000 to 5555, this has already been fixed for this specific model in PR https://github.com/home-assistant/core/pull/64012, but this will ensure a more future proof method that will work for all models.

Also bumps pynetgear version to 0.9.0:
https://github.com/MatMaul/pynetgear/compare/0.8.0...0.9.0
- improve login method
- Improve log messages regarding re-login attempts
- disable InsecureRequestWarning
- add login_try_port


~NOTE: PYNETGEAR VERSION 0.9.0 STILL NEEDS TO BE UPLOADED TO PYPI
I (StarkillerOG) still need to get acces rights from eather @MatMaul or @balloob see https://github.com/MatMaul/pynetgear/pull/90#issuecomment-1013725261~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/63966 https://github.com/home-assistant/home-assistant.io/issues/21199
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
