### PR TITLE
Upgrade miflora to 0.7.2

### DIFF
--- a/homeassistant/components/miflora/manifest.json
+++ b/homeassistant/components/miflora/manifest.json
@@ -2,7 +2,7 @@
   "domain": "miflora",
   "name": "Mi Flora",
   "documentation": "https://www.home-assistant.io/integrations/miflora",
-  "requirements": ["bluepy==1.3.0", "miflora==0.7.0"],
+  "requirements": ["bluepy==1.3.0", "miflora==0.7.2"],
   "codeowners": ["@danielhiversen", "@basnijholt"],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1031,7 +1031,7 @@ mficlient==0.3.0
 micloud==0.5
 
 # homeassistant.components.miflora
-miflora==0.7.0
+miflora==0.7.2
 
 # homeassistant.components.mill
 mill-local==0.1.1


### PR DESCRIPTION
## Proposed change
Upgrade `miflora` from `0.7.0` to `0.7.2`. Another fix for #64058

**For `0.7.1`**
Release note: https://github.com/basnijholt/miflora/releases/tag/v0.7.1
Compare view: https://github.com/basnijholt/miflora/compare/v0.7.0...v0.7.1

**For `0.7.2`**
Release note: https://github.com/basnijholt/miflora/releases/tag/v0.7.2
Compare view: https://github.com/basnijholt/miflora/compare/v0.7.1...v0.7.2

The update remove the default `retries` parameter from `MiFloraPoller` which is technically a breaking change. We didn't use it though, so the update should be fine. More importantly though, it also bumps the dependency range for `btlewrap` which helps resolve a potential conflict.

https://github.com/home-assistant/core/blob/849abaca8bbb61947bd7fa0f4923db8c466406fe/homeassistant/components/miflora/sensor.py#L124-L129

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
