### PR TITLE
Ignore unavailable entities when creating zwave_js device actions list

### DIFF
--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -178,7 +178,10 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
         # is no longer valid. Additionally, if an entry is disabled, its
         # underlying value is not being monitored by HA so we shouldn't allow
         # actions against it.
-        if hass.states.get(entry.entity_id) == STATE_UNAVAILABLE or entry.disabled:
+        if (
+            (state := hass.states.get(entry.entity_id))
+            and state.state == STATE_UNAVAILABLE
+        ) or entry.disabled:
             continue
         entity_action = {**base_action, CONF_ENTITY_ID: entry.entity_id}
         actions.append({**entity_action, CONF_TYPE: SERVICE_REFRESH_VALUE})

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -173,15 +173,16 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
 
     meter_endpoints: dict[int, dict[str, Any]] = defaultdict(dict)
 
-    for entry in entity_registry.async_entries_for_device(registry, device_id):
+    for entry in entity_registry.async_entries_for_device(
+        registry, device_id, include_disabled_entities=False
+    ):
         # If an entry is unavailable, it is possible that the underlying value
         # is no longer valid. Additionally, if an entry is disabled, its
         # underlying value is not being monitored by HA so we shouldn't allow
         # actions against it.
         if (
-            (state := hass.states.get(entry.entity_id))
-            and state.state == STATE_UNAVAILABLE
-        ) or entry.disabled:
+            state := hass.states.get(entry.entity_id)
+        ) and state.state == STATE_UNAVAILABLE:
             continue
         entity_action = {**base_action, CONF_ENTITY_ID: entry.entity_id}
         actions.append({**entity_action, CONF_TYPE: SERVICE_REFRESH_VALUE})

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -194,10 +194,9 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
             value_id = entry.unique_id.split(".")[1]
             # If this unique ID doesn't have a value ID, we know it is the node status
             # sensor which doesn't have any relevant actions
-            if re.match(VALUE_ID_REGEX, value_id):
-                value = node.values[value_id]
-            else:
+            if not re.match(VALUE_ID_REGEX, value_id):
                 continue
+            value = node.values[value_id]
             # If the value has the meterType CC specific value, we can add a reset_meter
             # action for it
             if CC_SPECIFIC_METER_TYPE in value.metadata.cc_specific:

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -12,6 +12,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.zwave_js import DOMAIN, device_action
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry
@@ -587,4 +588,28 @@ async def test_failure_scenarios(
             hass, {"type": "failed.test", "device_id": device.id}
         )
         == {}
+    )
+
+
+async def test_disabled_entity_actions(
+    hass: HomeAssistant,
+    client: Client,
+    lock_schlage_be469: Node,
+    integration: ConfigEntry,
+) -> None:
+    """Test disabled and unavailable entities are not included in actions list."""
+    entity_id_disabled = "sensor.touchscreen_deadbolt_access_control_lock_state"
+    entity_id_unavailable = "binary_sensor.touchscreen_deadbolt_home_security_intrusion"
+    hass.states.async_set(entity_id_unavailable, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    node = lock_schlage_be469
+    dev_reg = device_registry.async_get(hass)
+    device = dev_reg.async_get_device({get_device_id(client, node)})
+    assert device
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device.id
+    )
+    assert not any(action.get("entity_id") == entity_id_disabled for action in actions)
+    assert not any(
+        action.get("entity_id") == entity_id_unavailable for action in actions
     )

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -591,16 +591,15 @@ async def test_failure_scenarios(
     )
 
 
-async def test_disabled_entity_actions(
+async def test_unavailable_entity_actions(
     hass: HomeAssistant,
     client: Client,
     lock_schlage_be469: Node,
     integration: ConfigEntry,
 ) -> None:
-    """Test disabled and unavailable entities are not included in actions list."""
-    entity_id_disabled = "sensor.touchscreen_deadbolt_access_control_lock_state"
+    """Test unavailable entities are not included in actions list."""
     entity_id_unavailable = "binary_sensor.touchscreen_deadbolt_home_security_intrusion"
-    hass.states.async_set(entity_id_unavailable, STATE_UNAVAILABLE)
+    hass.states.async_set(entity_id_unavailable, STATE_UNAVAILABLE, force_update=True)
     await hass.async_block_till_done()
     node = lock_schlage_be469
     dev_reg = device_registry.async_get(hass)
@@ -609,7 +608,6 @@ async def test_disabled_entity_actions(
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device.id
     )
-    assert not any(action.get("entity_id") == entity_id_disabled for action in actions)
     assert not any(
         action.get("entity_id") == entity_id_unavailable for action in actions
     )


### PR DESCRIPTION
## Proposed change
We should not try to generate device actions for unavailable entities since they may no longer be backed by a valid Z-Wave Value. This PR fixes that and fixes #63331 where this issue was originally reported


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63331
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
