### PR TITLE
Add two new sensors to Launch Library

### DIFF
--- a/homeassistant/components/launch_library/const.py
+++ b/homeassistant/components/launch_library/const.py
@@ -2,10 +2,13 @@
 
 DOMAIN = "launch_library"
 
-ATTR_AGENCY = "agency"
-ATTR_AGENCY_COUNTRY_CODE = "agency_country_code"
-ATTR_LAUNCH_TIME = "launch_time"
-ATTR_STREAM = "stream"
+ATTR_LAUNCH_FACILITY = "facility"
+ATTR_STREAM_LIVE = "stream_live"
+ATTR_LAUNCH_PAD = "pad"
+ATTR_LAUNCH_PAD_COUNTRY_CODE = "provider_country_code"
+ATTR_LAUNCH_PROVIDER = "provider"
+ATTR_WINDOW_START = "window_start"
+ATTR_WINDOW_END = "window_end"
 
 ATTRIBUTION = "Data provided by Launch Library."
 

--- a/homeassistant/components/launch_library/const.py
+++ b/homeassistant/components/launch_library/const.py
@@ -13,3 +13,7 @@ ATTR_WINDOW_END = "window_end"
 ATTRIBUTION = "Data provided by Launch Library."
 
 DEFAULT_NAME = "Next launch"
+
+NEXT_LAUNCH = "next_launch"
+LAUNCH_TIME = "launch_time"
+LAUNCH_PROBABILITY = "launch_probability"

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -37,6 +37,9 @@ from .const import (
     ATTRIBUTION,
     DEFAULT_NAME,
     DOMAIN,
+    LAUNCH_PROBABILITY,
+    LAUNCH_TIME,
+    NEXT_LAUNCH,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,25 +50,25 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
-        key="next_launch",
+SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
+    NEXT_LAUNCH: SensorEntityDescription(
+        key=NEXT_LAUNCH,
         icon="mdi:rocket-launch",
         name=DEFAULT_NAME,
     ),
-    SensorEntityDescription(
-        key="launch_time",
+    LAUNCH_TIME: SensorEntityDescription(
+        key=LAUNCH_TIME,
         icon="mdi:clock-outline",
         name="Launch time",
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
-    SensorEntityDescription(
-        key="launch_probability",
+    LAUNCH_PROBABILITY: SensorEntityDescription(
+        key=LAUNCH_PROBABILITY,
         icon="mdi:horseshoe",
         name="Launch Probability",
         native_unit_of_measurement=PERCENTAGE,
     ),
-)
+}
 
 
 async def async_setup_platform(
@@ -106,18 +109,18 @@ async def async_setup_entry(
             NextLaunchSensor(
                 coordinator,
                 entry.entry_id,
-                SENSOR_DESCRIPTIONS[0],
+                SENSOR_DESCRIPTIONS[NEXT_LAUNCH],
                 name,
             ),
             LaunchTimeSensor(
                 coordinator,
                 entry.entry_id,
-                SENSOR_DESCRIPTIONS[1],
+                SENSOR_DESCRIPTIONS[LAUNCH_TIME],
             ),
             LaunchProbabilitySensor(
                 coordinator,
                 entry.entry_id,
-                SENSOR_DESCRIPTIONS[2],
+                SENSOR_DESCRIPTIONS[LAUNCH_PROBABILITY],
             ),
         ]
     )

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -1,6 +1,7 @@
 """Support for Launch Library sensors."""
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -9,11 +10,12 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, PERCENTAGE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -22,12 +24,16 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util.dt import parse_datetime
 
 from .const import (
-    ATTR_AGENCY,
-    ATTR_AGENCY_COUNTRY_CODE,
-    ATTR_LAUNCH_TIME,
-    ATTR_STREAM,
+    ATTR_LAUNCH_FACILITY,
+    ATTR_LAUNCH_PAD,
+    ATTR_LAUNCH_PAD_COUNTRY_CODE,
+    ATTR_LAUNCH_PROVIDER,
+    ATTR_STREAM_LIVE,
+    ATTR_WINDOW_END,
+    ATTR_WINDOW_START,
     ATTRIBUTION,
     DEFAULT_NAME,
     DOMAIN,
@@ -41,10 +47,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-SENSOR_DESCRIPTION = SensorEntityDescription(
+NEXT_LAUNCH_SENSOR_DESCRIPTION = SensorEntityDescription(
     key="next_launch",
     icon="mdi:rocket-launch",
     name=DEFAULT_NAME,
+)
+
+LAUNCH_TIME_SENSOR_DESCRIPTION = SensorEntityDescription(
+    key="launch_time",
+    icon="mdi:clock-outline",
+    name="Launch time",
+    device_class=SensorDeviceClass.TIMESTAMP,
+)
+
+LAUNCH_PROBABILITY_SENSOR_DESCRIPTION = SensorEntityDescription(
+    key="launch_probability",
+    icon="mdi:horseshoe",
+    name="Launch Probability",
+    native_unit_of_measurement=PERCENTAGE,
 )
 
 
@@ -86,15 +106,25 @@ async def async_setup_entry(
             NextLaunchSensor(
                 coordinator,
                 entry.entry_id,
+                NEXT_LAUNCH_SENSOR_DESCRIPTION,
                 name,
-                SENSOR_DESCRIPTION,
+            ),
+            LaunchTimeSensor(
+                coordinator,
+                entry.entry_id,
+                LAUNCH_TIME_SENSOR_DESCRIPTION,
+            ),
+            LaunchProbabilitySensor(
+                coordinator,
+                entry.entry_id,
+                LAUNCH_PROBABILITY_SENSOR_DESCRIPTION,
             ),
         ]
     )
 
 
-class NextLaunchSensor(CoordinatorEntity, SensorEntity):
-    """Representation of the next launch sensor."""
+class LaunchLibraryBaseSensor(CoordinatorEntity, SensorEntity):
+    """Representation of the base sensor."""
 
     _attr_attribution = ATTRIBUTION
     _next_launch: Launch | None = None
@@ -103,12 +133,12 @@ class NextLaunchSensor(CoordinatorEntity, SensorEntity):
         self,
         coordinator: DataUpdateCoordinator,
         entry_id: str,
-        name: str,
         description: SensorEntityDescription,
+        name: str | None = None,
     ) -> None:
         """Initialize a Launch Library entity."""
         super().__init__(coordinator)
-        self._attr_name = name
+        self._attr_name = name if name else description.name
         self._attr_unique_id = f"{entry_id}_{description.key}"
         self.entity_description = description
 
@@ -116,6 +146,21 @@ class NextLaunchSensor(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return if the sensor is available."""
         return super().available and self._next_launch is not None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._next_launch = next((launch for launch in self.coordinator.data), None)
+        super()._handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
+
+
+class NextLaunchSensor(LaunchLibraryBaseSensor):
+    """Representation of the next launch information sensor."""
 
     @property
     def native_value(self) -> str | None:
@@ -130,19 +175,47 @@ class NextLaunchSensor(CoordinatorEntity, SensorEntity):
         if self._next_launch is None:
             return None
         return {
-            ATTR_LAUNCH_TIME: self._next_launch.net,
-            ATTR_AGENCY: self._next_launch.launch_service_provider.name,
-            ATTR_AGENCY_COUNTRY_CODE: self._next_launch.pad.location.country_code,
-            ATTR_STREAM: self._next_launch.webcast_live,
+            ATTR_LAUNCH_PROVIDER: self._next_launch.launch_service_provider.name,
+            ATTR_LAUNCH_PAD: self._next_launch.pad.name,
+            ATTR_LAUNCH_FACILITY: self._next_launch.pad.location.name,
+            ATTR_LAUNCH_PAD_COUNTRY_CODE: self._next_launch.pad.location.country_code,
         }
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._next_launch = next((launch for launch in self.coordinator.data), None)
-        super()._handle_coordinator_update()
 
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to hass."""
-        await super().async_added_to_hass()
-        self._handle_coordinator_update()
+class LaunchTimeSensor(LaunchLibraryBaseSensor):
+    """Representation of the next launch time sensor."""
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the state of the sensor."""
+        if self._next_launch is None:
+            return None
+        return parse_datetime(self._next_launch.net)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the attributes of the sensor."""
+        if self._next_launch is None:
+            return None
+        return {
+            ATTR_WINDOW_START: self._next_launch.window_start,
+            ATTR_WINDOW_END: self._next_launch.window_end,
+            ATTR_STREAM_LIVE: self._next_launch.webcast_live,
+        }
+
+
+class LaunchProbabilitySensor(LaunchLibraryBaseSensor):
+    """Representation of the launch probability sensor."""
+
+    @property
+    def native_value(self) -> int | str | None:
+        """Return the state of the sensor."""
+        if self._next_launch is None:
+            return None
+
+        # Library will return -1 if the probability is unknown, therefore
+        #  we check for it and return STATE_UNKNOWN instead so
+        # it is represent correctly that the probability is unknown.
+        if self._next_launch.probability == -1:
+            return STATE_UNKNOWN
+        return self._next_launch.probability

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -133,9 +133,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-
     name = entry.data.get(CONF_NAME, DEFAULT_NAME)
-
     coordinator = hass.data[DOMAIN]
 
     async_add_entities(
@@ -154,7 +152,6 @@ class NextLaunchSensor(CoordinatorEntity, SensorEntity):
 
     _attr_attribution = ATTRIBUTION
     _next_launch: Launch | None = None
-
     entity_description: NextLaunchSensorEntityDescription
 
     def __init__(
@@ -164,7 +161,7 @@ class NextLaunchSensor(CoordinatorEntity, SensorEntity):
         description: NextLaunchSensorEntityDescription,
         name: str | None = None,
     ) -> None:
-        """Initialize a Launch Library entity."""
+        """Initialize a Launch Library sensor."""
         super().__init__(coordinator)
         if name:
             self._attr_name = name

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -144,7 +144,7 @@ async def async_setup_entry(
                 coordinator=coordinator,
                 entry_id=entry.entry_id,
                 description=description,
-                name=name if description.name == NEXT_LAUNCH else None,
+                name=name if description.key == NEXT_LAUNCH else None,
             )
             for description in SENSOR_DESCRIPTIONS
         ]

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -123,8 +123,8 @@ async def async_setup_entry(
     )
 
 
-class LaunchLibraryBaseSensor(CoordinatorEntity, SensorEntity):
-    """Representation of the base sensor."""
+class NextLaunchBaseSensor(CoordinatorEntity, SensorEntity):
+    """Representation of the base next launch sensor."""
 
     _attr_attribution = ATTRIBUTION
     _next_launch: Launch | None = None
@@ -138,7 +138,8 @@ class LaunchLibraryBaseSensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Initialize a Launch Library entity."""
         super().__init__(coordinator)
-        self._attr_name = name if name else description.name
+        if name:
+            self._attr_name = name
         self._attr_unique_id = f"{entry_id}_{description.key}"
         self.entity_description = description
 
@@ -159,7 +160,7 @@ class LaunchLibraryBaseSensor(CoordinatorEntity, SensorEntity):
         self._handle_coordinator_update()
 
 
-class NextLaunchSensor(LaunchLibraryBaseSensor):
+class NextLaunchSensor(NextLaunchBaseSensor):
     """Representation of the next launch information sensor."""
 
     @property
@@ -182,7 +183,7 @@ class NextLaunchSensor(LaunchLibraryBaseSensor):
         }
 
 
-class LaunchTimeSensor(LaunchLibraryBaseSensor):
+class LaunchTimeSensor(NextLaunchBaseSensor):
     """Representation of the next launch time sensor."""
 
     @property

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -152,7 +152,7 @@ async def async_setup_entry(
 
 
 class NextLaunchSensor(CoordinatorEntity, SensorEntity):
-    """Representation of the base next launch sensor."""
+    """Representation of the next launch sensors."""
 
     _attr_attribution = ATTRIBUTION
     _next_launch: Launch | None = None

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -47,24 +47,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-NEXT_LAUNCH_SENSOR_DESCRIPTION = SensorEntityDescription(
-    key="next_launch",
-    icon="mdi:rocket-launch",
-    name=DEFAULT_NAME,
-)
-
-LAUNCH_TIME_SENSOR_DESCRIPTION = SensorEntityDescription(
-    key="launch_time",
-    icon="mdi:clock-outline",
-    name="Launch time",
-    device_class=SensorDeviceClass.TIMESTAMP,
-)
-
-LAUNCH_PROBABILITY_SENSOR_DESCRIPTION = SensorEntityDescription(
-    key="launch_probability",
-    icon="mdi:horseshoe",
-    name="Launch Probability",
-    native_unit_of_measurement=PERCENTAGE,
+SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="next_launch",
+        icon="mdi:rocket-launch",
+        name=DEFAULT_NAME,
+    ),
+    SensorEntityDescription(
+        key="launch_time",
+        icon="mdi:clock-outline",
+        name="Launch time",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        key="launch_probability",
+        icon="mdi:horseshoe",
+        name="Launch Probability",
+        native_unit_of_measurement=PERCENTAGE,
+    ),
 )
 
 
@@ -106,18 +106,18 @@ async def async_setup_entry(
             NextLaunchSensor(
                 coordinator,
                 entry.entry_id,
-                NEXT_LAUNCH_SENSOR_DESCRIPTION,
+                SENSOR_DESCRIPTIONS[0],
                 name,
             ),
             LaunchTimeSensor(
                 coordinator,
                 entry.entry_id,
-                LAUNCH_TIME_SENSOR_DESCRIPTION,
+                SENSOR_DESCRIPTIONS[1],
             ),
             LaunchProbabilitySensor(
                 coordinator,
                 entry.entry_id,
-                LAUNCH_PROBABILITY_SENSOR_DESCRIPTION,
+                SENSOR_DESCRIPTIONS[2],
             ),
         ]
     )
@@ -205,7 +205,7 @@ class LaunchTimeSensor(NextLaunchBaseSensor):
         }
 
 
-class LaunchProbabilitySensor(LaunchLibraryBaseSensor):
+class LaunchProbabilitySensor(NextLaunchBaseSensor):
     """Representation of the launch probability sensor."""
 
     @property

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -139,15 +139,13 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN]
 
     async_add_entities(
-        [
-            NextLaunchSensor(
-                coordinator=coordinator,
-                entry_id=entry.entry_id,
-                description=description,
-                name=name if description.key == NEXT_LAUNCH else None,
-            )
-            for description in SENSOR_DESCRIPTIONS
-        ]
+        NextLaunchSensor(
+            coordinator=coordinator,
+            entry_id=entry.entry_id,
+            description=description,
+            name=name if description.key == NEXT_LAUNCH else None,
+        )
+        for description in SENSOR_DESCRIPTIONS
     )
 
 

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -94,7 +94,7 @@ SENSOR_DESCRIPTIONS: tuple[NextLaunchSensorEntityDescription, ...] = (
     ),
     NextLaunchSensorEntityDescription(
         key=LAUNCH_PROBABILITY,
-        icon="mdi:horseshoe",
+        icon="mdi:dice-multiple",
         name="Launch Probability",
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda next_launch: next_launch.probability


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Attributes on the current sensor is changed. Names of these attributes are changed to better describe what information they provide. (Ex. `agency` changes name to `provider` as this is the more correct terminology.) New attributes are added to give more information about where it takes place.

I have moved the `stream` attribute to the new sensor, and changed it's name to `stream_live` as it represent if the stream is live and not if a stream is available. 

And finally, I have moved the attribute `launch_time` into it's own sensor. This made it possible to add some information about the launch window start and end as attributes for the new sensor. This sensor will also contain the `stream_live` attribute.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I have also added a launch probability sensor, that gives you the launch probability (I believe this is mostly weather related) if available.

I recognize that this heavily diverts from what the original sensor was and extends it quiet a bit. And i hope it if welcome 😃 

More incoming after this. 

Also a better name for the `Launch time` sensor is welcome if someone have a better suggestion 😃 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
