### PR TITLE
Fix root package relative imports

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -8,7 +8,11 @@ import platform
 import sys
 import threading
 
-from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
+from homeassistant.const import (  # pylint: disable=hass-relative-import
+    REQUIRED_PYTHON_VER,
+    RESTART_EXIT_CODE,
+    __version__,
+)
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
@@ -25,8 +29,8 @@ def validate_python() -> None:
 
 def ensure_config_path(config_dir: str) -> None:
     """Validate the configuration directory."""
-    # pylint: disable=import-outside-toplevel
-    from . import config as config_util
+    # pylint: disable=import-outside-toplevel,hass-relative-import
+    import homeassistant.config as config_util
 
     lib_dir = os.path.join(config_dir, "deps")
 
@@ -59,8 +63,8 @@ def ensure_config_path(config_dir: str) -> None:
 
 def get_arguments() -> argparse.Namespace:
     """Get parsed passed in arguments."""
-    # pylint: disable=import-outside-toplevel
-    from . import config as config_util
+    # pylint: disable=import-outside-toplevel,hass-relative-import
+    import homeassistant.config as config_util
 
     parser = argparse.ArgumentParser(
         description="Home Assistant: Observe, Control, Automate."
@@ -267,8 +271,8 @@ def main() -> int:
     args = get_arguments()
 
     if args.script is not None:
-        # pylint: disable=import-outside-toplevel
-        from . import scripts
+        # pylint: disable=import-outside-toplevel,hass-relative-import
+        from homeassistant import scripts
 
         return scripts.run(args.script)
 
@@ -283,8 +287,8 @@ def main() -> int:
     if args.pid_file:
         write_pid(args.pid_file)
 
-    # pylint: disable=import-outside-toplevel
-    from . import runner
+    # pylint: disable=import-outside-toplevel,hass-relative-import
+    from homeassistant import runner
 
     runtime_conf = runner.RuntimeConfig(
         config_dir=config_dir,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a partial revert of https://github.com/home-assistant/core/pull/62693

When restarting core we run python with `__main__.py` as an argument:

 `/usr/local/bin/python /workspaces/core/homeassistant/__main__.py` 

Which does not run it as a package which breaks non relative imports, I have looked into several ways to fix it, but I think the simplest way would be to revert relative imports in `__main__` and disable relative imports warning only in this file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
