### PR TITLE
Add `restrict_watering` and `unrestrict_watering` services to RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -67,9 +67,9 @@ UPDATE_INTERVALS = {
     DATA_ZONES: timedelta(seconds=15),
 }
 
-# Constants expected by the RainMachine API for Service Data
 CONF_CONDITION = "condition"
 CONF_DEWPOINT = "dewpoint"
+CONF_DURATION = "duration"
 CONF_ET = "et"
 CONF_MAXRH = "maxrh"
 CONF_MAXTEMP = "maxtemp"
@@ -95,8 +95,10 @@ CV_WX_DATA_VALID_SOLARRAD = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=5.
 
 SERVICE_NAME_PAUSE_WATERING = "pause_watering"
 SERVICE_NAME_PUSH_WEATHER_DATA = "push_weather_data"
+SERVICE_NAME_RESTRICT_WATERING = "restrict_watering"
 SERVICE_NAME_STOP_ALL = "stop_all"
 SERVICE_NAME_UNPAUSE_WATERING = "unpause_watering"
+SERVICE_NAME_UNRESTRICT_WATERING = "unrestrict_watering"
 
 SERVICE_SCHEMA = vol.Schema(
     {
@@ -126,6 +128,12 @@ SERVICE_PUSH_WEATHER_DATA_SCHEMA = SERVICE_SCHEMA.extend(
         vol.Optional(CONF_CONDITION): cv.string,
         vol.Optional(CONF_PRESSURE): CV_WX_DATA_VALID_PRESSURE,
         vol.Optional(CONF_DEWPOINT): CV_WX_DATA_VALID_TEMP_RANGE,
+    }
+)
+
+SERVICE_RESTRICT_WATERING_SCHEMA = SERVICE_SCHEMA.extend(
+    {
+        vol.Required(CONF_DURATION): cv.time_period,
     }
 )
 
@@ -275,6 +283,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             }
         )
 
+    async def async_restrict_watering(call: ServiceCall) -> None:
+        """Restrict watering for a time period."""
+        controller = async_get_controller_for_service_call(hass, call)
+        await controller.restrictions.restrict(call.data[CONF_DURATION])
+        await async_update_programs_and_zones(hass, entry)
+
     async def async_stop_all(call: ServiceCall) -> None:
         """Stop all watering."""
         controller = async_get_controller_for_service_call(hass, call)
@@ -285,6 +299,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Unpause watering."""
         controller = async_get_controller_for_service_call(hass, call)
         await controller.watering.unpause_all()
+        await async_update_programs_and_zones(hass, entry)
+
+    async def async_unrestrict_watering(call: ServiceCall) -> None:
+        """Unrestrict watering."""
+        controller = async_get_controller_for_service_call(hass, call)
+        await controller.restrictions.unrestrict()
         await async_update_programs_and_zones(hass, entry)
 
     for service_name, schema, method in (
@@ -298,8 +318,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             SERVICE_PUSH_WEATHER_DATA_SCHEMA,
             async_push_weather_data,
         ),
+        (
+            SERVICE_NAME_RESTRICT_WATERING,
+            SERVICE_RESTRICT_WATERING_SCHEMA,
+            async_restrict_watering,
+        ),
         (SERVICE_NAME_STOP_ALL, SERVICE_SCHEMA, async_stop_all),
         (SERVICE_NAME_UNPAUSE_WATERING, SERVICE_SCHEMA, async_unpause_watering),
+        (
+            SERVICE_NAME_UNRESTRICT_WATERING,
+            SERVICE_SCHEMA,
+            async_unrestrict_watering,
+        ),
     ):
         if hass.services.has_service(DOMAIN, service_name):
             continue
@@ -325,8 +355,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for service_name in (
             SERVICE_NAME_PAUSE_WATERING,
             SERVICE_NAME_PUSH_WEATHER_DATA,
+            SERVICE_NAME_RESTRICT_WATERING,
             SERVICE_NAME_STOP_ALL,
             SERVICE_NAME_UNPAUSE_WATERING,
+            SERVICE_NAME_UNRESTRICT_WATERING,
         ):
             hass.services.async_remove(DOMAIN, service_name)
 

--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -47,6 +47,24 @@ pause_watering:
           min: 1
           max: 43200
           unit_of_measurement: seconds
+restrict_watering:
+  name: Restrict All Watering
+  description: Restrict all watering activities from starting for a time period
+  fields:
+    device_id:
+      name: Controller
+      description: The controller whose watering activities should be restricted
+      required: true
+      selector:
+        device:
+          integration: rainmachine
+    duration:
+      name: Duration
+      description: The time period to restrict watering activities from starting
+      required: true
+      default: "01:00:00"
+      selector:
+        text:
 start_program:
   name: Start Program
   description: Start a program
@@ -241,3 +259,14 @@ push_weather_data:
           max: 40
           step: 0.1
           unit_of_measurement: '°C'
+unrestrict_watering:
+  name: Unrestrict All Watering
+  description: Unrestrict all watering activities
+  fields:
+    device_id:
+      name: Controller
+      description: The controller whose watering activities should be unrestricted
+      required: true
+      selector:
+        device:
+          integration: rainmachine


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds two new services to RainMachine:

1. `rainmachine.restrict_watering`: restricts all watering activities for a time period
2. `rainmachine.unrestrict_watering`: removes all watering restrictions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: M/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21222

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
