### PR TITLE
Support Ecobee climate Aux Heat on /off

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -71,6 +71,7 @@ PRESET_HOLD_INDEFINITE = "indefinite"
 AWAY_MODE = "awayMode"
 PRESET_HOME = "home"
 PRESET_SLEEP = "sleep"
+HAS_HEAT_PUMP = "hasHeatPump"
 
 DEFAULT_MIN_HUMIDITY = 15
 DEFAULT_MAX_HUMIDITY = 50
@@ -173,7 +174,6 @@ SET_FAN_MIN_ON_TIME_SCHEMA = vol.Schema(
 SUPPORT_FLAGS = (
     SUPPORT_TARGET_TEMPERATURE
     | SUPPORT_PRESET_MODE
-    | SUPPORT_AUX_HEAT
     | SUPPORT_TARGET_TEMPERATURE_RANGE
     | SUPPORT_FAN_MODE
 )
@@ -362,9 +362,12 @@ class Thermostat(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
+        supported = SUPPORT_FLAGS
         if self.has_humidifier_control:
-            return SUPPORT_FLAGS | SUPPORT_TARGET_HUMIDITY
-        return SUPPORT_FLAGS
+            supported = supported | SUPPORT_TARGET_HUMIDITY
+        if self.has_aux_heat:
+            supported = supported | SUPPORT_AUX_HEAT
+        return supported
 
     @property
     def name(self):
@@ -431,8 +434,16 @@ class Thermostat(ClimateEntity):
     def has_humidifier_control(self):
         """Return true if humidifier connected to thermostat and set to manual/on mode."""
         return (
-            self.thermostat["settings"]["hasHumidifier"]
+            "hasHumidifer" in self.thermostat["settings"]
             and self.thermostat["settings"]["humidifierMode"] == HUMIDIFIER_MANUAL_MODE
+        )
+
+    @property
+    def has_aux_heat(self):
+        """Return true if the ecobee has a heat pump."""
+        return (
+            HAS_HEAT_PUMP in self.thermostat["settings"]
+            and self.thermostat["settings"][HAS_HEAT_PUMP]
         )
 
     @property

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -76,6 +76,8 @@ DEFAULT_MIN_HUMIDITY = 15
 DEFAULT_MAX_HUMIDITY = 50
 HUMIDIFIER_MANUAL_MODE = "manual"
 
+ECOBEE_AUX_HEAT_ONLY = "auxHeatOnly"
+
 
 # Order matters, because for reverse mapping we don't want to map HEAT to AUX
 ECOBEE_HVAC_TO_HASS = collections.OrderedDict(
@@ -562,17 +564,18 @@ class Thermostat(ClimateEntity):
     @property
     def is_aux_heat(self):
         """Return true if aux heater."""
-        return "auxHeat" in self.thermostat["equipmentStatus"]
+        return self.thermostat["settings"]["hvacMode"] == ECOBEE_AUX_HEAT_ONLY
 
-    async def async_turn_aux_heat_on(self) -> None:
+    def turn_aux_heat_on(self):
         """Turn auxiliary heater on."""
-        if not self.is_aux_heat:
-            _LOGGER.warning("# Changing aux heat is not supported")
+        _LOGGER.debug("Setting HVAC mode to auxHeatOnly to turn on aux heat")
+        self.data.ecobee.set_hvac_mode(self.thermostat_index, ECOBEE_AUX_HEAT_ONLY)
+        self.update_without_throttle = True
 
-    async def async_turn_aux_heat_off(self) -> None:
+    def turn_aux_heat_off(self) -> None:
         """Turn auxiliary heater off."""
-        if self.is_aux_heat:
-            _LOGGER.warning("# Changing aux heat is not supported")
+        _LOGGER.debug("Setting HVAC mode to heat to disable aux heat")
+        self.set_hvac_mode(self._last_active_hvac_mode)
 
     def set_preset_mode(self, preset_mode):
         """Activate a preset."""

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -349,5 +349,6 @@ async def test_turn_aux_heat_on(thermostat, data):
 async def test_turn_aux_heat_off(thermostat, data):
     """Test when aux heat is tuned off.  Must change HVAC mode back to last used."""
     data.reset_mock()
+    thermostat._last_active_hvac_mode = "heat"
     thermostat.turn_aux_heat_off()
-    data.ecobee.set_hvac_mode.assert_has_calls([mock.call(1, "auto")])
+    data.ecobee.set_hvac_mode.assert_has_calls([mock.call(1, "heat")])

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from homeassistant.components.climate.const import SUPPORT_AUX_HEAT
 from homeassistant.components.ecobee import climate as ecobee
 import homeassistant.const as const
 from homeassistant.const import STATE_OFF
@@ -74,6 +75,17 @@ def thermostat_fixture(data):
 async def test_name(thermostat):
     """Test name property."""
     assert thermostat.name == "Ecobee"
+
+
+async def test_aux_heat_not_supported_by_default(ecobee_fixture, thermostat):
+    """Default setup should not support Aux heat."""
+    assert not thermostat.supported_features & SUPPORT_AUX_HEAT
+
+
+async def test_aux_heat_supported_with_heat_pump(ecobee_fixture, thermostat):
+    """Aux Heat shouuld be supported if thermostat has heatpump."""
+    ecobee_fixture["settings"]["hasHeatPump"] = True
+    assert thermostat.supported_features & SUPPORT_AUX_HEAT
 
 
 async def test_current_temperature(ecobee_fixture, thermostat):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This potentially changes the behavior of the `is_aux_heat` property / "Aux Heat" toggle for the Ecobee climate entity.  Previously this was intended to be toggled whenever the aux heat was running, however I am not sure if it worked properly.  This property will now only be true when the climate entity is in "aux heat only" mode.  This means aux heat could be automatically triggered by ecobee itself and the aux heat toggle would **not** be enabled.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allows an Ecobee thermostat to be set to aux heat only mode by toggling the "Aux heat" toggle in the UI or calling `climate.set_aux_heat`.  Calling this service will change the Ecobee hvac mode to "auxHeatOnly", and disabling will change the hvac mode back to last active mode ("heat", "heat_cool", etc).  I am open to other ways to implement this functionality, but this is the best I could come up with.

Currently there does not appear to be away to control the Auxiliary heat functionality of an Ecobee thermostat via Home Assistant, despite it being documented.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64043
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21224

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
