### PR TITLE
WeMo state changes are seen by all coordinator entities

### DIFF
--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -67,7 +67,7 @@ class WemoEntity(CoordinatorEntity):
         return self._device_info
 
     @contextlib.contextmanager
-    def _wemo_exception_handler(self, message: str) -> Generator[None, None, None]:
+    def _wemo_call_wrapper(self, message: str) -> Generator[None, None, None]:
         """Wrap calls to the device that change its state.
 
         1. Takes care of making available=False when communications with the

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -8,7 +8,6 @@ from typing import cast
 
 from pywemo.exceptions import ActionException
 
-from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -19,6 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class WemoEntity(CoordinatorEntity):
     """Common methods for Wemo entities."""
+
+    coordinator: DeviceCoordinator  # Override CoordinatorEntity.coordinator type.
 
     # Most pyWeMo devices are associated with a single Home Assistant entity. When
     # that is not the case, name_suffix & unique_id_suffix can be used to provide
@@ -31,7 +32,6 @@ class WemoEntity(CoordinatorEntity):
         super().__init__(coordinator)
         self.wemo = coordinator.wemo
         self._device_info = coordinator.device_info
-        self._available = True
 
     @property
     def name_suffix(self) -> str | None:
@@ -45,11 +45,6 @@ class WemoEntity(CoordinatorEntity):
         if suffix := self.name_suffix:
             return f"{wemo_name} {suffix}"
         return wemo_name
-
-    @property
-    def available(self) -> bool:
-        """Return true if the device is available."""
-        return super().available and self._available
 
     @property
     def unique_id_suffix(self) -> str | None:
@@ -71,20 +66,23 @@ class WemoEntity(CoordinatorEntity):
         """Return the device info."""
         return self._device_info
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._available = True
-        super()._handle_coordinator_update()
-
     @contextlib.contextmanager
     def _wemo_exception_handler(self, message: str) -> Generator[None, None, None]:
-        """Wrap device calls to set `_available` when wemo exceptions happen."""
+        """Wrap calls to the device that change its state.
+
+        1. Takes care of making available=False when communications with the
+           device fails.
+        2. Ensures all entities sharing the same coordinator are aware of
+           updates to the device state.
+        """
         try:
             yield
         except ActionException as err:
             _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
-            self._available = False
+            self.coordinator.last_exception = err
+            self.coordinator.last_update_success = False  # Used for self.available.
+        finally:
+            self.hass.add_job(self.coordinator.async_update_listeners)
 
 
 class WemoBinaryStateEntity(WemoEntity):

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -160,7 +160,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        with self._wemo_exception_handler("turn off"):
+        with self._wemo_call_wrapper("turn off"):
             self.wemo.set_state(WEMO_FAN_OFF)
 
     def set_percentage(self, percentage: int | None) -> None:
@@ -172,7 +172,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         else:
             named_speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
 
-        with self._wemo_exception_handler("set speed"):
+        with self._wemo_call_wrapper("set speed"):
             self.wemo.set_state(named_speed)
 
     def set_humidity(self, target_humidity: float) -> None:
@@ -188,10 +188,10 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         elif target_humidity >= 100:
             pywemo_humidity = WEMO_HUMIDITY_100
 
-        with self._wemo_exception_handler("set humidity"):
+        with self._wemo_call_wrapper("set humidity"):
             self.wemo.set_humidity(pywemo_humidity)
 
     def reset_filter_life(self) -> None:
         """Reset the filter life to 100%."""
-        with self._wemo_exception_handler("reset filter life"):
+        with self._wemo_call_wrapper("reset filter life"):
             self.wemo.reset_filter_life()

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -163,8 +163,6 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         with self._wemo_exception_handler("turn off"):
             self.wemo.set_state(WEMO_FAN_OFF)
 
-        self.schedule_update_ha_state()
-
     def set_percentage(self, percentage: int | None) -> None:
         """Set the fan_mode of the Humidifier."""
         if percentage is None:
@@ -176,8 +174,6 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
 
         with self._wemo_exception_handler("set speed"):
             self.wemo.set_state(named_speed)
-
-        self.schedule_update_ha_state()
 
     def set_humidity(self, target_humidity: float) -> None:
         """Set the target humidity level for the Humidifier."""
@@ -195,11 +191,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         with self._wemo_exception_handler("set humidity"):
             self.wemo.set_humidity(pywemo_humidity)
 
-        self.schedule_update_ha_state()
-
     def reset_filter_life(self) -> None:
         """Reset the filter life to 100%."""
         with self._wemo_exception_handler("reset filter life"):
             self.wemo.reset_filter_life()
-
-        self.schedule_update_ha_state()

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -169,7 +169,7 @@ class WemoLight(WemoEntity, LightEntity):
             "force_update": False,
         }
 
-        with self._wemo_exception_handler("turn on"):
+        with self._wemo_call_wrapper("turn on"):
             if xy_color is not None:
                 self.light.set_color(xy_color, transition=transition_time)
 
@@ -184,7 +184,7 @@ class WemoLight(WemoEntity, LightEntity):
         """Turn the light off."""
         transition_time = int(kwargs.get(ATTR_TRANSITION, 0))
 
-        with self._wemo_exception_handler("turn off"):
+        with self._wemo_call_wrapper("turn off"):
             self.light.turn_off(transition=transition_time)
 
 
@@ -209,13 +209,13 @@ class WemoDimmer(WemoBinaryStateEntity, LightEntity):
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
             brightness = int((brightness / 255) * 100)
-            with self._wemo_exception_handler("set brightness"):
+            with self._wemo_call_wrapper("set brightness"):
                 self.wemo.set_brightness(brightness)
         else:
-            with self._wemo_exception_handler("turn on"):
+            with self._wemo_call_wrapper("turn on"):
                 self.wemo.on()
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the dimmer off."""
-        with self._wemo_exception_handler("turn off"):
+        with self._wemo_call_wrapper("turn off"):
             self.wemo.off()

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -180,16 +180,12 @@ class WemoLight(WemoEntity, LightEntity):
 
             self.light.turn_on(**turn_on_kwargs)
 
-        self.schedule_update_ha_state()
-
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition_time = int(kwargs.get(ATTR_TRANSITION, 0))
 
         with self._wemo_exception_handler("turn off"):
             self.light.turn_off(transition=transition_time)
-
-        self.schedule_update_ha_state()
 
 
 class WemoDimmer(WemoBinaryStateEntity, LightEntity):
@@ -219,11 +215,7 @@ class WemoDimmer(WemoBinaryStateEntity, LightEntity):
             with self._wemo_exception_handler("turn on"):
                 self.wemo.on()
 
-        self.schedule_update_ha_state()
-
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the dimmer off."""
         with self._wemo_exception_handler("turn off"):
             self.wemo.off()
-
-        self.schedule_update_ha_state()

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -154,10 +154,10 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        with self._wemo_exception_handler("turn on"):
+        with self._wemo_call_wrapper("turn on"):
             self.wemo.on()
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        with self._wemo_exception_handler("turn off"):
+        with self._wemo_call_wrapper("turn off"):
             self.wemo.off()

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -157,11 +157,7 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
         with self._wemo_exception_handler("turn on"):
             self.wemo.on()
 
-        self.schedule_update_ha_state()
-
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         with self._wemo_exception_handler("turn off"):
             self.wemo.off()
-
-        self.schedule_update_ha_state()

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -123,6 +123,12 @@ class DeviceCoordinator(DataUpdateCoordinator):
             except ActionException as err:
                 raise UpdateFailed("WeMo update failed") from err
 
+    @callback
+    def async_update_listeners(self) -> None:
+        """Update all listeners."""
+        for update_callback in self._listeners:
+            update_callback()
+
 
 def _device_info(wemo: WeMoDevice) -> DeviceInfo:
     return DeviceInfo(

--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -123,8 +123,6 @@ async def test_avaliable_after_update(
     ActionException when the SERVICE_TURN_ON method is called and that the
     state will be On after the update.
     """
-    await async_setup_component(hass, domain, {})
-
     await hass.services.async_call(
         domain,
         SERVICE_TURN_ON,
@@ -140,8 +138,6 @@ async def test_avaliable_after_update(
 
 async def test_turn_off_state(hass, wemo_entity, domain):
     """Test that the device state is updated after turning off."""
-    await async_setup_component(hass, domain, {})
-
     await hass.services.async_call(
         domain,
         SERVICE_TURN_OFF,

--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -9,7 +9,9 @@ from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
 from homeassistant.components.wemo import wemo_device
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
@@ -134,6 +136,19 @@ async def test_avaliable_after_update(
     pywemo_registry.callbacks[pywemo_device.name](pywemo_device, "", "")
     await hass.async_block_till_done()
     assert hass.states.get(wemo_entity.entity_id).state == STATE_ON
+
+
+async def test_turn_off_state(hass, wemo_entity, domain):
+    """Test that the device state is updated after turning off."""
+    await async_setup_component(hass, domain, {})
+
+    await hass.services.async_call(
+        domain,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
+        blocking=True,
+    )
+    assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF
 
 
 class EntityTestHelpers:

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -88,6 +88,11 @@ async def test_available_after_update(
     )
 
 
+async def test_turn_off_state(hass, wemo_entity):
+    """Test that the device state is updated after turning off."""
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.FAN)
+
+
 async def test_fan_reset_filter_service(hass, pywemo_device, wemo_entity):
     """Verify that SERVICE_RESET_FILTER_LIFE is registered and works."""
     assert await hass.services.async_call(

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -3,13 +3,14 @@
 import pytest
 from pywemo.exceptions import ActionException
 
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.wemo import fan
 from homeassistant.components.wemo.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -84,13 +85,13 @@ async def test_available_after_update(
     pywemo_device.set_state.side_effect = ActionException
     pywemo_device.get_state.return_value = 1
     await entity_test_helpers.test_avaliable_after_update(
-        hass, pywemo_registry, pywemo_device, wemo_entity, Platform.FAN
+        hass, pywemo_registry, pywemo_device, wemo_entity, FAN_DOMAIN
     )
 
 
 async def test_turn_off_state(hass, wemo_entity):
     """Test that the device state is updated after turning off."""
-    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.FAN)
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, FAN_DOMAIN)
 
 
 async def test_fan_reset_filter_service(hass, pywemo_device, wemo_entity):

--- a/tests/components/wemo/test_light_bridge.py
+++ b/tests/components/wemo/test_light_bridge.py
@@ -8,8 +8,8 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.light import ATTR_COLOR_TEMP
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
+from homeassistant.components.light import ATTR_COLOR_TEMP, DOMAIN as LIGHT_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -76,13 +76,13 @@ async def test_available_after_update(
     pywemo_bridge_light.turn_on.side_effect = pywemo.exceptions.ActionException
     pywemo_bridge_light.state["onoff"] = 1
     await entity_test_helpers.test_avaliable_after_update(
-        hass, pywemo_registry, pywemo_device, wemo_entity, Platform.LIGHT
+        hass, pywemo_registry, pywemo_device, wemo_entity, LIGHT_DOMAIN
     )
 
 
 async def test_turn_off_state(hass, pywemo_bridge_light, wemo_entity):
     """Test that the device state is updated after turning off."""
-    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.LIGHT)
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, LIGHT_DOMAIN)
 
 
 async def test_light_update_entity(

--- a/tests/components/wemo/test_light_bridge.py
+++ b/tests/components/wemo/test_light_bridge.py
@@ -80,6 +80,11 @@ async def test_available_after_update(
     )
 
 
+async def test_turn_off_state(hass, pywemo_bridge_light, wemo_entity):
+    """Test that the device state is updated after turning off."""
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.LIGHT)
+
+
 async def test_light_update_entity(
     hass, pywemo_registry, pywemo_bridge_light, wemo_entity
 ):

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -44,6 +44,11 @@ async def test_available_after_update(
     )
 
 
+async def test_turn_off_state(hass, wemo_entity):
+    """Test that the device state is updated after turning off."""
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.LIGHT)
+
+
 async def test_light_registry_state_callback(
     hass, pywemo_registry, pywemo_device, wemo_entity
 ):

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -7,14 +7,8 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.light import ATTR_BRIGHTNESS
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    STATE_OFF,
-    STATE_ON,
-    Platform,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, DOMAIN as LIGHT_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -47,13 +41,13 @@ async def test_available_after_update(
     pywemo_device.on.side_effect = ActionException
     pywemo_device.get_state.return_value = 1
     await entity_test_helpers.test_avaliable_after_update(
-        hass, pywemo_registry, pywemo_device, wemo_entity, Platform.LIGHT
+        hass, pywemo_registry, pywemo_device, wemo_entity, LIGHT_DOMAIN
     )
 
 
 async def test_turn_off_state(hass, wemo_entity):
     """Test that the device state is updated after turning off."""
-    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.LIGHT)
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, LIGHT_DOMAIN)
 
 
 async def test_turn_on_brightness(hass, pywemo_device, wemo_entity):
@@ -71,7 +65,7 @@ async def test_turn_on_brightness(hass, pywemo_device, wemo_entity):
     pywemo_device.set_brightness.side_effect = set_brightness
 
     await hass.services.async_call(
-        Platform.LIGHT,
+        LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: [wemo_entity.entity_id], ATTR_BRIGHTNESS: 204},
         blocking=True,

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -7,7 +7,14 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
+from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    Platform,
+)
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -47,6 +54,19 @@ async def test_available_after_update(
 async def test_turn_off_state(hass, wemo_entity):
     """Test that the device state is updated after turning off."""
     await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.LIGHT)
+
+
+async def test_turn_on_brightness(hass, pywemo_device, wemo_entity):
+    """Test setting the brightness value of the light."""
+    await async_setup_component(hass, Platform.LIGHT, {})
+    await hass.services.async_call(
+        Platform.LIGHT,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: [wemo_entity.entity_id], ATTR_BRIGHTNESS: 200},
+        blocking=True,
+    )
+
+    pywemo_device.set_brightness.assert_called_once_with(78)
 
 
 async def test_light_registry_state_callback(

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -70,7 +70,6 @@ async def test_turn_on_brightness(hass, pywemo_device, wemo_entity):
     pywemo_device.get_brightness.side_effect = lambda: brightness
     pywemo_device.set_brightness.side_effect = set_brightness
 
-    await async_setup_component(hass, Platform.LIGHT, {})
     await hass.services.async_call(
         Platform.LIGHT,
         SERVICE_TURN_ON,

--- a/tests/components/wemo/test_switch.py
+++ b/tests/components/wemo/test_switch.py
@@ -84,3 +84,8 @@ async def test_available_after_update(
     await entity_test_helpers.test_avaliable_after_update(
         hass, pywemo_registry, pywemo_device, wemo_entity, Platform.SWITCH
     )
+
+
+async def test_turn_off_state(hass, wemo_entity):
+    """Test that the device state is updated after turning off."""
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.SWITCH)

--- a/tests/components/wemo/test_switch.py
+++ b/tests/components/wemo/test_switch.py
@@ -7,7 +7,8 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -82,10 +83,10 @@ async def test_available_after_update(
     pywemo_device.on.side_effect = ActionException
     pywemo_device.get_state.return_value = 1
     await entity_test_helpers.test_avaliable_after_update(
-        hass, pywemo_registry, pywemo_device, wemo_entity, Platform.SWITCH
+        hass, pywemo_registry, pywemo_device, wemo_entity, SWITCH_DOMAIN
     )
 
 
 async def test_turn_off_state(hass, wemo_entity):
     """Test that the device state is updated after turning off."""
-    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, Platform.SWITCH)
+    await entity_test_helpers.test_turn_off_state(hass, wemo_entity, SWITCH_DOMAIN)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, when the state of a WeMo entity (light,switch,fan) is updated by Home Assistant other entities (binary_sensor,sensor) that share the same DataUpdateCoordinator are not aware of the change. This PR aims to ensure that the `available` property and device state are updated in all entities that share the same coordinator when call is made to change the device state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: [#63704](https://github.com/home-assistant/core/issues/63704#issuecomment-1014066268)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
