### PR TITLE
spelling: components/analytics

### DIFF
--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -26,7 +26,7 @@ MOCK_VERSION_NIGHTLY = "1970.1.0.dev19700101"
 
 
 async def test_no_send(hass, caplog, aioclient_mock):
-    """Test send when no prefrences are defined."""
+    """Test send when no preferences are defined."""
     analytics = Analytics(hass)
     with patch(
         "homeassistant.components.hassio.is_hassio",
@@ -102,7 +102,7 @@ async def test_failed_to_send_raises(hass, caplog, aioclient_mock):
 
 
 async def test_send_base(hass, caplog, aioclient_mock):
-    """Test send base prefrences are defined."""
+    """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
 
@@ -123,7 +123,7 @@ async def test_send_base(hass, caplog, aioclient_mock):
 
 
 async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
-    """Test send base prefrences are defined."""
+    """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
 
     analytics = Analytics(hass)
@@ -170,7 +170,7 @@ async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
 
 
 async def test_send_usage(hass, caplog, aioclient_mock):
-    """Test send usage prefrences are defined."""
+    """Test send usage preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
@@ -187,7 +187,7 @@ async def test_send_usage(hass, caplog, aioclient_mock):
 
 
 async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
-    """Test send usage with supervisor prefrences are defined."""
+    """Test send usage with supervisor preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
 
     analytics = Analytics(hass)
@@ -240,7 +240,7 @@ async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
 
 
 async def test_send_statistics(hass, caplog, aioclient_mock):
-    """Test send statistics prefrences are defined."""
+    """Test send statistics preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
@@ -258,7 +258,7 @@ async def test_send_statistics(hass, caplog, aioclient_mock):
 
 
 async def test_send_statistics_one_integration_fails(hass, caplog, aioclient_mock):
-    """Test send statistics prefrences are defined."""
+    """Test send statistics preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
@@ -280,7 +280,7 @@ async def test_send_statistics_one_integration_fails(hass, caplog, aioclient_moc
 async def test_send_statistics_async_get_integration_unknown_exception(
     hass, caplog, aioclient_mock
 ):
-    """Test send statistics prefrences are defined."""
+    """Test send statistics preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
@@ -296,7 +296,7 @@ async def test_send_statistics_async_get_integration_unknown_exception(
 
 
 async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
-    """Test send statistics prefrences are defined."""
+    """Test send statistics preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
@@ -427,7 +427,7 @@ async def test_nightly_endpoint(hass, aioclient_mock):
 
 
 async def test_send_with_no_energy(hass, aioclient_mock):
-    """Test send base prefrences are defined."""
+    """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
 
@@ -448,7 +448,7 @@ async def test_send_with_no_energy(hass, aioclient_mock):
 
 
 async def test_send_with_no_energy_config(hass, aioclient_mock):
-    """Test send base prefrences are defined."""
+    """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
 
@@ -472,7 +472,7 @@ async def test_send_with_no_energy_config(hass, aioclient_mock):
 
 
 async def test_send_with_energy_config(hass, aioclient_mock):
-    """Test send base prefrences are defined."""
+    """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
 

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -16,7 +16,7 @@ async def test_setup(hass):
 
 
 async def test_websocket(hass, hass_ws_client, aioclient_mock):
-    """Test websocekt commands."""
+    """Test websocket commands."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -16,7 +16,7 @@ async def test_setup(hass):
 
 
 async def test_websocket(hass, hass_ws_client, aioclient_mock):
-    """Test websocket commands."""
+    """Test WebSocket commands."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spelling, split from #64224 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
