### PR TITLE
Fix tests and add setup type in feedreader

### DIFF
--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -9,8 +9,10 @@ import feedparser
 import voluptuous as vol
 
 from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
+from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = getLogger(__name__)
 
@@ -40,11 +42,11 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Feedreader component."""
-    urls = config.get(DOMAIN)[CONF_URLS]
-    scan_interval = config.get(DOMAIN).get(CONF_SCAN_INTERVAL)
-    max_entries = config.get(DOMAIN).get(CONF_MAX_ENTRIES)
+    urls = config[DOMAIN][CONF_URLS]
+    scan_interval = config[DOMAIN].get(CONF_SCAN_INTERVAL)
+    max_entries = config[DOMAIN].get(CONF_MAX_ENTRIES)
     data_file = hass.config.path(f"{DOMAIN}.pickle")
     storage = StoredData(data_file)
     feeds = [

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from os import remove
 from os.path import exists
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -32,6 +32,13 @@ def load_fixture_bytes(src):
     feed_data = load_fixture(src)
     raw = bytes(feed_data, "utf-8")
     return raw
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_pickle_open():
+    """Mock builtins.open for feedreader storage."""
+    with patch("homeassistant.components.feedreader.open", mock_open(), create=True):
+        yield
 
 
 @pytest.fixture(name="feed_one_event")

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -1,7 +1,5 @@
 """The tests for the feedreader component."""
 from datetime import timedelta
-from os import remove
-from os.path import exists
 from unittest import mock
 from unittest.mock import mock_open, patch
 
@@ -32,13 +30,6 @@ def load_fixture_bytes(src):
     feed_data = load_fixture(src)
     raw = bytes(feed_data, "utf-8")
     return raw
-
-
-@pytest.fixture(scope="module", autouse=True)
-def mock_pickle_open():
-    """Mock builtins.open for feedreader storage."""
-    with patch("homeassistant.components.feedreader.open", mock_open(), create=True):
-        yield
 
 
 @pytest.fixture(name="feed_one_event")
@@ -72,14 +63,10 @@ async def fixture_events(hass):
 
 
 @pytest.fixture(name="feed_storage", autouse=True)
-def fixture_feed_storage(hass):
-    """Create storage account for feedreader."""
-    data_file = hass.config.path(f"{feedreader.DOMAIN}.pickle")
-
-    yield
-
-    if exists(data_file):
-        remove(data_file)
+def fixture_feed_storage():
+    """Mock builtins.open for feedreader storage."""
+    with patch("homeassistant.components.feedreader.open", mock_open(), create=True):
+        yield
 
 
 async def test_setup_one_feed(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Feedreader tests are currently failing in partial CI. This fixes the tests accordingly.

It also adds the setup type hints, which is how I originally spotted the tests were failing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63433
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
