### PR TITLE
Fix webostv YAML migration failure if the entity is removed

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -166,6 +166,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             else:
                 break
 
+        ent_reg = entity_registry.async_get(hass)
+        if not ent_reg.async_get_entity_id(Platform.MEDIA_PLAYER, DOMAIN, key):
+            _LOGGER.debug(
+                "Not updating webOSTV Smart TV entity %s unique_id, entity unavailable",
+                entity_id,
+            )
+            return
+
         uuid = client.hello_info["deviceUUID"]
         ent_reg.async_update_entity(entity_id, new_unique_id=uuid)
         await hass.config_entries.flow.async_init(

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -167,7 +167,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 break
 
         ent_reg = entity_registry.async_get(hass)
-        if not ent_reg.async_get_entity_id(Platform.MEDIA_PLAYER, DOMAIN, key):
+        if not (
+            new_entity_id := ent_reg.async_get_entity_id(
+                Platform.MEDIA_PLAYER, DOMAIN, key
+            )
+        ):
             _LOGGER.debug(
                 "Not updating webOSTV Smart TV entity %s unique_id, entity missing",
                 entity_id,
@@ -175,7 +179,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             return
 
         uuid = client.hello_info["deviceUUID"]
-        ent_reg.async_update_entity(entity_id, new_unique_id=uuid)
+        ent_reg.async_update_entity(new_entity_id, new_unique_id=uuid)
         await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_IMPORT},

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -169,7 +169,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ent_reg = entity_registry.async_get(hass)
         if not ent_reg.async_get_entity_id(Platform.MEDIA_PLAYER, DOMAIN, key):
             _LOGGER.debug(
-                "Not updating webOSTV Smart TV entity %s unique_id, entity unavailable",
+                "Not updating webOSTV Smart TV entity %s unique_id, entity missing",
                 entity_id,
             )
             return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Fix webostv YAML migration failure if the entity is removed before the TV is online.**
At startup we check if there are entities to be migrated and wait for a connection with the device. Since this process can be very long, the user can delete the entities or do a new paring with the TV, this PR adds a check again before we do the actual unique id update to make sure the entity is still available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/64174
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
