### PR TITLE
Fix media player image url password logged

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1009,8 +1009,11 @@ class MediaPlayerEntity(Entity):
 
         if content is None:
             url_parts = URL(url)
+            if url_parts.user is not None:
+                url_parts = url_parts.with_user("xxxx")
             if url_parts.password is not None:
-                url = str(url_parts.with_password("xxxxxxxx"))
+                url_parts = url_parts.with_password("xxxxxxxx")
+            url = str(url_parts)
             _LOGGER.warning("Error retrieving proxied image from %s", url)
 
         return content, content_type

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1008,6 +1008,9 @@ class MediaPlayerEntity(Entity):
                     content_type = content_type.split(";")[0]
 
         if content is None:
+            url_parts = URL(url)
+            if url_parts.password is not None:
+                url = str(url_parts.with_password("xxxxxxxx"))
             _LOGGER.warning("Error retrieving proxied image from %s", url)
 
         return content, content_type

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -94,10 +94,10 @@ async def test_get_image_http_remote(hass, hass_client_no_auth):
         assert content == b"image"
 
 
-async def test_get_image_http_log_password_redacted(
+async def test_get_image_http_log_credentials_redacted(
     hass, hass_client_no_auth, aioclient_mock, caplog
 ):
-    """Test password is redacted when logging url when fetching image."""
+    """Test credentials are redacted when logging url when fetching image."""
     url = "http://vi:pass@example.com/default.jpg"
     with patch(
         "homeassistant.components.demo.media_player.DemoYoutubePlayer.media_image_url",

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -101,7 +101,7 @@ async def test_get_image_http_log_password_redacted(
     url = "http://vi:pass@example.com/default.jpg"
     with patch(
         "homeassistant.components.demo.media_player.DemoYoutubePlayer.media_image_url",
-        "http://vi:pass@example.com/default.jpg",
+        url,
     ):
         await async_setup_component(
             hass, "media_player", {"media_player": {"platform": "demo"}}
@@ -120,9 +120,9 @@ async def test_get_image_http_log_password_redacted(
     assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
     assert f"Error retrieving proxied image from {url}" not in caplog.text
     assert (
-        f"Error retrieving proxied image from {url.replace('pass', 'xxxxxxxx')}"
-        in caplog.text
-    )
+        "Error retrieving proxied image from "
+        f"{url.replace('pass', 'xxxxxxxx').replace('vi', 'xxxx')}"
+    ) in caplog.text
 
 
 async def test_get_async_get_browse_image(hass, hass_client_no_auth, hass_ws_client):

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -1,5 +1,7 @@
 """Test the base functions of the media player."""
+import asyncio
 import base64
+from http import HTTPStatus
 from unittest.mock import patch
 
 from homeassistant.components import media_player
@@ -90,6 +92,37 @@ async def test_get_image_http_remote(hass, hass_client_no_auth):
             content = await resp.read()
 
         assert content == b"image"
+
+
+async def test_get_image_http_log_password_redacted(
+    hass, hass_client_no_auth, aioclient_mock, caplog
+):
+    """Test password is redacted when logging url when fetching image."""
+    url = "http://vi:pass@example.com/default.jpg"
+    with patch(
+        "homeassistant.components.demo.media_player.DemoYoutubePlayer.media_image_url",
+        "http://vi:pass@example.com/default.jpg",
+    ):
+        await async_setup_component(
+            hass, "media_player", {"media_player": {"platform": "demo"}}
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("media_player.bedroom")
+        assert "entity_picture_local" not in state.attributes
+
+        aioclient_mock.get(url, exc=asyncio.TimeoutError())
+
+        client = await hass_client_no_auth()
+
+        resp = await client.get(state.attributes["entity_picture"])
+
+    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert f"Error retrieving proxied image from {url}" not in caplog.text
+    assert (
+        f"Error retrieving proxied image from {url.replace('pass', 'xxxxxxxx')}"
+        in caplog.text
+    )
 
 
 async def test_get_async_get_browse_image(hass, hass_client_no_auth, hass_ws_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Redact password when logging warning for retrieving proxied image from url, on failure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
