### PR TITLE
Add changed states device trigger to media_player entity

### DIFF
--- a/homeassistant/components/media_player/device_trigger.py
+++ b/homeassistant/components/media_player/device_trigger.py
@@ -9,7 +9,10 @@ from homeassistant.components.automation import (
     AutomationActionType,
     AutomationTriggerInfo,
 )
-from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation import (
+    DEVICE_TRIGGER_BASE_SCHEMA,
+    entity,
+)
 from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -32,12 +35,20 @@ from .const import DOMAIN
 
 TRIGGER_TYPES = {"turned_on", "turned_off", "idle", "paused", "playing"}
 
-TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+MEDIA_PLAYER_TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
+)
+
+TRIGGER_SCHEMA = vol.All(
+    vol.Any(
+        MEDIA_PLAYER_TRIGGER_SCHEMA,
+        entity.TRIGGER_SCHEMA,
+    ),
+    vol.Schema({vol.Required(CONF_DOMAIN): DOMAIN}, extra=vol.ALLOW_EXTRA),
 )
 
 
@@ -46,7 +57,7 @@ async def async_get_triggers(
 ) -> list[dict[str, Any]]:
     """List device triggers for Media player entities."""
     registry = await entity_registry.async_get_registry(hass)
-    triggers = []
+    triggers = await entity.async_get_triggers(hass, device_id, DOMAIN)
 
     # Get all the integration entities for this device
     for entry in entity_registry.async_entries_for_device(registry, device_id):
@@ -72,6 +83,8 @@ async def async_get_trigger_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List trigger capabilities."""
+    if config[CONF_TYPE] not in TRIGGER_TYPES:
+        return await entity.async_get_trigger_capabilities(hass, config)
     return {
         "extra_fields": vol.Schema(
             {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
@@ -86,6 +99,8 @@ async def async_attach_trigger(
     automation_info: AutomationTriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
+    if config[CONF_TYPE] not in TRIGGER_TYPES:
+        return await entity.async_attach_trigger(hass, config, action, automation_info)
     if config[CONF_TYPE] == "turned_on":
         to_state = STATE_ON
     elif config[CONF_TYPE] == "turned_off":

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -13,7 +13,8 @@
       "turned_off": "{entity_name} turned off",
       "idle": "{entity_name} becomes idle",
       "paused": "{entity_name} is paused",
-      "playing": "{entity_name} starts playing"
+      "playing": "{entity_name} starts playing",
+      "changed_states": "{entity_name} changed states"
     }
   },
   "state": {

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -58,7 +58,14 @@ async def test_get_triggers(hass, device_reg, entity_reg):
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
 
-    trigger_types = {"turned_on", "turned_off", "idle", "paused", "playing"}
+    trigger_types = {
+        "turned_on",
+        "turned_off",
+        "idle",
+        "paused",
+        "playing",
+        "changed_states",
+    }
     expected_triggers = [
         {
             "platform": "device",
@@ -88,7 +95,7 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
-    assert len(triggers) == 5
+    assert len(triggers) == 6
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
             hass, DeviceAutomationType.TRIGGER, trigger
@@ -109,7 +116,14 @@ async def test_if_fires_on_state_change(hass, calls):
         "{{{{ trigger.entity_id}}}} - {{{{ trigger.from_state.state}}}} - "
         "{{{{ trigger.to_state.state}}}} - {{{{ trigger.for }}}}"
     )
-    trigger_types = {"turned_on", "turned_off", "idle", "paused", "playing"}
+    trigger_types = {
+        "turned_on",
+        "turned_off",
+        "idle",
+        "paused",
+        "playing",
+        "changed_states",
+    }
 
     assert await async_setup_component(
         hass,
@@ -137,47 +151,47 @@ async def test_if_fires_on_state_change(hass, calls):
     # Fake that the entity is turning on.
     hass.states.async_set("media_player.entity", STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert (
-        calls[0].data["some"]
-        == "turned_on - device - media_player.entity - off - on - None"
-    )
+    assert len(calls) == 2
+    assert {calls[0].data["some"], calls[1].data["some"]} == {
+        "turned_on - device - media_player.entity - off - on - None",
+        "changed_states - device - media_player.entity - off - on - None",
+    }
 
     # Fake that the entity is turning off.
     hass.states.async_set("media_player.entity", STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert (
-        calls[1].data["some"]
-        == "turned_off - device - media_player.entity - on - off - None"
-    )
+    assert len(calls) == 4
+    assert {calls[2].data["some"], calls[3].data["some"]} == {
+        "turned_off - device - media_player.entity - on - off - None",
+        "changed_states - device - media_player.entity - on - off - None",
+    }
 
     # Fake that the entity becomes idle.
     hass.states.async_set("media_player.entity", STATE_IDLE)
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert (
-        calls[2].data["some"]
-        == "idle - device - media_player.entity - off - idle - None"
-    )
+    assert len(calls) == 6
+    assert {calls[4].data["some"], calls[5].data["some"]} == {
+        "idle - device - media_player.entity - off - idle - None",
+        "changed_states - device - media_player.entity - off - idle - None",
+    }
 
     # Fake that the entity starts playing.
     hass.states.async_set("media_player.entity", STATE_PLAYING)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert (
-        calls[3].data["some"]
-        == "playing - device - media_player.entity - idle - playing - None"
-    )
+    assert len(calls) == 8
+    assert {calls[6].data["some"], calls[7].data["some"]} == {
+        "playing - device - media_player.entity - idle - playing - None",
+        "changed_states - device - media_player.entity - idle - playing - None",
+    }
 
     # Fake that the entity is paused.
     hass.states.async_set("media_player.entity", STATE_PAUSED)
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert (
-        calls[4].data["some"]
-        == "paused - device - media_player.entity - playing - paused - None"
-    )
+    assert len(calls) == 10
+    assert {calls[8].data["some"], calls[9].data["some"]} == {
+        "paused - device - media_player.entity - playing - paused - None",
+        "changed_states - device - media_player.entity - playing - paused - None",
+    }
 
 
 async def test_if_fires_on_state_change_with_for(hass, calls):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add changed states device trigger to media_player entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
