### PR TITLE
Add discovery support to unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -33,6 +33,7 @@ from .const import (
     PLATFORMS,
 )
 from .data import ProtectData
+from .discovery import async_start_discovery
 from .services import async_cleanup_services, async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +44,7 @@ SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the UniFi Protect config entries."""
 
+    await async_start_discovery(hass)
     session = async_create_clientsession(hass, cookie_jar=CookieJar(unsafe=True))
     protect = ProtectApiClient(
         host=entry.data[CONF_HOST],

--- a/homeassistant/components/unifiprotect/discovery.py
+++ b/homeassistant/components/unifiprotect/discovery.py
@@ -1,0 +1,66 @@
+"""The unifiprotect integration discovery."""
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+import logging
+from typing import Any
+
+from unifi_discovery import AIOUnifiScanner, UnifiDevice, UnifiService
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVERY = "discovery"
+DISCOVERY_INTERVAL = timedelta(minutes=60)
+
+
+async def async_start_discovery(hass: HomeAssistant) -> None:
+    """Start discovery."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if DISCOVERY in domain_data:
+        return
+    domain_data[DISCOVERY] = True
+
+    async def _async_discovery(*_: Any) -> None:
+        async_trigger_discovery(hass, await async_discover_devices(hass))
+
+    # Do not block startup since discovery takes 31s or more
+    asyncio.create_task(_async_discovery())
+
+    async_track_time_interval(hass, _async_discovery, DISCOVERY_INTERVAL)
+
+
+async def async_discover_devices(hass: HomeAssistant) -> list[UnifiDevice]:
+    """Discover devices."""
+    scanner = AIOUnifiScanner()
+    devices = await scanner.async_scan()
+    _LOGGER.debug("Found devices: %s", devices)
+    return devices
+
+
+@callback
+def async_trigger_discovery(
+    hass: HomeAssistant,
+    discovered_devices: list[UnifiDevice],
+) -> None:
+    """Trigger config flows for discovered devices."""
+    for device in discovered_devices:
+        if device.services[UnifiService.Protect] and device.hw_addr:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_DISCOVERY},
+                    data={
+                        "ip_address": device.source_ip,
+                        "mac": device.hw_addr,
+                        "hostname": device.hostname,  # can be None
+                        "platform": device.platform,  # can be None
+                    },
+                )
+            )

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "requirements": [
-    "pyunifiprotect==3.1.1"
+    "pyunifiprotect==3.1.1", "unifi-discovery==1.0.0"
   ],
   "dependencies": [
     "http"
@@ -15,5 +15,48 @@
     "@bdraco"
   ],
   "quality_scale": "platinum",
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "dhcp": [
+    {
+      "macaddress": "B4FBE4*"
+    },
+    {
+      "macaddress": "802AA8*"
+    },
+    {
+      "macaddress": "F09FC2*"
+    },
+    {
+      "macaddress": "68D79A*"
+    },
+    {
+      "macaddress": "18E829*"
+    },
+    {
+      "macaddress": "245A4C*"
+    },
+    {
+      "macaddress": "784558*"
+    },
+    {
+      "macaddress": "E063DA*"
+    },
+    {
+      "macaddress": "265A4C*"
+    }
+  ],
+  "ssdp": [
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine Pro"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine SE"
+    }    
+  ]
 }

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name} ({ip_address})",
     "step": {
       "user": {
         "title": "UniFi Protect Setup",
@@ -19,7 +20,15 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
-      }
+      },
+      "discovery_confirm": {
+        "description": "Do you want to setup {name} ({ip_address})?",
+        "data": {
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"        
+        }
+      }      
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -27,7 +36,8 @@
       "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry."
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "discovery_started": "Discovery started"
     }
   },
   "options": {

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -1,15 +1,24 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "discovery_started": "Discovery started"
         },
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry.",
-            "unknown": "Unexpected error"
+            "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry."
         },
+        "flow_title": "{name} ({ip_address})",
         "step": {
+            "discovery_confirm": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username",
+                    "verify_ssl": "Verify SSL certificate"
+                },
+                "description": "Do you want to setup {name} ({ip_address})?"
+            },
             "reauth_confirm": {
                 "data": {
                     "host": "IP/Host of UniFi Protect Server",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -547,6 +547,42 @@ DHCP = [
         "hostname": "twinkly_*"
     },
     {
+        "domain": "unifiprotect",
+        "macaddress": "B4FBE4*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "802AA8*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "F09FC2*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "68D79A*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "18E829*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "245A4C*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "784558*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "E063DA*"
+    },
+    {
+        "domain": "unifiprotect",
+        "macaddress": "265A4C*"
+    },
+    {
         "domain": "verisure",
         "macaddress": "0023C1*"
     },

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -238,6 +238,20 @@ SSDP = {
             "modelDescription": "UniFi Dream Machine Pro"
         }
     ],
+    "unifiprotect": [
+        {
+            "manufacturer": "Ubiquiti Networks",
+            "modelDescription": "UniFi Dream Machine"
+        },
+        {
+            "manufacturer": "Ubiquiti Networks",
+            "modelDescription": "UniFi Dream Machine Pro"
+        },
+        {
+            "manufacturer": "Ubiquiti Networks",
+            "modelDescription": "UniFi Dream Machine SE"
+        }
+    ],
     "upnp": [
         {
             "st": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2391,6 +2391,9 @@ twilio==6.32.0
 # homeassistant.components.rainforest_eagle
 uEagle==0.0.2
 
+# homeassistant.components.unifiprotect
+unifi-discovery==1.0.0
+
 # homeassistant.components.unifiled
 unifiled==0.11
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1449,6 +1449,9 @@ twilio==6.32.0
 # homeassistant.components.rainforest_eagle
 uEagle==0.0.2
 
+# homeassistant.components.unifiprotect
+unifi-discovery==1.0.0
+
 # homeassistant.components.upb
 upb_lib==0.4.12
 

--- a/tests/components/unifiprotect/__init__.py
+++ b/tests/components/unifiprotect/__init__.py
@@ -1,1 +1,36 @@
 """Tests for the UniFi Protect integration."""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from unifi_discovery import AIOUnifiScanner, UnifiDevice, UnifiService
+
+DEVICE_HOSTNAME = "unvr"
+DEVICE_IP_ADDRESS = "127.0.0.1"
+DEVICE_MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
+
+
+UNIFI_DISCOVERY = UnifiDevice(
+    source_ip=DEVICE_IP_ADDRESS,
+    hw_addr=DEVICE_MAC_ADDRESS,
+    platform=DEVICE_HOSTNAME,
+    hostname=DEVICE_HOSTNAME,
+    services={UnifiService.Protect: True},
+)
+
+
+def _patch_discovery(device=None, no_device=False):
+    mock_aio_discovery = MagicMock(auto_spec=AIOUnifiScanner)
+    scanner_return = [] if no_device else [device or UNIFI_DISCOVERY]
+    mock_aio_discovery.async_scan = AsyncMock(return_value=scanner_return)
+    mock_aio_discovery.found_devices = scanner_return
+
+    @contextmanager
+    def _patcher():
+        with patch(
+            "homeassistant.components.unifiprotect.discovery.AIOUnifiScanner",
+            return_value=mock_aio_discovery,
+        ):
+            yield
+
+    return _patcher()

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -23,6 +23,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityDescription
 import homeassistant.util.dt as dt_util
 
+from . import _patch_discovery
+
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 MAC_ADDR = "aa:bb:cc:dd:ee:ff"
@@ -71,6 +73,24 @@ def mock_nvr_fixture():
     yield nvr
 
     NVR.__config__.validate_assignment = True
+
+
+@pytest.fixture(name="mock_ufp_config_entry")
+def mock_ufp_config_entry():
+    """Mock the unifiprotect config entry."""
+
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.1.1.1",
+            "username": "test-username",
+            "password": "test-password",
+            "id": "UnifiProtect",
+            "port": 443,
+            "verify_ssl": False,
+        },
+        version=2,
+    )
 
 
 @pytest.fixture(name="mock_old_nvr")
@@ -122,28 +142,20 @@ def mock_client(mock_bootstrap: MockBootstrap):
 
 @pytest.fixture
 def mock_entry(
-    hass: HomeAssistant, mock_client  # pylint: disable=redefined-outer-name
+    hass: HomeAssistant,
+    mock_ufp_config_entry: MockConfigEntry,
+    mock_client,  # pylint: disable=redefined-outer-name
 ):
     """Mock ProtectApiClient for testing."""
 
-    with patch("homeassistant.components.unifiprotect.ProtectApiClient") as mock_api:
-        mock_config = MockConfigEntry(
-            domain=DOMAIN,
-            data={
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-                "id": "UnifiProtect",
-                "port": 443,
-                "verify_ssl": False,
-            },
-            version=2,
-        )
-        mock_config.add_to_hass(hass)
+    with _patch_discovery(no_device=True), patch(
+        "homeassistant.components.unifiprotect.ProtectApiClient"
+    ) as mock_api:
+        mock_ufp_config_entry.add_to_hass(hass)
 
         mock_api.return_value = mock_client
 
-        yield MockEntityFixture(mock_config, mock_client)
+        yield MockEntityFixture(mock_ufp_config_entry, mock_client)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add discovery support to unifiprotect

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21235

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
