### PR TITLE
Remove --runner option from __main__.py

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -63,7 +63,7 @@ def get_arguments() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(
         description="Home Assistant: Observe, Control, Automate.",
-        epilog="If restart is requested, exits with code {RESTART_EXIT_CODE}",
+        epilog=f"If restart is requested, exits with code {RESTART_EXIT_CODE}",
     )
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument(

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -179,8 +179,7 @@ def main() -> int:
     if os.path.getsize(fault_file_name) == 0:
         os.remove(fault_file_name)
 
-    if exit_code == RESTART_EXIT_CODE:
-        check_threads()
+    check_threads()
 
     return exit_code
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import faulthandler
 import os
-import platform
 import sys
 import threading
 
@@ -63,7 +62,8 @@ def get_arguments() -> argparse.Namespace:
     from . import config as config_util
 
     parser = argparse.ArgumentParser(
-        description="Home Assistant: Observe, Control, Automate."
+        description="Home Assistant: Observe, Control, Automate.",
+        epilog="If restart is requested, exits with code {RESTART_EXIT_CODE}",
     )
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument(
@@ -106,36 +106,12 @@ def get_arguments() -> argparse.Namespace:
         "--log-no-color", action="store_true", help="Disable color logs"
     )
     parser.add_argument(
-        "--runner",
-        action="store_true",
-        help=f"On restart exit with code {RESTART_EXIT_CODE}",
-    )
-    parser.add_argument(
         "--script", nargs=argparse.REMAINDER, help="Run one of the embedded scripts"
     )
 
     arguments = parser.parse_args()
 
     return arguments
-
-
-def closefds_osx(min_fd: int, max_fd: int) -> None:
-    """Make sure file descriptors get closed when we restart.
-
-    We cannot call close on guarded fds, and we cannot easily test which fds
-    are guarded. But we can set the close-on-exec flag on everything we want to
-    get rid of.
-    """
-    # pylint: disable=import-outside-toplevel
-    from fcntl import F_GETFD, F_SETFD, FD_CLOEXEC, fcntl
-
-    for _fd in range(min_fd, max_fd):
-        try:
-            val = fcntl(_fd, F_GETFD)
-            if not val & FD_CLOEXEC:
-                fcntl(_fd, F_SETFD, val | FD_CLOEXEC)
-        except OSError:
-            pass
 
 
 def cmdline() -> list[str]:
@@ -148,15 +124,8 @@ def cmdline() -> list[str]:
     return sys.argv
 
 
-def try_to_restart() -> None:
-    """Attempt to clean up state and start a new Home Assistant instance."""
-    # Things should be mostly shut down already at this point, now just try
-    # to clean up things that may have been left behind.
-    sys.stderr.write("Home Assistant attempting to restart.\n")
-
-    # Count remaining threads, ideally there should only be one non-daemonized
-    # thread left (which is us). Nothing we really do with it, but it might be
-    # useful when debugging shutdown/restart issues.
+def check_threads() -> None:
+    """Check if there are any lingering threads."""
     try:
         nthreads = sum(
             thread.is_alive() and not thread.daemon for thread in threading.enumerate()
@@ -169,25 +138,6 @@ def try_to_restart() -> None:
     # which are not marked as stopped at the python level.
     except AssertionError:
         sys.stderr.write("Failed to count non-daemonic threads.\n")
-
-    # Try to not leave behind open filedescriptors with the emphasis on try.
-    try:
-        max_fd = os.sysconf("SC_OPEN_MAX")
-    except ValueError:
-        max_fd = 256
-
-    if platform.system() == "Darwin":
-        closefds_osx(3, max_fd)
-    else:
-        os.closerange(3, max_fd)
-
-    # Now launch into a new instance of Home Assistant. If this fails we
-    # fall through and exit with error 100 (RESTART_EXIT_CODE) in which case
-    # systemd will restart us when RestartForceExitStatus=100 is set in the
-    # systemd.service file.
-    sys.stderr.write("Restarting Home Assistant\n")
-    args = cmdline()
-    os.execv(args[0], args)
 
 
 def main() -> int:
@@ -229,8 +179,8 @@ def main() -> int:
     if os.path.getsize(fault_file_name) == 0:
         os.remove(fault_file_name)
 
-    if exit_code == RESTART_EXIT_CODE and not args.runner:
-        try_to_restart()
+    if exit_code == RESTART_EXIT_CODE:
+        check_threads()
 
     return exit_code
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `--runner` option is no longer supported by the `hass` command.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `--runner` option support from `__main__.py`, and always exit with code 100 if a restart is requested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
