### PR TITLE
Add entity options to entity registry

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -109,7 +109,7 @@ class RegistryEntry:
     icon: str | None = attr.ib(default=None)
     id: str = attr.ib(factory=uuid_util.random_uuid_hex)
     name: str | None = attr.ib(default=None)
-    options: Mapping[str, Any] = attr.ib(
+    options: Mapping[str, Mapping[str, Any]] = attr.ib(
         default=None, converter=attr.converters.default_if_none(factory=dict)  # type: ignore[misc]
     )
     # As set by integration
@@ -321,7 +321,6 @@ class EntityRegistry:
         config_entry: ConfigEntry | None = None,
         device_id: str | None = None,
         entity_category: str | None = None,
-        options: Mapping[str, Any] | None = None,
         original_device_class: str | None = None,
         original_icon: str | None = None,
         original_name: str | None = None,
@@ -343,7 +342,6 @@ class EntityRegistry:
                 config_entry_id=config_entry_id or UNDEFINED,
                 device_id=device_id or UNDEFINED,
                 entity_category=entity_category or UNDEFINED,
-                options=options or UNDEFINED,
                 original_device_class=original_device_class or UNDEFINED,
                 original_icon=original_icon or UNDEFINED,
                 original_name=original_name or UNDEFINED,
@@ -387,7 +385,6 @@ class EntityRegistry:
             disabled_by=disabled_by,
             entity_category=entity_category,
             entity_id=entity_id,
-            options=options,
             original_device_class=original_device_class,
             original_icon=original_icon,
             original_name=original_name,
@@ -477,7 +474,6 @@ class EntityRegistry:
         name: str | None | UndefinedType = UNDEFINED,
         new_entity_id: str | UndefinedType = UNDEFINED,
         new_unique_id: str | UndefinedType = UNDEFINED,
-        options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         original_device_class: str | None | UndefinedType = UNDEFINED,
         original_icon: str | None | UndefinedType = UNDEFINED,
         original_name: str | None | UndefinedType = UNDEFINED,
@@ -511,7 +507,6 @@ class EntityRegistry:
             ("entity_category", entity_category),
             ("icon", icon),
             ("name", name),
-            ("options", options),
             ("original_device_class", original_device_class),
             ("original_icon", original_icon),
             ("original_name", original_name),
@@ -567,6 +562,25 @@ class EntityRegistry:
         self.hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, data)
 
         return new
+
+    @callback
+    def async_update_entity_options(
+        self, entity_id: str, domain: str, options: dict[str, Any]
+    ) -> None:
+        """Update entity options."""
+        old = self.entities[entity_id]
+        new_options: Mapping[str, Mapping[str, Any]] = {**old.options, domain: options}
+        self.entities[entity_id] = attr.evolve(old, options=new_options)
+
+        self.async_schedule_save()
+
+        data: dict[str, str | dict[str, Any]] = {
+            "action": "update",
+            "entity_id": entity_id,
+            "changes": {"options": old.options},
+        }
+
+        self.hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, data)
 
     async def async_load(self) -> None:
         """Load the entity registry."""
@@ -759,7 +773,7 @@ async def _async_migrate(
     old_major_version: int, old_minor_version: int, data: dict
 ) -> dict:
     """Migrate to the new version."""
-    if old_major_version < 2 and old_minor_version < 2:
+    if old_major_version == 1 and old_minor_version < 2:
         # From version 1.1
         for entity in data["entities"]:
             # Populate all keys
@@ -778,19 +792,19 @@ async def _async_migrate(
             entity["supported_features"] = entity.get("supported_features", 0)
             entity["unit_of_measurement"] = entity.get("unit_of_measurement")
 
-    if old_major_version < 2 and old_minor_version < 3:
+    if old_major_version == 1 and old_minor_version < 3:
         # Version 1.3 adds original_device_class
         for entity in data["entities"]:
             # Move device_class to original_device_class
             entity["original_device_class"] = entity["device_class"]
             entity["device_class"] = None
 
-    if old_major_version < 2 and old_minor_version < 4:
+    if old_major_version == 1 and old_minor_version < 4:
         # Version 1.4 adds id
         for entity in data["entities"]:
             entity["id"] = uuid_util.random_uuid_hex()
 
-    if old_major_version < 2 and old_minor_version < 5:
+    if old_major_version == 1 and old_minor_version < 5:
         # Version 1.5 adds entity options
         for entity in data["entities"]:
             entity["options"] = {}

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -34,10 +34,10 @@ async def test_remote_setup_works(hass):
             {(DOMAIN, mock_setup.entry.unique_id)}
         )
         entries = async_entries_for_device(entity_registry, device_entry.id)
-        remotes = {entry for entry in entries if entry.domain == Platform.REMOTE}
+        remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
         assert len(remotes) == 1
 
-        remote = remotes.pop()
+        remote = remotes[0]
         assert remote.original_name == f"{device.name} Remote"
         assert hass.states.get(remote.entity_id).state == STATE_ON
         assert mock_setup.api.auth.call_count == 1
@@ -54,10 +54,10 @@ async def test_remote_send_command(hass):
             {(DOMAIN, mock_setup.entry.unique_id)}
         )
         entries = async_entries_for_device(entity_registry, device_entry.id)
-        remotes = {entry for entry in entries if entry.domain == Platform.REMOTE}
+        remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
         assert len(remotes) == 1
 
-        remote = remotes.pop()
+        remote = remotes[0]
         await hass.services.async_call(
             Platform.REMOTE,
             SERVICE_SEND_COMMAND,
@@ -81,10 +81,10 @@ async def test_remote_turn_off_turn_on(hass):
             {(DOMAIN, mock_setup.entry.unique_id)}
         )
         entries = async_entries_for_device(entity_registry, device_entry.id)
-        remotes = {entry for entry in entries if entry.domain == Platform.REMOTE}
+        remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
         assert len(remotes) == 1
 
-        remote = remotes.pop()
+        remote = remotes[0]
         await hass.services.async_call(
             Platform.REMOTE,
             SERVICE_TURN_OFF,

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -190,6 +190,7 @@ async def test_loading_saving_data(hass, registry):
         device_id="mock-dev-id",
         disabled_by=er.RegistryEntryDisabler.HASS,
         entity_category="config",
+        options={"light": {"minimum_brightness": 20}},
         original_device_class="mock-device-class",
         original_icon="hass:original-icon",
         original_name="Original Name",
@@ -227,6 +228,7 @@ async def test_loading_saving_data(hass, registry):
     assert new_entry2.entity_category == "config"
     assert new_entry2.icon == "hass:user-icon"
     assert new_entry2.name == "User Name"
+    assert new_entry2.options == {"light": {"minimum_brightness": 20}}
     assert new_entry2.original_device_class == "mock-device-class"
     assert new_entry2.original_icon == "hass:original-icon"
     assert new_entry2.original_name == "Original Name"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity options to entity registry.

This could for example be the wanted unit of a sensor or weather entity, the minimum brightness of a light or the maximum volume of a speaker.

Entity options should be indexed by domain, e.g. `options["light"]["minimum_brightness"]`
A new helper method for setting options, `EntityRegistry.async_update_entity_options`, is added to the entity registry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
