### PR TITLE
Validate operating system is supported

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -14,7 +14,7 @@ FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
 def validate_os() -> None:
     """Validate that Home Assistant is running in a supported operating system."""
-    if not sys.platform.startswith("darwin") and not sys.platform.startswith("linux"):
+    if not sys.platform.startswith(("darwin", "linux")):
         print("Home Assistant only supports Linux, OSX and Windows using WSL")
         sys.exit(1)
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -12,6 +12,13 @@ from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
 
+def validate_os() -> None:
+    """Validate that Home Assistant is running in a supported operating system."""
+    if not sys.platform.startswith("darwin") and not sys.platform.startswith("linux"):
+        print("Home Assistant only supports Linux, OSX and Windows using WSL")
+        sys.exit(1)
+
+
 def validate_python() -> None:
     """Validate that the right Python version is running."""
     if sys.version_info[:3] < REQUIRED_PYTHON_VER:
@@ -108,6 +115,11 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--script", nargs=argparse.REMAINDER, help="Run one of the embedded scripts"
     )
+    parser.add_argument(
+        "--ignore-os-check",
+        action="store_true",
+        help="Skips validation of operating system",
+    )
 
     arguments = parser.parse_args()
 
@@ -145,6 +157,9 @@ def main() -> int:
     validate_python()
 
     args = get_arguments()
+
+    if not args.ignore_os_check:
+        validate_os()
 
     if args.script is not None:
         # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Home Assistant will exit immediately if not started from a supported operating system according to ADR-0016: Linux (including WSL) or OSX. A new command line parameter `--ignore-os-check` has been added to allow overriding this check.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate operating system is supported according to ADR-0016: Linux (including WSL) and OSX
If the operating system is not supported `hass` exits with code 1.

A new command line parameter `--ignore-os-check` is added to override this check.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
