### PR TITLE
Remove http dependency from system log

### DIFF
--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -8,7 +8,7 @@ import traceback
 import voluptuous as vol
 
 from homeassistant import __path__ as HOMEASSISTANT_PATH
-from homeassistant.components.http import HomeAssistantView
+from homeassistant.components import websocket_api
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
@@ -224,7 +224,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_stop_queue_handler)
 
-    hass.http.register_view(AllErrorsView(handler))
+    websocket_api.async_register_command(hass, list_errors)
 
     async def async_service_handler(service: ServiceCall) -> None:
         """Handle logger services."""
@@ -255,16 +255,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class AllErrorsView(HomeAssistantView):
-    """Get all logged errors and warnings."""
-
-    url = "/api/error/all"
-    name = "api:error:all"
-
-    def __init__(self, handler):
-        """Initialize a new AllErrorsView."""
-        self.handler = handler
-
-    async def get(self, request):
-        """Get all errors and warnings."""
-        return self.json(self.handler.records.to_list())
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "system_log/list"})
+@callback
+def list_errors(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+):
+    """List all possible diagnostic handlers."""
+    connection.send_result(
+        msg["id"],
+        hass.data[DOMAIN].records.to_list(),
+    )

--- a/homeassistant/components/system_log/manifest.json
+++ b/homeassistant/components/system_log/manifest.json
@@ -2,7 +2,7 @@
   "domain": "system_log",
   "name": "System Log",
   "documentation": "https://www.home-assistant.io/integrations/system_log",
-  "dependencies": ["http"],
+  "dependencies": [],
   "codeowners": [],
   "quality_scale": "internal"
 }

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -96,7 +96,7 @@ async def test_normal_logs(hass, simple_queue, hass_ws_client):
 
     # Assert done by get_error_log
     logs = await get_error_log(hass_ws_client)
-    assert len([msg for msg in logs if msg["level"] not in ("DEBUG", "INFO")]) == 0
+    assert len([msg for msg in logs if msg["level"] in ("DEBUG", "INFO")]) == 0
 
 
 async def test_exception(hass, simple_queue, hass_ws_client):

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -1,6 +1,5 @@
 """Test system log component."""
 import asyncio
-from http import HTTPStatus
 import logging
 import queue
 from unittest.mock import MagicMock, patch
@@ -10,6 +9,8 @@ import pytest
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import system_log
 from homeassistant.core import callback
+
+from tests.common import async_capture_events
 
 _LOGGER = logging.getLogger("test_logger")
 BASIC_CONFIG = {"system_log": {"max_entries": 2}}
@@ -34,16 +35,19 @@ async def _async_block_until_queue_empty(hass, sq):
     hass.data[system_log.DOMAIN].acquire()
     hass.data[system_log.DOMAIN].release()
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
 
-async def get_error_log(hass, hass_client, expected_count):
+async def get_error_log(hass_ws_client, expected_count):
     """Fetch all entries from system_log via the API."""
+    client = await hass_ws_client()
+    await client.send_json({"id": 5, "type": "system_log/list"})
 
-    client = await hass_client()
-    resp = await client.get("/api/error/all")
-    assert resp.status == HTTPStatus.OK
+    msg = await client.receive_json()
 
-    data = await resp.json()
+    assert msg["id"] == 5
+    assert msg["success"]
+    data = msg["result"]
 
     assert len(data) == expected_count
     return data
@@ -73,7 +77,7 @@ def get_frame(name):
     return (name, 5, None, None)
 
 
-async def test_normal_logs(hass, simple_queue, hass_client):
+async def test_normal_logs(hass, simple_queue, hass_ws_client):
     """Test that debug and info are not logged."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
 
@@ -82,36 +86,36 @@ async def test_normal_logs(hass, simple_queue, hass_client):
     await _async_block_until_queue_empty(hass, simple_queue)
 
     # Assert done by get_error_log
-    await get_error_log(hass, hass_client, 0)
+    await get_error_log(hass_ws_client, 0)
 
 
-async def test_exception(hass, simple_queue, hass_client):
+async def test_exception(hass, simple_queue, hass_ws_client):
     """Test that exceptions are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _generate_and_log_exception("exception message", "log message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = (await get_error_log(hass, hass_client, 1))[0]
+    log = (await get_error_log(hass_ws_client, 1))[0]
     assert_log(log, "exception message", "log message", "ERROR")
 
 
-async def test_warning(hass, simple_queue, hass_client):
+async def test_warning(hass, simple_queue, hass_ws_client):
     """Test that warning are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.warning("warning message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = (await get_error_log(hass, hass_client, 1))[0]
+    log = (await get_error_log(hass_ws_client, 1))[0]
     assert_log(log, "", "warning message", "WARNING")
 
 
-async def test_error(hass, simple_queue, hass_client):
+async def test_error(hass, simple_queue, hass_ws_client):
     """Test that errors are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error("error message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = (await get_error_log(hass, hass_client, 1))[0]
+    log = (await get_error_log(hass_ws_client, 1))[0]
     assert_log(log, "", "error message", "ERROR")
 
 
@@ -138,14 +142,7 @@ async def test_error_posted_as_event(hass, simple_queue):
     await async_setup_component(
         hass, system_log.DOMAIN, {"system_log": {"max_entries": 2, "fire_event": True}}
     )
-    events = []
-
-    @callback
-    def event_listener(event):
-        """Listen to events of type system_log_event."""
-        events.append(event)
-
-    hass.bus.async_listen(system_log.EVENT_SYSTEM_LOG, event_listener)
+    events = async_capture_events(hass, system_log.EVENT_SYSTEM_LOG)
 
     _LOGGER.error("error message")
     await _async_block_until_queue_empty(hass, simple_queue)
@@ -154,17 +151,17 @@ async def test_error_posted_as_event(hass, simple_queue):
     assert_log(events[0].data, "", "error message", "ERROR")
 
 
-async def test_critical(hass, simple_queue, hass_client):
+async def test_critical(hass, simple_queue, hass_ws_client):
     """Test that critical are logged and retrieved correctly."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.critical("critical message")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = (await get_error_log(hass, hass_client, 1))[0]
+    log = (await get_error_log(hass_ws_client, 1))[0]
     assert_log(log, "", "critical message", "CRITICAL")
 
 
-async def test_remove_older_logs(hass, simple_queue, hass_client):
+async def test_remove_older_logs(hass, simple_queue, hass_ws_client):
     """Test that older logs are rotated out."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error("error message 1")
@@ -172,7 +169,7 @@ async def test_remove_older_logs(hass, simple_queue, hass_client):
     _LOGGER.error("error message 3")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = await get_error_log(hass, hass_client, 2)
+    log = await get_error_log(hass_ws_client, 2)
     assert_log(log[0], "", "error message 3", "ERROR")
     assert_log(log[1], "", "error message 2", "ERROR")
 
@@ -182,7 +179,7 @@ def log_msg(nr=2):
     _LOGGER.error("error message %s", nr)
 
 
-async def test_dedupe_logs(hass, simple_queue, hass_client):
+async def test_dedupe_logs(hass, simple_queue, hass_ws_client):
     """Test that duplicate log entries are dedupe."""
     await async_setup_component(hass, system_log.DOMAIN, {})
     _LOGGER.error("error message 1")
@@ -191,7 +188,7 @@ async def test_dedupe_logs(hass, simple_queue, hass_client):
     _LOGGER.error("error message 3")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = await get_error_log(hass, hass_client, 3)
+    log = await get_error_log(hass_ws_client, 3)
     assert_log(log[0], "", "error message 3", "ERROR")
     assert log[1]["count"] == 2
     assert_log(log[1], "", ["error message 2", "error message 2-2"], "ERROR")
@@ -199,7 +196,7 @@ async def test_dedupe_logs(hass, simple_queue, hass_client):
     log_msg()
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = await get_error_log(hass, hass_client, 3)
+    log = await get_error_log(hass_ws_client, 3)
     assert_log(log[0], "", ["error message 2", "error message 2-2"], "ERROR")
     assert log[0]["timestamp"] > log[0]["first_occurred"]
 
@@ -209,7 +206,7 @@ async def test_dedupe_logs(hass, simple_queue, hass_client):
     log_msg("2-6")
     await _async_block_until_queue_empty(hass, simple_queue)
 
-    log = await get_error_log(hass, hass_client, 3)
+    log = await get_error_log(hass_ws_client, 3)
     assert_log(
         log[0],
         "",
@@ -224,7 +221,7 @@ async def test_dedupe_logs(hass, simple_queue, hass_client):
     )
 
 
-async def test_clear_logs(hass, simple_queue, hass_client):
+async def test_clear_logs(hass, simple_queue, hass_ws_client):
     """Test that the log can be cleared via a service call."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error("error message")
@@ -234,7 +231,7 @@ async def test_clear_logs(hass, simple_queue, hass_client):
     await _async_block_until_queue_empty(hass, simple_queue)
 
     # Assert done by get_error_log
-    await get_error_log(hass, hass_client, 0)
+    await get_error_log(hass_ws_client, 0)
 
 
 async def test_write_log(hass):
@@ -277,13 +274,13 @@ async def test_write_choose_level(hass):
     assert logger.method_calls[0] == ("debug", ("test_message",))
 
 
-async def test_unknown_path(hass, simple_queue, hass_client):
+async def test_unknown_path(hass, simple_queue, hass_ws_client):
     """Test error logged from unknown path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.findCaller = MagicMock(return_value=("unknown_path", 0, None, None))
     _LOGGER.error("error message")
     await _async_block_until_queue_empty(hass, simple_queue)
-    log = (await get_error_log(hass, hass_client, 1))[0]
+    log = (await get_error_log(hass_ws_client, 1))[0]
     assert log["source"] == ["unknown_path", 0]
 
 
@@ -307,7 +304,7 @@ async def async_log_error_from_test_path(hass, path, sq):
         await _async_block_until_queue_empty(hass, sq)
 
 
-async def test_homeassistant_path(hass, simple_queue, hass_client):
+async def test_homeassistant_path(hass, simple_queue, hass_ws_client):
     """Test error logged from Home Assistant path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     with patch(
@@ -317,16 +314,16 @@ async def test_homeassistant_path(hass, simple_queue, hass_client):
         await async_log_error_from_test_path(
             hass, "venv_path/homeassistant/component/component.py", simple_queue
         )
-        log = (await get_error_log(hass, hass_client, 1))[0]
+        log = (await get_error_log(hass_ws_client, 1))[0]
     assert log["source"] == ["component/component.py", 5]
 
 
-async def test_config_path(hass, simple_queue, hass_client):
+async def test_config_path(hass, simple_queue, hass_ws_client):
     """Test error logged from config path."""
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     with patch.object(hass.config, "config_dir", new="config"):
         await async_log_error_from_test_path(
             hass, "config/custom_component/test.py", simple_queue
         )
-        log = (await get_error_log(hass, hass_client, 1))[0]
+        log = (await get_error_log(hass_ws_client, 1))[0]
     assert log["source"] == ["custom_component/test.py", 5]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change from Rest API to a WebSocket API. System Log is one of the first integrations to load and it was now pulling the HTTP server with it. This is now no longer the case.

Websocket API can register command without the websocket integration being set up.

Needs https://github.com/home-assistant/frontend/pull/11361

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
