### PR TITLE
Add launch mission sensor for launch_library

### DIFF
--- a/homeassistant/components/launch_library/const.py
+++ b/homeassistant/components/launch_library/const.py
@@ -2,12 +2,15 @@
 
 DOMAIN = "launch_library"
 
+ATTR_DESCRIPTION = "description"
 ATTR_LAUNCH_FACILITY = "facility"
 ATTR_LAUNCH_PAD = "pad"
 ATTR_LAUNCH_PAD_COUNTRY_CODE = "provider_country_code"
 ATTR_LAUNCH_PROVIDER = "provider"
+ATTR_ORBIT = "target_orbit"
 ATTR_REASON = "reason"
 ATTR_STREAM_LIVE = "stream_live"
+ATTR_TYPE = "mission_type"
 ATTR_WINDOW_END = "window_end"
 ATTR_WINDOW_START = "window_start"
 
@@ -19,3 +22,4 @@ NEXT_LAUNCH = "next_launch"
 LAUNCH_TIME = "launch_time"
 LAUNCH_PROBABILITY = "launch_probability"
 LAUNCH_STATUS = "launch_status"
+LAUNCH_MISSION = "launch_mission"

--- a/homeassistant/components/launch_library/sensor.py
+++ b/homeassistant/components/launch_library/sensor.py
@@ -29,17 +29,21 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util.dt import parse_datetime
 
 from .const import (
+    ATTR_DESCRIPTION,
     ATTR_LAUNCH_FACILITY,
     ATTR_LAUNCH_PAD,
     ATTR_LAUNCH_PAD_COUNTRY_CODE,
     ATTR_LAUNCH_PROVIDER,
+    ATTR_ORBIT,
     ATTR_REASON,
     ATTR_STREAM_LIVE,
+    ATTR_TYPE,
     ATTR_WINDOW_END,
     ATTR_WINDOW_START,
     ATTRIBUTION,
     DEFAULT_NAME,
     DOMAIN,
+    LAUNCH_MISSION,
     LAUNCH_PROBABILITY,
     LAUNCH_STATUS,
     LAUNCH_TIME,
@@ -114,6 +118,17 @@ SENSOR_DESCRIPTIONS: tuple[NextLaunchSensorEntityDescription, ...] = (
         }
         if next_launch.inhold
         else None,
+    ),
+    NextLaunchSensorEntityDescription(
+        key=LAUNCH_MISSION,
+        icon="mdi:orbit",
+        name="Launch mission",
+        value_fn=lambda next_launch: next_launch.mission.name,
+        attributes_fn=lambda next_launch: {
+            ATTR_TYPE: next_launch.mission.type,
+            ATTR_ORBIT: next_launch.mission.orbit.name,
+            ATTR_DESCRIPTION: next_launch.mission.description,
+        },
     ),
 )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add launch mission sensor giving details about the next launch's mission in space.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
