### PR TITLE
Use wemo enums in fan entity

### DIFF
--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -95,7 +95,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         if self.wemo.fan_mode != FanMode.Off:
             self._last_fan_on_mode = self.wemo.fan_mode
         else:
-            self._last_fan_on_mode = FanMode.Medium
+            self._last_fan_on_mode = FanMode.High
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import math
 from typing import Any
 
+from pywemo.ouimeaux_device.humidifier import DesiredHumidity, FanMode, Humidifier
 import voluptuous as vol
 
 from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
@@ -38,22 +39,7 @@ ATTR_FILTER_LIFE = "filter_life"
 ATTR_FILTER_EXPIRED = "filter_expired"
 ATTR_WATER_LEVEL = "water_level"
 
-WEMO_HUMIDITY_45 = 0
-WEMO_HUMIDITY_50 = 1
-WEMO_HUMIDITY_55 = 2
-WEMO_HUMIDITY_60 = 3
-WEMO_HUMIDITY_100 = 4
-
-WEMO_FAN_OFF = 0
-WEMO_FAN_MINIMUM = 1
-WEMO_FAN_MEDIUM = 4
-WEMO_FAN_MAXIMUM = 5
-
-SPEED_RANGE = (WEMO_FAN_MINIMUM, WEMO_FAN_MAXIMUM)  # off is not included
-
-WEMO_WATER_EMPTY = 0
-WEMO_WATER_LOW = 1
-WEMO_WATER_GOOD = 2
+SPEED_RANGE = (FanMode.Minimum, FanMode.Maximum)  # off is not included
 
 SUPPORTED_FEATURES = SUPPORT_SET_SPEED
 
@@ -101,13 +87,15 @@ async def async_setup_entry(
 class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     """Representation of a WeMo humidifier."""
 
+    wemo: Humidifier
+
     def __init__(self, coordinator: DeviceCoordinator) -> None:
         """Initialize the WeMo switch."""
         super().__init__(coordinator)
-        if self.wemo.fan_mode != WEMO_FAN_OFF:
+        if self.wemo.fan_mode != FanMode.Off:
             self._last_fan_on_mode = self.wemo.fan_mode
         else:
-            self._last_fan_on_mode = WEMO_FAN_MEDIUM
+            self._last_fan_on_mode = FanMode.Medium
 
     @property
     def icon(self) -> str:
@@ -144,7 +132,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.wemo.fan_mode != WEMO_FAN_OFF:
+        if self.wemo.fan_mode != FanMode.Off:
             self._last_fan_on_mode = self.wemo.fan_mode
         super()._handle_coordinator_update()
 
@@ -161,16 +149,18 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         with self._wemo_call_wrapper("turn off"):
-            self.wemo.set_state(WEMO_FAN_OFF)
+            self.wemo.set_state(FanMode.Off)
 
     def set_percentage(self, percentage: int | None) -> None:
         """Set the fan_mode of the Humidifier."""
         if percentage is None:
             named_speed = self._last_fan_on_mode
         elif percentage == 0:
-            named_speed = WEMO_FAN_OFF
+            named_speed = FanMode.Off
         else:
-            named_speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
+            named_speed = FanMode(
+                math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
+            )
 
         with self._wemo_call_wrapper("set speed"):
             self.wemo.set_state(named_speed)
@@ -178,15 +168,15 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     def set_humidity(self, target_humidity: float) -> None:
         """Set the target humidity level for the Humidifier."""
         if target_humidity < 50:
-            pywemo_humidity = WEMO_HUMIDITY_45
+            pywemo_humidity = DesiredHumidity.FortyFivePercent
         elif 50 <= target_humidity < 55:
-            pywemo_humidity = WEMO_HUMIDITY_50
+            pywemo_humidity = DesiredHumidity.FiftyPercent
         elif 55 <= target_humidity < 60:
-            pywemo_humidity = WEMO_HUMIDITY_55
+            pywemo_humidity = DesiredHumidity.FiftyFivePercent
         elif 60 <= target_humidity < 100:
-            pywemo_humidity = WEMO_HUMIDITY_60
+            pywemo_humidity = DesiredHumidity.SixtyPercent
         elif target_humidity >= 100:
-            pywemo_humidity = WEMO_HUMIDITY_100
+            pywemo_humidity = DesiredHumidity.OneHundredPercent
 
         with self._wemo_call_wrapper("set humidity"):
             self.wemo.set_humidity(pywemo_humidity)

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -162,7 +162,7 @@ async def test_fan_set_percentage(
 
 
 class TestInitialFanMode:
-    """Test that the fan mode is set to high the first time turned on."""
+    """Test that the FanMode is set to High when turned on the first time."""
 
     @pytest.fixture
     def pywemo_device(self, pywemo_device):

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -2,15 +2,20 @@
 
 import pytest
 from pywemo.exceptions import ActionException
+from pywemo.ouimeaux_device.humidifier import DesiredHumidity, FanMode
 
-from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+)
 from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.wemo import fan
 from homeassistant.components.wemo.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 from . import entity_test_helpers
@@ -108,12 +113,12 @@ async def test_fan_reset_filter_service(hass, pywemo_device, wemo_entity):
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        (0, fan.WEMO_HUMIDITY_45),
-        (45, fan.WEMO_HUMIDITY_45),
-        (50, fan.WEMO_HUMIDITY_50),
-        (55, fan.WEMO_HUMIDITY_55),
-        (60, fan.WEMO_HUMIDITY_60),
-        (100, fan.WEMO_HUMIDITY_100),
+        (0, DesiredHumidity.FortyFivePercent),
+        (45, DesiredHumidity.FortyFivePercent),
+        (50, DesiredHumidity.FiftyPercent),
+        (55, DesiredHumidity.FiftyFivePercent),
+        (60, DesiredHumidity.SixtyPercent),
+        (100, DesiredHumidity.OneHundredPercent),
     ],
 )
 async def test_fan_set_humidity_service(
@@ -130,3 +135,47 @@ async def test_fan_set_humidity_service(
         blocking=True,
     )
     pywemo_device.set_humidity.assert_called_with(expected)
+
+
+@pytest.mark.parametrize(
+    "percentage,expected_fan_mode",
+    [
+        (0, FanMode.Off),
+        (10, FanMode.Minimum),
+        (30, FanMode.Low),
+        (50, FanMode.Medium),
+        (70, FanMode.High),
+        (100, FanMode.Maximum),
+    ],
+)
+async def test_fan_set_percentage(
+    hass, pywemo_device, wemo_entity, percentage, expected_fan_mode
+):
+    """Verify set_percentage works properly through the entire range of FanModes."""
+    assert await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: [wemo_entity.entity_id], ATTR_PERCENTAGE: percentage},
+        blocking=True,
+    )
+    pywemo_device.set_state.assert_called_with(expected_fan_mode)
+
+
+class TestInitialFanMode:
+    """Test that the fan mode is set to medium initially."""
+
+    @pytest.fixture
+    def pywemo_device(self, pywemo_device):
+        """Set the FanMode to off initially."""
+        pywemo_device.fan_mode = FanMode.Off
+        yield pywemo_device
+
+    async def test_fan_mode_medium_initially(self, hass, pywemo_device, wemo_entity):
+        """Verify the FanMode is set to Medium when turned on."""
+        assert await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
+            blocking=True,
+        )
+        pywemo_device.set_state.assert_called_with(FanMode.Medium)

--- a/tests/components/wemo/test_fan.py
+++ b/tests/components/wemo/test_fan.py
@@ -162,7 +162,7 @@ async def test_fan_set_percentage(
 
 
 class TestInitialFanMode:
-    """Test that the fan mode is set to medium initially."""
+    """Test that the fan mode is set to high the first time turned on."""
 
     @pytest.fixture
     def pywemo_device(self, pywemo_device):
@@ -170,12 +170,12 @@ class TestInitialFanMode:
         pywemo_device.fan_mode = FanMode.Off
         yield pywemo_device
 
-    async def test_fan_mode_medium_initially(self, hass, pywemo_device, wemo_entity):
-        """Verify the FanMode is set to Medium when turned on."""
+    async def test_fan_mode_high_initially(self, hass, pywemo_device, wemo_entity):
+        """Verify the FanMode is set to High when turned on."""
         assert await hass.services.async_call(
             FAN_DOMAIN,
             SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
             blocking=True,
         )
-        pywemo_device.set_state.assert_called_with(FanMode.Medium)
+        pywemo_device.set_state.assert_called_with(FanMode.High)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Code cleanup to use the enums present in pyWeMo instead of redefining them in Home Assistant.

The pyWeMo enums can be found here: https://github.com/pywemo/pywemo/blob/0.7.0/pywemo/ouimeaux_device/humidifier.py

Note that the `FanMode.High` enum value (`4`) from pyWeMo is the same as the `WEMO_FAN_MEDIUM` constant in Home Assistant.

I'm doing this ahead of the next pyWeMo version bump, which will include better type support and will rely on the enums more heavily. (https://github.com/pywemo/pywemo/issues/315)

I've also added tests for the the changed lines that didn't previously have coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
