### PR TITLE
Fix the Android TV volume mute service

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -612,7 +612,7 @@ class AndroidTVDevice(ADBDevice):
         is_muted = await self.aftv.is_volume_muted()
 
         # `None` indicates that the muted status could not be determined
-        if is_muted is not None and is_muted ^ mute:
+        if is_muted is not None and is_muted != mute:
             await self.aftv.mute_volume()
 
     @adb_decorator()

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -609,7 +609,11 @@ class AndroidTVDevice(ADBDevice):
     @adb_decorator()
     async def async_mute_volume(self, mute):
         """Mute the volume."""
-        await self.aftv.mute_volume()
+        is_muted = await self.aftv.is_volume_muted()
+
+        # `None` indicates that the muted status could not be determined
+        if is_muted is not None and is_muted ^ mute:
+            await self.aftv.mute_volume()
 
     @adb_decorator()
     async def async_set_volume_level(self, volume):

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -1114,13 +1114,6 @@ async def test_services_androidtv(hass):
             await _test_service(
                 hass,
                 entity_id,
-                SERVICE_VOLUME_MUTE,
-                "mute_volume",
-                {ATTR_MEDIA_VOLUME_MUTED: False},
-            )
-            await _test_service(
-                hass,
-                entity_id,
                 SERVICE_VOLUME_SET,
                 "set_volume_level",
                 {ATTR_MEDIA_VOLUME_LEVEL: 0.5},
@@ -1150,6 +1143,48 @@ async def test_services_firetv(hass):
             await _test_service(hass, entity_id, SERVICE_MEDIA_STOP, "back")
             await _test_service(hass, entity_id, SERVICE_TURN_OFF, "adb_shell")
             await _test_service(hass, entity_id, SERVICE_TURN_ON, "adb_shell")
+
+
+async def test_volume_mute(hass):
+    """Test the volume mute service."""
+    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
+    config_entry.add_to_hass(hass)
+
+    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
+        with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        with patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key]:
+            service_data = {ATTR_ENTITY_ID: entity_id, ATTR_MEDIA_VOLUME_MUTED: True}
+            with patch(
+                "androidtv.androidtv.androidtv_async.AndroidTVAsync.mute_volume",
+                return_value=None,
+            ) as mute_volume:
+                # Don't send the mute key if the volume is already muted
+                with patch(
+                    "androidtv.androidtv.androidtv_async.AndroidTVAsync.is_volume_muted",
+                    return_value=True,
+                ):
+                    await hass.services.async_call(
+                        MP_DOMAIN,
+                        SERVICE_VOLUME_MUTE,
+                        service_data=service_data,
+                        blocking=True,
+                    )
+                    assert not mute_volume.called
+
+                # Send the mute key because the volume is not already muted
+                with patch(
+                    "androidtv.androidtv.androidtv_async.AndroidTVAsync.is_volume_muted",
+                    return_value=False,
+                ):
+                    await hass.services.async_call(
+                        MP_DOMAIN,
+                        SERVICE_VOLUME_MUTE,
+                        service_data=service_data,
+                        blocking=True,
+                    )
 
 
 async def test_connection_closed_on_ha_stop(hass):

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -1185,6 +1185,7 @@ async def test_volume_mute(hass):
                         service_data=service_data,
                         blocking=True,
                     )
+                    assert mute_volume.called
 
 
 async def test_connection_closed_on_ha_stop(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Check if the volume is muted before sending the mute key

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/57204
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
