### PR TITLE
Add diagnostic information for nest

### DIFF
--- a/homeassistant/components/nest/diagnostics.py
+++ b/homeassistant/components/nest/diagnostics.py
@@ -38,7 +38,7 @@ async def async_get_config_entry_diagnostics(
 
 def get_device_data(device: Device) -> dict[str, Any]:
     """Return diagnostic information about a device."""
-    # Return a simplified view of the API object, but skipping and id fields or
+    # Return a simplified view of the API object, but skipping any id fields or
     # traits that include unique identifiers or personally identifiable information.
     # See https://developers.google.com/nest/device-access/traits for API details
     return {

--- a/homeassistant/components/nest/diagnostics.py
+++ b/homeassistant/components/nest/diagnostics.py
@@ -1,0 +1,51 @@
+"""Diagnostics support for Nest."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google_nest_sdm.device import Device
+from google_nest_sdm.device_traits import InfoTrait
+from google_nest_sdm.exceptions import ApiException
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DATA_SUBSCRIBER, DOMAIN
+
+REDACT_DEVICE_TRAITS = {InfoTrait.NAME}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    if DATA_SUBSCRIBER not in hass.data[DOMAIN]:
+        return {"error": "No subscriber configured"}
+
+    subscriber = hass.data[DOMAIN][DATA_SUBSCRIBER]
+    try:
+        device_manager = await subscriber.async_get_device_manager()
+    except ApiException as err:
+        return {"error": str(err)}
+
+    return {
+        "devices": [
+            get_device_data(device) for device in device_manager.devices.values()
+        ]
+    }
+
+
+def get_device_data(device: Device) -> dict[str, Any]:
+    """Return diagnostic information about a device."""
+    # Return a simplified view of the API object, but skipping and id fields or
+    # traits that include unique identifiers or personally identifiable information.
+    # See https://developers.google.com/nest/device-access/traits for API details
+    return {
+        "type": device.type,
+        "traits": {
+            trait: data
+            for trait, data in device.raw_data.get("traits", {}).items()
+            if trait not in REDACT_DEVICE_TRAITS
+        },
+    }

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -109,9 +109,12 @@ async def async_setup_sdm_platform(
     if structures:
         for structure in structures.values():
             device_manager.add_structure(structure)
+    platforms = []
+    if platform:
+        platforms = [platform]
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
-    ), patch("homeassistant.components.nest.PLATFORMS", [platform]), patch(
+    ), patch("homeassistant.components.nest.PLATFORMS", platforms), patch(
         "homeassistant.components.nest.api.GoogleNestSubscriber",
         return_value=subscriber,
     ):

--- a/tests/components/nest/test_diagnostics.py
+++ b/tests/components/nest/test_diagnostics.py
@@ -1,0 +1,86 @@
+"""Test nest diagnostics."""
+
+from unittest.mock import patch
+
+from google_nest_sdm.device import Device
+from google_nest_sdm.exceptions import SubscriberException
+
+from homeassistant.components.nest import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.setup import async_setup_component
+
+from .common import CONFIG, async_setup_sdm_platform, create_config_entry
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+THERMOSTAT_TYPE = "sdm.devices.types.THERMOSTAT"
+
+
+async def test_entry_diagnostics(hass, hass_client):
+    """Test config entry diagnostics."""
+    devices = {
+        "some-device-id": Device.MakeDevice(
+            {
+                "name": "enterprises/project-id/devices/device-id",
+                "type": "sdm.devices.types.THERMOSTAT",
+                "assignee": "enterprises/project-id/structures/structure-id/rooms/room-id",
+                "traits": {
+                    "sdm.devices.traits.Info": {
+                        "customName": "My Sensor",
+                    },
+                    "sdm.devices.traits.Temperature": {
+                        "ambientTemperatureCelsius": 25.1,
+                    },
+                    "sdm.devices.traits.Humidity": {
+                        "ambientHumidityPercent": 35.0,
+                    },
+                },
+                "parentRelations": [
+                    {
+                        "parent": "enterprises/project-id/structures/structure-id/rooms/room-id",
+                        "displayName": "Lobby",
+                    }
+                ],
+            },
+            auth=None,
+        )
+    }
+    assert await async_setup_sdm_platform(hass, platform=None, devices=devices)
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    config_entry = entries[0]
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Test that only non identifiable device information is returned
+    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+        "devices": [
+            {
+                "traits": {
+                    "sdm.devices.traits.Humidity": {"ambientHumidityPercent": 35.0},
+                    "sdm.devices.traits.Temperature": {
+                        "ambientTemperatureCelsius": 25.1
+                    },
+                },
+                "type": "sdm.devices.types.THERMOSTAT",
+            }
+        ],
+    }
+
+
+async def test_setup_susbcriber_failure(hass, hass_client):
+    """Test configuration error."""
+    config_entry = create_config_entry(hass)
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
+    ), patch(
+        "homeassistant.components.nest.api.GoogleNestSubscriber.start_async",
+        side_effect=SubscriberException(),
+    ):
+        assert await async_setup_component(hass, DOMAIN, CONFIG)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+        "error": "No subscriber configured"
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostic information for nest. This is an initial version that only includes traits about a device for a successfully setup integration.

As is, the biggest value from this would likely just be getting details about the type of camera device a user has given the large number of supported variations for devices, or details about the current state of a thermostat.  Most debugging sessions I need to do with users are related to setup errors (and they don't know how to read logs) or related to event delivery -- perhaps those can be future improvements.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
