### PR TITLE
Add webostv 100% tests coverage for notify

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1291,7 +1291,6 @@ omit =
     homeassistant/components/waze_travel_time/sensor.py
     homeassistant/components/webostv/__init__.py
     homeassistant/components/webostv/media_player.py
-    homeassistant/components/webostv/notify.py
     homeassistant/components/whois/__init__.py
     homeassistant/components/whois/sensor.py
     homeassistant/components/wiffi/*

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -123,4 +123,4 @@ async def test_no_discovery_info(hass, caplog):
     await hass.async_block_till_done()
     assert NOTIFY_DOMAIN in hass.config.components
     assert f"Failed to initialize notification service {DOMAIN}" in caplog.text
-    assert DOMAIN not in hass.services.async_services()
+    assert not hass.services.has_service("notify", TV_NAME)

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -1,0 +1,121 @@
+"""The tests for the WebOS TV notify platform."""
+from unittest.mock import Mock, call
+
+from aiowebostv import WebOsTvPairError
+import pytest
+
+from homeassistant.components.notify import ATTR_MESSAGE, DOMAIN as NOTIFY_DOMAIN
+from homeassistant.components.webostv import DOMAIN
+from homeassistant.const import CONF_ICON, CONF_SERVICE_DATA
+from homeassistant.helpers import discovery
+
+from . import TV_NAME, setup_webostv
+
+ICON_PATH = "/some/path"
+MESSAGE = "one, two, testing, testing"
+
+
+async def test_notify(hass, client):
+    """Test sending a message."""
+    await setup_webostv(hass, "fake-uuid")
+    assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        TV_NAME,
+        {
+            ATTR_MESSAGE: MESSAGE,
+            CONF_SERVICE_DATA: {
+                CONF_ICON: ICON_PATH,
+            },
+        },
+        blocking=True,
+    )
+    assert client.mock_calls[0] == call.connect()
+    assert client.connect.call_count == 1
+    client.send_message.assert_called_with(MESSAGE, icon_path=ICON_PATH)
+
+
+async def test_notify_not_connected(hass, client, monkeypatch):
+    """Test sending a message when client is not connected."""
+    await setup_webostv(hass, "fake-uuid")
+    assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
+
+    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        TV_NAME,
+        {
+            ATTR_MESSAGE: MESSAGE,
+            CONF_SERVICE_DATA: {
+                CONF_ICON: ICON_PATH,
+            },
+        },
+        blocking=True,
+    )
+    assert client.mock_calls[0] == call.connect()
+    assert client.connect.call_count == 2
+    client.send_message.assert_called_with(MESSAGE, icon_path=ICON_PATH)
+
+
+async def test_icon_not_found(hass, caplog, client, monkeypatch):
+    """Test notify icon not found error."""
+    await setup_webostv(hass, "fake-uuid")
+    assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
+
+    monkeypatch.setattr(client, "send_message", Mock(side_effect=FileNotFoundError))
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        TV_NAME,
+        {
+            ATTR_MESSAGE: MESSAGE,
+            CONF_SERVICE_DATA: {
+                CONF_ICON: ICON_PATH,
+            },
+        },
+        blocking=True,
+    )
+    assert client.mock_calls[0] == call.connect()
+    assert client.connect.call_count == 1
+    client.send_message.assert_called_with(MESSAGE, icon_path=ICON_PATH)
+    assert f"Icon {ICON_PATH} not found" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "side_effect,error",
+    [
+        (WebOsTvPairError, "Pairing with TV failed"),
+        (ConnectionRefusedError, "TV unreachable"),
+    ],
+)
+async def test_connection_errors(hass, caplog, client, monkeypatch, side_effect, error):
+    """Test connection errors scenarios."""
+    await setup_webostv(hass, "fake-uuid")
+    assert hass.services.has_service("notify", TV_NAME)
+
+    monkeypatch.setattr(client, "is_connected", Mock(side_effect=side_effect))
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        TV_NAME,
+        {
+            ATTR_MESSAGE: MESSAGE,
+            CONF_SERVICE_DATA: {
+                CONF_ICON: ICON_PATH,
+            },
+        },
+        blocking=True,
+    )
+    assert client.mock_calls[0] == call.connect()
+    assert client.connect.call_count == 1
+    client.send_message.assert_not_called()
+    assert error in caplog.text
+
+
+async def test_no_discovery_info(hass):
+    """Test no error when no discovery info."""
+    assert NOTIFY_DOMAIN not in hass.config.components
+    await discovery.async_load_platform(
+        hass, NOTIFY_DOMAIN, DOMAIN, None, {"domain": DOMAIN}
+    )
+    await hass.async_block_till_done()
+    assert NOTIFY_DOMAIN in hass.config.components


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 100% tests coverage for webostv notify platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
