### PR TITLE
fix: 17track package summary status is not updated when there are no more packages in that summary

### DIFF
--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -150,7 +150,10 @@ class SeventeenTrackSummarySensor(SensorEntity):
                 }
             )
 
-        self._attr_extra_state_attributes[ATTR_PACKAGES] = package_data
+        if package_data:
+            self._attr_extra_state_attributes[ATTR_PACKAGES] = package_data
+        else:
+            self._attr_extra_state_attributes[ATTR_PACKAGES] = None
 
         self._state = self._data.summary.get(self._status)
 

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -150,10 +150,9 @@ class SeventeenTrackSummarySensor(SensorEntity):
                 }
             )
 
-        if package_data:
-            self._attr_extra_state_attributes[ATTR_PACKAGES] = package_data
-        else:
-            self._attr_extra_state_attributes[ATTR_PACKAGES] = None
+        self._attr_extra_state_attributes[ATTR_PACKAGES] = (
+            package_data if package_data else None
+        )
 
         self._state = self._data.summary.get(self._status)
 

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -150,8 +150,7 @@ class SeventeenTrackSummarySensor(SensorEntity):
                 }
             )
 
-        if package_data:
-            self._attr_extra_state_attributes[ATTR_PACKAGES] = package_data
+        self._attr_extra_state_attributes[ATTR_PACKAGES] = package_data
 
         self._state = self._data.summary.get(self._status)
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -379,12 +379,37 @@ async def test_becomes_delivered_not_shown_notification(hass):
 
 async def test_summary_correctly_updated(hass):
     """Ensure summary entities are not duplicated."""
+    package = Package(
+        tracking_number="456",
+        destination_country=206,
+        friendly_name="friendly name 1",
+        info_text="info text 1",
+        location="location 1",
+        timestamp="2020-08-10 10:32",
+        origin_country=206,
+        package_type=2,
+        status=30,
+    )
+    ProfileMock.package_list = [package]
+
     await _setup_seventeentrack(hass, summary_data=DEFAULT_SUMMARY)
 
-    assert len(hass.states.async_entity_ids()) == 7
+    assert len(hass.states.async_entity_ids()) == 8
     for state in hass.states.async_all():
+        if state.entity_id == "sensor.seventeentrack_package_456":
+            break
         assert state.state == "0"
 
+    assert (
+        len(
+            hass.states.get(
+                "sensor.seventeentrack_packages_ready_to_be_picked_up"
+            ).attributes["packages"]
+        )
+        == 1
+    )
+
+    ProfileMock.package_list = []
     ProfileMock.summary_data = NEW_SUMMARY_DATA
 
     await _goto_future(hass)
@@ -392,6 +417,13 @@ async def test_summary_correctly_updated(hass):
     assert len(hass.states.async_entity_ids()) == 7
     for state in hass.states.async_all():
         assert state.state == "1"
+
+    assert (
+        hass.states.get(
+            "sensor.seventeentrack_packages_ready_to_be_picked_up"
+        ).attributes["packages"]
+        is None
+    )
 
 
 async def test_utc_timestamp(hass):


### PR DESCRIPTION
## Proposed change
When 17track summary sensor, had a package(s) in it, and then suddenly there are *none*, it will never get updated accordingly. We need to remove that if statement that prevents that case.

Example scenario - I had a single package that was in the "ready to pickup" state, and once I picked up the package and deleted it from my 17track account, the sensor kept showing that package. The only way to sync the sensor was to restart HA,


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
