### PR TITLE
Allow specifying a list for google_assistant secure_devices_pin

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -73,7 +73,9 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             ): cv.ensure_list,
             vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ENTITY_SCHEMA},
             # str on purpose, makes sure it is configured correctly.
-            vol.Optional(CONF_SECURE_DEVICES_PIN): vol.Any(str, [str]),
+            vol.Optional(CONF_SECURE_DEVICES_PIN): vol.All(
+                cv.ensure_list(str), [cv.string]
+            ),
             vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
             vol.Optional(CONF_SERVICE_ACCOUNT): GOOGLE_SERVICE_ACCOUNT,
             # deprecated configuration options

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -73,7 +73,7 @@ GOOGLE_ASSISTANT_SCHEMA = vol.All(
             ): cv.ensure_list,
             vol.Optional(CONF_ENTITY_CONFIG): {cv.entity_id: ENTITY_SCHEMA},
             # str on purpose, makes sure it is configured correctly.
-            vol.Optional(CONF_SECURE_DEVICES_PIN): str,
+            vol.Optional(CONF_SECURE_DEVICES_PIN): vol.Any(str, [str]),
             vol.Optional(CONF_REPORT_STATE, default=False): cv.boolean,
             vol.Optional(CONF_SERVICE_ACCOUNT): GOOGLE_SERVICE_ACCOUNT,
             # deprecated configuration options

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1351,9 +1351,11 @@ class ArmDisArmTrait(_Trait):
             _verify_pin_challenge(data, self.state, challenge)
             service = SERVICE_ALARM_DISARM
 
-        pin = data.config.secure_devices_pin
-        if isinstance(pin, list):
-            pin = pin[0]
+        pin = (
+            data.config.secure_devices_pin[0]
+            if data.config.secure_devices_pin is not None
+            else None
+        )
         await self.hass.services.async_call(
             alarm_control_panel.DOMAIN,
             service,
@@ -2057,10 +2059,7 @@ def _verify_pin_challenge(data, state, challenge):
     if not challenge:
         raise ChallengeNeeded(CHALLENGE_PIN_NEEDED)
 
-    pins = data.config.secure_devices_pin
-    if not isinstance(pins, list):
-        pins = [pins]
-    if not challenge.get("pin") in pins:
+    if challenge.get("pin") not in data.config.secure_devices_pin:
         raise ChallengeNeeded(CHALLENGE_FAILED_PIN_NEEDED)
 
 

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1351,12 +1351,15 @@ class ArmDisArmTrait(_Trait):
             _verify_pin_challenge(data, self.state, challenge)
             service = SERVICE_ALARM_DISARM
 
+        pin = data.config.secure_devices_pin
+        if isinstance(pin, list):
+            pin = pin[0]
         await self.hass.services.async_call(
             alarm_control_panel.DOMAIN,
             service,
             {
                 ATTR_ENTITY_ID: self.state.entity_id,
-                ATTR_CODE: data.config.secure_devices_pin,
+                ATTR_CODE: pin,
             },
             blocking=not self.config.should_report_state,
             context=data.context,
@@ -2054,7 +2057,10 @@ def _verify_pin_challenge(data, state, challenge):
     if not challenge:
         raise ChallengeNeeded(CHALLENGE_PIN_NEEDED)
 
-    if challenge.get("pin") != data.config.secure_devices_pin:
+    pins = data.config.secure_devices_pin
+    if not isinstance(pins, list):
+        pins = [pins]
+    if not challenge.get("pin") in pins:
         raise ChallengeNeeded(CHALLENGE_FAILED_PIN_NEEDED)
 
 

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -215,12 +215,12 @@ async def test_secure_device_pin_config(hass):
                 "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKYscIlwm7soDsHAz6L6YvUkCvkrX19rS6yeYOmovvhoK5WeYGWUsd8V72zmsyHB7XO94YgJVjvxfzn5K8bLePjFzwoSJjZvhBJ/ZQ05d8VmbvgyWUoPdG9oEa4fZ/lCYrXoaFdTot2xcJvrb/ZuiRl4s4eZpNeFYvVK/Am7UeFPAgMBAAECgYAUetOfzLYUudofvPCaKHu7tKZ5kQPfEa0w6BAPnBF1Mfl1JiDBRDMryFtKs6AOIAVwx00dY/Ex0BCbB3+Cr58H7t4NaPTJxCpmR09pK7o17B7xAdQv8+SynFNud9/5vQ5AEXMOLNwKiU7wpXT6Z7ZIibUBOR7ewsWgsHCDpN1iqQJBAOMODPTPSiQMwRAUHIc6GPleFSJnIz2PAoG3JOG9KFAL6RtIc19lob2ZXdbQdzKtjSkWo+O5W20WDNAl1k32h6MCQQC7W4ZCIY67mPbL6CxXfHjpSGF4Dr9VWJ7ZrKHr6XUoOIcEvsn/pHvWonjMdy93rQMSfOE8BKd/I1+GHRmNVgplAkAnSo4paxmsZVyfeKt7Jy2dMY+8tVZe17maUuQaAE7Sk00SgJYegwrbMYgQnWCTL39HBfj0dmYA2Zj8CCAuu6O7AkEAryFiYjaUAO9+4iNoL27+ZrFtypeeadyov7gKs0ZKaQpNyzW8A+Zwi7TbTeSqzic/E+z/bOa82q7p/6b7141xsQJBANCAcIwMcVb6KVCHlQbOtKspo5Eh4ZQi8bGl+IcwbQ6JSxeTx915IfAldgbuU047wOB04dYCFB2yLDiUGVXTifU=\n-----END PRIVATE KEY-----\n",
                 "client_email": "dummy@dummy.iam.gserviceaccount.com",
             },
-            "secure_devices_pin": secure_pin,
+            "secure_devices_pin": [secure_pin],
         }
     )
     config = GoogleConfig(hass, secure_config)
 
-    assert config.secure_devices_pin == secure_pin
+    assert config.secure_devices_pin == [secure_pin]
 
 
 async def test_should_expose(hass):

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -71,10 +71,16 @@ BASIC_DATA = helpers.RequestData(
     BASIC_CONFIG, "test-agent", const.SOURCE_CLOUD, REQ_ID, None
 )
 
-PIN_CONFIG = MockConfig(secure_devices_pin="1234")
+PIN_CONFIG = MockConfig(secure_devices_pin=["1234", "4444"])
 
 PIN_DATA = helpers.RequestData(
     PIN_CONFIG, "test-agent", const.SOURCE_CLOUD, REQ_ID, None
+)
+
+PIN_CONFIG_SINGLE = MockConfig(secure_devices_pin="1234")
+
+PIN_DATA_SINGLE = helpers.RequestData(
+    PIN_CONFIG_SINGLE, "test-agent", const.SOURCE_CLOUD, REQ_ID, None
 )
 
 
@@ -1244,8 +1250,83 @@ async def test_lock_unlock_unlock(hass):
     assert err.value.code == const.ERR_CHALLENGE_NEEDED
     assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED
 
+    # Test first pin
     await trt.execute(
         trait.COMMAND_LOCKUNLOCK, PIN_DATA, {"lock": False}, {"pin": "1234"}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {ATTR_ENTITY_ID: "lock.front_door"}
+
+    # Test second pin
+    trt = trait.LockUnlockTrait(
+        hass, State("lock.front_door", lock.STATE_LOCKED), BASIC_CONFIG
+    )
+    await trt.execute(
+        trait.COMMAND_LOCKUNLOCK, PIN_DATA, {"lock": False}, {"pin": "4444"}
+    )
+
+    assert len(calls) == 2
+    assert calls[1].data == {ATTR_ENTITY_ID: "lock.front_door"}
+
+    # Test without pin
+    trt = trait.LockUnlockTrait(
+        hass, State("lock.front_door", lock.STATE_LOCKED), BASIC_CONFIG
+    )
+
+    with pytest.raises(error.SmartHomeError) as err:
+        await trt.execute(trait.COMMAND_LOCKUNLOCK, BASIC_DATA, {"lock": False}, {})
+    assert len(calls) == 2
+    assert err.value.code == const.ERR_CHALLENGE_NOT_SETUP
+
+    # Test with 2FA override
+    with patch.object(
+        BASIC_CONFIG,
+        "should_2fa",
+        return_value=False,
+    ):
+        await trt.execute(trait.COMMAND_LOCKUNLOCK, BASIC_DATA, {"lock": False}, {})
+    assert len(calls) == 3
+
+
+async def test_lock_unlock_unlock_pin_single(hass):
+    """Test LockUnlock trait unlocking support for lock domain with a single pin string."""
+    assert helpers.get_google_type(lock.DOMAIN, None) is not None
+    assert trait.LockUnlockTrait.supported(lock.DOMAIN, lock.SUPPORT_OPEN, None, None)
+
+    trt = trait.LockUnlockTrait(
+        hass, State("lock.front_door", lock.STATE_LOCKED), PIN_CONFIG
+    )
+
+    assert trt.sync_attributes() == {}
+
+    assert trt.query_attributes() == {"isLocked": True}
+
+    assert trt.can_execute(trait.COMMAND_LOCKUNLOCK, {"lock": False})
+
+    calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_UNLOCK)
+
+    # No challenge data
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_LOCKUNLOCK, PIN_DATA_SINGLE, {"lock": False}, {}
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_PIN_NEEDED
+
+    # invalid pin
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_LOCKUNLOCK, PIN_DATA_SINGLE, {"lock": False}, {"pin": 9999}
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED
+
+    # Test first pin
+    await trt.execute(
+        trait.COMMAND_LOCKUNLOCK, PIN_DATA_SINGLE, {"lock": False}, {"pin": "1234"}
     )
 
     assert len(calls) == 1
@@ -2504,7 +2585,7 @@ async def test_openclose_cover_secure(hass, device_class):
     assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED
 
     await trt.execute(
-        trait.COMMAND_OPENCLOSE, PIN_DATA, {"openPercent": 50}, {"pin": "1234"}
+        trait.COMMAND_OPENCLOSE, PIN_DATA, {"openPercent": 50}, {"pin": "4444"}
     )
     assert len(calls) == 1
     assert calls[0].data == {ATTR_ENTITY_ID: "cover.bla", cover.ATTR_POSITION: 50}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying a list of pins for secure_devices_pin config option

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
