### PR TITLE
Move logger to constants in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from dataclasses import dataclass
-import logging
 
 from aiohttp import ClientError, ServerDisconnectedError
 from pyoverkiz.client import OverkizClient
@@ -26,14 +25,13 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from .const import (
     CONF_HUB,
     DOMAIN,
+    LOGGER,
     OVERKIZ_DEVICE_TO_PLATFORM,
     PLATFORMS,
     UPDATE_INTERVAL,
     UPDATE_INTERVAL_ALL_ASSUMED_STATE,
 )
 from .coordinator import OverkizDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -67,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ]
         )
     except BadCredentialsException:
-        _LOGGER.error("Invalid authentication")
+        LOGGER.error("Invalid authentication")
         return False
     except TooManyRequestsException as exception:
         raise ConfigEntryNotReady("Too many requests, try again later") from exception
@@ -78,7 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = OverkizDataUpdateCoordinator(
         hass,
-        _LOGGER,
+        LOGGER,
         name="device events",
         client=client,
         devices=setup.devices,
@@ -90,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     if coordinator.is_stateless:
-        _LOGGER.debug(
+        LOGGER.debug(
             "All devices have an assumed state. Update interval has been reduced to: %s",
             UPDATE_INTERVAL_ALL_ASSUMED_STATE,
         )
@@ -104,7 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Map Overkiz entities to Home Assistant platform
     for device in coordinator.data.values():
-        _LOGGER.debug(
+        LOGGER.debug(
             "The following device has been retrieved. Report an issue if not supported correctly (%s)",
             device,
         )
@@ -119,7 +117,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_registry = dr.async_get(hass)
 
     for gateway in setup.gateways:
-        _LOGGER.debug("Added gateway (%s)", gateway)
+        LOGGER.debug("Added gateway (%s)", gateway)
 
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Overkiz (by Somfy) integration."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from aiohttp import ClientError
@@ -21,9 +20,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_HUB, DEFAULT_HUB, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_HUB, DEFAULT_HUB, DOMAIN, LOGGER
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -68,7 +65,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "server_in_maintenance"
             except Exception as exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"
-                _LOGGER.exception(exception)
+                LOGGER.exception(exception)
             else:
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
@@ -94,7 +91,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         hostname = discovery_info.hostname
         gateway_id = hostname[8:22]
 
-        _LOGGER.debug("DHCP discovery detected gateway %s", obfuscate_id(gateway_id))
+        LOGGER.debug("DHCP discovery detected gateway %s", obfuscate_id(gateway_id))
 
         await self.async_set_unique_id(gateway_id)
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 from typing import Final
 
 from pyoverkiz.enums import UIClass
@@ -10,6 +11,7 @@ from pyoverkiz.enums.ui import UIWidget
 from homeassistant.const import Platform
 
 DOMAIN: Final = "overkiz"
+LOGGER: logging.Logger = logging.getLogger(__package__)
 
 CONF_HUB: Final = "hub"
 DEFAULT_HUB: Final = "somfy_europe"

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -20,9 +20,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.decorator import Registry
 
-from .const import DOMAIN, UPDATE_INTERVAL
-
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN, LOGGER, UPDATE_INTERVAL
 
 EVENT_HANDLERS = Registry()
 
@@ -89,7 +87,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             return self.devices
 
         for event in events:
-            _LOGGER.debug(event)
+            LOGGER.debug(event)
 
             if event_handler := EVENT_HANDLERS.get(event.name):
                 await event_handler(self, event)
@@ -101,7 +99,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
     async def _get_devices(self) -> dict[str, Device]:
         """Fetch devices."""
-        _LOGGER.debug("Fetching all devices and state via /setup/devices")
+        LOGGER.debug("Fetching all devices and state via /setup/devices")
         return {d.device_url: d for d in await self.client.get_devices(refresh=True)}
 
     def _places_to_area(self, place: Place) -> dict[str, str]:

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -1,16 +1,14 @@
 """Class for helpers and communication with the OverKiz API."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 from urllib.parse import urlparse
 
 from pyoverkiz.models import Command, Device
 from pyoverkiz.types import StateType as OverkizStateType
 
+from .const import LOGGER
 from .coordinator import OverkizDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class OverkizExecutor:
@@ -67,7 +65,7 @@ class OverkizExecutor:
                 "Home Assistant",
             )
         except Exception as exception:  # pylint: disable=broad-except
-            _LOGGER.error(exception)
+            LOGGER.error(exception)
             return
 
         # ExecutionRegisteredEvent doesn't contain the device_url, thus we need to register it here


### PR DESCRIPTION
## Proposed change
To bring Overkiz on speed with the latest code style from core (if I am not mistaken), it would be good to move the logger to constants.

There are quite some platforms around climate to come, thus would be good to set a solid foundation first.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
