### PR TITLE
Make setup tests async

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 import asyncio
 import datetime
-import os
 import threading
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -10,7 +9,6 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries, setup
-import homeassistant.config as config_util
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
@@ -18,24 +16,18 @@ from homeassistant.helpers.config_validation import (
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
 )
-import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
     MockModule,
     MockPlatform,
     assert_setup_component,
-    get_test_config_dir,
-    get_test_home_assistant,
     mock_entity_platform,
     mock_integration,
 )
 
-ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
-VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
 
-
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_handlers():
     """Mock config flows."""
 
@@ -48,438 +40,430 @@ def mock_handlers():
         yield
 
 
-class TestSetup:
-    """Test the bootstrap utils."""
+async def test_validate_component_config(hass):
+    """Test validating component configuration."""
+    config_schema = vol.Schema({"comp_conf": {"hello": str}}, required=True)
+    mock_integration(hass, MockModule("comp_conf", config_schema=config_schema))
 
-    hass = None
-    backup_cache = None
+    with assert_setup_component(0):
+        assert not await setup.async_setup_component(hass, "comp_conf", {})
 
-    # pylint: disable=invalid-name, no-self-use
-    def setup_method(self, method):
-        """Set up the test."""
-        self.hass = get_test_home_assistant()
+    hass.data.pop(setup.DATA_SETUP)
 
-    def teardown_method(self, method):
-        """Clean up."""
-        self.hass.stop()
-
-    def test_validate_component_config(self):
-        """Test validating component configuration."""
-        config_schema = vol.Schema({"comp_conf": {"hello": str}}, required=True)
-        mock_integration(
-            self.hass, MockModule("comp_conf", config_schema=config_schema)
+    with assert_setup_component(0):
+        assert not await setup.async_setup_component(
+            hass, "comp_conf", {"comp_conf": None}
         )
 
-        with assert_setup_component(0):
-            assert not setup.setup_component(self.hass, "comp_conf", {})
+    hass.data.pop(setup.DATA_SETUP)
 
-        self.hass.data.pop(setup.DATA_SETUP)
-
-        with assert_setup_component(0):
-            assert not setup.setup_component(
-                self.hass, "comp_conf", {"comp_conf": None}
-            )
-
-        self.hass.data.pop(setup.DATA_SETUP)
-
-        with assert_setup_component(0):
-            assert not setup.setup_component(self.hass, "comp_conf", {"comp_conf": {}})
-
-        self.hass.data.pop(setup.DATA_SETUP)
-
-        with assert_setup_component(0):
-            assert not setup.setup_component(
-                self.hass,
-                "comp_conf",
-                {"comp_conf": {"hello": "world", "invalid": "extra"}},
-            )
-
-        self.hass.data.pop(setup.DATA_SETUP)
-
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass, "comp_conf", {"comp_conf": {"hello": "world"}}
-            )
-
-    def test_validate_platform_config(self, caplog):
-        """Test validating platform configuration."""
-        platform_schema = PLATFORM_SCHEMA.extend({"hello": str})
-        platform_schema_base = PLATFORM_SCHEMA_BASE.extend({})
-        mock_integration(
-            self.hass,
-            MockModule("platform_conf", platform_schema_base=platform_schema_base),
-        )
-        mock_entity_platform(
-            self.hass,
-            "platform_conf.whatever",
-            MockPlatform(platform_schema=platform_schema),
+    with assert_setup_component(0):
+        assert not await setup.async_setup_component(
+            hass, "comp_conf", {"comp_conf": {}}
         )
 
-        with assert_setup_component(0):
-            assert setup.setup_component(
-                self.hass,
-                "platform_conf",
-                {"platform_conf": {"platform": "not_existing", "hello": "world"}},
-            )
+    hass.data.pop(setup.DATA_SETUP)
 
-        self.hass.data.pop(setup.DATA_SETUP)
-        self.hass.config.components.remove("platform_conf")
-
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "platform_conf",
-                {"platform_conf": {"platform": "whatever", "hello": "world"}},
-            )
-
-        self.hass.data.pop(setup.DATA_SETUP)
-        self.hass.config.components.remove("platform_conf")
-
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "platform_conf",
-                {"platform_conf": [{"platform": "whatever", "hello": "world"}]},
-            )
-
-        self.hass.data.pop(setup.DATA_SETUP)
-        self.hass.config.components.remove("platform_conf")
-
-        # Any falsey platform config will be ignored (None, {}, etc)
-        with assert_setup_component(0) as config:
-            assert setup.setup_component(
-                self.hass, "platform_conf", {"platform_conf": None}
-            )
-            assert "platform_conf" in self.hass.config.components
-            assert not config["platform_conf"]  # empty
-
-            assert setup.setup_component(
-                self.hass, "platform_conf", {"platform_conf": {}}
-            )
-            assert "platform_conf" in self.hass.config.components
-            assert not config["platform_conf"]  # empty
-
-    def test_validate_platform_config_2(self, caplog):
-        """Test component PLATFORM_SCHEMA_BASE prio over PLATFORM_SCHEMA."""
-        platform_schema = PLATFORM_SCHEMA.extend({"hello": str})
-        platform_schema_base = PLATFORM_SCHEMA_BASE.extend({"hello": "world"})
-        mock_integration(
-            self.hass,
-            MockModule(
-                "platform_conf",
-                platform_schema=platform_schema,
-                platform_schema_base=platform_schema_base,
-            ),
+    with assert_setup_component(0):
+        assert not await setup.async_setup_component(
+            hass,
+            "comp_conf",
+            {"comp_conf": {"hello": "world", "invalid": "extra"}},
         )
 
-        mock_entity_platform(
-            self.hass,
-            "platform_conf.whatever",
-            MockPlatform("whatever", platform_schema=platform_schema),
+    hass.data.pop(setup.DATA_SETUP)
+
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass, "comp_conf", {"comp_conf": {"hello": "world"}}
         )
 
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "platform_conf",
-                {
-                    # pass
-                    "platform_conf": {"platform": "whatever", "hello": "world"},
-                    # fail: key hello violates component platform_schema_base
-                    "platform_conf 2": {"platform": "whatever", "hello": "there"},
-                },
-            )
 
-    def test_validate_platform_config_3(self, caplog):
-        """Test fallback to component PLATFORM_SCHEMA."""
-        component_schema = PLATFORM_SCHEMA_BASE.extend({"hello": str})
-        platform_schema = PLATFORM_SCHEMA.extend({"cheers": str, "hello": "world"})
-        mock_integration(
-            self.hass, MockModule("platform_conf", platform_schema=component_schema)
+async def test_validate_platform_config(hass, caplog):
+    """Test validating platform configuration."""
+    platform_schema = PLATFORM_SCHEMA.extend({"hello": str})
+    platform_schema_base = PLATFORM_SCHEMA_BASE.extend({})
+    mock_integration(
+        hass,
+        MockModule("platform_conf", platform_schema_base=platform_schema_base),
+    )
+    mock_entity_platform(
+        hass,
+        "platform_conf.whatever",
+        MockPlatform(platform_schema=platform_schema),
+    )
+
+    with assert_setup_component(0):
+        assert await setup.async_setup_component(
+            hass,
+            "platform_conf",
+            {"platform_conf": {"platform": "not_existing", "hello": "world"}},
         )
 
-        mock_entity_platform(
-            self.hass,
-            "platform_conf.whatever",
-            MockPlatform("whatever", platform_schema=platform_schema),
+    hass.data.pop(setup.DATA_SETUP)
+    hass.config.components.remove("platform_conf")
+
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "platform_conf",
+            {"platform_conf": {"platform": "whatever", "hello": "world"}},
         )
 
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "platform_conf",
-                {
-                    # pass
-                    "platform_conf": {"platform": "whatever", "hello": "world"},
-                    # fail: key hello violates component platform_schema
-                    "platform_conf 2": {"platform": "whatever", "hello": "there"},
-                },
-            )
+    hass.data.pop(setup.DATA_SETUP)
+    hass.config.components.remove("platform_conf")
 
-    def test_validate_platform_config_4(self):
-        """Test entity_namespace in PLATFORM_SCHEMA."""
-        component_schema = PLATFORM_SCHEMA_BASE
-        platform_schema = PLATFORM_SCHEMA
-        mock_integration(
-            self.hass,
-            MockModule("platform_conf", platform_schema_base=component_schema),
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "platform_conf",
+            {"platform_conf": [{"platform": "whatever", "hello": "world"}]},
         )
 
-        mock_entity_platform(
-            self.hass,
-            "platform_conf.whatever",
-            MockPlatform(platform_schema=platform_schema),
+    hass.data.pop(setup.DATA_SETUP)
+    hass.config.components.remove("platform_conf")
+
+    # Any falsey platform config will be ignored (None, {}, etc)
+    with assert_setup_component(0) as config:
+        assert await setup.async_setup_component(
+            hass, "platform_conf", {"platform_conf": None}
+        )
+        assert "platform_conf" in hass.config.components
+        assert not config["platform_conf"]  # empty
+
+        assert await setup.async_setup_component(
+            hass, "platform_conf", {"platform_conf": {}}
+        )
+        assert "platform_conf" in hass.config.components
+        assert not config["platform_conf"]  # empty
+
+
+async def test_validate_platform_config_2(hass, caplog):
+    """Test component PLATFORM_SCHEMA_BASE prio over PLATFORM_SCHEMA."""
+    platform_schema = PLATFORM_SCHEMA.extend({"hello": str})
+    platform_schema_base = PLATFORM_SCHEMA_BASE.extend({"hello": "world"})
+    mock_integration(
+        hass,
+        MockModule(
+            "platform_conf",
+            platform_schema=platform_schema,
+            platform_schema_base=platform_schema_base,
+        ),
+    )
+
+    mock_entity_platform(
+        hass,
+        "platform_conf.whatever",
+        MockPlatform("whatever", platform_schema=platform_schema),
+    )
+
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "platform_conf",
+            {
+                # pass
+                "platform_conf": {"platform": "whatever", "hello": "world"},
+                # fail: key hello violates component platform_schema_base
+                "platform_conf 2": {"platform": "whatever", "hello": "there"},
+            },
         )
 
-        with assert_setup_component(1):
-            assert setup.setup_component(
-                self.hass,
-                "platform_conf",
-                {
-                    "platform_conf": {
-                        # pass: entity_namespace accepted by PLATFORM_SCHEMA
-                        "platform": "whatever",
-                        "entity_namespace": "yummy",
-                    }
-                },
-            )
 
-        self.hass.data.pop(setup.DATA_SETUP)
-        self.hass.config.components.remove("platform_conf")
+async def test_validate_platform_config_3(hass, caplog):
+    """Test fallback to component PLATFORM_SCHEMA."""
+    component_schema = PLATFORM_SCHEMA_BASE.extend({"hello": str})
+    platform_schema = PLATFORM_SCHEMA.extend({"cheers": str, "hello": "world"})
+    mock_integration(
+        hass, MockModule("platform_conf", platform_schema=component_schema)
+    )
 
-    def test_component_not_found(self):
-        """setup_component should not crash if component doesn't exist."""
-        assert setup.setup_component(self.hass, "non_existing", {}) is False
+    mock_entity_platform(
+        hass,
+        "platform_conf.whatever",
+        MockPlatform("whatever", platform_schema=platform_schema),
+    )
 
-    def test_component_not_double_initialized(self):
-        """Test we do not set up a component twice."""
-        mock_setup = Mock(return_value=True)
-
-        mock_integration(self.hass, MockModule("comp", setup=mock_setup))
-
-        assert setup.setup_component(self.hass, "comp", {})
-        assert mock_setup.called
-
-        mock_setup.reset_mock()
-
-        assert setup.setup_component(self.hass, "comp", {})
-        assert not mock_setup.called
-
-    @patch("homeassistant.util.package.install_package", return_value=False)
-    def test_component_not_installed_if_requirement_fails(self, mock_install):
-        """Component setup should fail if requirement can't install."""
-        self.hass.config.skip_pip = False
-        mock_integration(self.hass, MockModule("comp", requirements=["package==0.0.1"]))
-
-        assert not setup.setup_component(self.hass, "comp", {})
-        assert "comp" not in self.hass.config.components
-
-    def test_component_not_setup_twice_if_loaded_during_other_setup(self):
-        """Test component setup while waiting for lock is not set up twice."""
-        result = []
-
-        async def async_setup(hass, config):
-            """Tracking Setup."""
-            result.append(1)
-
-        mock_integration(self.hass, MockModule("comp", async_setup=async_setup))
-
-        def setup_component():
-            """Set up the component."""
-            setup.setup_component(self.hass, "comp", {})
-
-        thread = threading.Thread(target=setup_component)
-        thread.start()
-        setup.setup_component(self.hass, "comp", {})
-
-        thread.join()
-
-        assert len(result) == 1
-
-    def test_component_not_setup_missing_dependencies(self):
-        """Test we do not set up a component if not all dependencies loaded."""
-        deps = ["maybe_existing"]
-        mock_integration(self.hass, MockModule("comp", dependencies=deps))
-
-        assert not setup.setup_component(self.hass, "comp", {})
-        assert "comp" not in self.hass.config.components
-
-        self.hass.data.pop(setup.DATA_SETUP)
-
-        mock_integration(self.hass, MockModule("comp2", dependencies=deps))
-        mock_integration(self.hass, MockModule("maybe_existing"))
-
-        assert setup.setup_component(self.hass, "comp2", {})
-
-    def test_component_failing_setup(self):
-        """Test component that fails setup."""
-        mock_integration(
-            self.hass, MockModule("comp", setup=lambda hass, config: False)
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "platform_conf",
+            {
+                # pass
+                "platform_conf": {"platform": "whatever", "hello": "world"},
+                # fail: key hello violates component platform_schema
+                "platform_conf 2": {"platform": "whatever", "hello": "there"},
+            },
         )
 
-        assert not setup.setup_component(self.hass, "comp", {})
-        assert "comp" not in self.hass.config.components
 
-    def test_component_exception_setup(self):
-        """Test component that raises exception during setup."""
+async def test_validate_platform_config_4(hass):
+    """Test entity_namespace in PLATFORM_SCHEMA."""
+    component_schema = PLATFORM_SCHEMA_BASE
+    platform_schema = PLATFORM_SCHEMA
+    mock_integration(
+        hass,
+        MockModule("platform_conf", platform_schema_base=component_schema),
+    )
 
-        def exception_setup(hass, config):
-            """Raise exception."""
-            raise Exception("fail!")
+    mock_entity_platform(
+        hass,
+        "platform_conf.whatever",
+        MockPlatform(platform_schema=platform_schema),
+    )
 
-        mock_integration(self.hass, MockModule("comp", setup=exception_setup))
-
-        assert not setup.setup_component(self.hass, "comp", {})
-        assert "comp" not in self.hass.config.components
-
-    def test_component_setup_with_validation_and_dependency(self):
-        """Test all config is passed to dependencies."""
-
-        def config_check_setup(hass, config):
-            """Test that config is passed in."""
-            if config.get("comp_a", {}).get("valid", False):
-                return True
-            raise Exception(f"Config not passed in: {config}")
-
-        platform = MockPlatform()
-
-        mock_integration(self.hass, MockModule("comp_a", setup=config_check_setup))
-        mock_integration(
-            self.hass,
-            MockModule("platform_a", setup=config_check_setup, dependencies=["comp_a"]),
+    with assert_setup_component(1):
+        assert await setup.async_setup_component(
+            hass,
+            "platform_conf",
+            {
+                "platform_conf": {
+                    # pass: entity_namespace accepted by PLATFORM_SCHEMA
+                    "platform": "whatever",
+                    "entity_namespace": "yummy",
+                }
+            },
         )
 
-        mock_entity_platform(self.hass, "switch.platform_a", platform)
+    hass.data.pop(setup.DATA_SETUP)
+    hass.config.components.remove("platform_conf")
 
-        setup.setup_component(
-            self.hass,
+
+async def test_component_not_found(hass):
+    """setup_component should not crash if component doesn't exist."""
+    assert await setup.async_setup_component(hass, "non_existing", {}) is False
+
+
+async def test_component_not_double_initialized(hass):
+    """Test we do not set up a component twice."""
+    mock_setup = Mock(return_value=True)
+
+    mock_integration(hass, MockModule("comp", setup=mock_setup))
+
+    assert await setup.async_setup_component(hass, "comp", {})
+    assert mock_setup.called
+
+    mock_setup.reset_mock()
+
+    assert await setup.async_setup_component(hass, "comp", {})
+    assert not mock_setup.called
+
+
+async def test_component_not_installed_if_requirement_fails(hass):
+    """Component setup should fail if requirement can't install."""
+    hass.config.skip_pip = False
+    mock_integration(hass, MockModule("comp", requirements=["package==0.0.1"]))
+
+    with patch("homeassistant.util.package.install_package", return_value=False):
+        assert not await setup.async_setup_component(hass, "comp", {})
+
+    assert "comp" not in hass.config.components
+
+
+async def test_component_not_setup_twice_if_loaded_during_other_setup(hass):
+    """Test component setup while waiting for lock is not set up twice."""
+    result = []
+
+    async def async_setup(hass, config):
+        """Tracking Setup."""
+        result.append(1)
+
+    mock_integration(hass, MockModule("comp", async_setup=async_setup))
+
+    def setup_component():
+        """Set up the component."""
+        setup.setup_component(hass, "comp", {})
+
+    thread = threading.Thread(target=setup_component)
+    thread.start()
+    await setup.async_setup_component(hass, "comp", {})
+
+    await hass.async_add_executor_job(thread.join)
+
+    assert len(result) == 1
+
+
+async def test_component_not_setup_missing_dependencies(hass):
+    """Test we do not set up a component if not all dependencies loaded."""
+    deps = ["maybe_existing"]
+    mock_integration(hass, MockModule("comp", dependencies=deps))
+
+    assert not await setup.async_setup_component(hass, "comp", {})
+    assert "comp" not in hass.config.components
+
+    hass.data.pop(setup.DATA_SETUP)
+
+    mock_integration(hass, MockModule("comp2", dependencies=deps))
+    mock_integration(hass, MockModule("maybe_existing"))
+
+    assert await setup.async_setup_component(hass, "comp2", {})
+
+
+async def test_component_failing_setup(hass):
+    """Test component that fails setup."""
+    mock_integration(hass, MockModule("comp", setup=lambda hass, config: False))
+
+    assert not await setup.async_setup_component(hass, "comp", {})
+    assert "comp" not in hass.config.components
+
+
+async def test_component_exception_setup(hass):
+    """Test component that raises exception during setup."""
+
+    def exception_setup(hass, config):
+        """Raise exception."""
+        raise Exception("fail!")
+
+    mock_integration(hass, MockModule("comp", setup=exception_setup))
+
+    assert not await setup.async_setup_component(hass, "comp", {})
+    assert "comp" not in hass.config.components
+
+
+async def test_component_setup_with_validation_and_dependency(hass):
+    """Test all config is passed to dependencies."""
+
+    def config_check_setup(hass, config):
+        """Test that config is passed in."""
+        if config.get("comp_a", {}).get("valid", False):
+            return True
+        raise Exception(f"Config not passed in: {config}")
+
+    platform = MockPlatform()
+
+    mock_integration(hass, MockModule("comp_a", setup=config_check_setup))
+    mock_integration(
+        hass,
+        MockModule("platform_a", setup=config_check_setup, dependencies=["comp_a"]),
+    )
+
+    mock_entity_platform(hass, "switch.platform_a", platform)
+
+    await setup.async_setup_component(
+        hass,
+        "switch",
+        {"comp_a": {"valid": True}, "switch": {"platform": "platform_a"}},
+    )
+    await hass.async_block_till_done()
+    assert "comp_a" in hass.config.components
+
+
+async def test_platform_specific_config_validation(hass):
+    """Test platform that specifies config."""
+    platform_schema = PLATFORM_SCHEMA.extend({"valid": True}, extra=vol.PREVENT_EXTRA)
+
+    mock_setup = Mock(spec_set=True)
+
+    mock_entity_platform(
+        hass,
+        "switch.platform_a",
+        MockPlatform(platform_schema=platform_schema, setup_platform=mock_setup),
+    )
+
+    with assert_setup_component(0, "switch"):
+        assert await setup.async_setup_component(
+            hass,
             "switch",
-            {"comp_a": {"valid": True}, "switch": {"platform": "platform_a"}},
+            {"switch": {"platform": "platform_a", "invalid": True}},
         )
-        self.hass.block_till_done()
-        assert "comp_a" in self.hass.config.components
+        await hass.async_block_till_done()
+        assert mock_setup.call_count == 0
 
-    def test_platform_specific_config_validation(self):
-        """Test platform that specifies config."""
-        platform_schema = PLATFORM_SCHEMA.extend(
-            {"valid": True}, extra=vol.PREVENT_EXTRA
+    hass.data.pop(setup.DATA_SETUP)
+    hass.config.components.remove("switch")
+
+    with assert_setup_component(0):
+        assert await setup.async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": {
+                    "platform": "platform_a",
+                    "valid": True,
+                    "invalid_extra": True,
+                }
+            },
         )
+        await hass.async_block_till_done()
+        assert mock_setup.call_count == 0
 
-        mock_setup = Mock(spec_set=True)
+    hass.data.pop(setup.DATA_SETUP)
+    hass.config.components.remove("switch")
 
-        mock_entity_platform(
-            self.hass,
-            "switch.platform_a",
-            MockPlatform(platform_schema=platform_schema, setup_platform=mock_setup),
+    with assert_setup_component(1, "switch"):
+        assert await setup.async_setup_component(
+            hass,
+            "switch",
+            {"switch": {"platform": "platform_a", "valid": True}},
         )
+        await hass.async_block_till_done()
+        assert mock_setup.call_count == 1
 
-        with assert_setup_component(0, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {"switch": {"platform": "platform_a", "invalid": True}},
-            )
-            self.hass.block_till_done()
-            assert mock_setup.call_count == 0
 
-        self.hass.data.pop(setup.DATA_SETUP)
-        self.hass.config.components.remove("switch")
+async def test_disable_component_if_invalid_return(hass):
+    """Test disabling component if invalid return."""
+    mock_integration(
+        hass, MockModule("disabled_component", setup=lambda hass, config: None)
+    )
 
-        with assert_setup_component(0):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {
-                    "switch": {
-                        "platform": "platform_a",
-                        "valid": True,
-                        "invalid_extra": True,
-                    }
-                },
-            )
-            self.hass.block_till_done()
-            assert mock_setup.call_count == 0
+    assert not await setup.async_setup_component(hass, "disabled_component", {})
+    assert "disabled_component" not in hass.config.components
 
-        self.hass.data.pop(setup.DATA_SETUP)
-        self.hass.config.components.remove("switch")
+    hass.data.pop(setup.DATA_SETUP)
+    mock_integration(
+        hass,
+        MockModule("disabled_component", setup=lambda hass, config: False),
+    )
 
-        with assert_setup_component(1, "switch"):
-            assert setup.setup_component(
-                self.hass,
-                "switch",
-                {"switch": {"platform": "platform_a", "valid": True}},
-            )
-            self.hass.block_till_done()
-            assert mock_setup.call_count == 1
+    assert not await setup.async_setup_component(hass, "disabled_component", {})
+    assert "disabled_component" not in hass.config.components
 
-    def test_disable_component_if_invalid_return(self):
-        """Test disabling component if invalid return."""
-        mock_integration(
-            self.hass, MockModule("disabled_component", setup=lambda hass, config: None)
+    hass.data.pop(setup.DATA_SETUP)
+    mock_integration(
+        hass, MockModule("disabled_component", setup=lambda hass, config: True)
+    )
+
+    assert await setup.async_setup_component(hass, "disabled_component", {})
+    assert "disabled_component" in hass.config.components
+
+
+async def test_all_work_done_before_start(hass):
+    """Test all init work done till start."""
+    # hass = HomeAssistant()
+    call_order = []
+
+    async def component1_setup(hass, config):
+        """Set up mock component."""
+        await discovery.async_discover(
+            hass, "test_component2", {}, "test_component2", {}
         )
-
-        assert not setup.setup_component(self.hass, "disabled_component", {})
-        assert "disabled_component" not in self.hass.config.components
-
-        self.hass.data.pop(setup.DATA_SETUP)
-        mock_integration(
-            self.hass,
-            MockModule("disabled_component", setup=lambda hass, config: False),
+        await discovery.async_discover(
+            hass, "test_component3", {}, "test_component3", {}
         )
+        return True
 
-        assert not setup.setup_component(self.hass, "disabled_component", {})
-        assert "disabled_component" not in self.hass.config.components
+    def component_track_setup(hass, config):
+        """Set up mock component."""
+        call_order.append(1)
+        return True
 
-        self.hass.data.pop(setup.DATA_SETUP)
-        mock_integration(
-            self.hass, MockModule("disabled_component", setup=lambda hass, config: True)
-        )
+    mock_integration(hass, MockModule("test_component1", async_setup=component1_setup))
 
-        assert setup.setup_component(self.hass, "disabled_component", {})
-        assert "disabled_component" in self.hass.config.components
+    mock_integration(hass, MockModule("test_component2", setup=component_track_setup))
 
-    def test_all_work_done_before_start(self):
-        """Test all init work done till start."""
-        call_order = []
+    mock_integration(hass, MockModule("test_component3", setup=component_track_setup))
 
-        async def component1_setup(hass, config):
-            """Set up mock component."""
-            await discovery.async_discover(
-                hass, "test_component2", {}, "test_component2", {}
-            )
-            await discovery.async_discover(
-                hass, "test_component3", {}, "test_component3", {}
-            )
-            return True
+    @callback
+    def track_start(event):
+        """Track start event."""
+        call_order.append(2)
 
-        def component_track_setup(hass, config):
-            """Set up mock component."""
-            call_order.append(1)
-            return True
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, track_start)
 
-        mock_integration(
-            self.hass, MockModule("test_component1", async_setup=component1_setup)
-        )
-
-        mock_integration(
-            self.hass, MockModule("test_component2", setup=component_track_setup)
-        )
-
-        mock_integration(
-            self.hass, MockModule("test_component3", setup=component_track_setup)
-        )
-
-        @callback
-        def track_start(event):
-            """Track start event."""
-            call_order.append(2)
-
-        self.hass.bus.listen_once(EVENT_HOMEASSISTANT_START, track_start)
-
-        self.hass.add_job(setup.async_setup_component(self.hass, "test_component1", {}))
-        self.hass.block_till_done()
-        self.hass.start()
-        assert call_order == [1, 1, 2]
+    hass.add_job(setup.async_setup_component(hass, "test_component1", {}))
+    await hass.async_block_till_done()
+    await hass.async_start()
+    assert call_order == [1, 1, 2]
 
 
 async def test_component_warn_slow_setup(hass):
@@ -513,7 +497,7 @@ async def test_platform_no_warn_slow(hass):
 async def test_platform_error_slow_setup(hass, caplog):
     """Don't block startup more than SLOW_SETUP_MAX_WAIT."""
 
-    with patch.object(setup, "SLOW_SETUP_MAX_WAIT", 1):
+    with patch.object(setup, "SLOW_SETUP_MAX_WAIT", 0.1):
         called = []
 
         async def async_setup(*args):
@@ -525,7 +509,7 @@ async def test_platform_error_slow_setup(hass, caplog):
         result = await setup.async_setup_component(hass, "test_component1", {})
         assert len(called) == 1
         assert not result
-        assert "test_component1 is taking longer than 1 seconds" in caplog.text
+        assert "test_component1 is taking longer than 0.1 seconds" in caplog.text
 
 
 async def test_when_setup_already_loaded(hass):
@@ -599,7 +583,7 @@ async def test_setup_import_blows_up(hass):
         assert not await setup.async_setup_component(hass, "sun", {})
 
 
-async def test_parallel_entry_setup(hass):
+async def test_parallel_entry_setup(hass, mock_handlers):
     """Test config entries are set up in parallel."""
     MockConfigEntry(domain="comp", data={"value": 1}).add_to_hass(hass)
     MockConfigEntry(domain="comp", data={"value": 2}).add_to_hass(hass)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -429,7 +429,6 @@ async def test_disable_component_if_invalid_return(hass):
 
 async def test_all_work_done_before_start(hass):
     """Test all init work done till start."""
-    # hass = HomeAssistant()
     call_order = []
 
     async def component1_setup(hass, config):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert the setup tests async.

Best reviewed [while ignoring whitespace](https://github.com/home-assistant/core/pull/64456/files?w=1)

Required for #64337 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
