### PR TITLE
Add support for checking if an entity is explicitly included in an entity filter

### DIFF
--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -22,19 +22,54 @@ CONF_EXCLUDE_ENTITIES = "exclude_entities"
 CONF_ENTITY_GLOBS = "entity_globs"
 
 
-def convert_filter(config: dict[str, list[str]]) -> Callable[[str], bool]:
+class EntityFilter:
+    """A entity filter."""
+
+    def __init__(self, config: dict[str, list[str]]) -> None:
+        """Init the filter."""
+        self.empty_filter: bool = sum(len(val) for val in config.values()) == 0
+        self.config = config
+        self._include_e = set(config[CONF_INCLUDE_ENTITIES])
+        self._exclude_e = set(config[CONF_EXCLUDE_ENTITIES])
+        self._include_d = set(config[CONF_INCLUDE_DOMAINS])
+        self._exclude_d = set(config[CONF_EXCLUDE_DOMAINS])
+        self._include_eg = _convert_globs_to_pattern_list(
+            config[CONF_INCLUDE_ENTITY_GLOBS]
+        )
+        self._exclude_eg = _convert_globs_to_pattern_list(
+            config[CONF_EXCLUDE_ENTITY_GLOBS]
+        )
+        self._filter: Callable[[str], bool] | None = None
+
+    def explicitly_included(self, entity_id: str) -> bool:
+        """Check if an entity is explicitly included."""
+        return entity_id in self._include_e or _test_against_patterns(
+            self._include_eg, entity_id
+        )
+
+    def explicitly_excluded(self, entity_id: str) -> bool:
+        """Check if an entity is explicitly excluded."""
+        return entity_id in self._exclude_e or _test_against_patterns(
+            self._exclude_eg, entity_id
+        )
+
+    def __call__(self, entity_id: str) -> bool:
+        """Run the filter."""
+        if self._filter is None:
+            self._filter = _generate_filter_from_sets_and_pattern_lists(
+                self._include_d,
+                self._include_e,
+                self._exclude_d,
+                self._exclude_e,
+                self._include_eg,
+                self._exclude_eg,
+            )
+        return self._filter(entity_id)
+
+
+def convert_filter(config: dict[str, list[str]]) -> EntityFilter:
     """Convert the filter schema into a filter."""
-    filt = generate_filter(
-        config[CONF_INCLUDE_DOMAINS],
-        config[CONF_INCLUDE_ENTITIES],
-        config[CONF_EXCLUDE_DOMAINS],
-        config[CONF_EXCLUDE_ENTITIES],
-        config[CONF_INCLUDE_ENTITY_GLOBS],
-        config[CONF_EXCLUDE_ENTITY_GLOBS],
-    )
-    setattr(filt, "config", config)
-    setattr(filt, "empty_filter", sum(len(val) for val in config.values()) == 0)
-    return filt
+    return EntityFilter(config)
 
 
 BASE_FILTER_SCHEMA = vol.Schema(
@@ -61,11 +96,11 @@ FILTER_SCHEMA = vol.All(BASE_FILTER_SCHEMA, convert_filter)
 
 def convert_include_exclude_filter(
     config: dict[str, dict[str, list[str]]]
-) -> Callable[[str], bool]:
+) -> EntityFilter:
     """Convert the include exclude filter schema into a filter."""
     include = config[CONF_INCLUDE]
     exclude = config[CONF_EXCLUDE]
-    filt = convert_filter(
+    return convert_filter(
         {
             CONF_INCLUDE_DOMAINS: include[CONF_DOMAINS],
             CONF_INCLUDE_ENTITY_GLOBS: include[CONF_ENTITY_GLOBS],
@@ -75,8 +110,6 @@ def convert_include_exclude_filter(
             CONF_EXCLUDE_ENTITIES: exclude[CONF_ENTITIES],
         }
     )
-    setattr(filt, "config", config)
-    return filt
 
 
 INCLUDE_EXCLUDE_FILTER_SCHEMA_INNER = vol.Schema(
@@ -119,6 +152,11 @@ def _test_against_patterns(patterns: list[re.Pattern[str]], entity_id: str) -> b
     return False
 
 
+def _convert_globs_to_pattern_list(globs: list[str] | None) -> list[re.Pattern[str]]:
+    """Convert a list of globs to a re pattern list."""
+    return list(map(_glob_to_re, set(globs or [])))
+
+
 def generate_filter(
     include_domains: list[str],
     include_entities: list[str],
@@ -128,19 +166,25 @@ def generate_filter(
     exclude_entity_globs: list[str] | None = None,
 ) -> Callable[[str], bool]:
     """Return a function that will filter entities based on the args."""
-    include_d = set(include_domains)
-    include_e = set(include_entities)
-    exclude_d = set(exclude_domains)
-    exclude_e = set(exclude_entities)
-    include_eg_set = (
-        set(include_entity_globs) if include_entity_globs is not None else set()
+    return _generate_filter_from_sets_and_pattern_lists(
+        set(include_domains),
+        set(include_entities),
+        set(exclude_domains),
+        set(exclude_entities),
+        _convert_globs_to_pattern_list(include_entity_globs),
+        _convert_globs_to_pattern_list(exclude_entity_globs),
     )
-    exclude_eg_set = (
-        set(exclude_entity_globs) if exclude_entity_globs is not None else set()
-    )
-    include_eg = list(map(_glob_to_re, include_eg_set))
-    exclude_eg = list(map(_glob_to_re, exclude_eg_set))
 
+
+def _generate_filter_from_sets_and_pattern_lists(
+    include_d: set[str],
+    include_e: set[str],
+    exclude_d: set[str],
+    exclude_e: set[str],
+    include_eg: list[re.Pattern[str]],
+    exclude_eg: list[re.Pattern[str]],
+) -> Callable[[str], bool]:
+    """Generate a filter from pre-comuted sets and pattern lists."""
     have_exclude = bool(exclude_e or exclude_d or exclude_eg)
     have_include = bool(include_e or include_d or include_eg)
 

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -2,6 +2,7 @@
 from homeassistant.helpers.entityfilter import (
     FILTER_SCHEMA,
     INCLUDE_EXCLUDE_FILTER_SCHEMA,
+    EntityFilter,
     generate_filter,
 )
 
@@ -267,5 +268,38 @@ def test_filter_schema_include_exclude():
         },
     }
     filt = INCLUDE_EXCLUDE_FILTER_SCHEMA(conf)
-    assert filt.config == conf
+    assert filt.config == {
+        "include_domains": ["light"],
+        "include_entity_globs": ["sensor.kitchen_*"],
+        "include_entities": ["switch.kitchen"],
+        "exclude_domains": ["cover"],
+        "exclude_entity_globs": ["sensor.weather_*"],
+        "exclude_entities": ["light.kitchen"],
+    }
     assert not filt.empty_filter
+
+
+def test_exlictly_included():
+    """Test if an entity is explicitly included."""
+    conf = {
+        "include": {
+            "domains": ["light"],
+            "entity_globs": ["sensor.kitchen_*"],
+            "entities": ["switch.kitchen"],
+        },
+        "exclude": {
+            "domains": ["cover"],
+            "entity_globs": ["sensor.weather_*"],
+            "entities": ["light.kitchen"],
+        },
+    }
+    filt: EntityFilter = INCLUDE_EXCLUDE_FILTER_SCHEMA(conf)
+    assert not filt.explicitly_included("light.any")
+    assert not filt.explicitly_included("switch.other")
+    assert filt.explicitly_included("sensor.kitchen_4")
+    assert filt.explicitly_included("switch.kitchen")
+
+    assert not filt.explicitly_excluded("light.any")
+    assert not filt.explicitly_excluded("switch.other")
+    assert filt.explicitly_excluded("sensor.weather_5")
+    assert filt.explicitly_excluded("light.kitchen")


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Pre-work for adding entity category support to HomeKit


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
