### PR TITLE
Add diagnostics to KNX

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -557,6 +557,7 @@ omit =
     homeassistant/components/knx/__init__.py
     homeassistant/components/knx/climate.py
     homeassistant/components/knx/cover.py
+    homeassistant/components/knx/diagnostics.py
     homeassistant/components/knx/expose.py
     homeassistant/components/knx/knx_entity.py
     homeassistant/components/knx/light.py

--- a/homeassistant/components/knx/diagnostics.py
+++ b/homeassistant/components/knx/diagnostics.py
@@ -1,0 +1,41 @@
+"""Diagnostics support for KNX."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config as conf_util
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.system_info import async_get_system_info
+
+from . import CONFIG_SCHEMA
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    diag: dict[str, Any] = {}
+    diag["home_assistant"] = await async_get_system_info(hass)
+
+    knx_module = hass.data[DOMAIN]
+    diag["xknx"] = {
+        "version": knx_module.xknx.version,
+        "current_address": str(knx_module.xknx.current_address),
+    }
+
+    diag["config_entry_data"] = dict(config_entry.data)
+
+    raw_config = await conf_util.async_hass_config_yaml(hass)
+    diag["configuration_yaml"] = raw_config.get(DOMAIN)
+    try:
+        CONFIG_SCHEMA(raw_config)
+    except vol.Invalid as ex:
+        diag["configuration_error"] = str(ex)
+    else:
+        diag["configuration_error"] = None
+
+    return diag


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostics to KNX

An example of the output would be:

```json
{
    "home_assistant": {
        "installation_type": "Home Assistant Core",
        "version": "2022.2.0.dev0",
        "dev": true,
        "hassio": false,
        "virtualenv": true,
        "python_version": "3.9.7",
        "docker": false,
        "arch": "arm64",
        "timezone": "UTC",
        "os_name": "Darwin",
        "os_version": "12.1",
        "user": "farmio"
    },
    "xknx": {
        "version": "0.18.16.dev",
        "current_address": "1.0.255"
    },
    "config_entry_data": {
        "state_updater": true,
        "rate_limit": 20,
        "individual_address": "15.15.250",
        "multicast_group": "224.0.23.12",
        "multicast_port": 3671,
        "connection_type": "tunneling",
        "local_ip": null,
        "host": "10.1.0.40",
        "port": 3671,
        "route_back": false
    },
    "configuration_yaml": {
        "light": [
            {
                "name": "K\u00fcche Esstisch",
                "address": "1/1/45",
                "state_address": "1/0/45"
            }
        ]
    },
    "configuration_error": null
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
