### PR TITLE
Add redacted constant in diagnostics

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -19,7 +19,9 @@ from homeassistant.util.json import (
     format_unserializable_data,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, REDACTED
+
+__all__ = ["REDACTED"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/diagnostics/const.py
+++ b/homeassistant/components/diagnostics/const.py
@@ -1,3 +1,5 @@
 """Constants for the Diagnostics integration."""
 
 DOMAIN = "diagnostics"
+
+REDACTED = "**REDACTED**"

--- a/homeassistant/components/evil_genius_labs/diagnostics.py
+++ b/homeassistant/components/evil_genius_labs/diagnostics.py
@@ -1,7 +1,7 @@
 """Diagnostics support for Evil Genius Labs."""
 from __future__ import annotations
 
-from homeassistant.components.diagnostics.const import REDACTED
+from homeassistant.components.diagnostics import REDACTED
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 

--- a/homeassistant/components/evil_genius_labs/diagnostics.py
+++ b/homeassistant/components/evil_genius_labs/diagnostics.py
@@ -1,6 +1,7 @@
 """Diagnostics support for Evil Genius Labs."""
 from __future__ import annotations
 
+from homeassistant.components.diagnostics.const import REDACTED
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -17,8 +18,8 @@ async def async_get_config_entry_diagnostics(
     return {
         "info": {
             **coordinator.info,
-            "wiFiSsidDefault": "REDACTED",
-            "wiFiSSID": "REDACTED",
+            "wiFiSsidDefault": REDACTED,
+            "wiFiSSID": REDACTED,
         },
         "data": coordinator.data,
     }

--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from tuya_iot import TuyaDevice
 
-from homeassistant.components.diagnostics.const import REDACTED
+from homeassistant.components.diagnostics import REDACTED
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er

--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 from tuya_iot import TuyaDevice
 
+from homeassistant.components.diagnostics.const import REDACTED
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -75,7 +76,7 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
     for dpcode, value in device.status.items():
         # These statuses may contain sensitive information, redact these..
         if dpcode in {DPCode.ALARM_MESSAGE, DPCode.MOVEMENT_DETECT_PIC}:
-            data["status"][dpcode] = "**REDACTED**"
+            data["status"][dpcode] = REDACTED
             continue
 
         with suppress(ValueError, TypeError):
@@ -133,7 +134,7 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
                 if "entity_picture" in state_dict["attributes"]:
                     state_dict["attributes"] = {
                         **state_dict["attributes"],
-                        "entity_picture": "**REDACTED**",
+                        "entity_picture": REDACTED,
                     }
 
                 # The context doesn't provide useful information in this case.

--- a/tests/components/evil_genius_labs/test_diagnostics.py
+++ b/tests/components/evil_genius_labs/test_diagnostics.py
@@ -1,6 +1,8 @@
 """Test evil genius labs diagnostics."""
 import pytest
 
+from homeassistant.components.diagnostics.const import REDACTED
+
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
@@ -12,8 +14,8 @@ async def test_entry_diagnostics(
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "info": {
             **info_fixture,
-            "wiFiSsidDefault": "REDACTED",
-            "wiFiSSID": "REDACTED",
+            "wiFiSsidDefault": REDACTED,
+            "wiFiSSID": REDACTED,
         },
         "data": data_fixture,
     }

--- a/tests/components/evil_genius_labs/test_diagnostics.py
+++ b/tests/components/evil_genius_labs/test_diagnostics.py
@@ -1,7 +1,7 @@
 """Test evil genius labs diagnostics."""
 import pytest
 
-from homeassistant.components.diagnostics.const import REDACTED
+from homeassistant.components.diagnostics import REDACTED
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Already seeing a couple of PRs up that redact in different ways or define their own constant for the redacted string. This PR suggests adding a constant for it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
