### PR TITLE
Use zeroconf for scanning in apple_tv

### DIFF
--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -7,6 +7,7 @@ from pyatv import connect, exceptions, scan
 from pyatv.const import DeviceModel, Protocol
 from pyatv.convert import model_str
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CONNECTIONS,
@@ -269,8 +270,13 @@ class AppleTVManager:
         }
 
         _LOGGER.debug("Discovering device %s", self.config_entry.title)
+        aiozc = await zeroconf.async_get_async_instance(self.hass)
         atvs = await scan(
-            self.hass.loop, identifier=identifiers, protocol=protocols, hosts=[address]
+            self.hass.loop,
+            identifier=identifiers,
+            protocol=protocols,
+            hosts=[address],
+            aiozc=aiozc,
         )
         if atvs:
             return atvs[0]

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -32,8 +32,14 @@ DEFAULT_START_OFF = False
 
 DISCOVERY_AGGREGATION_TIME = 15  # seconds
 
+UPDATE_IP_ONLY_SERVICES = {
+    "_companion-link._tcp.local.",
+    "_airport._tcp.local.",
+    "_sleep-proxy._udp.local.",
+}
 
-async def device_scan(identifier, loop):
+
+async def device_scan(hass, identifier, loop):
     """Scan for a specific device using identifier as filter."""
 
     def _filter_device(dev):
@@ -53,7 +59,8 @@ async def device_scan(identifier, loop):
 
     # If we have an address, only probe that address to avoid
     # broadcast traffic on the network
-    scan_result = await scan(loop, timeout=3, hosts=_host_filter())
+    aiozc = await zeroconf.async_get_async_instance(hass)
+    scan_result = await scan(loop, timeout=3, hosts=_host_filter(), aiozc=aiozc)
     matches = [atv for atv in scan_result if _filter_device(atv)]
 
     if matches:
@@ -180,6 +187,10 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured(updates={CONF_ADDRESS: host})
 
         self._async_abort_entries_match({CONF_ADDRESS: host})
+        if discovery_info.type in UPDATE_IP_ONLY_SERVICES:
+            # No device found and we only use these to update ips
+            return self.async_abort(reason="device_not_found")
+
         await self._async_aggregate_discoveries(host, unique_id)
         # Scan for the device in order to extract _all_ unique identifiers assigned to
         # it. Not doing it like this will yield multiple config flows for the same
@@ -279,7 +290,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_find_device(self, allow_exist=False):
         """Scan for the selected device to discover services."""
         self.atv, self.atv_identifiers = await device_scan(
-            self.scan_filter, self.hass.loop
+            self.hass, self.scan_filter, self.hass.loop
         )
         if not self.atv:
             raise DeviceNotFound()

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -32,12 +32,6 @@ DEFAULT_START_OFF = False
 
 DISCOVERY_AGGREGATION_TIME = 15  # seconds
 
-UPDATE_IP_ONLY_SERVICES = {
-    "_companion-link._tcp.local.",
-    "_airport._tcp.local.",
-    "_sleep-proxy._udp.local.",
-}
-
 
 async def device_scan(hass, identifier, loop):
     """Scan for a specific device using identifier as filter."""
@@ -187,9 +181,6 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured(updates={CONF_ADDRESS: host})
 
         self._async_abort_entries_match({CONF_ADDRESS: host})
-        if discovery_info.type in UPDATE_IP_ONLY_SERVICES:
-            # No device found and we only use these to update ips
-            return self.async_abort(reason="device_not_found")
 
         await self._async_aggregate_discoveries(host, unique_id)
         # Scan for the device in order to extract _all_ unique identifiers assigned to

--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -4,8 +4,12 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/apple_tv",
   "requirements": ["pyatv==0.9.8"],
+  "dependencies": ["zeroconf"],
   "zeroconf": [
     "_mediaremotetv._tcp.local.",
+    "_companion-link._tcp.local.",
+    "_airport._tcp.local.",
+    "_sleep-proxy._udp.local.",
     "_touch-able._tcp.local.",
     "_appletv-v2._tcp.local.",
     "_hscp._tcp.local.",

--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Apple TV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/apple_tv",
-  "requirements": ["pyatv==0.9.8"],
+  "requirements": ["pyatv==0.10.0"],
   "dependencies": ["zeroconf"],
   "zeroconf": [
     "_mediaremotetv._tcp.local.",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -37,6 +37,11 @@ ZEROCONF = {
             }
         }
     ],
+    "_airport._tcp.local.": [
+        {
+            "domain": "apple_tv"
+        }
+    ],
     "_api._udp.local.": [
         {
             "domain": "guardian"
@@ -76,6 +81,11 @@ ZEROCONF = {
     "_bond._tcp.local.": [
         {
             "domain": "bond"
+        }
+    ],
+    "_companion-link._tcp.local.": [
+        {
+            "domain": "apple_tv"
         }
     ],
     "_daap._tcp.local.": [
@@ -300,6 +310,11 @@ ZEROCONF = {
             "properties": {
                 "mdl": "ecobee*"
             }
+        }
+    ],
+    "_sleep-proxy._udp.local.": [
+        {
+            "domain": "apple_tv"
         }
     ],
     "_sonos._tcp.local.": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1401,7 +1401,7 @@ pyatmo==6.2.2
 pyatome==0.1.1
 
 # homeassistant.components.apple_tv
-pyatv==0.9.8
+pyatv==0.10.0
 
 # homeassistant.components.aussie_broadband
 pyaussiebb==0.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -875,7 +875,7 @@ pyatag==0.3.5.3
 pyatmo==6.2.2
 
 # homeassistant.components.apple_tv
-pyatv==0.9.8
+pyatv==0.10.0
 
 # homeassistant.components.aussie_broadband
 pyaussiebb==0.0.9

--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -15,7 +15,9 @@ def mock_scan_fixture():
     """Mock pyatv.scan."""
     with patch("homeassistant.components.apple_tv.config_flow.scan") as mock_scan:
 
-        async def _scan(loop, timeout=5, identifier=None, protocol=None, hosts=None):
+        async def _scan(
+            loop, timeout=5, identifier=None, protocol=None, hosts=None, aiozc=None
+        ):
             if not mock_scan.hosts:
                 mock_scan.hosts = hosts
             return mock_scan.result

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -40,16 +40,6 @@ RAOP_SERVICE = zeroconf.ZeroconfServiceInfo(
 )
 
 
-AIRPORT_SERVICE = zeroconf.ZeroconfServiceInfo(
-    host="127.0.0.1",
-    hostname="mock_hostname",
-    port=None,
-    type="_airport._tcp.local.",
-    name="Master Bed._airport._tcp.local.",
-    properties={},
-)
-
-
 @pytest.fixture(autouse=True)
 def zero_aggregation_time():
     """Prevent the aggregation time from delaying the tests."""
@@ -1063,16 +1053,3 @@ async def test_option_start_off(hass):
     assert result2["type"] == "create_entry"
 
     assert config_entry.options[CONF_START_OFF]
-
-
-async def test_zeroconf_abort_on_ip_update_services_only(
-    hass, mock_scan, pairing, mock_zeroconf
-):
-    """Test abort on ip update services only."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_ZEROCONF},
-        data=AIRPORT_SERVICE,
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "device_not_found"

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -40,6 +40,16 @@ RAOP_SERVICE = zeroconf.ZeroconfServiceInfo(
 )
 
 
+AIRPORT_SERVICE = zeroconf.ZeroconfServiceInfo(
+    host="127.0.0.1",
+    hostname="mock_hostname",
+    port=None,
+    type="_airport._tcp.local.",
+    name="Master Bed._airport._tcp.local.",
+    properties={},
+)
+
+
 @pytest.fixture(autouse=True)
 def zero_aggregation_time():
     """Prevent the aggregation time from delaying the tests."""
@@ -1053,3 +1063,16 @@ async def test_option_start_off(hass):
     assert result2["type"] == "create_entry"
 
     assert config_entry.options[CONF_START_OFF]
+
+
+async def test_zeroconf_abort_on_ip_update_services_only(
+    hass, mock_scan, pairing, mock_zeroconf
+):
+    """Test abort on ip update services only."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=AIRPORT_SERVICE,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "device_not_found"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use zeroconf for scanning in apple_tv

Fixes https://github.com/postlund/pyatv/issues/1570
Changes: https://github.com/postlund/pyatv/compare/v0.9.8...v0.10.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
