### PR TITLE
Fix bug for zwave_js diagnostics

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -301,7 +301,6 @@ def async_register_api(hass: HomeAssistant) -> None:
     """Register all of our api endpoints."""
     websocket_api.async_register_command(hass, websocket_network_status)
     websocket_api.async_register_command(hass, websocket_node_status)
-    websocket_api.async_register_command(hass, websocket_node_state)
     websocket_api.async_register_command(hass, websocket_node_metadata)
     websocket_api.async_register_command(hass, websocket_ping_node)
     websocket_api.async_register_command(hass, websocket_add_node)
@@ -465,29 +464,6 @@ async def websocket_node_status(
     connection.send_result(
         msg[ID],
         data,
-    )
-
-
-@websocket_api.require_admin
-@websocket_api.websocket_command(
-    {
-        vol.Required(TYPE): "zwave_js/node_state",
-        vol.Required(ENTRY_ID): str,
-        vol.Required(NODE_ID): int,
-    }
-)
-@websocket_api.async_response
-@async_get_node
-async def websocket_node_state(
-    hass: HomeAssistant,
-    connection: ActiveConnection,
-    msg: dict,
-    node: Node,
-) -> None:
-    """Get the state data of a Z-Wave JS node."""
-    connection.send_result(
-        msg[ID],
-        {**node.data, "values": [value.data for value in node.values.values()]},
     )
 
 

--- a/homeassistant/components/zwave_js/diagnostics.py
+++ b/homeassistant/components/zwave_js/diagnostics.py
@@ -34,4 +34,5 @@ async def async_get_device_diagnostics(
     node_id = identifiers[1] if identifiers else None
     if node_id is None or node_id not in client.driver.controller.nodes:
         raise ValueError(f"Node for device {device.id} can't be found")
-    return client.driver.controller.nodes[node_id].data
+    node = client.driver.controller.nodes[node_id]
+    return {**node.data, "values": [value.data for value in node.values.values()]}

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import pytest
 from zwave_js_server.const import (
-    CommandClass,
     InclusionStrategy,
     LogLevel,
     Protocols,
@@ -27,7 +26,6 @@ from zwave_js_server.model.controller import (
     QRProvisioningInformation,
 )
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import _get_value_id_from_dict, get_value_id
 
 from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 from homeassistant.components.zwave_js.api import (
@@ -71,8 +69,6 @@ from homeassistant.components.zwave_js.const import (
     DOMAIN,
 )
 from homeassistant.helpers import device_registry as dr
-
-from .common import PROPERTY_ULTRAVIOLET
 
 
 async def test_network_status(hass, integration, hass_ws_client):
@@ -193,86 +189,6 @@ async def test_node_status(hass, multisensor_6, integration, hass_ws_client):
         {
             ID: 5,
             TYPE: "zwave_js/node_status",
-            ENTRY_ID: entry.entry_id,
-            NODE_ID: node.node_id,
-        }
-    )
-    msg = await ws_client.receive_json()
-
-    assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_LOADED
-
-
-async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
-    """Test the node_state websocket command."""
-    entry = integration
-    ws_client = await hass_ws_client(hass)
-
-    node = multisensor_6
-
-    # Update a value and ensure it is reflected in the node state
-    value_id = get_value_id(node, CommandClass.SENSOR_MULTILEVEL, PROPERTY_ULTRAVIOLET)
-    event = Event(
-        type="value updated",
-        data={
-            "source": "node",
-            "event": "value updated",
-            "nodeId": node.node_id,
-            "args": {
-                "commandClassName": "Multilevel Sensor",
-                "commandClass": 49,
-                "endpoint": 0,
-                "property": PROPERTY_ULTRAVIOLET,
-                "newValue": 1,
-                "prevValue": 0,
-                "propertyName": PROPERTY_ULTRAVIOLET,
-            },
-        },
-    )
-    node.receive_event(event)
-
-    await ws_client.send_json(
-        {
-            ID: 3,
-            TYPE: "zwave_js/node_state",
-            ENTRY_ID: entry.entry_id,
-            NODE_ID: node.node_id,
-        }
-    )
-    msg = await ws_client.receive_json()
-
-    # Assert that the data returned doesn't match the stale node state data
-    assert msg["result"] != node.data
-
-    # Replace data for the value we updated and assert the new node data is the same
-    # as what's returned
-    updated_node_data = node.data.copy()
-    for n, value in enumerate(updated_node_data["values"]):
-        if _get_value_id_from_dict(node, value) == value_id:
-            updated_node_data["values"][n] = node.values[value_id].data.copy()
-    assert msg["result"] == updated_node_data
-
-    # Test getting non-existent node fails
-    await ws_client.send_json(
-        {
-            ID: 4,
-            TYPE: "zwave_js/node_state",
-            ENTRY_ID: entry.entry_id,
-            NODE_ID: 99999,
-        }
-    )
-    msg = await ws_client.receive_json()
-    assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
-
-    # Test sending command with not loaded entry fails
-    await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
-
-    await ws_client.send_json(
-        {
-            ID: 5,
-            TYPE: "zwave_js/node_state",
             ENTRY_ID: entry.entry_id,
             NODE_ID: node.node_id,
         }

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -2,10 +2,15 @@
 from unittest.mock import patch
 
 import pytest
+from zwave_js_server.const import CommandClass
+from zwave_js_server.event import Event
+from zwave_js_server.model.value import _get_value_id_from_dict, get_value_id
 
 from homeassistant.components.zwave_js.diagnostics import async_get_device_diagnostics
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.helpers.device_registry import async_get
+
+from .common import PROPERTY_ULTRAVIOLET
 
 from tests.components.diagnostics import (
     get_diagnostics_for_config_entry,
@@ -27,19 +32,54 @@ async def test_config_entry_diagnostics(hass, hass_client, integration):
 async def test_device_diagnostics(
     hass,
     client,
-    aeon_smart_switch_6,
-    aeon_smart_switch_6_state,
+    multisensor_6,
     integration,
     hass_client,
 ):
     """Test the device level diagnostics data dump."""
     dev_reg = async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client, aeon_smart_switch_6)})
+    device = dev_reg.async_get_device({get_device_id(client, multisensor_6)})
     assert device
-    assert (
-        await get_diagnostics_for_device(hass, hass_client, integration, device)
-        == aeon_smart_switch_6_state
+
+    # Update a value and ensure it is reflected in the node state
+    value_id = get_value_id(
+        multisensor_6, CommandClass.SENSOR_MULTILEVEL, PROPERTY_ULTRAVIOLET
     )
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": multisensor_6.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": PROPERTY_ULTRAVIOLET,
+                "newValue": 1,
+                "prevValue": 0,
+                "propertyName": PROPERTY_ULTRAVIOLET,
+            },
+        },
+    )
+    multisensor_6.receive_event(event)
+
+    diagnostics_data = await get_diagnostics_for_device(
+        hass, hass_client, integration, device
+    )
+
+    # Assert that the data returned doesn't match the stale node state data
+    assert diagnostics_data != multisensor_6.data
+
+    # Replace data for the value we updated and assert the new node data is the same
+    # as what's returned
+    updated_node_data = multisensor_6.data.copy()
+    for idx, value in enumerate(updated_node_data["values"]):
+        if _get_value_id_from_dict(multisensor_6, value) == value_id:
+            updated_node_data["values"][idx] = multisensor_6.values[
+                value_id
+            ].data.copy()
+    assert diagnostics_data == updated_node_data
 
 
 async def test_device_diagnostics_error(hass, integration):


### PR DESCRIPTION
## Proposed change
I was originally planning to just remove the WS API command to get node state since it will now be retrieved via diagnostics (we never implemented anything for this command in the frontend). While doing so I recalled that the node data's values dict becomes stale because updates go to the `Value` directly. I basically mirrored the same logic I had added to the WS API command in the diagnostics command.

Side note: We may want to consider opening an issue to update the node state data along with the value data because the staleness of the node state data is not going to be immediately obvious to a new consumer of the lib and could result in extra cycles trying to troubleshoot an issue.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
