### PR TITLE
Mark webOS TV as a platinum quality integration

### DIFF
--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -6,5 +6,6 @@
   "requirements": ["aiowebostv==0.1.1", "sqlalchemy==1.4.27"],
   "codeowners": ["@bendavid", "@thecode"],
   "ssdp": [{"st": "urn:lge-com:service:webos-second-screen:1"}],
-  "iot_class": "local_polling"
+  "quality_scale": "platinum",
+  "iot_class": "local_push"
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### Silver 🥈

- ✅ Connection/configuration is handled via a component.
- ✅ Set an appropriate SCAN_INTERVAL (if a polling integration)
   > ℹ️ Doesn't apply (local_push)
- ✅ Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
   > ℹ️ Doesn't apply - device is allowed to be off during setup
- ✅ Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.
   > ℹ️ Doesn't apply
- ✅ Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- ✅ Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- ✅ Set available property to False if appropriate
- ✅ Entities have unique ID (if available) (docs)

### Gold 🥇

- ✅ Configurable via config entries.
- ✅ Don't allow configuring already configured device/service (example: no 2 entries for same hub)
- ✅ Tests for the config flow
- ✅ Discoverable (if available)
- ✅ Set unique ID in config flow (if available)
- ✅ Raise ConfigEntryNotReady if unable to connect during entry setup (if appropriate)
   > ℹ️ Doesn't apply
- ✅ Entities have device info (if available)
- ✅ Tests for fetching data from the integration and controlling it (docs)
- ✅ Has a code owner @thecode
- ✅ Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass (docs)
- ✅ Entities have correct device classes where appropriate
- ✅ Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities
- ✅ If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
   > ℹ️Doesn't apply

### Platinum 🏆

- ✅ Set appropriate PARALLEL_UPDATES constant
  > ℹ️ Doesn't apply
- ✅ Support config entry unloading (called when config entry is removed)
- ✅ Integration + dependency are async (docs)
- ✅ Uses aiohttp or httpx and allows passing in websession (if making HTTP requests)
  > ℹ️ Doesn't apply
  
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
