### PR TITLE
Add IntelliFire sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -513,6 +513,7 @@ omit =
     homeassistant/components/intellifire/__init__.py
     homeassistant/components/intellifire/coordinator.py
     homeassistant/components/intellifire/binary_sensor.py
+    homeassistant/components/intellifire/sensor.py
     homeassistant/components/incomfort/*
     homeassistant/components/intesishome/*
     homeassistant/components/ios/*

--- a/homeassistant/components/intellifire/__init__.py
+++ b/homeassistant/components/intellifire/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN, LOGGER
 from .coordinator import IntellifireDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/intellifire/binary_sensor.py
+++ b/homeassistant/components/intellifire/binary_sensor.py
@@ -20,7 +20,7 @@ from .const import DOMAIN
 
 
 @dataclass
-class IntellifireBinarySensorEntityDescriptionMixin:
+class IntellifireBinarySensorRequiredKeysMixin:
     """Mixin for required keys."""
 
     value_fn: Callable[[IntellifirePollData], bool]
@@ -28,7 +28,7 @@ class IntellifireBinarySensorEntityDescriptionMixin:
 
 @dataclass
 class IntellifireBinarySensorEntityDescription(
-    BinarySensorEntityDescription, IntellifireBinarySensorEntityDescriptionMixin
+    BinarySensorEntityDescription, IntellifireBinarySensorRequiredKeysMixin
 ):
     """Describes a binary sensor entity."""
 

--- a/homeassistant/components/intellifire/binary_sensor.py
+++ b/homeassistant/components/intellifire/binary_sensor.py
@@ -20,7 +20,7 @@ from .const import DOMAIN
 
 
 @dataclass
-class IntellifireSensorEntityDescriptionMixin:
+class IntellifireBinarySensorEntityDescriptionMixin:
     """Mixin for required keys."""
 
     value_fn: Callable[[IntellifirePollData], bool]
@@ -28,7 +28,7 @@ class IntellifireSensorEntityDescriptionMixin:
 
 @dataclass
 class IntellifireBinarySensorEntityDescription(
-    BinarySensorEntityDescription, IntellifireSensorEntityDescriptionMixin
+    BinarySensorEntityDescription, IntellifireBinarySensorEntityDescriptionMixin
 ):
     """Describes a binary sensor entity."""
 

--- a/homeassistant/components/intellifire/manifest.json
+++ b/homeassistant/components/intellifire/manifest.json
@@ -3,12 +3,8 @@
   "name": "IntelliFire",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/intellifire",
-  "requirements": [
-    "intellifire4py==0.4.3"
-  ],
+  "requirements": ["intellifire4py==0.5"],
   "dependencies": [],
-  "codeowners": [
-    "@jeeftor"
-  ],
+  "codeowners": ["@jeeftor"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -39,9 +39,6 @@ class IntellifireSensorEntityDescription(
     """Describes a sensor sensor entity."""
 
 
-ATTRIBUTION = "Data provided by unpublished Intellifire API"
-
-
 INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
     IntellifireSensorEntityDescription(
         key="flame_height",

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -75,7 +75,9 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:timer-sand",
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: (
+        value_fn=lambda data: "disabled"
+        if (data.timeremaining_s == 0)
+        else (
             datetime.datetime.now() + datetime.timedelta(seconds=data.timeremaining_s)
         ).strftime("%X"),
     ),

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from intellifire4py import IntellifirePollData
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -12,12 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ATTRIBUTION,
-    DEVICE_CLASS_TEMPERATURE,
-    TEMP_CELSIUS,
-    TIME_MINUTES,
-)
+from homeassistant.const import TEMP_CELSIUS, TIME_MINUTES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -122,6 +122,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:timer-sand",
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data: _time_remaining_to_timestamp(data),
     ),
 )

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -135,7 +135,6 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:timer-sand",
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
-        entity_class=IntellifireTimeSensor,
-        value_fn=lambda data: data.timeremaining_s,
+        value_fn=_time_remaining_to_timestamp,
     ),
 )

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -78,7 +78,7 @@ class IntellifireSensorRequiredKeysMixin:
 
     # Although sensors could have a variety of different return values,
     # all the ones below are only returning ints
-    value_fn: Callable[[IntellifirePollData], int | str]
+    value_fn: Callable[[IntellifirePollData], int | str | datetime | None]
 
 
 @dataclass

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -79,7 +79,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         if (data.timeremaining_s == 0)
         else (
             datetime.datetime.now() + datetime.timedelta(seconds=data.timeremaining_s)
-        ).strftime("%X"),
+        ).strftime("%I:%M %p"),
     ),
 )
 

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -49,7 +49,7 @@ class IntellifireSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = self.coordinator.device_info
 
     @property
-    def native_value(self) -> int | str | datetime:
+    def native_value(self) -> int | str | datetime | None:
         """Return the state."""
         # return self.entity_description.value_fn(self.coordinator.api.data)
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -27,7 +27,7 @@ from .const import DOMAIN
 
 
 @dataclass
-class IntellifireSensorRequireKeysMixin:
+class IntellifireSensorRequiredKeysMixin:
     """Mixin for required keys."""
 
     # Although sensors could have a variety of different return values,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 
 from intellifire4py import IntellifirePollData
 
+from intellifire4py import IntellifirePollData
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -75,7 +75,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:timer-sand",
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: "disabled"
+        value_fn=lambda data: "Off"
         if (data.timeremaining_s == 0)
         else (
             datetime.datetime.now() + datetime.timedelta(seconds=data.timeremaining_s)

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -7,8 +7,6 @@ from datetime import datetime, timedelta
 
 from intellifire4py import IntellifirePollData
 
-from intellifire4py import IntellifirePollData
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -20,7 +18,6 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.dt import utcnow
 
 from . import IntellifireDataUpdateCoordinator
 from .const import DOMAIN
@@ -55,12 +52,9 @@ class IntellifireSensor(CoordinatorEntity, SensorEntity):
         return self.entity_description.value_fn(self.coordinator.api.data)
 
 
-def _time_remaining_to_timestamp(seconds_offset: int) -> datetime | None:
+def _time_remaining_to_timestamp(data: IntellifirePollData) -> datetime | None:
     """Define a sensor that takes into account timezone."""
-    #    seconds_offset = coordinator.api.data.timeremaining_s
-
-    # If disabled return None - else return a timestamp with correct TZ info
-    if seconds_offset == 0:
+    if not (seconds_offset := data.timeremaining_s):
         return None
     return (datetime.now() + timedelta(seconds=seconds_offset)).replace(microsecond=0)
 
@@ -127,6 +121,6 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:timer-sand",
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: _time_remaining_to_timestamp(data.timeremaining_s),
+        value_fn=lambda data: _time_remaining_to_timestamp(data),
     ),
 )

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.dt import utcnow
 
 from . import IntellifireDataUpdateCoordinator
 from .const import DOMAIN

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -61,7 +61,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         key="target_temp",
         name="Target Temperature",
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         value_fn=lambda data: data.thermostat_setpoint_c,
     ),

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -75,7 +75,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:timer-sand",
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: "Off"
+        value_fn=lambda data: "Stopped"
         if (data.timeremaining_s == 0)
         else (
             datetime.datetime.now() + datetime.timedelta(seconds=data.timeremaining_s)

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -37,7 +37,7 @@ class IntellifireSensorRequireKeysMixin:
 
 @dataclass
 class IntellifireSensorEntityDescription(
-    SensorEntityDescription, IntellifireSensorRequireKeysMixin
+    SensorEntityDescription, IntellifireSensorRequiredKeysMixin
 ):
     """Describes a sensor sensor entity."""
 

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -54,7 +54,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         icon="mdi:car-brake-temperature",
         name="Temperature",
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         value_fn=lambda data: data.temperature_c,
     ),

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -123,6 +123,6 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         name="Timer End",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data: _time_remaining_to_timestamp(data),
+        value_fn=_time_remaining_to_timestamp,
     ),
 )

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -57,7 +57,7 @@ def _time_remaining_to_timestamp(data: IntellifirePollData) -> datetime | None:
     """Define a sensor that takes into account timezone."""
     if not (seconds_offset := data.timeremaining_s):
         return None
-    return (datetime.now() + timedelta(seconds=seconds_offset)).replace(microsecond=0)
+    return utcnow() + timedelta(seconds=seconds_offset)
 
 
 @dataclass

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -51,7 +51,6 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
     ),
     IntellifireSensorEntityDescription(
         key="temperature",
-        icon="mdi:car-brake-temperature",
         name="Temperature",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -54,22 +54,17 @@ class IntellifireSensor(CoordinatorEntity, SensorEntity):
         return self.entity_description.value_fn(self.coordinator.api.data)
 
 
-class IntellifireTimeSensor(IntellifireSensor):
+def _time_remaining_to_timestamp(data: IntellifirePollData) -> datetime | None:
     """Define a sensor that takes into account timezone."""
 
-    @property
-    def native_value(self) -> Any:
-        """Return a datetime value."""
-        seconds_offset = int(
-            self.entity_description.value_fn(self.coordinator.api.data)
-        )
-        # If disabled return None - else return a timestamp with correct TZ info
-        if seconds_offset == 0:
-            return None
+    seconds_offset = data.timeremaining_s
+    # If disabled return None - else return a timestamp with correct TZ info
+    if seconds_offset == 0:
+        return None
 
-        return datetime.now().replace(
-            tzinfo=pytz.timezone(self.hass.config.time_zone)
-        ) + timedelta(seconds=seconds_offset)
+    return datetime.now().replace(
+        tzinfo=pytz.timezone(self.hass.config.time_zone)
+    ) + timedelta(seconds=seconds_offset)
 
 
 @dataclass

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -60,7 +60,6 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
     ),
     IntellifireSensorEntityDescription(
         key="target_temp",
-        icon="mdi:thermometer-lines",
         name="Target Temperature",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=DEVICE_CLASS_TEMPERATURE,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -107,6 +107,7 @@ class IntellifireSensor(CoordinatorEntity, SensorEntity):
     # Define types
     coordinator: IntellifireDataUpdateCoordinator
     entity_description: IntellifireSensorEntityDescription
+    _attr_attribution = "Data provided by unpublished Intellifire API"
 
     def __init__(
         self,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -125,6 +125,6 @@ class IntellifireSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = self.coordinator.device_info
 
     @property
-    def native_value(self):
+    def native_value(self) -> int:
         """Return the state."""
         return self.entity_description.value_fn(self.coordinator.api.data)

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -30,9 +30,11 @@ from .const import DOMAIN
 class IntellifireSensorEntityDescriptionMixin:
     """Mixin for required keys."""
 
+    # Although sensors could have a variety of different return values,
+    # all the ones below are only returning ints
     value_fn: Callable[
         [IntellifirePollData], int
-    ]  # Although sensours could have a variety of different return values - all the ones below are only reutrning ints
+    ]
 
 
 @dataclass

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 from intellifire4py import IntellifirePollData
 
-from homeassistant.components.intellifire import IntellifireDataUpdateCoordinator
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -23,6 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import IntellifireDataUpdateCoordinator
 from .const import DOMAIN
 
 

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -118,7 +118,6 @@ class IntellifireSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator=coordinator)
         self.entity_description = description
 
-        self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         # Set the Display name the User will see
         self._attr_name = f"Fireplace {description.name}"
         self._attr_unique_id = f"{description.key}_{coordinator.api.data.serial}"

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -27,19 +27,17 @@ from .const import DOMAIN
 
 
 @dataclass
-class IntellifireSensorEntityDescriptionMixin:
+class IntellifireSensorRequireKeysMixin:
     """Mixin for required keys."""
 
     # Although sensors could have a variety of different return values,
     # all the ones below are only returning ints
-    value_fn: Callable[
-        [IntellifirePollData], int
-    ]
+    value_fn: Callable[[IntellifirePollData], int]
 
 
 @dataclass
 class IntellifireSensorEntityDescription(
-    SensorEntityDescription, IntellifireSensorEntityDescriptionMixin
+    SensorEntityDescription, IntellifireSensorRequireKeysMixin
 ):
     """Describes a sensor sensor entity."""
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -914,7 +914,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.4.3
+intellifire4py==0.5
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -586,7 +586,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.4.3
+intellifire4py==0.5
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Adding the `sensor` entities into the IntelliFire integration + Dependency Bump


#### intellifire4py version 0.5

I found a bug in the HTML returned by the fireplace in that it doesn't have proper MIME typing so in my module I changed from:

```python
                    json_data = await response.json()
```
to 
```python
                    json_data = await response.json(content_type=None)
```

which allows for improper mime-typed JSON data. This should solve an issue that I missed when I was using a mock fireplace return which was proper HTML

https://github.com/jeeftor/intellifire4py/commit/802ac5939300385b4ab396ad50ee10087429445a#diff-62214b24e25e35bdb90640cbfa5dccc883f2a174793015a6e75c4acbe5600983

## Type of change

Currently has `binary_sensors` this PR adds in the `sensors`

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/compare/next...jeeftor:patch-1

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
