### PR TITLE
Revert "Add version constraint for `google-auth`"

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -92,7 +92,3 @@ pytest_asyncio==1000000000.0.0
 # https://github.com/jkeljo/sisyphus-control/issues/6
 python-engineio>=3.13.1,<4.0
 python-socketio>=4.6.0,<5.0
-
-# Resolve a dependency conflict with cachetools.
-# Version 2.4.0 bumps the allowed dependency range.
-google-auth>=2.4.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -117,10 +117,6 @@ pytest_asyncio==1000000000.0.0
 # https://github.com/jkeljo/sisyphus-control/issues/6
 python-engineio>=3.13.1,<4.0
 python-socketio>=4.6.0,<5.0
-
-# Resolve a dependency conflict with cachetools.
-# Version 2.4.0 bumps the allowed dependency range.
-google-auth>=2.4.0
 """
 
 IGNORE_PRE_COMMIT_HOOK_ID = (

--- a/script/pip_check
+++ b/script/pip_check
@@ -3,7 +3,7 @@ PIP_CACHE=$1
 
 # Number of existing dependency conflicts
 # Update if a PR resolve one!
-DEPENDENCY_CONFLICTS=13
+DEPENDENCY_CONFLICTS=14
 
 PIP_CHECK=$(pip check --cache-dir=$PIP_CACHE)
 LINE_COUNT=$(echo "$PIP_CHECK" | wc -l)


### PR DESCRIPTION
Reverts home-assistant/core#64583 as google-auth 2.4.0 was yanked: https://pypi.org/project/google-auth/#history



Dev build currently fails w/:
 ERROR: Could not find a version that satisfies the requirement google-auth>=2.4.0 (from -c homeassistant/homeassistant/package_constraints.txt (line 98)) (from versions: 1.35.0, 2.0.1, 2.3.3)

e.g. https://github.com/home-assistant/core/runs/4891168174?check_suite_focus=true