### PR TITLE
Add type hint to RegistryEntry.entity_category

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -227,7 +227,7 @@ class EntityDescription:
     key: str
 
     device_class: str | None = None
-    # Type Literal (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
+    # Type string is deprecated as of 2021.12, use EntityCategory
     entity_category: EntityCategory | Literal[
         "config", "diagnostic", "system"
     ] | None = None
@@ -459,7 +459,7 @@ class Entity(ABC):
         """Return the attribution."""
         return self._attr_attribution
 
-    # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
+    # Type str is deprecated as of 2021.12, use EntityCategory
     @property
     def entity_category(self) -> EntityCategory | str | None:
         """Return the category of the entity, if any."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -11,7 +11,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import Any, Final, Literal, TypedDict, final
+from typing import Any, Final, TypedDict, final
 
 import voluptuous as vol
 
@@ -200,6 +200,24 @@ class EntityCategory(StrEnum):
     SYSTEM = "system"
 
 
+def convert_to_entity_category(
+    value: EntityCategory | str | None,
+) -> EntityCategory | None:
+    """Force incoming entity_category to be an enum."""
+
+    if value is None:
+        return value
+
+    if not isinstance(value, EntityCategory):
+        _LOGGER.warning(
+            "An entity_category should only be assigned an enum.  Strings or other assignments are deprecated. Value %s is type %s",
+            value,
+            type(value),
+        )
+        return EntityCategory(value)
+    return value
+
+
 @dataclass
 class EntityDescription:
     """A class that describes Home Assistant entities."""
@@ -208,9 +226,8 @@ class EntityDescription:
     key: str
 
     device_class: str | None = None
-    entity_category: EntityCategory | Literal[
-        "config", "diagnostic", "system"
-    ] | None = None
+    # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
+    entity_category: EntityCategory | str | None = None
     entity_registry_enabled_default: bool = True
     force_update: bool = False
     icon: str | None = None
@@ -272,7 +289,7 @@ class Entity(ABC):
     _attr_context_recent_time: timedelta = timedelta(seconds=5)
     _attr_device_class: str | None
     _attr_device_info: DeviceInfo | None = None
-    _attr_entity_category: EntityCategory | str | None
+    _attr_entity_category: EntityCategory | None
     _attr_entity_picture: str | None = None
     _attr_entity_registry_enabled_default: bool
     _attr_extra_state_attributes: MutableMapping[str, Any]
@@ -439,6 +456,7 @@ class Entity(ABC):
         """Return the attribution."""
         return self._attr_attribution
 
+    # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
     @property
     def entity_category(self) -> EntityCategory | str | None:
         """Return the category of the entity, if any."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -11,7 +11,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import Any, Final, TypedDict, final
+from typing import Any, Final, Literal, TypedDict, final
 
 import voluptuous as vol
 
@@ -226,8 +226,10 @@ class EntityDescription:
     key: str
 
     device_class: str | None = None
-    # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
-    entity_category: EntityCategory | str | None = None
+    # Type Literal (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
+    entity_category: EntityCategory | Literal[
+        "config", "diagnostic", "system"
+    ] | None = None
     entity_registry_enabled_default: bool = True
     force_update: bool = False
     icon: str | None = None

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -37,7 +37,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, NoEntitySpecifiedError
-from homeassistant.helpers.frame import report
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
 
@@ -45,6 +44,7 @@ from . import entity_registry as er
 from .device_registry import DeviceEntryType
 from .entity_platform import EntityPlatform
 from .event import Event, async_track_entity_registry_updated_event
+from .frame import report
 from .typing import StateType
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, NoEntitySpecifiedError
+from homeassistant.helpers.frame import report
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
 
@@ -209,10 +210,10 @@ def convert_to_entity_category(
         return value
 
     if not isinstance(value, EntityCategory):
-        _LOGGER.warning(
-            "An entity_category should only be assigned an enum.  Strings or other assignments are deprecated. Value %s is type %s",
-            value,
-            type(value),
+        report(
+            "An entity_category should only be assigned an enum.  Strings or other assignments are deprecated. Value %s is type %s"
+            % (value, type(value)),
+            error_if_core=False,
         )
         return EntityCategory(value)
     return value

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -50,6 +50,8 @@ from .typing import UNDEFINED, UndefinedType
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
+    from .entity import EntityCategory
+
 PATH_REGISTRY = "entity_registry.yaml"
 DATA_REGISTRY = "entity_registry"
 EVENT_ENTITY_REGISTRY_UPDATED = "entity_registry_updated"
@@ -91,6 +93,16 @@ DISABLED_INTEGRATION = RegistryEntryDisabler.INTEGRATION.value
 DISABLED_USER = RegistryEntryDisabler.USER.value
 
 
+def _convert_to_entity_category(
+    value: EntityCategory | str | None,
+) -> EntityCategory | None:
+    """Force incoming entity_category to be an enum."""
+    # pylint: disable=import-outside-toplevel
+    from .entity import convert_to_entity_category
+
+    return convert_to_entity_category(value)
+
+
 @attr.s(slots=True, frozen=True)
 class RegistryEntry:
     """Entity Registry Entry."""
@@ -105,7 +117,9 @@ class RegistryEntry:
     device_id: str | None = attr.ib(default=None)
     domain: str = attr.ib(init=False, repr=False)
     disabled_by: RegistryEntryDisabler | None = attr.ib(default=None)
-    entity_category: str | None = attr.ib(default=None)
+    entity_category: EntityCategory | None = attr.ib(
+        default=None, converter=_convert_to_entity_category
+    )
     icon: str | None = attr.ib(default=None)
     id: str = attr.ib(factory=uuid_util.random_uuid_hex)
     name: str | None = attr.ib(default=None)
@@ -320,7 +334,8 @@ class EntityRegistry:
         capabilities: Mapping[str, Any] | None = None,
         config_entry: ConfigEntry | None = None,
         device_id: str | None = None,
-        entity_category: str | None = None,
+        # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
+        entity_category: EntityCategory | str | None = None,
         original_device_class: str | None = None,
         original_icon: str | None = None,
         original_name: str | None = None,
@@ -467,7 +482,7 @@ class EntityRegistry:
         config_entry_id: str | None | UndefinedType = UNDEFINED,
         device_class: str | None | UndefinedType = UNDEFINED,
         disabled_by: RegistryEntryDisabler | None | UndefinedType = UNDEFINED,
-        entity_category: str | None | UndefinedType = UNDEFINED,
+        entity_category: EntityCategory | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         new_entity_id: str | UndefinedType = UNDEFINED,
@@ -506,7 +521,8 @@ class EntityRegistry:
         device_class: str | None | UndefinedType = UNDEFINED,
         device_id: str | None | UndefinedType = UNDEFINED,
         disabled_by: RegistryEntryDisabler | None | UndefinedType = UNDEFINED,
-        entity_category: str | None | UndefinedType = UNDEFINED,
+        # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
+        entity_category: EntityCategory | str | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         new_entity_id: str | UndefinedType = UNDEFINED,


### PR DESCRIPTION
Backup of #62225 following bad merge/rebase
cc @davet2001

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As per [this request](https://github.com/home-assistant/core/pull/62117#discussion_r771165336) from @epenet, it seems that the type hint for `RegistryEntry.entity_category` might benefit from updating to include `EntityCategory`.

Full disclosure: I am not that familiar with this part of the code, so definitely need someone to review this and the implications, in particular:

- Is `EntityCategory | str | None` correct, or should it be:
  - `EntityCategory | None`
  - `EntityCategory`
- Maybe the `str` can be removed at the end of the deprecation period (if so is a comment a good way to indicate this?).
- Does anything need to change with `attr.ib(default=None)`? I am not v familiar with that either.
- Putting the import inside the if statement seemed to be necessary to prevent circular import errors, but I don't fully understand why.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
