### PR TITLE
Fix incorrect usage of ToggleEntity in switch platforms

### DIFF
--- a/homeassistant/components/advantage_air/switch.py
+++ b/homeassistant/components/advantage_air/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for Advantage Air integration."""
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -28,7 +28,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class AdvantageAirFreshAir(AdvantageAirEntity, ToggleEntity):
+class AdvantageAirFreshAir(AdvantageAirEntity, SwitchEntity):
     """Representation of Advantage Air fresh air control."""
 
     _attr_icon = "mdi:air-filter"

--- a/homeassistant/components/bbb_gpio/switch.py
+++ b/homeassistant/components/bbb_gpio/switch.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.components import bbb_gpio
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -44,7 +43,7 @@ def setup_platform(
     add_entities(switches)
 
 
-class BBBGPIOSwitch(ToggleEntity):
+class BBBGPIOSwitch(SwitchEntity):
     """Representation of a BeagleBone Black GPIO."""
 
     _attr_should_poll = False

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Daikin climate based on config_entry."""
     daikin_api = hass.data[DAIKIN_DOMAIN][entry.entry_id]
-    switches: list[SwitchEntity] = []
+    switches: list[DaikinZoneSwitch | DaikinStreamerSwitch] = []
     if zones := daikin_api.device.zones:
         switches.extend(
             [

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -34,7 +33,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Daikin climate based on config_entry."""
     daikin_api = hass.data[DAIKIN_DOMAIN][entry.entry_id]
-    switches: list[ToggleEntity] = []
+    switches: list[SwitchEntity] = []
     if zones := daikin_api.device.zones:
         switches.extend(
             [
@@ -52,7 +51,7 @@ async def async_setup_entry(
         async_add_entities(switches)
 
 
-class DaikinZoneSwitch(ToggleEntity):
+class DaikinZoneSwitch(SwitchEntity):
     """Representation of a zone."""
 
     def __init__(self, daikin_api, zone_id):

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -6,7 +6,7 @@ import logging
 from deluge_client import DelugeRPCClient, FailedToReconnectException
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -19,7 +19,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -63,7 +62,7 @@ def setup_platform(
     add_entities([DelugeSwitch(deluge_api, name)])
 
 
-class DelugeSwitch(ToggleEntity):
+class DelugeSwitch(SwitchEntity):
     """Representation of a Deluge switch."""
 
     def __init__(self, deluge_client, name):

--- a/homeassistant/components/enocean/switch.py
+++ b/homeassistant/components/enocean/switch.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -39,7 +38,7 @@ def setup_platform(
     add_entities([EnOceanSwitch(dev_id, dev_name, channel)])
 
 
-class EnOceanSwitch(EnOceanEntity, ToggleEntity):
+class EnOceanSwitch(EnOceanEntity, SwitchEntity):
     """Representation of an EnOcean switch device."""
 
     def __init__(self, dev_id, dev_name, channel):

--- a/homeassistant/components/gc100/switch.py
+++ b/homeassistant/components/gc100/switch.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -35,7 +34,7 @@ def setup_platform(
     add_entities(switches, True)
 
 
-class GC100Switch(ToggleEntity):
+class GC100Switch(SwitchEntity):
     """Represent a switch/relay from GC100."""
 
     def __init__(self, name, port_addr, gc100):

--- a/homeassistant/components/hlk_sw16/switch.py
+++ b/homeassistant/components/hlk_sw16/switch.py
@@ -1,5 +1,5 @@
 """Support for HLK-SW16 switches."""
-from homeassistant.components.switch import ToggleEntity
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,7 +28,7 @@ async def async_setup_entry(
     async_add_entities(devices_from_entities(hass, entry))
 
 
-class SW16Switch(SW16Device, ToggleEntity):
+class SW16Switch(SW16Device, SwitchEntity):
     """Representation of a HLK-SW16 switch."""
 
     @property

--- a/homeassistant/components/konnected/switch.py
+++ b/homeassistant/components/konnected/switch.py
@@ -1,6 +1,7 @@
 """Support for wired switches attached to a Konnected device."""
 import logging
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_STATE,
@@ -12,7 +13,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, ToggleEntity
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -42,7 +43,7 @@ async def async_setup_entry(
     async_add_entities(switches)
 
 
-class KonnectedSwitch(ToggleEntity):
+class KonnectedSwitch(SwitchEntity):
     """Representation of a Konnected switch."""
 
     def __init__(self, device_id, zone_num, data):

--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -9,11 +9,10 @@ import busio
 import digitalio
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -65,7 +64,7 @@ def setup_platform(
     add_entities(switches)
 
 
-class MCP23017Switch(ToggleEntity):
+class MCP23017Switch(SwitchEntity):
     """Representation of a  MCP23017 output pin."""
 
     def __init__(self, name, pin, invert_logic):

--- a/homeassistant/components/neato/switch.py
+++ b/homeassistant/components/neato/switch.py
@@ -8,10 +8,11 @@ from typing import Any
 from pybotvac.exceptions import NeatoRobotException
 from pybotvac.robot import Robot
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory, ToggleEntity
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import NEATO_DOMAIN, NEATO_LOGIN, NEATO_ROBOTS, SCAN_INTERVAL_MINUTES
@@ -44,7 +45,7 @@ async def async_setup_entry(
     async_add_entities(dev, True)
 
 
-class NeatoConnectedSwitch(ToggleEntity):
+class NeatoConnectedSwitch(SwitchEntity):
     """Neato Connected Switches."""
 
     def __init__(self, neato: NeatoHub, robot: Robot, switch_type: str) -> None:

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from pycarwings2.pycarwings2 import Leaf
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -35,7 +35,7 @@ def setup_platform(
     add_entities(entities, True)
 
 
-class LeafClimateSwitch(LeafEntity, ToggleEntity):
+class LeafClimateSwitch(LeafEntity, SwitchEntity):
     """Nissan Leaf Climate Control switch."""
 
     def __init__(self, car: Leaf) -> None:

--- a/homeassistant/components/numato/switch.py
+++ b/homeassistant/components/numato/switch.py
@@ -5,6 +5,7 @@ import logging
 
 from numato_gpio import NumatoGpioError
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_ID,
@@ -12,7 +13,6 @@ from homeassistant.const import (
     DEVICE_DEFAULT_NAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -64,7 +64,7 @@ def setup_platform(
     add_entities(switches, True)
 
 
-class NumatoGpioSwitch(ToggleEntity):
+class NumatoGpioSwitch(SwitchEntity):
     """Representation of a Numato USB GPIO switch port."""
 
     def __init__(self, name, device_id, port, invert_logic, api):

--- a/homeassistant/components/raspihats/switch.py
+++ b/homeassistant/components/raspihats/switch.py
@@ -6,11 +6,10 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -90,7 +89,7 @@ def setup_platform(
     add_entities(switches)
 
 
-class I2CHatSwitch(ToggleEntity):
+class I2CHatSwitch(SwitchEntity):
     """Representation  a switch that uses a I2C-HAT digital output."""
 
     I2C_HATS_MANAGER: I2CHatsManager | None = None

--- a/homeassistant/components/rpi_gpio/switch.py
+++ b/homeassistant/components/rpi_gpio/switch.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.components import rpi_gpio
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -49,7 +48,7 @@ def setup_platform(
     add_entities(switches)
 
 
-class RPiGPIOSwitch(ToggleEntity):
+class RPiGPIOSwitch(SwitchEntity):
     """Representation of a  Raspberry Pi GPIO."""
 
     def __init__(self, name, port, invert_logic):

--- a/homeassistant/components/rpi_pfio/switch.py
+++ b/homeassistant/components/rpi_pfio/switch.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.components import rpi_pfio
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import ATTR_NAME, DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -47,7 +46,7 @@ def setup_platform(
     add_entities(switches)
 
 
-class RPiPFIOSwitch(ToggleEntity):
+class RPiPFIOSwitch(SwitchEntity):
     """Representation of a PiFace Digital Output."""
 
     def __init__(self, port, name, invert_logic):

--- a/homeassistant/components/synology_dsm/switch.py
+++ b/homeassistant/components/synology_dsm/switch.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from synology_dsm.api.surveillance_station import SynoSurveillanceStation
 
-from homeassistant.components.switch import ToggleEntity
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -54,7 +54,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, ToggleEntity):
+class SynoDSMSurveillanceHomeModeToggle(SynologyDSMBaseEntity, SwitchEntity):
     """Representation a Synology Surveillance Station Home Mode toggle."""
 
     coordinator: DataUpdateCoordinator[dict[str, dict[str, bool]]]

--- a/homeassistant/components/tellduslive/switch.py
+++ b/homeassistant/components/tellduslive/switch.py
@@ -1,9 +1,9 @@
 """Support for Tellstick switches using Tellstick Net."""
 from homeassistant.components import switch, tellduslive
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entry import TelldusLiveEntity
@@ -28,7 +28,7 @@ async def async_setup_entry(
     )
 
 
-class TelldusLiveSwitch(TelldusLiveEntity, ToggleEntity):
+class TelldusLiveSwitch(TelldusLiveEntity, SwitchEntity):
     """Representation of a Tellstick switch."""
 
     @property

--- a/homeassistant/components/tellstick/switch.py
+++ b/homeassistant/components/tellstick/switch.py
@@ -1,8 +1,8 @@
 """Support for Tellstick switches."""
 from __future__ import annotations
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -39,7 +39,7 @@ def setup_platform(
     )
 
 
-class TellstickSwitch(TellstickDevice, ToggleEntity):
+class TellstickSwitch(TellstickDevice, SwitchEntity):
     """Representation of a Tellstick switch."""
 
     def _parse_ha_data(self, kwargs):

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -1,11 +1,11 @@
 """Support for setting the Transmission BitTorrent client Turtle Mode."""
 import logging
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, SWITCH_TYPES
@@ -30,7 +30,7 @@ async def async_setup_entry(
     async_add_entities(dev, True)
 
 
-class TransmissionSwitch(ToggleEntity):
+class TransmissionSwitch(SwitchEntity):
     """Representation of a Transmission switch."""
 
     def __init__(self, switch_type, switch_name, tm_client, name):

--- a/homeassistant/components/volvooncall/switch.py
+++ b/homeassistant/components/volvooncall/switch.py
@@ -1,8 +1,8 @@
 """Support for Volvo heater."""
 from __future__ import annotations
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -21,7 +21,7 @@ async def async_setup_platform(
     async_add_entities([VolvoSwitch(hass.data[DATA_KEY], *discovery_info)])
 
 
-class VolvoSwitch(VolvoEntity, ToggleEntity):
+class VolvoSwitch(VolvoEntity, SwitchEntity):
     """Representation of a Volvo switch."""
 
     @property

--- a/homeassistant/components/xs1/switch.py
+++ b/homeassistant/components/xs1/switch.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from xs1_api_client.api_constants import ActuatorType
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -30,7 +30,7 @@ def setup_platform(
     add_entities(switch_entities)
 
 
-class XS1SwitchEntity(XS1DeviceEntity, ToggleEntity):
+class XS1SwitchEntity(XS1DeviceEntity, SwitchEntity):
     """Representation of a XS1 switch actuator."""
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Found a couple of places that used the `ToggleEntity` to created switches, instead of the `SwitchEntity`. This PR corrects that.

Need this for another refactor step.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
