### PR TITLE
Allow toggles (switches) state to be None

### DIFF
--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -117,7 +117,7 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
         )
 
     @esphome_state_property
-    def is_on(self) -> bool | None:  # type: ignore[override]
+    def is_on(self) -> bool | None:
         """Return true if the entity is on."""
         return self._state.state
 

--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -144,7 +144,7 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
         return self._api_version >= APIVersion(1, 6)
 
     @esphome_state_property
-    def is_on(self) -> bool | None:  # type: ignore[override]
+    def is_on(self) -> bool | None:
         """Return true if the light is on."""
         return self._state.state
 

--- a/homeassistant/components/esphome/switch.py
+++ b/homeassistant/components/esphome/switch.py
@@ -41,7 +41,7 @@ class EsphomeSwitch(EsphomeEntity[SwitchInfo, SwitchState], SwitchEntity):
         return self._static_info.assumed_state
 
     @esphome_state_property
-    def is_on(self) -> bool | None:  # type: ignore[override]
+    def is_on(self) -> bool | None:
         """Return true if the switch is on."""
         return self._state.state
 

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -1,4 +1,6 @@
 """Support for Freedompro fan."""
+from __future__ import annotations
+
 import json
 
 from pyfreedompro import put_state
@@ -51,7 +53,7 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
         self._attr_percentage = 0
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if entity is on."""
         return self._attr_is_on
 

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -364,6 +364,8 @@ async def async_setup_entry(
 class FritzBoxBaseSwitch(FritzBoxBaseEntity):
     """Fritz switch base class."""
 
+    _attr_is_on: bool | None = False
+
     def __init__(
         self,
         avm_wrapper: AvmWrapper,
@@ -385,8 +387,6 @@ class FritzBoxBaseSwitch(FritzBoxBaseEntity):
 
         self._attributes: dict[str, str] = {}
         self._is_available = True
-
-        self._attr_is_on = False
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/modbus/fan.py
+++ b/homeassistant/components/modbus/fan.py
@@ -48,7 +48,7 @@ class ModbusFan(BaseSwitch, FanEntity):
         await self.async_turn(self.command_on)
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if fan is on.
 
         This is needed due to the ongoing conversion of fan.

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -161,7 +161,7 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
         return False
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if device is on."""
         if not self.data["data"]["switchMode"]:
             return self._attr_is_on

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -100,7 +100,7 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         await self.info.node.async_set_value(self._target_value, 0)
 
     @property
-    def is_on(self) -> bool | None:  # type: ignore
+    def is_on(self) -> bool | None:
         """Return true if device is on (speed above 0)."""
         if self.info.primary_value.value is None:
             # guard missing value

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -65,7 +65,7 @@ class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
         self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
 
     @property
-    def is_on(self) -> bool | None:  # type: ignore
+    def is_on(self) -> bool | None:
         """Return a boolean for the state of the switch."""
         if self.info.primary_value.value is None:
             # guard missing value
@@ -107,7 +107,7 @@ class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):
         self._update_state()
 
     @property
-    def is_on(self) -> bool | None:  # type: ignore
+    def is_on(self) -> bool | None:
         """Return a boolean for the state of the switch."""
         return self._state
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -927,17 +927,19 @@ class ToggleEntity(Entity):
     """An abstract class for entities that can be turned on and off."""
 
     entity_description: ToggleEntityDescription
-    _attr_is_on: bool
+    _attr_is_on: bool | None
     _attr_state: None = None
 
     @property
     @final
-    def state(self) -> str | None:
+    def state(self) -> Literal["on", "off"] | None:
         """Return the state."""
-        return STATE_ON if self.is_on else STATE_OFF
+        if (is_on := self.is_on) is None:
+            return None
+        return STATE_ON if is_on else STATE_OFF
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if entity is on."""
         return self._attr_is_on
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -927,7 +927,7 @@ class ToggleEntity(Entity):
     """An abstract class for entities that can be turned on and off."""
 
     entity_description: ToggleEntityDescription
-    _attr_is_on: bool | None
+    _attr_is_on: bool | None = None
     _attr_state: None = None
 
     @property

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -12,7 +12,13 @@ from homeassistant.components.light import (
     COLOR_MODE_BRIGHTNESS,
     COLOR_MODE_RGBW,
 )
-from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+)
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
@@ -226,7 +232,7 @@ async def test_wlightbox_s_init(wlightbox_s, hass, config):
     assert color_modes == [COLOR_MODE_BRIGHTNESS]
 
     assert ATTR_BRIGHTNESS not in state.attributes
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
@@ -327,7 +333,7 @@ async def test_wlightbox_init(wlightbox, hass, config):
 
     assert ATTR_BRIGHTNESS not in state.attributes
     assert ATTR_RGBW_COLOR not in state.attributes
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.helpers import device_registry as dr
 
@@ -202,7 +203,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     state = hass.states.get(entity_ids[0])
     assert state.name == "switchBoxD-0.relay"
     assert state.attributes[ATTR_DEVICE_CLASS] == SwitchDeviceClass.SWITCH
-    assert state.state == STATE_OFF  # NOTE: should instead be STATE_UNKNOWN?
+    assert state.state == STATE_UNKNOWN
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
@@ -219,7 +220,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     state = hass.states.get(entity_ids[1])
     assert state.name == "switchBoxD-1.relay"
     assert state.attributes[ATTR_DEVICE_CLASS] == SwitchDeviceClass.SWITCH
-    assert state.state == STATE_OFF  # NOTE: should instead be STATE_UNKNOWN?
+    assert state.state == STATE_UNKNOWN
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
@@ -25,7 +26,7 @@ async def test_one_light(hass, rfxtrx):
 
     state = hass.states.get("light.ac_213c7f2_16")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 213c7f2:16"
 
     await hass.services.async_call(
@@ -132,17 +133,17 @@ async def test_several_lights(hass, rfxtrx):
 
     state = hass.states.get("light.ac_213c7f2_48")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
     state = hass.states.get("light.ac_118cdea_2")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
     state = hass.states.get("light.ac_1118cdea_2")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
     await rfxtrx.signal("0b1100cd0213c7f230010f71")

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import State
 
 from tests.common import MockConfigEntry, mock_restore_cache
@@ -28,7 +29,7 @@ async def test_one_switch(hass, rfxtrx):
 
     state = hass.states.get("switch.ac_213c7f2_16")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 213c7f2:16"
 
     await hass.services.async_call(
@@ -90,17 +91,17 @@ async def test_several_switches(hass, rfxtrx):
 
     state = hass.states.get("switch.ac_213c7f2_48")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
     state = hass.states.get("switch.ac_118cdea_2")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
     state = hass.states.get("switch.ac_1118cdea_2")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
 
@@ -142,22 +143,22 @@ async def test_switch_events(hass, rfxtrx):
 
     state = hass.states.get("switch.ac_213c7f2_16")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 213c7f2:16"
 
     state = hass.states.get("switch.ac_213c7f2_5")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("friendly_name") == "AC 213c7f2:5"
 
     # "16: On"
     await rfxtrx.signal("0b1100100213c7f210010f70")
-    assert hass.states.get("switch.ac_213c7f2_5").state == "off"
+    assert hass.states.get("switch.ac_213c7f2_5").state == STATE_UNKNOWN
     assert hass.states.get("switch.ac_213c7f2_16").state == "on"
 
     # "16: Off"
     await rfxtrx.signal("0b1100100213c7f210000f70")
-    assert hass.states.get("switch.ac_213c7f2_5").state == "off"
+    assert hass.states.get("switch.ac_213c7f2_5").state == STATE_UNKNOWN
     assert hass.states.get("switch.ac_213c7f2_16").state == "off"
 
     # "5: On"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Previously, toggle-based entities (like `fan`, `light`, `switch`, `remote`, `siren`, `vacuum`, `humidifier`) could have the state `on` or `off`, and in case the device was unreachable: `unavailable`. However, compared to other entities, toggle entities aren't able to have an `unknown` state, this now has changed.

As of now, toggle-based entities can now have the `on`, `off`, `unavailable`, or `unknown` state.

You might need to adapt your automations or scripts to take this new `unknown` state into account.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Proposal: This PR adds an "unknown" state capability to `ToggleEntity` based entities.

The impact is actually very minimal, the reason is that we actually already do this 😟 , so I guess this makes it official 🤷 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1192

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
