### PR TITLE
Enable Low Latency HLS (LL-HLS) by default to lower stream latency

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -97,19 +97,21 @@ def create_stream(
     return stream
 
 
+DOMAIN_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_LL_HLS, default=True): cv.boolean,
+        vol.Optional(CONF_SEGMENT_DURATION, default=6): vol.All(
+            cv.positive_float, vol.Range(min=2, max=10)
+        ),
+        vol.Optional(CONF_PART_DURATION, default=1): vol.All(
+            cv.positive_float, vol.Range(min=0.2, max=1.5)
+        ),
+    }
+)
+
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_LL_HLS, default=False): cv.boolean,
-                vol.Optional(CONF_SEGMENT_DURATION, default=6): vol.All(
-                    cv.positive_float, vol.Range(min=2, max=10)
-                ),
-                vol.Optional(CONF_PART_DURATION, default=1): vol.All(
-                    cv.positive_float, vol.Range(min=0.2, max=1.5)
-                ),
-            }
-        )
+        DOMAIN: DOMAIN_SCHEMA,
     },
     extra=vol.ALLOW_EXTRA,
 )
@@ -154,7 +156,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][ATTR_ENDPOINTS] = {}
     hass.data[DOMAIN][ATTR_STREAMS] = []
-    if (conf := config.get(DOMAIN)) and conf[CONF_LL_HLS]:
+    conf = DOMAIN_SCHEMA(config.get(DOMAIN, {}))
+    if conf[CONF_LL_HLS]:
         assert isinstance(conf[CONF_SEGMENT_DURATION], float)
         assert isinstance(conf[CONF_PART_DURATION], float)
         hass.data[DOMAIN][ATTR_SETTINGS] = StreamSettings(

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -29,6 +29,18 @@ SEGMENT_DURATION = 10
 TEST_TIMEOUT = 5.0  # Lower than 9s home assistant timeout
 MAX_ABORT_SEGMENTS = 20  # Abort test to avoid looping forever
 
+HLS_CONFIG = {
+    "stream": {
+        "ll_hls": False,
+    }
+}
+
+
+@pytest.fixture
+async def setup_component(hass) -> None:
+    """Test fixture to setup the stream component."""
+    await async_setup_component(hass, "stream", HLS_CONFIG)
+
 
 class HlsClient:
     """Test fixture for fetching the hls stream."""
@@ -114,14 +126,15 @@ def make_playlist(
     return "\n".join(response)
 
 
-async def test_hls_stream(hass, hls_stream, stream_worker_sync, h264_video):
+async def test_hls_stream(
+    hass, setup_component, hls_stream, stream_worker_sync, h264_video
+):
     """
     Test hls stream.
 
     Purposefully not mocking anything here to test full
     integration with the stream component.
     """
-    await async_setup_component(hass, "stream", {"stream": {}})
 
     stream_worker_sync.pause()
 
@@ -164,10 +177,10 @@ async def test_hls_stream(hass, hls_stream, stream_worker_sync, h264_video):
     assert fail_response.status == HTTPStatus.NOT_FOUND
 
 
-async def test_stream_timeout(hass, hass_client, stream_worker_sync, h264_video):
+async def test_stream_timeout(
+    hass, hass_client, setup_component, stream_worker_sync, h264_video
+):
     """Test hls stream timeout."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream_worker_sync.pause()
 
     # Setup demo HLS track
@@ -217,11 +230,9 @@ async def test_stream_timeout(hass, hass_client, stream_worker_sync, h264_video)
 
 
 async def test_stream_timeout_after_stop(
-    hass, hass_client, stream_worker_sync, h264_video
+    hass, hass_client, setup_component, stream_worker_sync, h264_video
 ):
     """Test hls stream timeout after the stream has been stopped already."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream_worker_sync.pause()
 
     # Setup demo HLS track
@@ -241,10 +252,8 @@ async def test_stream_timeout_after_stop(
     await hass.async_block_till_done()
 
 
-async def test_stream_keepalive(hass):
+async def test_stream_keepalive(hass, setup_component):
     """Test hls stream retries the stream when keepalive=True."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     # Setup demo HLS track
     source = "test_stream_keepalive_source"
     stream = create_stream(hass, source, {})
@@ -291,10 +300,8 @@ async def test_stream_keepalive(hass):
     assert available_states == [True, False, True]
 
 
-async def test_hls_playlist_view_no_output(hass, hls_stream):
+async def test_hls_playlist_view_no_output(hass, setup_component, hls_stream):
     """Test rendering the hls playlist with no output segments."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream.add_provider(HLS_PROVIDER)
 
@@ -305,10 +312,8 @@ async def test_hls_playlist_view_no_output(hass, hls_stream):
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-async def test_hls_playlist_view(hass, hls_stream, stream_worker_sync):
+async def test_hls_playlist_view(hass, setup_component, hls_stream, stream_worker_sync):
     """Test rendering the hls playlist with 1 and 2 output segments."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream_worker_sync.pause()
     hls = stream.add_provider(HLS_PROVIDER)
@@ -338,10 +343,8 @@ async def test_hls_playlist_view(hass, hls_stream, stream_worker_sync):
     stream.stop()
 
 
-async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
+async def test_hls_max_segments(hass, setup_component, hls_stream, stream_worker_sync):
     """Test rendering the hls playlist with more segments than the segment deque can hold."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream_worker_sync.pause()
     hls = stream.add_provider(HLS_PROVIDER)
@@ -389,9 +392,10 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
     stream.stop()
 
 
-async def test_hls_playlist_view_discontinuity(hass, hls_stream, stream_worker_sync):
+async def test_hls_playlist_view_discontinuity(
+    hass, setup_component, hls_stream, stream_worker_sync
+):
     """Test a discontinuity across segments in the stream with 3 segments."""
-    await async_setup_component(hass, "stream", {"stream": {}})
 
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream_worker_sync.pause()
@@ -426,10 +430,10 @@ async def test_hls_playlist_view_discontinuity(hass, hls_stream, stream_worker_s
     stream.stop()
 
 
-async def test_hls_max_segments_discontinuity(hass, hls_stream, stream_worker_sync):
+async def test_hls_max_segments_discontinuity(
+    hass, setup_component, hls_stream, stream_worker_sync
+):
     """Test a discontinuity with more segments than the segment deque can hold."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream_worker_sync.pause()
     hls = stream.add_provider(HLS_PROVIDER)
@@ -469,10 +473,10 @@ async def test_hls_max_segments_discontinuity(hass, hls_stream, stream_worker_sy
     stream.stop()
 
 
-async def test_remove_incomplete_segment_on_exit(hass, stream_worker_sync):
+async def test_remove_incomplete_segment_on_exit(
+    hass, setup_component, stream_worker_sync
+):
     """Test that the incomplete segment gets removed when the worker thread quits."""
-    await async_setup_component(hass, "stream", {"stream": {}})
-
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream_worker_sync.pause()
     stream.start()


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable Low Latency HLS (LL-HLS) by default. Since it increases network connections, an http/2 proxy is
recommended and the frontend can detect  and enable/disable based on network conditions.
https://github.com/home-assistant/frontend/pull/11372


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: In Progress

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
