### PR TITLE
Add diagnostics support to Open-Meteo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -785,6 +785,7 @@ omit =
     homeassistant/components/onvif/event.py
     homeassistant/components/onvif/parsers.py
     homeassistant/components/onvif/sensor.py
+    homeassistant/components/open_meteo/diagnostics.py
     homeassistant/components/open_meteo/weather.py
     homeassistant/components/opencv/*
     homeassistant/components/openevse/sensor.py

--- a/homeassistant/components/open_meteo/diagnostics.py
+++ b/homeassistant/components/open_meteo/diagnostics.py
@@ -1,0 +1,30 @@
+"""Diagnostics support for Open-Meteo."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from open_meteo import Forecast
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+TO_REDACT = {
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: DataUpdateCoordinator[Forecast] = hass.data[DOMAIN][entry.entry_id]
+    # Round-trip via JSON to trigger serialization
+    data: dict[str, Any] = json.loads(coordinator.data.json())
+    return async_redact_data(data, TO_REDACT)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to Open-Meteo

Example output:

```json
{
  "current_weather": {
    "time": "2022-01-21T18:00:00",
    "wind_speed": 11.5,
    "wind_direction": 296,
    "temperature": 5.6,
    "weather_code": 3
  },
  "daily_units": {
    "apparent_temperature_max": null,
    "apparent_temperature_min": null,
    "precipitation_hours": null,
    "precipitation_sum": "mm",
    "shortwave_radiation_sum": null,
    "sunrise": null,
    "sunset": null,
    "temperature_2m_max": "\u00b0C",
    "temperature_2m_min": "\u00b0C",
    "time": "iso8601",
    "weather_code": "wmo code",
    "wind_direction_10m_dominant": "\u00b0",
    "wind_gusts_10m_max": null,
    "wind_speed_10m_max": "km/h"
  },
  "daily": {
    "apparent_temperature_max": null,
    "apparent_temperature_min": null,
    "precipitation_hours": null,
    "precipitation_sum": [
      0.68,
      0.16,
      0.0,
      0.0,
      0.42,
      0.39,
      1.02
    ],
    "shortwave_radiation_sum": null,
    "sunrise": null,
    "sunset": null,
    "temperature_2m_max": [
      6.7,
      7.5,
      7.9,
      5.1,
      7.1,
      7.0,
      7.6
    ],
    "temperature_2m_min": [
      2.6,
      4.6,
      2.3,
      3.1,
      3.8,
      4.5,
      4.7
    ],
    "time": [
      "2022-01-21",
      "2022-01-22",
      "2022-01-23",
      "2022-01-24",
      "2022-01-25",
      "2022-01-26",
      "2022-01-27"
    ],
    "weathercode": [
      61,
      61,
      45,
      45,
      51,
      53,
      61
    ],
    "wind_direction_10m_dominant": [
      302,
      296,
      248,
      225,
      262,
      258,
      271
    ],
    "wind_gusts_10m_max": null,
    "wind_speed_10m_max": [
      16.6,
      13.7,
      8.5,
      7.0,
      7.4,
      12.7,
      18.3
    ]
  },
  "elevation": 1.5683594,
  "generation_time_ms": 0.5669593811035156,
  "hourly_units": null,
  "hourly": null,
  "latitude": "**REDACTED**",
  "longitude": "**REDACTED**",
  "utc_offset_seconds": 0
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
