### PR TITLE
Add note to unifiprotect flow that a local user is required

### DIFF
--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -19,10 +19,11 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.loader import async_get_integration
 
 from .const import (
     CONF_ALL_UPDATES,
@@ -38,6 +39,12 @@ from .discovery import async_start_discovery
 from .utils import _async_short_mac, _async_unifi_mac_from_hass
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_local_user_documentation_url(hass: HomeAssistant) -> str:
+    """Get the documentation url for creating a local user."""
+    integration = await async_get_integration(hass, DOMAIN)
+    return f"{integration.documentation}#local-user"
 
 
 def _host_is_direct_connect(host: str) -> bool:
@@ -134,6 +141,9 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             or discovery_info["platform"]
             or f"NVR {_async_short_mac(discovery_info['hw_addr'])}",
             "ip_address": discovery_info["source_ip"],
+            "local_user_documentation_url": await async_local_user_documentation_url(
+                self.hass
+            ),
         }
         self.context["title_placeholders"] = placeholders
         user_input = user_input or {}
@@ -269,6 +279,11 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         user_input = user_input or {}
         return self.async_show_form(
             step_id="user",
+            description_placeholders={
+                "local_user_documentation_url": await async_local_user_documentation_url(
+                    self.hass
+                )
+            },
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST, default=user_input.get(CONF_HOST)): str,

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -141,15 +141,17 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             or discovery_info["platform"]
             or f"NVR {_async_short_mac(discovery_info['hw_addr'])}",
             "ip_address": discovery_info["source_ip"],
-            "local_user_documentation_url": await async_local_user_documentation_url(
-                self.hass
-            ),
         }
         self.context["title_placeholders"] = placeholders
         user_input = user_input or {}
         return self.async_show_form(
             step_id="discovery_confirm",
-            description_placeholders=placeholders,
+            description_placeholders={
+                **placeholders,
+                "local_user_documentation_url": await async_local_user_documentation_url(
+                    self.hass
+                ),
+            },
             data_schema=vol.Schema(
                 {
                     vol.Required(

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -23,6 +23,7 @@
         }
       },
       "discovery_confirm": {
+        "title": "UniFi Protect Discovered",
         "description": "Do you want to setup {name} ({ip_address})? [%key:component::unifiprotect::config::step::user::description%]",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -4,6 +4,7 @@
     "step": {
       "user": {
         "title": "UniFi Protect Setup",
+        "description": "You will need a local user created in your UniFi OS Console to log in with. Ubiquiti Cloud Users will not work. For more information: {local_user_documentation_url}",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
@@ -22,7 +23,7 @@
         }
       },
       "discovery_confirm": {
-        "description": "Do you want to setup {name} ({ip_address})?",
+        "description": "Do you want to setup {name} ({ip_address})? [%key:component::unifiprotect::config::step::user::description%]",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"        

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -7,18 +7,16 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry.",
-            "unknown": "Unexpected error"
+            "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry."
         },
         "flow_title": "{name} ({ip_address})",
         "step": {
             "discovery_confirm": {
                 "data": {
                     "password": "Password",
-                    "username": "Username",
-                    "verify_ssl": "Verify SSL certificate"
+                    "username": "Username"
                 },
-                "description": "Do you want to setup {name} ({ip_address})?"
+                "description": "Do you want to setup {name} ({ip_address})? You will need a local user created in your UniFi OS Console to log in with. Ubiquiti Cloud Users will not work. For more information: {local_user_documentation_url}"
             },
             "reauth_confirm": {
                 "data": {
@@ -37,6 +35,7 @@
                     "username": "Username",
                     "verify_ssl": "Verify SSL certificate"
                 },
+                "description": "You will need a local user created in your UniFi OS Console to log in with. Ubiquiti Cloud Users will not work. For more information: {local_user_documentation_url}",
                 "title": "UniFi Protect Setup"
             }
         }

--- a/homeassistant/components/unifiprotect/translations/en.json
+++ b/homeassistant/components/unifiprotect/translations/en.json
@@ -16,7 +16,8 @@
                     "password": "Password",
                     "username": "Username"
                 },
-                "description": "Do you want to setup {name} ({ip_address})? You will need a local user created in your UniFi OS Console to log in with. Ubiquiti Cloud Users will not work. For more information: {local_user_documentation_url}"
+                "description": "Do you want to setup {name} ({ip_address})? You will need a local user created in your UniFi OS Console to log in with. Ubiquiti Cloud Users will not work. For more information: {local_user_documentation_url}",
+                "title": "UniFi Protect Discovered"
             },
             "reauth_confirm": {
                 "data": {


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- This has always been a friction point for new users since they do not
  know they need to create a local user for the integration to work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
