### PR TITLE
Add diagnostics platform to Shelly

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -431,14 +431,16 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
     def async_setup(self) -> None:
         """Set up the wrapper."""
         dev_reg = device_registry.async_get(self.hass)
-        sw_version = self.device.firmware_version if self.device.initialized else ""
+        self.sw_version = (
+            self.device.firmware_version if self.device.initialized else ""
+        )
         entry = dev_reg.async_get_or_create(
             config_entry_id=self.entry.entry_id,
             name=self.name,
             connections={(device_registry.CONNECTION_NETWORK_MAC, self.mac)},
             manufacturer="Shelly",
             model=aioshelly.const.MODEL_NAMES.get(self.model, self.model),
-            sw_version=sw_version,
+            sw_version=self.sw_version,
             hw_version=f"gen{self.device.gen} ({self.model})",
             configuration_url=f"http://{self.entry.data[CONF_HOST]}",
         )
@@ -716,14 +718,16 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
     def async_setup(self) -> None:
         """Set up the wrapper."""
         dev_reg = device_registry.async_get(self.hass)
-        sw_version = self.device.firmware_version if self.device.initialized else ""
+        self.sw_version = (
+            self.device.firmware_version if self.device.initialized else ""
+        )
         entry = dev_reg.async_get_or_create(
             config_entry_id=self.entry.entry_id,
             name=self.name,
             connections={(device_registry.CONNECTION_NETWORK_MAC, self.mac)},
             manufacturer="Shelly",
             model=aioshelly.const.MODEL_NAMES.get(self.model, self.model),
-            sw_version=sw_version,
+            sw_version=self.sw_version,
             hw_version=f"gen{self.device.gen} ({self.model})",
             configuration_url=f"http://{self.entry.data[CONF_HOST]}",
         )

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -292,6 +292,7 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.hass = hass
         self.entry = entry
         self.device = device
+        self.sw_version: str | None = None
 
         self._debounced_reload = Debouncer(
             hass,
@@ -630,6 +631,7 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         )
         self.entry = entry
         self.device = device
+        self.sw_version: str | None = None
 
         self._debounced_reload = Debouncer(
             hass,

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -292,7 +292,6 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.hass = hass
         self.entry = entry
         self.device = device
-        self.sw_version: str | None = None
 
         self._debounced_reload = Debouncer(
             hass,
@@ -429,12 +428,14 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         """Mac address of the device."""
         return cast(str, self.entry.unique_id)
 
+    @property
+    def sw_version(self) -> str:
+        """Firmware version of the device."""
+        return self.device.firmware_version if self.device.initialized else ""
+
     def async_setup(self) -> None:
         """Set up the wrapper."""
         dev_reg = device_registry.async_get(self.hass)
-        self.sw_version = (
-            self.device.firmware_version if self.device.initialized else ""
-        )
         entry = dev_reg.async_get_or_create(
             config_entry_id=self.entry.entry_id,
             name=self.name,
@@ -631,7 +632,6 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         )
         self.entry = entry
         self.device = device
-        self.sw_version: str | None = None
 
         self._debounced_reload = Debouncer(
             hass,
@@ -717,12 +717,14 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         """Mac address of the device."""
         return cast(str, self.entry.unique_id)
 
+    @property
+    def sw_version(self) -> str:
+        """Firmware version of the device."""
+        return self.device.firmware_version if self.device.initialized else ""
+
     def async_setup(self) -> None:
         """Set up the wrapper."""
         dev_reg = device_registry.async_get(self.hass)
-        self.sw_version = (
-            self.device.firmware_version if self.device.initialized else ""
-        )
         entry = dev_reg.async_get_or_create(
             config_entry_id=self.entry.entry_id,
             name=self.name,

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -20,10 +20,17 @@ async def async_get_config_entry_diagnostics(
 
     if BLOCK in data:
         wrapper = data.get(BLOCK)
+        assert isinstance(wrapper, BlockDeviceWrapper)
+        device_settings = {
+            k: v for k, v in wrapper.device.settings.items() if k in ["cloud", "coiot"]
+        }
+
     else:
         wrapper = data.get(RPC)
-
-    assert isinstance(wrapper, (BlockDeviceWrapper, RpcDeviceWrapper))
+        assert isinstance(wrapper, RpcDeviceWrapper)
+        device_settings = {
+            k: v for k, v in wrapper.device.config.items() if k in ["cloud"]
+        }
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
@@ -32,4 +39,5 @@ async def async_get_config_entry_diagnostics(
             "model": wrapper.model,
             "sw_version": wrapper.sw_version,
         },
+        "device_settings": device_settings,
     }

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -5,7 +5,6 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.system_info import async_get_system_info
 
 from . import BlockDeviceWrapper, RpcDeviceWrapper
 from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
@@ -35,7 +34,6 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "home_assistant": await async_get_system_info(hass),
         "device_info": {
             "name": wrapper.name,
             "model": wrapper.model,

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -19,30 +19,30 @@ async def async_get_config_entry_diagnostics(
     data: dict = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id]
 
     device_settings: str | dict = "not initialized"
-    device_info: str | dict = "not initialized"
     if BLOCK in data:
         block_wrapper: BlockDeviceWrapper = data[BLOCK]
+        device_info = {
+            "name": block_wrapper.name,
+            "model": block_wrapper.model,
+            "sw_version": block_wrapper.sw_version,
+        }
         if block_wrapper.device.initialized:
             device_settings = {
                 k: v
                 for k, v in block_wrapper.device.settings.items()
                 if k in ["cloud", "coiot"]
             }
-            device_info = {
-                "name": block_wrapper.name,
-                "model": block_wrapper.model,
-                "sw_version": block_wrapper.sw_version,
-            }
+
     else:
         rpc_wrapper: RpcDeviceWrapper = data[RPC]
+        device_info = {
+            "name": rpc_wrapper.name,
+            "model": rpc_wrapper.model,
+            "sw_version": rpc_wrapper.sw_version,
+        }
         if rpc_wrapper.device.initialized:
             device_settings = {
                 k: v for k, v in rpc_wrapper.device.config.items() if k in ["cloud"]
-            }
-            device_info = {
-                "name": rpc_wrapper.name,
-                "model": rpc_wrapper.model,
-                "sw_version": rpc_wrapper.sw_version,
             }
 
     return {

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -5,6 +5,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.system_info import async_get_system_info
 
 from . import BlockDeviceWrapper, RpcDeviceWrapper
 from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
@@ -34,6 +35,7 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "home_assistant": await async_get_system_info(hass),
         "device_info": {
             "name": wrapper.name,
             "model": wrapper.model,

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -1,0 +1,35 @@
+"""Diagnostics support for Shelly."""
+from __future__ import annotations
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.shelly import BlockDeviceWrapper, RpcDeviceWrapper
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
+
+TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    data: dict = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id]
+
+    if BLOCK in data:
+        wrapper = data.get(BLOCK)
+    else:
+        wrapper = data.get(RPC)
+
+    assert isinstance(wrapper, (BlockDeviceWrapper, RpcDeviceWrapper))
+
+    return {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "device_info": {
+            "name": wrapper.name,
+            "model": wrapper.model,
+            "sw_version": wrapper.sw_version,
+        },
+    }

--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.components.shelly import BlockDeviceWrapper, RpcDeviceWrapper
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
+from . import BlockDeviceWrapper, RpcDeviceWrapper
 from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
 
 TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -33,6 +33,15 @@ async def test_block_config_entry_diagnostics(
             "sw_version": coap_wrapper.sw_version,
         },
         "device_settings": {"coiot": {"update_period": 15}},
+        "device_status": {
+            "update": {
+                "beta_version": "some_beta_version",
+                "has_update": True,
+                "new_version": "some_new_version",
+                "old_version": "some_old_version",
+                "status": "pending",
+            }
+        },
     }
 
 
@@ -60,4 +69,12 @@ async def test_rpc_config_entry_diagnostics(
             "sw_version": rpc_wrapper.sw_version,
         },
         "device_settings": {},
+        "device_status": {
+            "sys": {
+                "available_updates": {
+                    "beta": {"version": "some_beta_version"},
+                    "stable": {"version": "some_beta_version"},
+                }
+            }
+        },
     }

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -1,0 +1,61 @@
+"""The scene tests for the myq platform."""
+from aiohttp import ClientSession
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.components.shelly.const import DOMAIN
+from homeassistant.components.shelly.diagnostics import TO_REDACT
+from homeassistant.core import HomeAssistant
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+RELAY_BLOCK_ID = 0
+
+
+async def test_block_config_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSession, coap_wrapper
+):
+    """Test config entry diagnostics for block device."""
+    assert coap_wrapper
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    entry_dict = entry.as_dict()
+    entry_dict["data"].update(
+        {key: REDACTED for key in TO_REDACT if key in entry_dict["data"]}
+    )
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert result == {
+        "entry": entry_dict,
+        "device_info": {
+            "name": coap_wrapper.name,
+            "model": coap_wrapper.model,
+            "sw_version": coap_wrapper.sw_version,
+        },
+    }
+
+
+async def test_rpc_config_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    rpc_wrapper,
+):
+    """Test config entry diagnostics for rpc device."""
+    assert rpc_wrapper
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    entry_dict = entry.as_dict()
+    entry_dict["data"].update(
+        {key: REDACTED for key in TO_REDACT if key in entry_dict["data"]}
+    )
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert result == {
+        "entry": entry_dict,
+        "device_info": {
+            "name": rpc_wrapper.name,
+            "model": rpc_wrapper.model,
+            "sw_version": rpc_wrapper.sw_version,
+        },
+    }

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -32,6 +32,7 @@ async def test_block_config_entry_diagnostics(
             "model": coap_wrapper.model,
             "sw_version": coap_wrapper.sw_version,
         },
+        "device_settings": {"coiot": {"update_period": 15}},
     }
 
 
@@ -58,4 +59,5 @@ async def test_rpc_config_entry_diagnostics(
             "model": rpc_wrapper.model,
             "sw_version": rpc_wrapper.sw_version,
         },
+        "device_settings": {},
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

example output
```json
{
  "entry": {
    "entry_id": "00d205f83eea73ad3b44cb7abf0daf23",
    "version": 1,
    "domain": "shelly",
    "title": "Kaffeemaschine",
    "data": {
      "username": "**REDACTED**",
      "password": "**REDACTED**",
      "host": "192.168.1.122",
      "sleep_period": 0,
      "model": "SHPLG-S"
    },
    "options": {},
    "pref_disable_new_entities": false,
    "pref_disable_polling": false,
    "source": "user",
    "unique_id": "E09806AB989F",
    "disabled_by": null
  },
  "device_info": {
    "name": "Kaffeemaschine",
    "model": "SHPLG-S",
    "sw_version": "20211109-130223/v1.11.7-g682a0db"
  },
  "device_settings": {
    "coiot": {
      "enabled": true,
      "update_period": 15,
      "peer": "192.168.1.5:5683"
    },
    "cloud": {
      "enabled": false,
      "connected": false
    }
  },
  "device_status": {
    "wifi_sta": {
      "connected": true,
      "ssid": "**REDACTED**",
      "ip": "192.168.1.122",
      "rssi": -66
    },
    "time": "02:43",
    "has_update": false,
    "update": {
      "status": "idle",
      "has_update": false,
      "new_version": "20211109-130223/v1.11.7-g682a0db",
      "old_version": "20211109-130223/v1.11.7-g682a0db"
    },
    "ram_total": 51272,
    "ram_free": 39220,
    "fs_size": 233681,
    "fs_free": 164907,
    "uptime": 2031850
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
