### PR TITLE
Enhancements for diagnostics platform

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -155,9 +155,9 @@ async def _async_get_json_file_response(
     try:
         json_data = json.dumps(
             {
-                "home-assistant": hass_sys_info,
-                "custom-components": custom_components,
-                "integration-manifest": integration.manifest,
+                "home_assistant": hass_sys_info,
+                "custom_components": custom_components,
+                "integration_manifest": integration.manifest,
                 "data": data,
             },
             indent=2,

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -146,11 +146,7 @@ async def _async_get_json_file_response(
     for cc_domain, cc_obj in hass.data[DATA_CUSTOM_COMPONENTS].items():
         custom_components[cc_domain] = {
             "version": cc_obj.manifest["version"],
-            "requirements": [
-                req
-                for req in cc_obj.manifest["requirements"]
-                if "://" not in req  # ignore url based requirements
-            ],
+            "requirements": cc_obj.manifest["requirements"],
         }
     try:
         json_data = json.dumps(

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -135,11 +135,21 @@ async def _async_get_json_file_response(
 ) -> web.Response:
     """Return JSON file from dictionary."""
     hass_sys_info = await async_get_system_info(hass)
+
     integration: Integration = hass.data[DATA_INTEGRATIONS][domain]
-    custom_components = {
-        ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
-        for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]
-    }
+
+    custom_components = {}
+    cc_domain: str
+    cc_obj: Integration
+    for cc_domain, cc_obj in hass.data[DATA_CUSTOM_COMPONENTS].items():
+        custom_components[cc_domain] = {
+            "version": cc_obj.manifest["version"],
+            "requirements": [
+                req
+                for req in cc_obj.manifest["requirements"]
+                if "://" not in req  # ignore url based requirements
+            ],
+        }
     try:
         json_data = json.dumps(
             {

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -138,7 +138,7 @@ async def _async_get_json_file_response(
     integration: Integration = hass.data[DATA_INTEGRATIONS][domain]
     custom_components = {
         ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
-        for ccmp in list(hass.data[DATA_CUSTOM_COMPONENTS].keys())
+        for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]
     }
     try:
         json_data = json.dumps(

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.device_registry import DeviceEntry, async_get
 from homeassistant.helpers.json import ExtendedJSONEncoder
 from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.loader import DATA_INTEGRATIONS, Integration
+from homeassistant.loader import DATA_CUSTOM_COMPONENTS, DATA_INTEGRATIONS, Integration
 from homeassistant.util.json import (
     find_paths_unserializable_data,
     format_unserializable_data,
@@ -136,10 +136,15 @@ async def _async_get_json_file_response(
     """Return JSON file from dictionary."""
     hass_sys_info = await async_get_system_info(hass)
     integration: Integration = hass.data[DATA_INTEGRATIONS][domain]
+    custom_components = {
+        ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
+        for ccmp in list(hass.data[DATA_CUSTOM_COMPONENTS].keys())
+    }
     try:
         json_data = json.dumps(
             {
                 "home-assistant": hass_sys_info,
+                "custom-components": custom_components,
                 "integration-manifest": integration.manifest,
                 "diagnostics-data": data,
             },

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -135,6 +135,8 @@ async def _async_get_json_file_response(
 ) -> web.Response:
     """Return JSON file from dictionary."""
     hass_sys_info = await async_get_system_info(hass)
+    if hass_sys_info.get("user") is not None:
+        hass_sys_info.update({"user": REDACTED})
 
     integration: Integration = hass.data[DATA_INTEGRATIONS][domain]
 

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -135,8 +135,8 @@ async def _async_get_json_file_response(
 ) -> web.Response:
     """Return JSON file from dictionary."""
     hass_sys_info = await async_get_system_info(hass)
-    if hass_sys_info.get("user") is not None:
-        hass_sys_info.update({"user": REDACTED})
+    hass_sys_info["run_as_root"] = hass_sys_info["user"] == "root"
+    del hass_sys_info["user"]
 
     integration: Integration = hass.data[DATA_INTEGRATIONS][domain]
 

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -146,7 +146,7 @@ async def _async_get_json_file_response(
                 "home-assistant": hass_sys_info,
                 "custom-components": custom_components,
                 "integration-manifest": integration.manifest,
-                "diagnostics-data": data,
+                "data": data,
             },
             indent=2,
             cls=ExtendedJSONEncoder,

--- a/tests/components/diagnostics/__init__.py
+++ b/tests/components/diagnostics/__init__.py
@@ -14,7 +14,7 @@ async def get_diagnostics_for_config_entry(hass, hass_client, config_entry):
     )
     assert response.status == HTTPStatus.OK
     data = await response.json()
-    return data["diagnostics-data"]
+    return data["data"]
 
 
 async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
@@ -27,4 +27,4 @@ async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
     )
     assert response.status == HTTPStatus.OK
     data = await response.json()
-    return data["diagnostics-data"]
+    return data["data"]

--- a/tests/components/diagnostics/__init__.py
+++ b/tests/components/diagnostics/__init__.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from homeassistant.setup import async_setup_component
 
 
-async def get_diagnostics_for_config_entry(hass, hass_client, config_entry):
+async def _get_diagnostics_for_config_entry(hass, hass_client, config_entry):
     """Return the diagnostics config entry for the specified domain."""
     assert await async_setup_component(hass, "diagnostics", {})
 
@@ -13,11 +13,16 @@ async def get_diagnostics_for_config_entry(hass, hass_client, config_entry):
         f"/api/diagnostics/config_entry/{config_entry.entry_id}"
     )
     assert response.status == HTTPStatus.OK
-    data = await response.json()
+    return await response.json()
+
+
+async def get_diagnostics_for_config_entry(hass, hass_client, config_entry):
+    """Return the diagnostics config entry for the specified domain."""
+    data = await _get_diagnostics_for_config_entry(hass, hass_client, config_entry)
     return data["data"]
 
 
-async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
+async def _get_diagnostics_for_device(hass, hass_client, config_entry, device):
     """Return the diagnostics for the specified device."""
     assert await async_setup_component(hass, "diagnostics", {})
 
@@ -26,5 +31,10 @@ async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
         f"/api/diagnostics/config_entry/{config_entry.entry_id}/device/{device.id}"
     )
     assert response.status == HTTPStatus.OK
-    data = await response.json()
+    return await response.json()
+
+
+async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
+    """Return the diagnostics for the specified device."""
+    data = await _get_diagnostics_for_device(hass, hass_client, config_entry, device)
     return data["data"]

--- a/tests/components/diagnostics/__init__.py
+++ b/tests/components/diagnostics/__init__.py
@@ -13,7 +13,8 @@ async def get_diagnostics_for_config_entry(hass, hass_client, config_entry):
         f"/api/diagnostics/config_entry/{config_entry.entry_id}"
     )
     assert response.status == HTTPStatus.OK
-    return await response.json()
+    data = await response.json()
+    return data["diagnostics-data"]
 
 
 async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
@@ -25,4 +26,5 @@ async def get_diagnostics_for_device(hass, hass_client, config_entry, device):
         f"/api/diagnostics/config_entry/{config_entry.entry_id}/device/{device.id}"
     )
     assert response.status == HTTPStatus.OK
-    return await response.json()
+    data = await response.json()
+    return data["diagnostics-data"]

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.helpers.device_registry import async_get
+from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.setup import async_setup_component
 
 from . import get_diagnostics_for_config_entry, get_diagnostics_for_device
@@ -77,9 +78,19 @@ async def test_download_diagnostics(hass, hass_client):
     """Test download diagnostics."""
     config_entry = MockConfigEntry(domain="fake_integration")
     config_entry.add_to_hass(hass)
+    hass_sys_info = await async_get_system_info(hass)
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
-        "config_entry": "info"
+        "home-assistant": hass_sys_info,
+        "integration-manifest": {
+            "codeowners": [],
+            "dependencies": [],
+            "domain": "fake_integration",
+            "is_built_in": True,
+            "name": "fake_integration",
+            "requirements": [],
+        },
+        "diagnostics-data": {"config_entry": "info"},
     }
 
     dev_reg = async_get(hass)
@@ -89,7 +100,18 @@ async def test_download_diagnostics(hass, hass_client):
 
     assert await get_diagnostics_for_device(
         hass, hass_client, config_entry, device
-    ) == {"device": "info"}
+    ) == {
+        "home-assistant": hass_sys_info,
+        "integration-manifest": {
+            "codeowners": [],
+            "dependencies": [],
+            "domain": "fake_integration",
+            "is_built_in": True,
+            "name": "fake_integration",
+            "requirements": [],
+        },
+        "diagnostics-data": {"device": "info"},
+    }
 
 
 async def test_failure_scenarios(hass, hass_client):

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from homeassistant.components.diagnostics.const import REDACTED
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.system_info import async_get_system_info
@@ -80,6 +81,8 @@ async def test_download_diagnostics(hass, hass_client):
     config_entry = MockConfigEntry(domain="fake_integration")
     config_entry.add_to_hass(hass)
     hass_sys_info = await async_get_system_info(hass)
+    if hass_sys_info.get("user") is not None:
+        hass_sys_info.update({"user": REDACTED})
     custom_components = {
         ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
         for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.system_info import async_get_system_info
-from homeassistant.loader import DATA_CUSTOM_COMPONENTS, DATA_INTEGRATIONS
 from homeassistant.setup import async_setup_component
 
 from . import _get_diagnostics_for_config_entry, _get_diagnostics_for_device
@@ -82,14 +81,10 @@ async def test_download_diagnostics(hass, hass_client):
     hass_sys_info = await async_get_system_info(hass)
     hass_sys_info["run_as_root"] = hass_sys_info["user"] == "root"
     del hass_sys_info["user"]
-    custom_components = {
-        ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
-        for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]
-    }
 
     assert await _get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "home_assistant": hass_sys_info,
-        "custom_components": custom_components,
+        "custom_components": {},
         "integration_manifest": {
             "codeowners": [],
             "dependencies": [],
@@ -110,7 +105,7 @@ async def test_download_diagnostics(hass, hass_client):
         hass, hass_client, config_entry, device
     ) == {
         "home_assistant": hass_sys_info,
-        "custom_components": custom_components,
+        "custom_components": {},
         "integration_manifest": {
             "codeowners": [],
             "dependencies": [],

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from homeassistant.components.diagnostics.const import REDACTED
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.system_info import async_get_system_info
@@ -81,8 +80,8 @@ async def test_download_diagnostics(hass, hass_client):
     config_entry = MockConfigEntry(domain="fake_integration")
     config_entry.add_to_hass(hass)
     hass_sys_info = await async_get_system_info(hass)
-    if hass_sys_info.get("user") is not None:
-        hass_sys_info.update({"user": REDACTED})
+    hass_sys_info["run_as_root"] = hass_sys_info["user"] == "root"
+    del hass_sys_info["user"]
     custom_components = {
         ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
         for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.system_info import async_get_system_info
+from homeassistant.loader import DATA_CUSTOM_COMPONENTS, DATA_INTEGRATIONS
 from homeassistant.setup import async_setup_component
 
 from . import get_diagnostics_for_config_entry, get_diagnostics_for_device
@@ -79,9 +80,14 @@ async def test_download_diagnostics(hass, hass_client):
     config_entry = MockConfigEntry(domain="fake_integration")
     config_entry.add_to_hass(hass)
     hass_sys_info = await async_get_system_info(hass)
+    custom_components = {
+        ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
+        for ccmp in list(hass.data[DATA_CUSTOM_COMPONENTS].keys())
+    }
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "home-assistant": hass_sys_info,
+        "custom-components": custom_components,
         "integration-manifest": {
             "codeowners": [],
             "dependencies": [],
@@ -102,6 +108,7 @@ async def test_download_diagnostics(hass, hass_client):
         hass, hass_client, config_entry, device
     ) == {
         "home-assistant": hass_sys_info,
+        "custom-components": custom_components,
         "integration-manifest": {
             "codeowners": [],
             "dependencies": [],

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -82,7 +82,7 @@ async def test_download_diagnostics(hass, hass_client):
     hass_sys_info = await async_get_system_info(hass)
     custom_components = {
         ccmp: hass.data[DATA_INTEGRATIONS][ccmp].manifest
-        for ccmp in list(hass.data[DATA_CUSTOM_COMPONENTS].keys())
+        for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]
     }
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.loader import DATA_CUSTOM_COMPONENTS, DATA_INTEGRATIONS
 from homeassistant.setup import async_setup_component
 
-from . import get_diagnostics_for_config_entry, get_diagnostics_for_device
+from . import _get_diagnostics_for_config_entry, _get_diagnostics_for_device
 
 from tests.common import MockConfigEntry, mock_platform
 
@@ -85,7 +85,7 @@ async def test_download_diagnostics(hass, hass_client):
         for ccmp in hass.data[DATA_CUSTOM_COMPONENTS]
     }
 
-    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+    assert await _get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "home-assistant": hass_sys_info,
         "custom-components": custom_components,
         "integration-manifest": {
@@ -104,7 +104,7 @@ async def test_download_diagnostics(hass, hass_client):
         config_entry_id=config_entry.entry_id, identifiers={("test", "test")}
     )
 
-    assert await get_diagnostics_for_device(
+    assert await _get_diagnostics_for_device(
         hass, hass_client, config_entry, device
     ) == {
         "home-assistant": hass_sys_info,

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -96,7 +96,7 @@ async def test_download_diagnostics(hass, hass_client):
             "name": "fake_integration",
             "requirements": [],
         },
-        "diagnostics-data": {"config_entry": "info"},
+        "data": {"config_entry": "info"},
     }
 
     dev_reg = async_get(hass)
@@ -117,7 +117,7 @@ async def test_download_diagnostics(hass, hass_client):
             "name": "fake_integration",
             "requirements": [],
         },
-        "diagnostics-data": {"device": "info"},
+        "data": {"device": "info"},
     }
 
 

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -89,9 +89,9 @@ async def test_download_diagnostics(hass, hass_client):
     }
 
     assert await _get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
-        "home-assistant": hass_sys_info,
-        "custom-components": custom_components,
-        "integration-manifest": {
+        "home_assistant": hass_sys_info,
+        "custom_components": custom_components,
+        "integration_manifest": {
             "codeowners": [],
             "dependencies": [],
             "domain": "fake_integration",
@@ -110,9 +110,9 @@ async def test_download_diagnostics(hass, hass_client):
     assert await _get_diagnostics_for_device(
         hass, hass_client, config_entry, device
     ) == {
-        "home-assistant": hass_sys_info,
-        "custom-components": custom_components,
-        "integration-manifest": {
+        "home_assistant": hass_sys_info,
+        "custom_components": custom_components,
+        "integration_manifest": {
             "codeowners": [],
             "dependencies": [],
             "domain": "fake_integration",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add further information in a central approach - added info/data
- hass system info
- manifests of each loaded customer component
- integrations manifest

example:
```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2022.2.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.60.1-microsoft-standard-WSL2",
    "run_as_root": true
  },
  "custom_components": {
    "rki_covid": {
      "version": "1.5.6",
      "requirements": [
        "rki-covid-parser>=1.2.4"
      ]
    }
  },
  "integration_manifest": {
    "domain": "shelly",
    "name": "Shelly",
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/shelly",
    "requirements": [
      "aioshelly==1.0.7"
    ],
    "zeroconf": [
      {
        "type": "_http._tcp.local.",
        "name": "shelly*"
      }
    ],
    "codeowners": [
      "@balloob",
      "@bieniu",
      "@thecode",
      "@chemelli74"
    ],
    "iot_class": "local_push",
    "is_built_in": true
  },
  "data": {...}
```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
