### PR TITLE
Use friendly name instead of hostname in Tailscale integration

### DIFF
--- a/homeassistant/components/tailscale/__init__.py
+++ b/homeassistant/components/tailscale/__init__.py
@@ -52,7 +52,8 @@ class TailscaleEntity(CoordinatorEntity):
         super().__init__(coordinator=coordinator)
         self.entity_description = description
         self.device_id = device.device_id
-        self._attr_name = f"{device.hostname} {description.name}"
+        self.friendly_name = device.name.split(".")[0]
+        self._attr_name = f"{self.friendly_name} {description.name}"
         self._attr_unique_id = f"{device.device_id}_{description.key}"
 
     @property
@@ -70,6 +71,6 @@ class TailscaleEntity(CoordinatorEntity):
             identifiers={(DOMAIN, device.device_id)},
             manufacturer="Tailscale Inc.",
             model=device.os,
-            name=device.hostname,
+            name=self.friendly_name,
             sw_version=device.client_version,
         )

--- a/tests/components/tailscale/test_binary_sensor.py
+++ b/tests/components/tailscale/test_binary_sensor.py
@@ -28,7 +28,7 @@ async def test_tailscale_binary_sensors(
     assert entry.unique_id == "123456_update_available"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frencks-iPhone Client"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Client"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.UPDATE
     assert ATTR_ICON not in state.attributes
 
@@ -43,7 +43,7 @@ async def test_tailscale_binary_sensors(
     assert state.state == STATE_OFF
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Frencks-iPhone Supports Hairpinning"
+        == "frencks-iphone Supports Hairpinning"
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:wan"
     assert ATTR_DEVICE_CLASS not in state.attributes
@@ -55,7 +55,7 @@ async def test_tailscale_binary_sensors(
     assert entry.unique_id == "123456_client_supports_ipv6"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frencks-iPhone Supports IPv6"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports IPv6"
     assert state.attributes.get(ATTR_ICON) == "mdi:wan"
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -66,7 +66,7 @@ async def test_tailscale_binary_sensors(
     assert entry.unique_id == "123456_client_supports_pcp"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frencks-iPhone Supports PCP"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports PCP"
     assert state.attributes.get(ATTR_ICON) == "mdi:wan"
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -77,7 +77,7 @@ async def test_tailscale_binary_sensors(
     assert entry.unique_id == "123456_client_supports_pmp"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frencks-iPhone Supports NAT-PMP"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports NAT-PMP"
     assert state.attributes.get(ATTR_ICON) == "mdi:wan"
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -88,7 +88,7 @@ async def test_tailscale_binary_sensors(
     assert entry.unique_id == "123456_client_supports_udp"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
     assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frencks-iPhone Supports UDP"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports UDP"
     assert state.attributes.get(ATTR_ICON) == "mdi:wan"
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -99,7 +99,7 @@ async def test_tailscale_binary_sensors(
     assert entry.unique_id == "123456_client_supports_upnp"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
     assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Frencks-iPhone Supports UPnP"
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "frencks-iphone Supports UPnP"
     assert state.attributes.get(ATTR_ICON) == "mdi:wan"
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -109,7 +109,7 @@ async def test_tailscale_binary_sensors(
     assert device_entry.identifiers == {(DOMAIN, "123456")}
     assert device_entry.manufacturer == "Tailscale Inc."
     assert device_entry.model == "iOS"
-    assert device_entry.name == "Frencks-iPhone"
+    assert device_entry.name == "frencks-iphone"
     assert device_entry.entry_type == dr.DeviceEntryType.SERVICE
     assert device_entry.sw_version == "1.12.3-td91ea7286-ge1bbbd90c"
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For Tailscale devices, use their custom friendly names instead of their network hostnames when generating device and entity names.

My Tailscale network looks like this:
![image](https://user-images.githubusercontent.com/2292715/150624743-1d8d221e-b77a-409c-91f0-5d0a0ac86e21.png)

Before this change, it was very hard to distinguish between my two Windows devices:
![image](https://user-images.githubusercontent.com/2292715/150624783-12e9792c-8b9b-4d8a-84fe-6c5015b1ad93.png)

After the change, it is much easier since the friendly names are used:
![image](https://user-images.githubusercontent.com/2292715/150624774-8e3ac8fb-ea1b-43e9-95f1-b75dbf2fc42b.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
