### PR TITLE
Add system info to Tuya diagnostics

### DIFF
--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.util import dt as dt_util
 
 from . import HomeAssistantTuyaData
@@ -29,18 +30,17 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    return _async_get_diagnostics(hass, entry)
+    return await _async_get_diagnostics(hass, entry)
 
 
 async def async_get_device_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a device entry."""
-    return _async_get_diagnostics(hass, entry, device)
+    return await _async_get_diagnostics(hass, entry, device)
 
 
-@callback
-def _async_get_diagnostics(
+async def _async_get_diagnostics(
     hass: HomeAssistant,
     entry: ConfigEntry,
     device: DeviceEntry | None = None,
@@ -52,7 +52,14 @@ def _async_get_diagnostics(
     if hass_data.home_manager.mq.client:
         mqtt_connected = hass_data.home_manager.mq.client.is_connected()
 
+    system_info = await async_get_system_info(hass)
+
     data = {
+        "system_info": {
+            "installation_type": system_info["installation_type"],
+            "version": system_info["version"],
+            "python_version": system_info["python_version"],
+        },
         "endpoint": entry.data[CONF_ENDPOINT],
         "auth_type": entry.data[CONF_AUTH_TYPE],
         "country_code": entry.data[CONF_COUNTRY_CODE],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a little bit of system information to Tuya diagnostics data

Example output:

```json
{
  "system_info": {
    "installation_type": "Home Assistant Core",
    "version": "2022.2.0.dev0",
    "python_version": "3.9.9"
  },
  "endpoint": "https://openapi.tuyaeu.com",
  "auth_type": 0,
  "country_code": "31",
  "app_type": "tuyaSmart",
  "mqtt_connected": true,
  "disabled_by": null,
  "disabled_polling": false,
  "name": "A6121",
  "model": "A6121",
  "category": "qt",
  "product_id": "C5IaBuQl",
  "product_name": "Basic WFZIG Panel",
  "online": false,
  "sub": true,
  "time_zone": "+02:00",
  "active_time": "2021-10-16T14:14:01+00:00",
  "create_time": "2021-10-16T14:13:20+00:00",
  "update_time": "2021-11-03T19:32:18+00:00",
  "function": {},
  "status_range": {},
  "status": {},
  "home_assistant": {
    "name": "Basic WFZIG Panel",
    "name_by_user": null,
    "disabled": false,
    "disabled_by": null,
    "entities": []
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
