### PR TITLE
Add missing voices to Amazon Polly

### DIFF
--- a/homeassistant/components/amazon_polly/const.py
+++ b/homeassistant/components/amazon_polly/const.py
@@ -33,67 +33,67 @@ CONF_SAMPLE_RATE: Final = "sample_rate"
 CONF_TEXT_TYPE: Final = "text_type"
 
 SUPPORTED_VOICES: Final[list[str]] = [
-    "Olivia",  # Female, Australian, Neural
-    "Zhiyu",  # Chinese
-    "Mads",
-    "Naja",  # Danish
-    "Ruben",
-    "Lotte",  # Dutch
-    "Russell",
-    "Nicole",  # English Australian
-    "Brian",
-    "Amy",
-    "Emma",  # English
     "Aditi",
-    "Raveena",  # English, Indian
-    "Joey",
-    "Justin",
-    "Matthew",
-    "Ivy",
-    "Joanna",
-    "Kendra",
-    "Kimberly",
-    "Salli",  # English
-    "Geraint",  # English Welsh
-    "Mathieu",
-    "Celine",
-    "Lea",  # French
-    "Chantal",  # French Canadian
-    "Hans",
-    "Marlene",
-    "Vicki",  # German
     "Aditi",  # Hindi
-    "Karl",
-    "Dora",  # Icelandic
-    "Giorgio",
-    "Carla",
+    "Amy",
+    "Astrid",  # Swedish
     "Bianca",  # Italian
-    "Takumi",
-    "Mizuki",  # Japanese
-    "Seoyeon",  # Korean
-    "Liv",  # Norwegian
+    "Brian",
+    "Camila",  # Portuguese, Brazilian
+    "Carla",
+    "Carmen",  # Romanian
+    "Celine",
+    "Chantal",  # French Canadian
+    "Conchita",
+    "Cristiano",
+    "Dora",  # Icelandic
+    "Emma",  # English
+    "Enrique",
+    "Ewa",
+    "Filiz",  # Turkish
+    "Geraint",  # English Welsh
+    "Giorgio",
+    "Gwyneth",  # Welsh
+    "Hans",
+    "Ines",  # Portuguese, European
+    "Ivy",
     "Jacek",
     "Jan",
-    "Ewa",
-    "Maja",  # Polish
-    "Ricardo",
-    "Vitoria",  # Portuguese, Brazilian
-    "Camila",  # Portuguese, Brazilian
-    "Cristiano",
-    "Ines",  # Portuguese, European
-    "Carmen",  # Romanian
-    "Maxim",
-    "Tatyana",  # Russian
-    "Enrique",
-    "Conchita",
+    "Joanna",
+    "Joey",
+    "Justin",
+    "Karl",
+    "Kendra",
+    "Kimberly",
+    "Lea",  # French
+    "Liv",  # Norwegian
+    "Lotte",  # Dutch
     "Lucia",  # Spanish European
+    "Lupe",  # Spanish US
+    "Mads",
+    "Maja",  # Polish
+    "Marlene",
+    "Mathieu",
+    "Matthew",
+    "Maxim",
     "Mia",  # Spanish Mexican
     "Miguel",  # Spanish US
+    "Mizuki",  # Japanese
+    "Naja",  # Danish
+    "Nicole",  # English Australian
+    "Olivia",  # Female, Australian, Neural
     "Penelope",  # Spanish US
-    "Lupe",  # Spanish US
-    "Astrid",  # Swedish
-    "Filiz",  # Turkish
-    "Gwyneth",  # Welsh
+    "Raveena",  # English, Indian
+    "Ricardo",
+    "Ruben",
+    "Russell",
+    "Salli",  # English
+    "Seoyeon",  # Korean
+    "Takumi",
+    "Tatyana",  # Russian
+    "Vicki",  # German
+    "Vitoria",  # Portuguese, Brazilian
+    "Zhiyu",  # Chinese
 ]
 
 SUPPORTED_OUTPUT_FORMATS: Final[list[str]] = ["mp3", "ogg_vorbis", "pcm"]

--- a/homeassistant/components/amazon_polly/const.py
+++ b/homeassistant/components/amazon_polly/const.py
@@ -35,7 +35,9 @@ CONF_TEXT_TYPE: Final = "text_type"
 SUPPORTED_VOICES: Final[list[str]] = [
     "Aditi",  # Hindi
     "Amy",
+    "Aria",
     "Astrid",  # Swedish
+    "Ayanda",
     "Bianca",  # Italian
     "Brian",
     "Camila",  # Portuguese, Brazilian
@@ -50,6 +52,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Enrique",
     "Ewa",
     "Filiz",  # Turkish
+    "Gabrielle",
     "Geraint",  # English Welsh
     "Giorgio",
     "Gwyneth",  # Welsh
@@ -63,6 +66,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Justin",
     "Karl",
     "Kendra",
+    "Kevin",
     "Kimberly",
     "Lea",  # French
     "Liv",  # Norwegian
@@ -92,6 +96,7 @@ SUPPORTED_VOICES: Final[list[str]] = [
     "Tatyana",  # Russian
     "Vicki",  # German
     "Vitoria",  # Portuguese, Brazilian
+    "Zeina",
     "Zhiyu",  # Chinese
 ]
 

--- a/homeassistant/components/amazon_polly/const.py
+++ b/homeassistant/components/amazon_polly/const.py
@@ -33,7 +33,6 @@ CONF_SAMPLE_RATE: Final = "sample_rate"
 CONF_TEXT_TYPE: Final = "text_type"
 
 SUPPORTED_VOICES: Final[list[str]] = [
-    "Aditi",
     "Aditi",  # Hindi
     "Amy",
     "Astrid",  # Swedish


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fix adds all currently missing voice for Amazon Polly (Aria, Ayanda, Gabrielle, Kevin, Zeina). One duplicate (Aditi) has been removed and the array has been sorted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64223

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
