### PR TITLE
Add button platform to bond to replace custom services

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -24,6 +24,7 @@ from .const import BPUP_SUBS, BRIDGE_MAKE, DOMAIN, HUB
 from .utils import BondHub
 
 PLATFORMS = [
+    Platform.BUTTON,
     Platform.COVER,
     Platform.FAN,
     Platform.LIGHT,

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -32,7 +32,7 @@ BUTTONS: tuple[ButtonEntityDescription, ...] = (
     ButtonEntityDescription(
         key=Action.TOGGLE_LIGHT,
         name="Toggle Light",
-        icon="mdi:lightbulb-question",
+        icon="mdi:lightbulb",
     ),
     ButtonEntityDescription(
         key=Action.INCREASE_BRIGHTNESS,
@@ -47,12 +47,12 @@ BUTTONS: tuple[ButtonEntityDescription, ...] = (
     ButtonEntityDescription(
         key=Action.TOGGLE_UP_LIGHT,
         name="Toggle Up Light",
-        icon="mdi:lightbulb-question",
+        icon="mdi:lightbulb",
     ),
     ButtonEntityDescription(
         key=Action.TOGGLE_DOWN_LIGHT,
         name="Toggle Down Light",
-        icon="mdi:lightbulb-question",
+        icon="mdi:lightbulb",
     ),
     ButtonEntityDescription(
         key=Action.START_UP_LIGHT_DIMMER,

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -201,17 +201,14 @@ async def async_setup_entry(
     bpup_subs: BPUPSubscriptions = data[BPUP_SUBS]
 
     async_add_entities(
-        [
-            BondButtonEntity(hub, device, bpup_subs, description)
-            for device in hub.devices
-            for description in BUTTONS
-            if device.has_action(description.key)
-            and (
-                description.mutually_exclusive is None
-                or not device.has_action(description.mutually_exclusive)
-            )
-        ],
-        True,
+        BondButtonEntity(hub, device, bpup_subs, description)
+        for device in hub.devices
+        for description in BUTTONS
+        if device.has_action(description.key)
+        and (
+            description.mutually_exclusive is None
+            or not device.has_action(description.mutually_exclusive)
+        )
     )
 
 

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -227,7 +227,7 @@ class BondButtonEntity(BondEntity, ButtonEntity):
     ) -> None:
         """Init Bond button."""
         super().__init__(
-            hub, device, bpup_subs, description.name, f"_{description.key.lower()}"
+            hub, device, bpup_subs, description.name, description.key.lower()
         )
         self.entity_description = description
 

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -176,13 +176,13 @@ BUTTONS: tuple[BondButtonEntityDescription, ...] = (
         key=Action.INCREASE_FLAME,
         name="Increase Flame",
         icon="mdi:fire",
-        mutually_exclusive=Action.SET_FLAME,
+        mutually_exclusive=None,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_FLAME,
         name="Decrease Flame",
         icon="mdi:fire-off",
-        mutually_exclusive=Action.SET_FLAME,
+        mutually_exclusive=None,
     ),
     BondButtonEntityDescription(
         key=Action.TOGGLE_OPEN, name="Toggle Open", mutually_exclusive=Action.OPEN

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -226,7 +226,9 @@ class BondButtonEntity(BondEntity, ButtonEntity):
         description: ButtonEntityDescription,
     ) -> None:
         """Init Bond button."""
-        super().__init__(hub, device, bpup_subs, description.name)
+        super().__init__(
+            hub, device, bpup_subs, description.name, f"_{description.key.lower()}"
+        )
         self.entity_description = description
 
     async def async_press(self, **kwargs: Any) -> None:

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -1,0 +1,196 @@
+"""Support for bond buttons."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bond_api import Action, BPUPSubscriptions
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import BPUP_SUBS, DOMAIN, HUB
+from .entity import BondEntity
+from .utils import BondDevice, BondHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+BUTTONS: tuple[ButtonEntityDescription, ...] = (
+    ButtonEntityDescription(
+        key=Action.STOP,
+        name="Stop Actions",
+        icon="mdi:stop-circle-outline",
+    ),
+    ButtonEntityDescription(
+        key=Action.TOGGLE_POWER,
+        name="Toggle Power",
+        icon="mdi:power-cycle",
+    ),
+    ButtonEntityDescription(
+        key=Action.TOGGLE_LIGHT,
+        name="Toggle Light",
+        icon="mdi:lightbulb-question",
+    ),
+    ButtonEntityDescription(
+        key=Action.INCREASE_BRIGHTNESS,
+        name="Increase Brightness",
+        icon="mdi:brightness-7",
+    ),
+    ButtonEntityDescription(
+        key=Action.DECREASE_BRIGHTNESS,
+        name="Decrease Brightness",
+        icon="mdi:brightness-1",
+    ),
+    ButtonEntityDescription(
+        key=Action.TOGGLE_UP_LIGHT,
+        name="Toggle Up Light",
+        icon="mdi:lightbulb-question",
+    ),
+    ButtonEntityDescription(
+        key=Action.TOGGLE_DOWN_LIGHT,
+        name="Toggle Down Light",
+        icon="mdi:lightbulb-question",
+    ),
+    ButtonEntityDescription(
+        key=Action.START_UP_LIGHT_DIMMER,
+        name="Start Up Light Dimmer",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.START_DOWN_LIGHT_DIMMER,
+        name="Start Down Light Dimmer",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.START_INCREASING_BRIGHTNESS,
+        name="Start Increasing Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.START_DECREASING_BRIGHTNESS,
+        name="Start Decreasing Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.INCREASE_UP_LIGHT_BRIGHTNESS,
+        name="Increase Up Light Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.DECREASE_UP_LIGHT_BRIGHTNESS,
+        name="Decrease Up Light Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.INCREASE_DOWN_LIGHT_BRIGHTNESS,
+        name="Increase Down Light Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.DECREASE_DOWN_LIGHT_BRIGHTNESS,
+        name="Decrease Down Light Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.CYCLE_DOWN_LIGHT_BRIGHTNESS,
+        name="Cycle Down Light Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.CYCLE_DOWN_LIGHT_BRIGHTNESS,
+        name="Cycle Down Light Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.CYCLE_BRIGHTNESS,
+        name="Cycle Brightness",
+        icon="mdi:brightness-percent",
+    ),
+    ButtonEntityDescription(
+        key=Action.INCREASE_SPEED,
+        name="Increase Speed",
+        icon="mdi:skew-more",
+    ),
+    ButtonEntityDescription(
+        key=Action.DECREASE_SPEED,
+        name="Decrease Speed",
+        icon="mdi:skew-less",
+    ),
+    ButtonEntityDescription(
+        key=Action.TOGGLE_DIRECTION,
+        name="Toggle Direction",
+        icon="mdi:directions-fork",
+    ),
+    ButtonEntityDescription(
+        key=Action.INCREASE_TEMPERATURE,
+        name="Increase Temperature",
+        icon="mdi:thermometer-plus",
+    ),
+    ButtonEntityDescription(
+        key=Action.DECREASE_TEMPERATURE,
+        name="Decrease Temperature",
+        icon="mdi:thermometer-minus",
+    ),
+    ButtonEntityDescription(
+        key=Action.INCREASE_FLAME,
+        name="Increase Flame",
+        icon="mdi:fire",
+    ),
+    ButtonEntityDescription(
+        key=Action.DECREASE_FLAME,
+        name="Decrease Flame",
+        icon="mdi:fire-off",
+    ),
+    ButtonEntityDescription(
+        key=Action.TOGGLE_OPEN,
+        name="Toggle Open",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Bond button devices."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    hub: BondHub = data[HUB]
+    bpup_subs: BPUPSubscriptions = data[BPUP_SUBS]
+
+    async_add_entities(
+        [
+            BondButtonEntity(hub, device, bpup_subs, description)
+            for device in hub.devices
+            for description in BUTTONS
+            if device.has_action(description.key)
+        ],
+        True,
+    )
+
+
+class BondButtonEntity(BondEntity, ButtonEntity):
+    """Bond Button Device."""
+
+    def __init__(
+        self,
+        hub: BondHub,
+        device: BondDevice,
+        bpup_subs: BPUPSubscriptions,
+        description: ButtonEntityDescription,
+    ) -> None:
+        """Init Bond button."""
+        super().__init__(hub, device, bpup_subs, description.name)
+        self.entity_description = description
+
+    async def async_press(self, **kwargs: Any) -> None:
+        """Press the button."""
+        await self._hub.bond.action(
+            self._device.device_id, Action(self.entity_description.key)
+        )
+
+    def _apply_state(self, state: dict) -> None:
+        """Apply the state."""

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -1,6 +1,7 @@
 """Support for bond buttons."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 from typing import Any
 
@@ -18,135 +19,173 @@ from .utils import BondDevice, BondHub
 _LOGGER = logging.getLogger(__name__)
 
 
-BUTTONS: tuple[ButtonEntityDescription, ...] = (
-    ButtonEntityDescription(
+@dataclass
+class BondButtonEntityDescriptionMixin:
+    """Mixin to describe a Bond Button entity."""
+
+    mutually_exclusive: Action | None
+
+
+@dataclass
+class BondButtonEntityDescription(
+    ButtonEntityDescription, BondButtonEntityDescriptionMixin
+):
+    """Class to describe a Bond Button entity."""
+
+
+BUTTONS: tuple[BondButtonEntityDescription, ...] = (
+    BondButtonEntityDescription(
         key=Action.STOP,
         name="Stop Actions",
         icon="mdi:stop-circle-outline",
+        mutually_exclusive=None,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.TOGGLE_POWER,
         name="Toggle Power",
         icon="mdi:power-cycle",
+        mutually_exclusive=Action.TURN_ON,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.TOGGLE_LIGHT,
         name="Toggle Light",
         icon="mdi:lightbulb",
+        mutually_exclusive=Action.TURN_LIGHT_ON,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.INCREASE_BRIGHTNESS,
         name="Increase Brightness",
         icon="mdi:brightness-7",
+        mutually_exclusive=Action.SET_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.DECREASE_BRIGHTNESS,
         name="Decrease Brightness",
         icon="mdi:brightness-1",
+        mutually_exclusive=Action.SET_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.TOGGLE_UP_LIGHT,
         name="Toggle Up Light",
         icon="mdi:lightbulb",
+        mutually_exclusive=Action.TURN_UP_LIGHT_ON,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.TOGGLE_DOWN_LIGHT,
         name="Toggle Down Light",
         icon="mdi:lightbulb",
+        mutually_exclusive=Action.TURN_DOWN_LIGHT_ON,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.START_UP_LIGHT_DIMMER,
         name="Start Up Light Dimmer",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.START_DOWN_LIGHT_DIMMER,
         name="Start Down Light Dimmer",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.START_INCREASING_BRIGHTNESS,
         name="Start Increasing Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.START_DECREASING_BRIGHTNESS,
         name="Start Decreasing Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.INCREASE_UP_LIGHT_BRIGHTNESS,
         name="Increase Up Light Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.DECREASE_UP_LIGHT_BRIGHTNESS,
         name="Decrease Up Light Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.INCREASE_DOWN_LIGHT_BRIGHTNESS,
         name="Increase Down Light Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.DECREASE_DOWN_LIGHT_BRIGHTNESS,
         name="Decrease Down Light Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
+        key=Action.CYCLE_UP_LIGHT_BRIGHTNESS,
+        name="Cycle Up Light Brightness",
+        icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
+    ),
+    BondButtonEntityDescription(
         key=Action.CYCLE_DOWN_LIGHT_BRIGHTNESS,
         name="Cycle Down Light Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
-        key=Action.CYCLE_DOWN_LIGHT_BRIGHTNESS,
-        name="Cycle Down Light Brightness",
-        icon="mdi:brightness-percent",
-    ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.CYCLE_BRIGHTNESS,
         name="Cycle Brightness",
         icon="mdi:brightness-percent",
+        mutually_exclusive=Action.SET_BRIGHTNESS,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.INCREASE_SPEED,
         name="Increase Speed",
         icon="mdi:skew-more",
+        mutually_exclusive=Action.SET_SPEED,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.DECREASE_SPEED,
         name="Decrease Speed",
         icon="mdi:skew-less",
+        mutually_exclusive=Action.SET_SPEED,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.TOGGLE_DIRECTION,
         name="Toggle Direction",
         icon="mdi:directions-fork",
+        mutually_exclusive=Action.SET_DIRECTION,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.INCREASE_TEMPERATURE,
         name="Increase Temperature",
         icon="mdi:thermometer-plus",
+        mutually_exclusive=None,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.DECREASE_TEMPERATURE,
         name="Decrease Temperature",
         icon="mdi:thermometer-minus",
+        mutually_exclusive=None,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.INCREASE_FLAME,
         name="Increase Flame",
         icon="mdi:fire",
+        mutually_exclusive=Action.SET_FLAME,
     ),
-    ButtonEntityDescription(
+    BondButtonEntityDescription(
         key=Action.DECREASE_FLAME,
         name="Decrease Flame",
         icon="mdi:fire-off",
+        mutually_exclusive=Action.SET_FLAME,
     ),
-    ButtonEntityDescription(
-        key=Action.TOGGLE_OPEN,
-        name="Toggle Open",
+    BondButtonEntityDescription(
+        key=Action.TOGGLE_OPEN, name="Toggle Open", mutually_exclusive=Action.OPEN
     ),
 )
 
@@ -167,6 +206,10 @@ async def async_setup_entry(
             for device in hub.devices
             for description in BUTTONS
             if device.has_action(description.key)
+            and (
+                description.mutually_exclusive is None
+                or not device.has_action(description.mutually_exclusive)
+            )
         ],
         True,
     )

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -41,6 +41,7 @@ class BondEntity(Entity):
         device: BondDevice,
         bpup_subs: BPUPSubscriptions,
         sub_device: str | None = None,
+        sub_device_id: str | None = None,
     ) -> None:
         """Initialize entity with API and device info."""
         self._hub = hub
@@ -51,7 +52,8 @@ class BondEntity(Entity):
         self._bpup_subs = bpup_subs
         self._update_lock: Lock | None = None
         self._initialized = False
-        sub_device_id: str = f"_{sub_device}" if sub_device else ""
+        if sub_device and not sub_device_id:
+            sub_device_id = f"_{sub_device}"
         self._attr_unique_id = f"{hub.bond_id}_{device.device_id}{sub_device_id}"
         if sub_device:
             sub_device_name = sub_device.replace("_", " ").title()

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -69,7 +69,7 @@ class BondEntity(Entity):
             configuration_url=f"http://{self._hub.host}",
         )
         if self.name is not None:
-            device_info[ATTR_NAME] = self.name
+            device_info[ATTR_NAME] = self._device.name
         if self._hub.bond_id is not None:
             device_info[ATTR_VIA_DEVICE] = (DOMAIN, self._hub.bond_id)
         if self._device.location is not None:

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -52,8 +52,12 @@ class BondEntity(Entity):
         self._bpup_subs = bpup_subs
         self._update_lock: Lock | None = None
         self._initialized = False
-        if sub_device and not sub_device_id:
+        if sub_device_id:
+            sub_device_id = f"_{sub_device_id}"
+        elif sub_device:
             sub_device_id = f"_{sub_device}"
+        else:
+            sub_device_id = ""
         self._attr_unique_id = f"{hub.bond_id}_{device.device_id}{sub_device_id}"
         if sub_device:
             sub_device_name = sub_device.replace("_", " ").title()

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -1,0 +1,114 @@
+"""Tests for the Bond button device."""
+
+from bond_api import Action, DeviceType
+
+from homeassistant import core
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import EntityRegistry
+
+from .common import patch_bond_action, patch_bond_device_state, setup_platform
+
+
+def light_brightness_increase_decrease_only(name: str):
+    """Create a light that can only increase or decrease brightness."""
+    return {
+        "name": name,
+        "type": DeviceType.LIGHT,
+        "actions": [
+            Action.TURN_LIGHT_ON,
+            Action.TURN_LIGHT_OFF,
+            Action.START_INCREASING_BRIGHTNESS,
+            Action.START_DECREASING_BRIGHTNESS,
+            Action.STOP,
+        ],
+    }
+
+
+def fireplace_increase_decrease_only(name: str):
+    """Create a fireplace that can only increase or decrease flame."""
+    return {
+        "name": name,
+        "type": DeviceType.LIGHT,
+        "actions": [
+            Action.INCREASE_FLAME,
+            Action.DECREASE_FLAME,
+        ],
+    }
+
+
+def fireplace_set_flame(name: str):
+    """Create a fireplace that can adjust the flame."""
+    return {
+        "name": name,
+        "type": DeviceType.LIGHT,
+        "actions": [Action.INCREASE_FLAME, Action.DECREASE_FLAME, Action.SET_FLAME],
+    }
+
+
+async def test_entity_registry(hass: core.HomeAssistant):
+    """Tests that the devices are registered in the entity registry."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        light_brightness_increase_decrease_only("name-1"),
+        bond_version={"bondid": "test-hub-id"},
+        bond_device_id="test-device-id",
+    )
+
+    registry: EntityRegistry = er.async_get(hass)
+    entity = registry.entities["button.name_1_stop_actions"]
+    assert entity.unique_id == "test-hub-id_test-device-id_stop"
+    entity = registry.entities["button.name_1_start_increasing_brightness"]
+    assert entity.unique_id == "test-hub-id_test-device-id_startincreasingbrightness"
+    entity = registry.entities["button.name_1_start_decreasing_brightness"]
+    assert entity.unique_id == "test-hub-id_test-device-id_startdecreasingbrightness"
+
+
+async def test_mutually_exclusive_actions(hass: core.HomeAssistant):
+    """Tests we do not create the button when there is a mutually exclusive action."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        fireplace_set_flame("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    assert not hass.states.async_all("button")
+
+
+async def test_press_button(hass: core.HomeAssistant):
+    """Tests we can press a button."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        fireplace_increase_decrease_only("name-1"),
+        bond_device_id="test-device-id",
+    )
+
+    assert hass.states.get("button.name_1_increase_flame")
+    assert hass.states.get("button.name_1_decrease_flame")
+
+    with patch_bond_action() as mock_action, patch_bond_device_state():
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.name_1_increase_flame"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_action.assert_called_once_with("test-device-id", Action(Action.INCREASE_FLAME))
+
+    with patch_bond_action() as mock_action, patch_bond_device_state():
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.name_1_decrease_flame"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_action.assert_called_once_with("test-device-id", Action(Action.DECREASE_FLAME))

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -39,12 +39,12 @@ def fireplace_increase_decrease_only(name: str):
     }
 
 
-def fireplace_set_flame(name: str):
-    """Create a fireplace that can adjust the flame."""
+def light(name: str):
+    """Create a light with a given name."""
     return {
         "name": name,
         "type": DeviceType.LIGHT,
-        "actions": [Action.INCREASE_FLAME, Action.DECREASE_FLAME, Action.SET_FLAME],
+        "actions": [Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF, Action.SET_BRIGHTNESS],
     }
 
 
@@ -72,7 +72,7 @@ async def test_mutually_exclusive_actions(hass: core.HomeAssistant):
     await setup_platform(
         hass,
         BUTTON_DOMAIN,
-        fireplace_set_flame("name-1"),
+        light("name-1"),
         bond_device_id="test-device-id",
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The custom `start_increasing_brightness`, `start_decreasing_brightness` and `stop` services are now deprecated and will be removed in a future release.  Use the new button platform instead.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add button platform to bond.

The following buttons are now available for devices that do not support tracking state.  For example, if the device can set brightness, increase and decrease brightness buttons will not be created.

- Stop Actions
- Toggle Power
- Toggle Light
- Increase Brightness
- Decrease Brightness
- Toggle Up Light
- Toggle Down Light
- Start Up Light Dimmer
- Start Down Light Dimmer
- Start Increasing Brightness
- Start Decreasing Brightness
- Increase Up Light Brightness
- Decrease Up Light Brightness
- Increase Down Light Brightness
- Decrease Down Light Brightness
- Cycle Up Light Brightness
- Cycle Down Light Brightness
- Cycle Brightness
- Increase Speed
- Decrease Speed
- Toggle Direction
- Increase Temperature
- Decrease Temperature
- Increase Flame
- Decrease Flame
- Toggle Open

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21300

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
