### PR TITLE
Refactor nest test_init_sdm tests to use fixtures with varied config types

### DIFF
--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -1,12 +1,33 @@
 """Common libraries for test setup."""
+from __future__ import annotations
 
+import copy
 import shutil
+from typing import Any
 from unittest.mock import patch
 import uuid
 
 import aiohttp
 from google_nest_sdm.auth import AbstractAuth
+from google_nest_sdm.device_manager import DeviceManager
 import pytest
+
+from homeassistant.components.nest import DOMAIN
+from homeassistant.components.nest.const import CONF_SUBSCRIBER_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .common import (
+    SUBSCRIBER_ID,
+    TEST_CONFIG_HYBRID,
+    TEST_CONFIG_YAML_ONLY,
+    FakeSubscriber,
+    NestTestConfig,
+    PlatformSetup,
+    YieldFixture,
+)
+
+from tests.common import MockConfigEntry
 
 
 class FakeAuth(AbstractAuth):
@@ -76,3 +97,100 @@ def cleanup_media_storage(hass):
     with patch("homeassistant.components.nest.media_source.MEDIA_PATH", new=tmp_path):
         yield
         shutil.rmtree(hass.config.path(tmp_path), ignore_errors=True)
+
+
+@pytest.fixture
+def subscriber() -> YieldFixture[FakeSubscriber]:
+    """Set up the FakeSusbcriber."""
+    subscriber = FakeSubscriber()
+    with patch(
+        "homeassistant.components.nest.api.GoogleNestSubscriber",
+        return_value=subscriber,
+    ):
+        yield subscriber
+
+
+@pytest.fixture
+async def device_manager(subscriber: FakeSubscriber) -> DeviceManager:
+    """Set up the DeviceManager."""
+    return await subscriber.async_get_device_manager()
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return []
+
+
+@pytest.fixture
+def subscriber_id() -> str:
+    """Fixture to let tests override subscriber id regardless of configuration type used."""
+    return SUBSCRIBER_ID
+
+
+@pytest.fixture(
+    params=[TEST_CONFIG_YAML_ONLY, TEST_CONFIG_HYBRID],
+    ids=["yaml-config-only", "hybrid-config"],
+)
+def nest_test_config(request) -> NestTestConfig:
+    """Fixture that sets up the configuration used for the test."""
+    return request.param
+
+
+@pytest.fixture
+def config(
+    subscriber_id: str | None, nest_test_config: NestTestConfig
+) -> dict[str, Any]:
+    """Fixture that sets up the configuration.yaml for the test."""
+    config = copy.deepcopy(nest_test_config.config)
+    if CONF_SUBSCRIBER_ID in config.get(DOMAIN, {}):
+        if subscriber_id:
+            config[DOMAIN][CONF_SUBSCRIBER_ID] = subscriber_id
+        else:
+            del config[DOMAIN][CONF_SUBSCRIBER_ID]
+    return config
+
+
+@pytest.fixture
+def config_entry(
+    subscriber_id: str | None, nest_test_config: NestTestConfig
+) -> MockConfigEntry | None:
+    """Fixture that sets up the ConfigEntry for the test."""
+    if nest_test_config.config_entry_data is None:
+        return None
+    data = copy.deepcopy(nest_test_config.config_entry_data)
+    if CONF_SUBSCRIBER_ID in data:
+        if subscriber_id:
+            data[CONF_SUBSCRIBER_ID] = subscriber_id
+        else:
+            del data[CONF_SUBSCRIBER_ID]
+    return MockConfigEntry(domain=DOMAIN, data=data)
+
+
+@pytest.fixture
+async def setup_base_platform(
+    hass: HomeAssistant,
+    platforms: list[str],
+    config: dict[str, Any],
+    config_entry: MockConfigEntry | None,
+) -> YieldFixture[PlatformSetup]:
+    """Fixture to setup the integration platform."""
+    if config_entry:
+        config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
+    ), patch("homeassistant.components.nest.PLATFORMS", platforms):
+
+        async def _setup_func() -> bool:
+            assert await async_setup_component(hass, DOMAIN, config)
+            await hass.async_block_till_done()
+
+        yield _setup_func
+
+
+@pytest.fixture
+async def setup_platform(
+    setup_base_platform: PlatformSetup, subscriber: FakeSubscriber
+) -> PlatformSetup:
+    """Fixture to setup the integration platform and subscriber."""
+    return setup_base_platform

--- a/tests/components/nest/test_api.py
+++ b/tests/components/nest/test_api.py
@@ -39,7 +39,7 @@ async def test_auth(hass, aioclient_mock):
     """Exercise authentication library creates valid credentials."""
 
     expiration_time = time.time() + 86400
-    create_config_entry(hass, expiration_time)
+    create_config_entry(expiration_time).add_to_hass(hass)
 
     # Prepare to capture credentials in API request.  Empty payloads just mean
     # no devices or structures are loaded.
@@ -88,7 +88,7 @@ async def test_auth_expired_token(hass, aioclient_mock):
     """Verify behavior of an expired token."""
 
     expiration_time = time.time() - 86400
-    create_config_entry(hass, expiration_time)
+    create_config_entry(expiration_time).add_to_hass(hass)
 
     # Prepare a token refresh response
     aioclient_mock.post(

--- a/tests/components/nest/test_diagnostics.py
+++ b/tests/components/nest/test_diagnostics.py
@@ -70,7 +70,8 @@ async def test_entry_diagnostics(hass, hass_client):
 
 async def test_setup_susbcriber_failure(hass, hass_client):
     """Test configuration error."""
-    config_entry = create_config_entry(hass)
+    config_entry = create_config_entry()
+    config_entry.add_to_hass(hass)
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"
     ), patch(

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -1043,7 +1043,8 @@ async def test_media_store_persistence(hass, auth, hass_client, event_store):
     # Fetch media for events when published
     subscriber.cache_policy.fetch = True
 
-    config_entry = create_config_entry(hass)
+    config_entry = create_config_entry()
+    config_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor nest test_init_sdm to use fixtures, and make the configuration types
used in the tests more explicit. This is in prepration for adding a pure
config-flow based setup.

The current tests use a configuration.yaml based test setup and modify it
to work for modes that have some options for config flows, and it is too
complex to repeat this pattern when adding more to the config flow. Instead,
we now codify these with a NestTestConfig class that feeds the config and config entry
into the test setup.

Also adds use in a simple platfomr (sensor) to show that it can work in that context also.

Follow-up PRs will add the config flow (#64680) and use the fixtures in more tests and
remove the common.py test setup entirely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
