### PR TITLE
Update nest media player device thumbnails

### DIFF
--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -206,9 +206,10 @@ async def test_no_eligible_devices(hass, auth):
     assert not browse.children
 
 
-async def test_supported_device(hass, auth):
+@pytest.mark.parametrize("traits", [CAMERA_TRAITS, BATTERY_CAMERA_TRAITS])
+async def test_supported_device(hass, auth, traits):
     """Test a media source with a supported camera."""
-    await async_setup_devices(hass, auth, CAMERA_DEVICE_TYPE, CAMERA_TRAITS)
+    await async_setup_devices(hass, auth, CAMERA_DEVICE_TYPE, traits)
 
     assert len(hass.states.async_all()) == 1
     camera = hass.states.get("camera.front")

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -104,7 +104,6 @@ def mp4() -> io.BytesIO:
     stream.width = 480
     stream.height = 320
     stream.pix_fmt = "yuv420p"
-    #    stream.options.update({"g": str(fps), "keyint_min": str(fps)})
 
     for frame_i in range(total_frames):
         img = frame_image_data(frame_i, total_frames)
@@ -770,6 +769,17 @@ async def test_camera_event_clip_preview(hass, auth, hass_client, mp4):
     assert received_event.data["type"] == "camera_motion"
     event_identifier = received_event.data["nest_event_id"]
 
+    # List devices
+    browse = await media_source.async_browse_media(hass, f"{const.URI_SCHEME}{DOMAIN}")
+    assert browse.domain == DOMAIN
+    assert len(browse.children) == 1
+    assert browse.children[0].domain == DOMAIN
+    assert browse.children[0].identifier == device.id
+    assert browse.children[0].title == "Front: Recent Events"
+    assert (
+        browse.children[0].thumbnail
+        == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
+    )
     # Browse to the device
     browse = await media_source.async_browse_media(
         hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
@@ -778,10 +788,7 @@ async def test_camera_event_clip_preview(hass, auth, hass_client, mp4):
     assert browse.identifier == device.id
     assert browse.title == "Front: Recent Events"
     assert browse.can_expand
-    assert (
-        browse.thumbnail
-        == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
-    )
+    assert not browse.thumbnail
     # The device expands recent events
     assert len(browse.children) == 1
     assert browse.children[0].domain == DOMAIN
@@ -1403,12 +1410,22 @@ async def test_camera_image_resize(hass, auth, hass_client):
     assert contents == IMAGE_BYTES_FROM_EVENT
 
     # The event thumbnail is used for the device thumbnail
+    browse = await media_source.async_browse_media(hass, f"{const.URI_SCHEME}{DOMAIN}")
+    assert browse.domain == DOMAIN
+    assert len(browse.children) == 1
+    assert browse.children[0].identifier == device.id
+    assert browse.children[0].title == "Front: Recent Events"
+    assert (
+        browse.children[0].thumbnail
+        == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
+    )
+
+    # Browse to device. No thumbnail is needed for the device on the device page
     browse = await media_source.async_browse_media(
         hass, f"{const.URI_SCHEME}{DOMAIN}/{device.id}"
     )
     assert browse.domain == DOMAIN
     assert browse.identifier == device.id
-    assert (
-        browse.thumbnail
-        == f"/api/nest/event_media/{device.id}/{event_identifier}/thumbnail"
-    )
+    assert browse.title == "Front: Recent Events"
+    assert not browse.thumbnail
+    assert len(browse.children) == 1


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the nest media player device thumbnails from the device itself to the page that lists devices.
There is no longer a thumbnail on the device page itself because it is redundant with the first
item in the list and it gets back some screen real estate.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
