### PR TITLE
Add diagnostics support to CPU Speed

### DIFF
--- a/homeassistant/components/cpuspeed/diagnostics.py
+++ b/homeassistant/components/cpuspeed/diagnostics.py
@@ -1,0 +1,17 @@
+"""Diagnostics support for CPU Speed."""
+from __future__ import annotations
+
+from typing import Any
+
+from cpuinfo import cpuinfo
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    info: dict[str, Any] = cpuinfo.get_cpu_info()
+    return info

--- a/tests/components/cpuspeed/test_diagnostics.py
+++ b/tests/components/cpuspeed/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Tests for the diagnostics data provided by the TwenteMilieu integration."""
+"""Tests for the diagnostics data provided by the CPU Speed integration."""
 from unittest.mock import patch
 
 from aiohttp import ClientSession

--- a/tests/components/cpuspeed/test_diagnostics.py
+++ b/tests/components/cpuspeed/test_diagnostics.py
@@ -1,0 +1,36 @@
+"""Tests for the diagnostics data provided by the TwenteMilieu integration."""
+from unittest.mock import patch
+
+from aiohttp import ClientSession
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    init_integration: MockConfigEntry,
+):
+    """Test diagnostics."""
+    info = {
+        "hz_actual": (3200000001, 0),
+        "arch_string_raw": "aargh",
+        "brand_raw": "Intel Ryzen 7",
+        "hz_advertised": (3600000001, 0),
+    }
+
+    with patch(
+        "homeassistant.components.cpuspeed.diagnostics.cpuinfo.get_cpu_info",
+        return_value=info,
+    ):
+        assert await get_diagnostics_for_config_entry(
+            hass, hass_client, init_integration
+        ) == {
+            "hz_actual": [3200000001, 0],
+            "arch_string_raw": "aargh",
+            "brand_raw": "Intel Ryzen 7",
+            "hz_advertised": [3600000001, 0],
+        }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to CPU Speed

Example output:
```json
{
  "python_version": "3.9.9.final.0 (64 bit)",
  "cpuinfo_version": [
    8,
    0,
    0
  ],
  "cpuinfo_version_string": "8.0.0",
  "arch": "X86_64",
  "bits": 64,
  "count": 4,
  "arch_string_raw": "x86_64",
  "vendor_id_raw": "AuthenticAMD",
  "brand_raw": "AMD EPYC Processor",
  "hz_advertised_friendly": "3.6000 GHz",
  "hz_actual_friendly": "3.6000 GHz",
  "hz_advertised": [
    3599998000,
    0
  ],
  "hz_actual": [
    3599998000,
    0
  ],
  "stepping": 2,
  "model": 1,
  "family": 23,
  "flags": [
    "3dnowprefetch",
    "abm",
    "adx",
    "aes",
    "apic",
    "arat",
    "avx",
    "avx2",
    "bmi1",
    "bmi2",
    "clflush",
    "clflushopt",
    "cmov",
    "cmp_legacy",
    "cpuid",
    "cr8_legacy",
    "cx16",
    "cx8",
    "de",
    "extd_apicid",
    "f16c",
    "fma",
    "fpu",
    "fsgsbase",
    "fxsr",
    "fxsr_opt",
    "ht",
    "hypervisor",
    "lahf_lm",
    "lm",
    "mca",
    "mce",
    "misalignsse",
    "mmx",
    "mmxext",
    "movbe",
    "msr",
    "mtrr",
    "nopl",
    "nx",
    "osvw",
    "osxsave",
    "pae",
    "pat",
    "pclmulqdq",
    "pdpe1gb",
    "pge",
    "pni",
    "popcnt",
    "pse",
    "pse36",
    "rdrand",
    "rdrnd",
    "rdseed",
    "rdtscp",
    "rep_good",
    "sep",
    "sha",
    "sha_ni",
    "smap",
    "smep",
    "sse",
    "sse2",
    "sse4_1",
    "sse4_2",
    "sse4a",
    "ssse3",
    "syscall",
    "topoext",
    "tsc",
    "tsc_known_freq",
    "vme",
    "vmmcall",
    "x2apic",
    "xgetbv1",
    "xsave",
    "xsavec",
    "xsaveopt"
  ],
  "l3_cache_size": 524288,
  "l2_cache_size": "2 MiB",
  "l1_data_cache_size": "128 KiB",
  "l1_instruction_cache_size": "256 KiB",
  "l2_cache_line_size": 512,
  "l2_cache_associativity": 6
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
