### PR TITLE
Point updates

### DIFF
--- a/homeassistant/components/point/binary_sensor.py
+++ b/homeassistant/components/point/binary_sensor.py
@@ -121,7 +121,7 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
         if self.device_class == BinarySensorDeviceClass.CONNECTIVITY:
             # connectivity is the other way around.
             return not self._is_on
-        return self._is_on
+        return bool(self._is_on)
 
     @property
     def name(self):

--- a/homeassistant/components/point/binary_sensor.py
+++ b/homeassistant/components/point/binary_sensor.py
@@ -1,4 +1,6 @@
 """Support for Minut Point binary sensors."""
+from __future__ import annotations
+
 import logging
 
 from pypoint import EVENTS
@@ -74,7 +76,7 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
         self._device_name = device_name
         self._async_unsub_hook_dispatcher_connect = None
         self._events = EVENTS[device_name]
-        self._is_on = None
+        self._attr_is_on = None
 
     async def async_added_to_hass(self):
         """Call when entity is added to HOme Assistant."""
@@ -93,10 +95,11 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
         """Update the value of the sensor."""
         if not self.is_updated:
             return
-        if self._events[0] in self.device.ongoing_events:
-            self._is_on = True
+        if self.device_class == BinarySensorDeviceClass.CONNECTIVITY:
+            # connectivity is the other way around.
+            self._attr_is_on = not (self._events[0] in self.device.ongoing_events)
         else:
-            self._is_on = None
+            self._attr_is_on = self._events[0] in self.device.ongoing_events
         self.async_write_ha_state()
 
     @callback
@@ -110,18 +113,18 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
             return
         _LOGGER.debug("Received webhook: %s", _type)
         if _type == self._events[0]:
-            self._is_on = True
-        if _type == self._events[1]:
-            self._is_on = None
-        self.async_write_ha_state()
+            _is_on = True
+        elif _type == self._events[1]:
+            _is_on = False
+        else:
+            return
 
-    @property
-    def is_on(self):
-        """Return the state of the binary sensor."""
         if self.device_class == BinarySensorDeviceClass.CONNECTIVITY:
             # connectivity is the other way around.
-            return not self._is_on
-        return bool(self._is_on)
+            self._attr_is_on = not _is_on
+        else:
+            self._attr_is_on = _is_on
+        self.async_write_ha_state()
 
     @property
     def name(self):

--- a/homeassistant/components/point/binary_sensor.py
+++ b/homeassistant/components/point/binary_sensor.py
@@ -76,7 +76,6 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
         self._device_name = device_name
         self._async_unsub_hook_dispatcher_connect = None
         self._events = EVENTS[device_name]
-        self._attr_is_on = None
 
     async def async_added_to_hass(self):
         """Call when entity is added to HOme Assistant."""

--- a/homeassistant/components/point/manifest.json
+++ b/homeassistant/components/point/manifest.json
@@ -3,7 +3,7 @@
   "name": "Minut Point",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/point",
-  "requirements": ["pypoint==2.2.1"],
+  "requirements": ["pypoint==2.3.0"],
   "dependencies": ["webhook", "http"],
   "codeowners": ["@fredrike"],
   "quality_scale": "gold",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1767,7 +1767,7 @@ pypjlink2==1.2.1
 pyplaato==0.0.15
 
 # homeassistant.components.point
-pypoint==2.2.1
+pypoint==2.3.0
 
 # homeassistant.components.profiler
 pyprof2calltree==1.4.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1121,7 +1121,7 @@ pypck==0.7.13
 pyplaato==0.0.15
 
 # homeassistant.components.point
-pypoint==2.2.1
+pypoint==2.3.0
 
 # homeassistant.components.profiler
 pyprof2calltree==1.4.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- fix binary_sensor state (when did the change for a binary sensor need to return a bool for `is_on` went live?)
- Bump pypoint version: [2.2.1 → 2.3.0](https://github.com/fredrike/pypoint/compare/v2.2.1...v2.3.0)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
