### PR TITLE
Allow homekit_controller to handle device registry entries for devices with poor serial numbers

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -210,24 +210,16 @@ class HKDevice:
             service_type=ServicesTypes.ACCESSORY_INFORMATION,
         )
 
-        serial_number = info.value(CharacteristicsTypes.SERIAL_NUMBER)
+        identifiers = {
+            (
+                IDENTIFIER_ACCESSORY_ID,
+                f"{self.unique_id}:aid:{accessory.aid}",
+            )
+        }
 
-        if self.unreliable_serial_numbers and accessory.aid > 1:
-            # Some accessories do not have a serial number
-            identifiers = {
-                (
-                    DOMAIN,
-                    IDENTIFIER_ACCESSORY_ID,
-                    f"{self.unique_id}_{accessory.aid}",
-                )
-            }
-        else:
-            identifiers = {(DOMAIN, IDENTIFIER_SERIAL_NUMBER, serial_number)}
-
-        if accessory.aid == 1:
-            # Accessory 1 is the root device (sometimes the only device, sometimes a bridge)
-            # Link the root device to the pairing id for the connection.
-            identifiers.add((DOMAIN, IDENTIFIER_ACCESSORY_ID, self.unique_id))
+        if not self.unreliable_serial_numbers:
+            serial_number = info.value(CharacteristicsTypes.SERIAL_NUMBER)
+            identifiers.add((IDENTIFIER_SERIAL_NUMBER, serial_number))
 
         device_info = DeviceInfo(
             identifiers=identifiers,
@@ -243,9 +235,8 @@ class HKDevice:
             # It *doesn't* have a via_device, as it is the device we are connecting to
             # Every other accessory should use it as its via device.
             device_info[ATTR_VIA_DEVICE] = (
-                DOMAIN,
-                IDENTIFIER_SERIAL_NUMBER,
-                self.connection_info["serial-number"],
+                IDENTIFIER_ACCESSORY_ID,
+                f"{self.unique_id}:aid:1",
             )
 
         return device_info

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -11,9 +11,10 @@ TRIGGERS = f"{DOMAIN}-triggers"
 HOMEKIT_DIR = ".homekit"
 PAIRING_FILE = "pairing.json"
 
-IDENTIFIER_SERIAL_NUMBER = "serial-number"
-IDENTIFIER_ACCESSORY_ID = "accessory-id"
-
+IDENTIFIER_SERIAL_NUMBER = "homekit_controller:serial-number"
+IDENTIFIER_ACCESSORY_ID = "homekit_controller:accessory-id"
+IDENTIFIER_LEGACY_SERIAL_NUMBER = "serial-number"
+IDENTIFIER_LEGACY_ACCESSORY_ID = "accessory-id"
 
 # Mapping from Homekit type to component.
 HOMEKIT_ACCESSORY_DISPATCH = {

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 # Root device in test harness always has an accessory id of this
-HUB_TEST_ACCESSORY_ID: Final[str] = "00:00:00:00:00:00"
+HUB_TEST_ACCESSORY_ID: Final[str] = "00:00:00:00:00:00:aid:1"
 
 
 @dataclass
@@ -263,8 +263,8 @@ async def assert_devices_and_entities_created(
 
         device = device_registry.async_get_device(
             {
-                (DOMAIN, IDENTIFIER_SERIAL_NUMBER, expected.serial_number),
-                (DOMAIN, IDENTIFIER_ACCESSORY_ID, expected.unique_id),
+                (IDENTIFIER_SERIAL_NUMBER, expected.serial_number),
+                (IDENTIFIER_ACCESSORY_ID, expected.unique_id),
             }
         )
 
@@ -282,7 +282,7 @@ async def assert_devices_and_entities_created(
         serial_number_set = False
         accessory_id_set = False
 
-        for _, key, value in device.identifiers:
+        for key, value in device.identifiers:
             if key == IDENTIFIER_SERIAL_NUMBER:
                 assert value == expected.serial_number
                 serial_number_set = True

--- a/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
+++ b/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
@@ -33,6 +33,7 @@ async def test_eufycam_setup(hass):
                     sw_version="1.6.7",
                     hw_version="1.0.0",
                     serial_number="A0000A000000000D",
+                    unique_id="00:00:00:00:00:00:aid:4",
                     devices=[],
                     entities=[
                         EntityTestInfo(

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -54,6 +54,7 @@ async def test_ecobee3_setup(hass):
                     sw_version="1.0.0",
                     hw_version="",
                     serial_number="AB1C",
+                    unique_id="00:00:00:00:00:00:aid:2",
                     devices=[],
                     entities=[
                         EntityTestInfo(
@@ -71,6 +72,7 @@ async def test_ecobee3_setup(hass):
                     sw_version="1.0.0",
                     hw_version="",
                     serial_number="AB2C",
+                    unique_id="00:00:00:00:00:00:aid:3",
                     devices=[],
                     entities=[
                         EntityTestInfo(
@@ -88,6 +90,7 @@ async def test_ecobee3_setup(hass):
                     sw_version="1.0.0",
                     hw_version="",
                     serial_number="AB3C",
+                    unique_id="00:00:00:00:00:00:aid:4",
                     devices=[],
                     entities=[
                         EntityTestInfo(
@@ -139,7 +142,7 @@ async def test_ecobee3_setup_from_cache(hass, hass_storage):
         "version": 1,
         "data": {
             "pairings": {
-                "00:00:00:00:00:00": {
+                HUB_TEST_ACCESSORY_ID: {
                     "config_num": 1,
                     "accessories": [
                         a.to_accessory_and_service_list() for a in accessories

--- a/tests/components/homekit_controller/specific_devices/test_haa_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_haa_fan.py
@@ -38,6 +38,7 @@ async def test_haa_fan_setup(hass):
                     sw_version="5.0.18",
                     hw_version="",
                     serial_number="C718B3-2",
+                    unique_id="00:00:00:00:00:00:aid:2",
                     devices=[],
                     entities=[
                         EntityTestInfo(

--- a/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
@@ -41,6 +41,7 @@ async def test_homeassistant_bridge_fan_setup(hass):
                     sw_version="0.104.0.dev0",
                     hw_version="",
                     serial_number="fan.living_room_fan",
+                    unique_id="00:00:00:00:00:00:aid:1256851357",
                     devices=[],
                     entities=[
                         EntityTestInfo(

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -36,6 +36,7 @@ async def test_hue_bridge_setup(hass):
                     sw_version="45.1.17846",
                     hw_version="",
                     serial_number="6623462389072572",
+                    unique_id="00:00:00:00:00:00:aid:6623462389072572",
                     devices=[],
                     entities=[
                         EntityTestInfo(

--- a/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
@@ -33,11 +33,9 @@ async def test_ryse_smart_bridge_setup(hass):
             manufacturer="RYSE Inc.",
             sw_version="1.3.0",
             hw_version="0101.3521.0436",
-            # This is an actual bug in the device..
-            serial_number="0101.3521.0436",
             devices=[
                 DeviceTestInfo(
-                    unique_id="00:00:00:00:00:00_2",
+                    unique_id="00:00:00:00:00:00:aid:2",
                     name="Master Bath South",
                     model="RYSE Shade",
                     manufacturer="RYSE Inc.",
@@ -63,7 +61,7 @@ async def test_ryse_smart_bridge_setup(hass):
                     ],
                 ),
                 DeviceTestInfo(
-                    unique_id="00:00:00:00:00:00_3",
+                    unique_id="00:00:00:00:00:00:aid:3",
                     name="RYSE SmartShade",
                     model="RYSE Shade",
                     manufacturer="RYSE Inc.",
@@ -110,11 +108,9 @@ async def test_ryse_smart_bridge_four_shades_setup(hass):
             manufacturer="RYSE Inc.",
             sw_version="1.3.0",
             hw_version="0401.3521.0679",
-            # This is an actual bug in the device..
-            serial_number="0401.3521.0679",
             devices=[
                 DeviceTestInfo(
-                    unique_id="00:00:00:00:00:00_2",
+                    unique_id="00:00:00:00:00:00:aid:2",
                     name="LR Left",
                     model="RYSE Shade",
                     manufacturer="RYSE Inc.",
@@ -140,7 +136,7 @@ async def test_ryse_smart_bridge_four_shades_setup(hass):
                     ],
                 ),
                 DeviceTestInfo(
-                    unique_id="00:00:00:00:00:00_3",
+                    unique_id="00:00:00:00:00:00:aid:3",
                     name="LR Right",
                     model="RYSE Shade",
                     manufacturer="RYSE Inc.",
@@ -166,7 +162,7 @@ async def test_ryse_smart_bridge_four_shades_setup(hass):
                     ],
                 ),
                 DeviceTestInfo(
-                    unique_id="00:00:00:00:00:00_4",
+                    unique_id="00:00:00:00:00:00:aid:4",
                     name="BR Left",
                     model="RYSE Shade",
                     manufacturer="RYSE Inc.",
@@ -192,7 +188,7 @@ async def test_ryse_smart_bridge_four_shades_setup(hass):
                     ],
                 ),
                 DeviceTestInfo(
-                    unique_id="00:00:00:00:00:00_5",
+                    unique_id="00:00:00:00:00:00:aid:5",
                     name="RZSS",
                     model="RYSE Shade",
                     manufacturer="RYSE Inc.",

--- a/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
@@ -48,6 +48,7 @@ async def test_velux_cover_setup(hass):
                     sw_version="48",
                     hw_version="",
                     serial_number="1111111a114a111a",
+                    unique_id="00:00:00:00:00:00:aid:3",
                     devices=[],
                     entities=[
                         EntityTestInfo(
@@ -68,6 +69,7 @@ async def test_velux_cover_setup(hass):
                     sw_version="16",
                     hw_version="",
                     serial_number="a11b111",
+                    unique_id="00:00:00:00:00:00:aid:2",
                     devices=[],
                     entities=[
                         EntityTestInfo(

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -1,0 +1,164 @@
+"""Tests for HKDevice."""
+
+import dataclasses
+
+import pytest
+
+from homeassistant.components.homekit_controller.const import (
+    DOMAIN,
+    IDENTIFIER_ACCESSORY_ID,
+    IDENTIFIER_LEGACY_ACCESSORY_ID,
+    IDENTIFIER_LEGACY_SERIAL_NUMBER,
+    IDENTIFIER_SERIAL_NUMBER,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+from tests.components.homekit_controller.common import (
+    setup_accessories_from_file,
+    setup_platform,
+    setup_test_accessories,
+)
+
+
+@dataclasses.dataclass
+class DeviceMigrationTest:
+    """Holds the expected state before and after testing a device identifier migration."""
+
+    fixture: str
+    manufacturer: str
+    before: set[tuple[str, str, str]]
+    after: set[tuple[str, str]]
+
+
+DEVICE_MIGRATION_TESTS = [
+    # 0401.3521.0679 was incorrectly treated as a serial number, it should be stripped out during migration
+    DeviceMigrationTest(
+        fixture="ryse_smart_bridge_four_shades.json",
+        manufacturer="RYSE Inc.",
+        before={
+            (DOMAIN, IDENTIFIER_LEGACY_ACCESSORY_ID, "00:00:00:00:00:00"),
+            (DOMAIN, IDENTIFIER_LEGACY_SERIAL_NUMBER, "0401.3521.0679"),
+        },
+        after={(IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:1")},
+    ),
+    # This shade has a serial of 1.0.0, which we should already ignore. Make sure it gets migrated to a 2-tuple
+    DeviceMigrationTest(
+        fixture="ryse_smart_bridge_four_shades.json",
+        manufacturer="RYSE Inc.",
+        before={
+            (DOMAIN, IDENTIFIER_LEGACY_ACCESSORY_ID, "00:00:00:00:00:00_3"),
+        },
+        after={(IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:3")},
+    ),
+    # Test migrating a Hue bridge - it has a valid serial number and has an accessory id
+    DeviceMigrationTest(
+        fixture="hue_bridge.json",
+        manufacturer="Philips Lighting",
+        before={
+            (DOMAIN, IDENTIFIER_LEGACY_ACCESSORY_ID, "00:00:00:00:00:00"),
+            (DOMAIN, IDENTIFIER_LEGACY_SERIAL_NUMBER, "123456"),
+        },
+        after={
+            (IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:1"),
+            (IDENTIFIER_SERIAL_NUMBER, "123456"),
+        },
+    ),
+    # Test migrating a Hue remote - it has a valid serial number
+    # Originally as a non-hub non-broken device it wouldn't have had an accessory id
+    DeviceMigrationTest(
+        fixture="hue_bridge.json",
+        manufacturer="Philips",
+        before={
+            (DOMAIN, IDENTIFIER_LEGACY_SERIAL_NUMBER, "6623462389072572"),
+        },
+        after={
+            (IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:6623462389072572"),
+            (IDENTIFIER_SERIAL_NUMBER, "6623462389072572"),
+        },
+    ),
+    # Test migrating a Koogeek LS1. This is just for completeness (testing hub and hub-less devices)
+    DeviceMigrationTest(
+        fixture="koogeek_ls1.json",
+        manufacturer="Koogeek",
+        before={
+            (DOMAIN, IDENTIFIER_LEGACY_ACCESSORY_ID, "00:00:00:00:00:00"),
+            (DOMAIN, IDENTIFIER_LEGACY_SERIAL_NUMBER, "AAAA011111111111"),
+        },
+        after={
+            (IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:1"),
+            (IDENTIFIER_SERIAL_NUMBER, "AAAA011111111111"),
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)
+async def test_migrate_device_id_no_serial_skip_if_other_owner(
+    hass: HomeAssistant, variant: DeviceMigrationTest
+):
+    """
+    Don't migrate unrelated devices.
+
+    Create a device registry entry that needs migrate, but belongs to a different
+    config entry. It should be ignored.
+    """
+    device_registry = dr.async_get(hass)
+
+    bridge = device_registry.async_get_or_create(
+        config_entry_id="XX",
+        identifiers=variant.before,
+        manufacturer="RYSE Inc.",
+        model="RYSE SmartBridge",
+        name="Wiring Closet",
+        sw_version="1.3.0",
+        hw_version="0101.2136.0344",
+    )
+
+    accessories = await setup_accessories_from_file(hass, variant.fixture)
+    await setup_test_accessories(hass, accessories)
+
+    bridge = device_registry.async_get(bridge.id)
+
+    assert bridge.identifiers == variant.before
+    assert bridge.config_entries == {"XX"}
+
+
+@pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)
+async def test_migrate_device_id_no_serial(
+    hass: HomeAssistant, variant: DeviceMigrationTest
+):
+    """Test that a Ryse smart bridge with four shades can be migrated correctly in HA."""
+    device_registry = dr.async_get(hass)
+
+    accessories = await setup_accessories_from_file(hass, variant.fixture)
+
+    fake_controller = await setup_platform(hass)
+    await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
+    config_entry = MockConfigEntry(
+        version=1,
+        domain="homekit_controller",
+        entry_id="TestData",
+        data={"AccessoryPairingID": "00:00:00:00:00:00"},
+        title="test",
+    )
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers=variant.before,
+        manufacturer="Dummy Manufacturer",
+        model="Dummy Model",
+        name="Dummy Name",
+        sw_version="99999999991",
+        hw_version="99999999999",
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get(device.id)
+
+    assert device.identifiers == variant.after
+    assert device.manufacturer == variant.manufacturer


### PR DESCRIPTION
## Proposed change

Part of discussion with @braco in https://github.com/home-assistant/core/issues/60667.

There are 3 types of identifiers we use in homekit_controller:

* The serial number. Assigned when the device is made and should not change. (In practice we have seen them change). In theory we could see collisions between vendors but in practice the only problems we have are from devices with invalid serials (blank, alll 0's, putting the hardware revision in the serial number field)
* The pairing id. This looks like a MAC address. It random and its generated when a device is paired. It's valid for the lifetime of the pairing.
* The indexes used in the HAP API - aid, sid and iid. Together the aid and pairing id uniquely identify a single accessory.

We primarily use the serial number right now. We do record the pairing id, but originally only for the root "hub" device (aid 1). If someone tries to use one of the more broken HomeKit devices (with duplicate serial numbers) it may end up sharing one device entry for multiple accessories. We have some mitigations in place for this, but they aren't complete and having 2 different identifier schemes in play at once is getting messy.

This PR makes a new identifier that is based on the pairing id and aid. Every pairing will use this identifier.  The serial number is recorded where we believe it is safe to do so, and it can still be used to match devices if the pairing id does change.

This simplifies the code, improves its behaviour for devices with low quality serial numbers, but also is seemless for devices with good serial numbers (its still safe to re-pair those devices).

This also migrates 3-tuple device identifiers to 2-tuple device identifiers. (AIUI, the 3-tuple ones are invalid according to our typing signatures). This could be done seperately, but then we'd need 2 migrations not just one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
