### PR TITLE
Add HUB_TEST_ACCESSORY_ID const for homekit_controller tests

### DIFF
--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Final
 from unittest import mock
 
 from aiohomekit.model import Accessories, Accessory
@@ -38,6 +38,10 @@ from tests.common import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Root device in test harness always has an accessory id of this
+HUB_TEST_ACCESSORY_ID: Final[str] = "00:00:00:00:00:00"
 
 
 @dataclass

--- a/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
+++ b/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
@@ -1,6 +1,7 @@
 """Test against characteristics captured from a eufycam."""
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -17,7 +18,7 @@ async def test_eufycam_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="eufy HomeBase2-0AAA",
             model="T8010",
             manufacturer="Anker",

--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -13,6 +13,7 @@ from homeassistant.components.number import NumberMode
 from homeassistant.helpers.entity import EntityCategory
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -29,7 +30,7 @@ async def test_aqara_gateway_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Aqara Hub-1563",
             model="ZHWA11LM",
             manufacturer="Aqara",
@@ -88,7 +89,7 @@ async def test_aqara_gateway_e1_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Aqara-Hub-E1-00A0",
             model="HE1-G01",
             manufacturer="Aqara",

--- a/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
@@ -10,6 +10,7 @@ https://github.com/home-assistant/core/pull/39090
 from homeassistant.const import PERCENTAGE
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     DeviceTriggerInfo,
     EntityTestInfo,
@@ -27,7 +28,7 @@ async def test_aqara_switch_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Programmable Switch",
             model="AR004",
             manufacturer="Aqara",

--- a/tests/components/homekit_controller/specific_devices/test_arlo_baby.py
+++ b/tests/components/homekit_controller/specific_devices/test_arlo_baby.py
@@ -5,6 +5,7 @@ from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -21,7 +22,7 @@ async def test_arlo_baby_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="ArloBabyA0",
             model="ABC1000",
             manufacturer="Netgear, Inc",

--- a/tests/components/homekit_controller/specific_devices/test_connectsense.py
+++ b/tests/components/homekit_controller/specific_devices/test_connectsense.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
 )
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -24,7 +25,7 @@ async def test_connectsense_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="InWall Outlet-0394DE",
             model="CS-IWO",
             manufacturer="ConnectSense",

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -20,6 +20,7 @@ from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers import entity_registry as er
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -38,7 +39,7 @@ async def test_ecobee3_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="HomeW",
             model="ecobee3",
             manufacturer="ecobee Inc.",

--- a/tests/components/homekit_controller/specific_devices/test_ecobee_occupancy.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee_occupancy.py
@@ -5,6 +5,7 @@ https://github.com/home-assistant/core/issues/31827
 """
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -21,7 +22,7 @@ async def test_ecobee_occupancy_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Master Fan",
             model="ecobee Switch+",
             manufacturer="ecobee Inc.",

--- a/tests/components/homekit_controller/specific_devices/test_eve_degree.py
+++ b/tests/components/homekit_controller/specific_devices/test_eve_degree.py
@@ -6,6 +6,7 @@ from homeassistant.const import PERCENTAGE, PRESSURE_HPA, TEMP_CELSIUS
 from homeassistant.helpers.entity import EntityCategory
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -22,7 +23,7 @@ async def test_eve_degree_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Eve Degree AA11",
             model="Eve Degree 00AAA0000",
             manufacturer="Elgato",

--- a/tests/components/homekit_controller/specific_devices/test_haa_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_haa_fan.py
@@ -4,6 +4,7 @@ from homeassistant.components.fan import SUPPORT_SET_SPEED
 from homeassistant.helpers.entity import EntityCategory
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -22,7 +23,7 @@ async def test_haa_fan_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="HAA-C718B3",
             model="RavenSystem HAA",
             manufacturer="José A. Jiménez Campos",

--- a/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
@@ -7,6 +7,7 @@ from homeassistant.components.fan import (
 )
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -25,7 +26,7 @@ async def test_homeassistant_bridge_fan_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Home Assistant Bridge",
             model="Bridge",
             manufacturer="Home Assistant",

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -3,6 +3,7 @@
 from homeassistant.const import PERCENTAGE
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     DeviceTriggerInfo,
     EntityTestInfo,
@@ -20,7 +21,7 @@ async def test_hue_bridge_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Philips hue - 482544",
             model="BSB002",
             manufacturer="Philips Lighting",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -12,6 +12,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     Helper,
@@ -31,7 +32,7 @@ async def test_koogeek_ls1_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Koogeek-LS1-20833F",
             model="LS1",
             manufacturer="Koogeek",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
@@ -4,6 +4,7 @@ from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import POWER_WATT
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -20,7 +21,7 @@ async def test_koogeek_p1eu_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Koogeek-P1-A00AA0",
             model="P1EU",
             manufacturer="Koogeek",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import POWER_WATT
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -26,7 +27,7 @@ async def test_koogeek_sw2_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Koogeek-SW2-187A91",
             model="KH02CN",
             manufacturer="Koogeek",

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -10,6 +10,7 @@ from homeassistant.components.climate.const import (
 )
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -26,7 +27,7 @@ async def test_lennox_e30_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Lennox",
             model="E30 2B",
             manufacturer="Lennox",

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -7,6 +7,7 @@ from homeassistant.components.media_player.const import (
 )
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -23,7 +24,7 @@ async def test_lg_tv(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="LG webOS TV AF80",
             model="OLED55B9PUA",
             manufacturer="LG Electronics",

--- a/tests/components/homekit_controller/specific_devices/test_mysa_living.py
+++ b/tests/components/homekit_controller/specific_devices/test_mysa_living.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -22,7 +23,7 @@ async def test_mysa_living_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Mysa-85dda9",
             model="v1",
             manufacturer="Empowered Homes Inc.",

--- a/tests/components/homekit_controller/specific_devices/test_netamo_doorbell.py
+++ b/tests/components/homekit_controller/specific_devices/test_netamo_doorbell.py
@@ -5,6 +5,7 @@ https://github.com/home-assistant/core/issues/44596
 """
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     DeviceTriggerInfo,
     EntityTestInfo,
@@ -22,7 +23,7 @@ async def test_netamo_doorbell_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="Netatmo-Doorbell-g738658",
             model="Netatmo Doorbell",
             manufacturer="Netatmo",

--- a/tests/components/homekit_controller/specific_devices/test_rainmachine_pro_8.py
+++ b/tests/components/homekit_controller/specific_devices/test_rainmachine_pro_8.py
@@ -5,6 +5,7 @@ https://github.com/home-assistant/core/issues/31745
 """
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -21,7 +22,7 @@ async def test_rainmachine_pro_8_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="RainMachine-00ce4a",
             model="SPK5 Pro",
             manufacturer="Green Electronics LLC",

--- a/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
@@ -8,6 +8,7 @@ from homeassistant.components.cover import (
 from homeassistant.const import PERCENTAGE
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -26,7 +27,7 @@ async def test_ryse_smart_bridge_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="RYSE SmartBridge",
             model="RYSE SmartBridge",
             manufacturer="RYSE Inc.",
@@ -103,7 +104,7 @@ async def test_ryse_smart_bridge_four_shades_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="RYSE SmartBridge",
             model="RYSE SmartBridge",
             manufacturer="RYSE Inc.",

--- a/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
@@ -7,6 +7,7 @@ https://github.com/home-assistant/core/issues/26180
 from homeassistant.components.fan import SUPPORT_DIRECTION, SUPPORT_SET_SPEED
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -23,7 +24,7 @@ async def test_simpleconnect_fan_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="SIMPLEconnect Fan-06F674",
             model="SIMPLEconnect",
             manufacturer="Hunter Fan",

--- a/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 )
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -32,7 +33,7 @@ async def test_velux_cover_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="VELUX Gateway",
             model="VELUX Gateway",
             manufacturer="VELUX",

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
@@ -8,6 +8,7 @@ from homeassistant.const import PERCENTAGE
 from homeassistant.helpers.entity import EntityCategory
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -24,7 +25,7 @@ async def test_vocolinc_flowerbud_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="VOCOlinc-Flowerbud-0d324b",
             model="Flowerbud",
             manufacturer="VOCOlinc",

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
@@ -4,6 +4,7 @@ from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import POWER_WATT
 
 from tests.components.homekit_controller.common import (
+    HUB_TEST_ACCESSORY_ID,
     DeviceTestInfo,
     EntityTestInfo,
     assert_devices_and_entities_created,
@@ -20,7 +21,7 @@ async def test_vocolinc_vp3_setup(hass):
     await assert_devices_and_entities_created(
         hass,
         DeviceTestInfo(
-            unique_id="00:00:00:00:00:00",
+            unique_id=HUB_TEST_ACCESSORY_ID,
             name="VOCOlinc-VP3-123456",
             model="VP3",
             manufacturer="VOCOlinc",


### PR DESCRIPTION
## Proposed change

This is a test-only change. #64749 changes one of the identifiers used in a lot of tests. This PR makes it a const. (I.e. it makes 64749 easier to review).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
