### PR TITLE
Fix import for new AWS aiobotocore lib

### DIFF
--- a/homeassistant/components/aws/__init__.py
+++ b/homeassistant/components/aws/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 from collections import OrderedDict
 import logging
 
-import aiobotocore
+from aiobotocore.session import AioSession
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -165,14 +165,14 @@ async def _validate_aws_credentials(hass, credential):
     del aws_config[CONF_VALIDATE]
 
     if (profile := aws_config.get(CONF_PROFILE_NAME)) is not None:
-        session = aiobotocore.session.AioSession(profile=profile)
+        session = AioSession(profile=profile)
         del aws_config[CONF_PROFILE_NAME]
         if CONF_ACCESS_KEY_ID in aws_config:
             del aws_config[CONF_ACCESS_KEY_ID]
         if CONF_SECRET_ACCESS_KEY in aws_config:
             del aws_config[CONF_SECRET_ACCESS_KEY]
     else:
-        session = aiobotocore.session.AioSession()
+        session = AioSession()
 
     if credential[CONF_VALIDATE]:
         async with session.create_client("iam", **aws_config) as client:

--- a/homeassistant/components/aws/notify.py
+++ b/homeassistant/components/aws/notify.py
@@ -4,7 +4,7 @@ import base64
 import json
 import logging
 
-import aiobotocore
+from aiobotocore.session import AioSession
 
 from homeassistant.components.notify import (
     ATTR_TARGET,
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def get_available_regions(hass, service):
     """Get available regions for a service."""
-    session = aiobotocore.session.get_session()
+    session = AioSession()
     return await session.get_available_regions(service)
 
 
@@ -83,10 +83,10 @@ async def async_get_service(hass, config, discovery_info=None):
 
     if session is None:
         if (profile := aws_config.get(CONF_PROFILE_NAME)) is not None:
-            session = aiobotocore.session.AioSession(profile=profile)
+            session = AioSession(profile=profile)
             del aws_config[CONF_PROFILE_NAME]
         else:
-            session = aiobotocore.session.AioSession()
+            session = AioSession()
 
     aws_config[CONF_REGION] = region_name
 

--- a/tests/components/aws/test_init.py
+++ b/tests/components/aws/test_init.py
@@ -36,7 +36,7 @@ class MockAioSession:
 
 async def test_empty_config(hass):
     """Test a default config will be create for empty config."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch("homeassistant.components.aws.AioSession", new=MockAioSession):
         await async_setup_component(hass, "aws", {"aws": {}})
         await hass.async_block_till_done()
 
@@ -51,7 +51,7 @@ async def test_empty_config(hass):
 
 async def test_empty_credential(hass):
     """Test a default config will be create for empty credential section."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch("homeassistant.components.aws.AioSession", new=MockAioSession):
         await async_setup_component(
             hass,
             "aws",
@@ -84,7 +84,7 @@ async def test_empty_credential(hass):
 
 async def test_profile_credential(hass):
     """Test credentials with profile name."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch("homeassistant.components.aws.AioSession", new=MockAioSession):
         await async_setup_component(
             hass,
             "aws",
@@ -122,7 +122,7 @@ async def test_profile_credential(hass):
 
 async def test_access_key_credential(hass):
     """Test credentials with access key."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch("homeassistant.components.aws.AioSession", new=MockAioSession):
         await async_setup_component(
             hass,
             "aws",
@@ -167,7 +167,11 @@ async def test_access_key_credential(hass):
 
 async def test_notify_credential(hass):
     """Test notify service can use access key directly."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch(
+        "homeassistant.components.aws.AioSession", new=MockAioSession
+    ), async_patch(
+        "homeassistant.components.aws.notify.AioSession", new=MockAioSession
+    ):
         await async_setup_component(
             hass,
             "aws",
@@ -201,7 +205,11 @@ async def test_notify_credential(hass):
 
 async def test_notify_credential_profile(hass):
     """Test notify service can use profile directly."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch(
+        "homeassistant.components.aws.AioSession", new=MockAioSession
+    ), async_patch(
+        "homeassistant.components.aws.notify.AioSession", new=MockAioSession
+    ):
         await async_setup_component(
             hass,
             "aws",
@@ -233,7 +241,7 @@ async def test_notify_credential_profile(hass):
 
 async def test_credential_skip_validate(hass):
     """Test credential can skip validate."""
-    with async_patch("aiobotocore.session.AioSession", new=MockAioSession):
+    with async_patch("homeassistant.components.aws.AioSession", new=MockAioSession):
         await async_setup_component(
             hass,
             "aws",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up of #64045 in order to fix

```log
2022-01-23 00:02:49 ERROR (MainThread) [homeassistant.components.aws] Validating credential [default] failed: module 'aiobotocore' has no attribute 'session'
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/aws/__init__.py", line 168, in _validate_aws_credentials
    session = aiobotocore.session.AioSession(profile=profile)
AttributeError: module 'aiobotocore' has no attribute 'session'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
