### PR TITLE
Fix bond buttons where an argument is required

### DIFF
--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -18,12 +18,18 @@ from .utils import BondDevice, BondHub
 
 _LOGGER = logging.getLogger(__name__)
 
+# The api requires a step size even though it does not
+# seem to matter what is is as the underlying device is likely
+# getting an increase/decrease signal only
+STEP_SIZE = 10
+
 
 @dataclass
 class BondButtonEntityDescriptionMixin:
     """Mixin to describe a Bond Button entity."""
 
     mutually_exclusive: Action | None
+    argument: int | None
 
 
 @dataclass
@@ -39,153 +45,181 @@ BUTTONS: tuple[BondButtonEntityDescription, ...] = (
         name="Stop Actions",
         icon="mdi:stop-circle-outline",
         mutually_exclusive=None,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.TOGGLE_POWER,
         name="Toggle Power",
         icon="mdi:power-cycle",
         mutually_exclusive=Action.TURN_ON,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.TOGGLE_LIGHT,
         name="Toggle Light",
         icon="mdi:lightbulb",
         mutually_exclusive=Action.TURN_LIGHT_ON,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.INCREASE_BRIGHTNESS,
         name="Increase Brightness",
         icon="mdi:brightness-7",
         mutually_exclusive=Action.SET_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_BRIGHTNESS,
         name="Decrease Brightness",
         icon="mdi:brightness-1",
         mutually_exclusive=Action.SET_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.TOGGLE_UP_LIGHT,
         name="Toggle Up Light",
         icon="mdi:lightbulb",
         mutually_exclusive=Action.TURN_UP_LIGHT_ON,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.TOGGLE_DOWN_LIGHT,
         name="Toggle Down Light",
         icon="mdi:lightbulb",
         mutually_exclusive=Action.TURN_DOWN_LIGHT_ON,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.START_UP_LIGHT_DIMMER,
         name="Start Up Light Dimmer",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.START_DOWN_LIGHT_DIMMER,
         name="Start Down Light Dimmer",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.START_INCREASING_BRIGHTNESS,
         name="Start Increasing Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_BRIGHTNESS,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.START_DECREASING_BRIGHTNESS,
         name="Start Decreasing Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_BRIGHTNESS,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.INCREASE_UP_LIGHT_BRIGHTNESS,
         name="Increase Up Light Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_UP_LIGHT_BRIGHTNESS,
         name="Decrease Up Light Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.INCREASE_DOWN_LIGHT_BRIGHTNESS,
         name="Increase Down Light Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_DOWN_LIGHT_BRIGHTNESS,
         name="Decrease Down Light Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.CYCLE_UP_LIGHT_BRIGHTNESS,
         name="Cycle Up Light Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_UP_LIGHT_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.CYCLE_DOWN_LIGHT_BRIGHTNESS,
         name="Cycle Down Light Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_DOWN_LIGHT_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.CYCLE_BRIGHTNESS,
         name="Cycle Brightness",
         icon="mdi:brightness-percent",
         mutually_exclusive=Action.SET_BRIGHTNESS,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.INCREASE_SPEED,
         name="Increase Speed",
         icon="mdi:skew-more",
         mutually_exclusive=Action.SET_SPEED,
+        argument=1,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_SPEED,
         name="Decrease Speed",
         icon="mdi:skew-less",
         mutually_exclusive=Action.SET_SPEED,
+        argument=1,
     ),
     BondButtonEntityDescription(
         key=Action.TOGGLE_DIRECTION,
         name="Toggle Direction",
         icon="mdi:directions-fork",
         mutually_exclusive=Action.SET_DIRECTION,
+        argument=None,
     ),
     BondButtonEntityDescription(
         key=Action.INCREASE_TEMPERATURE,
         name="Increase Temperature",
         icon="mdi:thermometer-plus",
         mutually_exclusive=None,
+        argument=1,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_TEMPERATURE,
         name="Decrease Temperature",
         icon="mdi:thermometer-minus",
         mutually_exclusive=None,
+        argument=1,
     ),
     BondButtonEntityDescription(
         key=Action.INCREASE_FLAME,
         name="Increase Flame",
         icon="mdi:fire",
         mutually_exclusive=None,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
         key=Action.DECREASE_FLAME,
         name="Decrease Flame",
         icon="mdi:fire-off",
         mutually_exclusive=None,
+        argument=STEP_SIZE,
     ),
     BondButtonEntityDescription(
-        key=Action.TOGGLE_OPEN, name="Toggle Open", mutually_exclusive=Action.OPEN
+        key=Action.TOGGLE_OPEN,
+        name="Toggle Open",
+        mutually_exclusive=Action.OPEN,
+        argument=None,
     ),
 )
 
@@ -215,12 +249,14 @@ async def async_setup_entry(
 class BondButtonEntity(BondEntity, ButtonEntity):
     """Bond Button Device."""
 
+    entity_description: BondButtonEntityDescription
+
     def __init__(
         self,
         hub: BondHub,
         device: BondDevice,
         bpup_subs: BPUPSubscriptions,
-        description: ButtonEntityDescription,
+        description: BondButtonEntityDescription,
     ) -> None:
         """Init Bond button."""
         super().__init__(
@@ -230,9 +266,13 @@ class BondButtonEntity(BondEntity, ButtonEntity):
 
     async def async_press(self, **kwargs: Any) -> None:
         """Press the button."""
-        await self._hub.bond.action(
-            self._device.device_id, Action(self.entity_description.key)
-        )
+        if self.entity_description.argument:
+            action = Action(
+                self.entity_description.key, self.entity_description.argument
+            )
+        else:
+            action = Action(self.entity_description.key)
+        await self._hub.bond.action(self._device.device_id, action)
 
     def _apply_state(self, state: dict) -> None:
         """Apply the state."""


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- It was discovered that some of these calls need a value
  passed to it even though the device does not appear
  to actually use it

  See: https://forum.bondhome.io/t/bond-hub-valor-fireplace-and-home-assistant/2988/19?u=bdraco


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
