### PR TITLE
Add diagnostics support to RDW

### DIFF
--- a/homeassistant/components/rdw/diagnostics.py
+++ b/homeassistant/components/rdw/diagnostics.py
@@ -1,0 +1,23 @@
+"""Diagnostics support for RDW."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from vehicle import Vehicle
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: DataUpdateCoordinator[Vehicle] = hass.data[DOMAIN][entry.entry_id]
+    # Round-trip via JSON to trigger serialization
+    data: dict[str, Any] = json.loads(coordinator.data.json())
+    return data

--- a/tests/components/rdw/test_diagnostics.py
+++ b/tests/components/rdw/test_diagnostics.py
@@ -1,0 +1,45 @@
+"""Tests for the diagnostics data provided by the RDW integration."""
+from aiohttp import ClientSession
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    init_integration: MockConfigEntry,
+):
+    """Test diagnostics."""
+    assert await get_diagnostics_for_config_entry(
+        hass, hass_client, init_integration
+    ) == {
+        "apk_expiration": "2022-01-04",
+        "ascription_date": "2021-11-04",
+        "ascription_possible": True,
+        "brand": "Skoda",
+        "energy_label": "A",
+        "engine_capacity": 999,
+        "exported": False,
+        "interior": "hatchback",
+        "last_odometer_registration_year": 2021,
+        "liability_insured": False,
+        "license_plate": "11ZKZ3",
+        "list_price": 10697,
+        "first_admission": "2013-01-04",
+        "first_admission_netherlands": "2013-01-04",
+        "mass_empty": 840,
+        "mass_driveable": 940,
+        "model": "Citigo",
+        "number_of_cylinders": 3,
+        "number_of_doors": 0,
+        "number_of_seats": 4,
+        "number_of_wheelchair_seats": 0,
+        "number_of_wheels": 4,
+        "odometer_judgement": "Logisch",
+        "pending_recall": False,
+        "taxi": None,
+        "vehicle_type": "Personenauto",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to the RDW integration.

Example output:
```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Core",
    "version": "2022.2.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.9.9",
    "docker": false,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.0-11-amd64",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "rdw",
    "name": "RDW",
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/rdw",
    "requirements": [
      "vehicle==0.3.1"
    ],
    "codeowners": [
      "@frenck"
    ],
    "quality_scale": "platinum",
    "iot_class": "cloud_polling",
    "is_built_in": true
  },
  "data": {
    "apk_expiration": null,
    "ascription_date": "2013-08-30",
    "ascription_possible": true,
    "brand": "Fiat",
    "energy_label": null,
    "engine_capacity": 499,
    "exported": false,
    "interior": "sedan",
    "last_odometer_registration_year": 2019,
    "liability_insured": true,
    "license_plate": "AR6458",
    "list_price": null,
    "first_admission": "1967-06-30",
    "first_admission_netherlands": "2013-08-30",
    "mass_empty": 511,
    "mass_driveable": 611,
    "model": "Nuova 500",
    "number_of_cylinders": 2,
    "number_of_doors": 2,
    "number_of_seats": 4,
    "number_of_wheelchair_seats": null,
    "number_of_wheels": 4,
    "odometer_judgement": "Geen oordeel",
    "pending_recall": false,
    "taxi": false,
    "vehicle_type": "Personenauto"
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
