### PR TITLE
Add diagnostics support to Verisure

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1256,6 +1256,7 @@ omit =
     homeassistant/components/verisure/binary_sensor.py
     homeassistant/components/verisure/camera.py
     homeassistant/components/verisure/coordinator.py
+    homeassistant/components/verisure/diagnostics.py
     homeassistant/components/verisure/lock.py
     homeassistant/components/verisure/sensor.py
     homeassistant/components/verisure/switch.py

--- a/homeassistant/components/verisure/diagnostics.py
+++ b/homeassistant/components/verisure/diagnostics.py
@@ -1,0 +1,28 @@
+"""Diagnostics support for Verisure."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import VerisureDataUpdateCoordinator
+
+TO_REDACT = {
+    "date",
+    "area",
+    "deviceArea",
+    "name",
+    "time",
+    "userString",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    return async_redact_data(coordinator.data, TO_REDACT)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to Verisure

Example output:

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Core",
    "version": "2022.2.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.9.9",
    "docker": false,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.0-11-amd64",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "verisure",
    "name": "Verisure",
    "documentation": "https://www.home-assistant.io/integrations/verisure",
    "requirements": [
      "vsure==1.7.3"
    ],
    "codeowners": [
      "@frenck"
    ],
    "config_flow": true,
    "dhcp": [
      {
        "macaddress": "0023C1*"
      }
    ],
    "iot_class": "cloud_polling",
    "is_built_in": true
  },
  "data": {
    "alarm": {
      "statusType": "DISARMED",
      "date": "**REDACTED**",
      "name": "**REDACTED**",
      "changedVia": "CODE"
    },
    "ethernet": true,
    "cameras": {},
    "climate": {
      "2AC4 8YCE": {
        "deviceLabel": "2AC4 8YCE",
        "deviceArea": "**REDACTED**",
        "deviceType": "SMOKE2",
        "temperature": 19.0,
        "humidity": 62.0,
        "time": "**REDACTED**"
      },
      "2AC4 8Z4B": {
        "deviceLabel": "2AC4 8Z4B",
        "deviceArea": "**REDACTED**",
        "deviceType": "SMOKE2",
        "temperature": 18.5,
        "humidity": 64.0,
        "time": "**REDACTED**"
      },
      "2AC4 9HEA": {
        "deviceLabel": "2AC4 9HEA",
        "deviceArea": "**REDACTED**",
        "deviceType": "SMOKE2",
        "temperature": 16.9,
        "humidity": 64.0,
        "time": "**REDACTED**"
      },
      "2S5B KXDF": {
        "deviceLabel": "2S5B KXDF",
        "deviceArea": "**REDACTED**",
        "deviceType": "SIREN1",
        "temperature": 17.1,
        "time": "**REDACTED**"
      }
    },
    "door_window": {
      "2JCR LJTD": {
        "deviceLabel": "2JCR LJTD",
        "area": "**REDACTED**",
        "state": "CLOSE",
        "wired": false,
        "reportTime": "2022-01-23T16:15:44.000Z"
      },
    },
    "locks": {},
    "mice": {},
    "smart_plugs": {
      "2A9P BN6B": {
        "icon": "LIGHT",
        "isHazardous": false,
        "deviceLabel": "2A9P BN6B",
        "area": "**REDACTED**",
        "currentState": "ON",
        "pendingState": "NONE"
      }
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
