### PR TITLE
Add dynamic icon update for volume entities

### DIFF
--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -29,3 +29,23 @@ def icon_for_signal_level(signal_level: int | None = None) -> str:
     if signal_level > 30:
         return "mdi:signal-cellular-2"
     return "mdi:signal-cellular-1"
+
+
+def icon_for_volume_level(
+    volume_level: int | None = None, volume_mute: bool = False
+) -> str:
+    """Return a volume icon valid identifier."""
+    icon = "mdi:volume"
+    if volume_level is None:
+        icon += "-variant-off"
+    elif volume_mute:
+        icon += "-mute"
+    elif volume_level == 0:
+        icon += "-off"
+    elif volume_level <= 35:
+        icon += "-low"
+    elif volume_level <= 70:
+        icon += "-medium"
+    elif volume_level > 70:
+        icon += "-high"
+    return icon


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The change consists of create icon_for_volume_level() so that the volume entities icon is dynamically updated from the entity value. It also considers a possible mute or do not disturb entity that may exist for the device.

#### Some examples of the feature in action:

Volume level 71-100% and not muted:
![image](https://user-images.githubusercontent.com/31328123/150699838-7917396e-6ff2-4f28-9b53-a30ff3c7d9e0.png)

Volume level 36-70% and not muted:
![image](https://user-images.githubusercontent.com/31328123/150699843-533db329-4a9a-454d-a0a1-a9f94944ae67.png)

Volume level 1-35% and not muted:
![image](https://user-images.githubusercontent.com/31328123/150699850-8e69984f-4e37-4a85-8736-d44c7dd1ed67.png)

Volume muted:
![image](https://user-images.githubusercontent.com/31328123/150699874-11cbf0ea-477d-4942-8fbe-002be6c20167.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
