### PR TITLE
Add webostv 100% tests coverage for init

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1297,7 +1297,6 @@ omit =
     homeassistant/components/waze_travel_time/__init__.py
     homeassistant/components/waze_travel_time/helpers.py
     homeassistant/components/waze_travel_time/sensor.py
-    homeassistant/components/webostv/__init__.py
     homeassistant/components/whois/__init__.py
     homeassistant/components/whois/sensor.py
     homeassistant/components/wiffi/*

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -169,8 +169,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 await asyncio.sleep(wait_time)
             except WebOsTvPairError:
                 return
-            else:
-                break
 
         ent_reg = entity_registry.async_get(hass)
         if not (

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -1,11 +1,12 @@
 """Common fixtures and objects for the LG webOS integration tests."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from homeassistant.components.webostv.const import LIVE_TV_APP_ID
+from homeassistant.helpers import entity_registry
 
-from . import CHANNEL_1, CHANNEL_2
+from . import CHANNEL_1, CHANNEL_2, FAKE_UUID
 
 from tests.common import async_mock_service
 
@@ -23,7 +24,7 @@ def client_fixture():
         "homeassistant.components.webostv.WebOsClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.hello_info = {"deviceUUID": "some-fake-uuid"}
+        client.hello_info = {"deviceUUID": FAKE_UUID}
         client.software_info = {"major_ver": "major", "minor_ver": "minor"}
         client.system_info = {"modelName": "TVFAKE"}
         client.client_key = "0123456789"
@@ -53,5 +54,30 @@ def client_fixture():
             await client.register_state_update_callback.call_args[0][0](client)
 
         client.mock_state_update = AsyncMock(side_effect=mock_state_update_callback)
+
+        yield client
+
+
+@pytest.fixture(name="client_entity_removed")
+def client_entity_removed_fixture(hass):
+    """Patch of client library, entity removed waiting for connect."""
+    with patch(
+        "homeassistant.components.webostv.WebOsClient", autospec=True
+    ) as mock_client_class:
+        client = mock_client_class.return_value
+        client.hello_info = {"deviceUUID": "some-fake-uuid"}
+        client.connected = False
+
+        def mock_is_conneted():
+            return client.connected
+
+        client.is_connected = Mock(side_effect=mock_is_conneted)
+
+        async def mock_conneted():
+            ent_reg = entity_registry.async_get(hass)
+            ent_reg.async_remove("media_player.webostv_some_secret")
+            client.connected = True
+
+        client.connect = AsyncMock(side_effect=mock_conneted)
 
         yield client

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -1,0 +1,141 @@
+"""The tests for the WebOS TV platform."""
+
+from unittest.mock import Mock, mock_open, patch
+
+from aiowebostv import WebOsTvPairError
+
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.webostv import DOMAIN
+
+from . import (
+    MOCK_JSON,
+    create_memory_sqlite_engine,
+    is_entity_unique_id_updated,
+    setup_legacy_component,
+)
+
+
+async def test_missing_keys_file_abort(hass, client, caplog):
+    """Test abort import when no pairing keys file."""
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=False)
+    ):
+        await setup_legacy_component(hass)
+
+    assert "No pairing keys, Not importing" in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_empty_json_abort(hass, client, caplog):
+    """Test abort import when keys file is empty."""
+    m_open = mock_open(read_data="[]")
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass)
+
+    assert "No pairing keys, Not importing" in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_valid_json_migrate_not_needed(hass, client, caplog):
+    """Test import from valid json entity already migrated or removed."""
+    m_open = mock_open(read_data=MOCK_JSON)
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass, False)
+
+    assert "Migrating webOS Smart TV entity" not in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_valid_json_missing_host_key(hass, client, caplog):
+    """Test import from valid json missing host key."""
+    m_open = mock_open(read_data='{"1.2.3.5": "other-key"}')
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass)
+
+    assert "Not importing webOS Smart TV host" in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_not_connected_import(hass, client, caplog, monkeypatch):
+    """Test import while device is not connected."""
+    m_open = mock_open(read_data=MOCK_JSON)
+    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
+    monkeypatch.setattr(client, "connect", Mock(side_effect=OSError))
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass)
+
+    assert f"Please make sure webOS TV {MP_DOMAIN}.{DOMAIN}" in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_pair_error_import_abort(hass, client, caplog, monkeypatch):
+    """Test abort import if device is not paired."""
+    m_open = mock_open(read_data=MOCK_JSON)
+    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
+    monkeypatch.setattr(client, "connect", Mock(side_effect=WebOsTvPairError))
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass)
+
+    assert f"Please make sure webOS TV {MP_DOMAIN}.{DOMAIN}" not in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_entity_removed_import_abort(hass, client_entity_removed, caplog):
+    """Test abort import if entity removed by user during import."""
+    m_open = mock_open(read_data=MOCK_JSON)
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass)
+
+    assert "Not updating webOSTV Smart TV entity" in caplog.text
+    assert not is_entity_unique_id_updated(hass)
+
+
+async def test_json_import(hass, client, caplog, monkeypatch):
+    """Test import from json keys file."""
+    m_open = mock_open(read_data=MOCK_JSON)
+    monkeypatch.setattr(client, "is_connected", Mock(return_value=True))
+    monkeypatch.setattr(client, "connect", Mock(return_value=True))
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True):
+        await setup_legacy_component(hass)
+
+    assert "imported from YAML config" in caplog.text
+    assert is_entity_unique_id_updated(hass)
+
+
+async def test_sqlite_import(hass, client, caplog, monkeypatch):
+    """Test import from sqlite keys file."""
+    m_open = mock_open(read_data="will raise JSONDecodeError")
+    monkeypatch.setattr(client, "is_connected", Mock(return_value=True))
+    monkeypatch.setattr(client, "connect", Mock(return_value=True))
+
+    with patch(
+        "homeassistant.components.webostv.os.path.isfile", Mock(return_value=True)
+    ), patch("homeassistant.components.webostv.open", m_open, create=True), patch(
+        "homeassistant.components.webostv.db.create_engine",
+        side_effect=create_memory_sqlite_engine,
+    ):
+        await setup_legacy_component(hass)
+
+    assert "imported from YAML config" in caplog.text
+    assert is_entity_unique_id_updated(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 100% tests coverage for init which complete the tests coverage of the integration to 100%

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
