### PR TITLE
Easier identification of devices with homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -45,7 +45,22 @@ BUTTON_ENTITIES: dict[str, HomeKitButtonEntityDescription] = {
         entity_category=EntityCategory.CONFIG,
         write_value="#HAA@trcmd",
     ),
+    CharacteristicsTypes.IDENTIFY: HomeKitButtonEntityDescription(
+        key=CharacteristicsTypes.IDENTIFY,
+        name="Identify",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        write_value=True,
+    ),
 }
+
+# For legacy reasons, "built-in" characteristic types are in their short form
+# And vendor types don't have a short form
+# This means long and short forms get mixed up in this dict, and comparisons
+# don't work!
+# We call get_uuid on *every* type to normalise them to the long form
+# Eventually aiohomekit will use the long form exclusively amd this can be removed.
+for k, v in list(BUTTON_ENTITIES.items()):
+    BUTTON_ENTITIES[CharacteristicsTypes.get_uuid(k)] = BUTTON_ENTITIES.pop(k)
 
 
 async def async_setup_entry(
@@ -92,7 +107,7 @@ class HomeKitButton(CharacteristicEntity, ButtonEntity):
     def name(self) -> str:
         """Return the name of the device if any."""
         if name := super().name:
-            return f"{name} - {self.entity_description.name}"
+            return f"{name} {self.entity_description.name}"
         return f"{self.entity_description.name}"
 
     async def async_press(self) -> None:

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -73,6 +73,7 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.DENSITY_NO2: "sensor",
     CharacteristicsTypes.DENSITY_SO2: "sensor",
     CharacteristicsTypes.DENSITY_VOC: "sensor",
+    CharacteristicsTypes.IDENTIFY: "button",
 }
 
 # For legacy reasons, "built-in" characteristic types are in their short form

--- a/tests/components/homekit_controller/specific_devices/test_haa_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_haa_fan.py
@@ -63,14 +63,14 @@ async def test_haa_fan_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="button.haa_c718b3_setup",
-                    friendly_name="HAA-C718B3 - Setup",
+                    friendly_name="HAA-C718B3 Setup",
                     unique_id="homekit-C718B3-1-aid:1-sid:1010-cid:1012",
                     entity_category=EntityCategory.CONFIG,
                     state="unknown",
                 ),
                 EntityTestInfo(
                     entity_id="button.haa_c718b3_update",
-                    friendly_name="HAA-C718B3 - Update",
+                    friendly_name="HAA-C718B3 Update",
                     unique_id="homekit-C718B3-1-aid:1-sid:1010-cid:1011",
                     entity_category=EntityCategory.CONFIG,
                     state="unknown",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -8,6 +8,7 @@ from aiohomekit.testing import FakePairing
 import pytest
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
+from homeassistant.helpers.entity import EntityCategory
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
@@ -48,6 +49,13 @@ async def test_koogeek_ls1_setup(hass):
                     supported_features=SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
                     capabilities={"supported_color_modes": ["hs"]},
                     state="off",
+                ),
+                EntityTestInfo(
+                    entity_id="button.koogeek_ls1_20833f_identify",
+                    friendly_name="Koogeek-LS1-20833F Identify",
+                    unique_id="homekit-AAAA011111111111-aid:1-sid:1-cid:6",
+                    entity_category=EntityCategory.DIAGNOSTIC,
+                    state="unknown",
                 ),
             ],
         ),

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -97,7 +97,14 @@ async def test_enumerate_remote(hass, utcnow):
             "entity_id": "sensor.testdevice_battery",
             "platform": "device",
             "type": "battery_level",
-        }
+        },
+        {
+            "device_id": device.id,
+            "domain": "button",
+            "entity_id": "button.testdevice_identify",
+            "platform": "device",
+            "type": "pressed",
+        },
     ]
 
     for button in ("button1", "button2", "button3", "button4"):
@@ -135,7 +142,14 @@ async def test_enumerate_button(hass, utcnow):
             "entity_id": "sensor.testdevice_battery",
             "platform": "device",
             "type": "battery_level",
-        }
+        },
+        {
+            "device_id": device.id,
+            "domain": "button",
+            "entity_id": "button.testdevice_identify",
+            "platform": "device",
+            "type": "pressed",
+        },
     ]
 
     for subtype in ("single_press", "double_press", "long_press"):
@@ -172,7 +186,14 @@ async def test_enumerate_doorbell(hass, utcnow):
             "entity_id": "sensor.testdevice_battery",
             "platform": "device",
             "type": "battery_level",
-        }
+        },
+        {
+            "device_id": device.id,
+            "domain": "button",
+            "entity_id": "button.testdevice_identify",
+            "platform": "device",
+            "type": "pressed",
+        },
     ]
 
     for subtype in ("single_press", "double_press", "long_press"):

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -235,6 +235,26 @@ async def test_config_entry(hass: HomeAssistant, hass_client: ClientSession, utc
                 "hw_version": "",
                 "entities": [
                     {
+                        "device_class": None,
+                        "disabled": False,
+                        "disabled_by": None,
+                        "entity_category": "diagnostic",
+                        "icon": None,
+                        "original_device_class": None,
+                        "original_icon": None,
+                        "original_name": "Koogeek-LS1-20833F Identify",
+                        "state": {
+                            "attributes": {
+                                "friendly_name": "Koogeek-LS1-20833F Identify"
+                            },
+                            "entity_id": "button.koogeek_ls1_20833f_identify",
+                            "last_changed": "2023-01-01T00:00:00+00:00",
+                            "last_updated": "2023-01-01T00:00:00+00:00",
+                            "state": "unknown",
+                        },
+                        "unit_of_measurement": None,
+                    },
+                    {
                         "original_name": "Koogeek-LS1-20833F",
                         "disabled": False,
                         "disabled_by": None,
@@ -255,7 +275,7 @@ async def test_config_entry(hass: HomeAssistant, hass_client: ClientSession, utc
                             "last_changed": "2023-01-01T00:00:00+00:00",
                             "last_updated": "2023-01-01T00:00:00+00:00",
                         },
-                    }
+                    },
                 ],
             }
         ],
@@ -485,6 +505,24 @@ async def test_device(hass: HomeAssistant, hass_client: ClientSession, utcnow):
             "hw_version": "",
             "entities": [
                 {
+                    "device_class": None,
+                    "disabled": False,
+                    "disabled_by": None,
+                    "entity_category": "diagnostic",
+                    "icon": None,
+                    "original_device_class": None,
+                    "original_icon": None,
+                    "original_name": "Koogeek-LS1-20833F Identify",
+                    "state": {
+                        "attributes": {"friendly_name": "Koogeek-LS1-20833F Identify"},
+                        "entity_id": "button.koogeek_ls1_20833f_identify",
+                        "last_changed": "2023-01-01T00:00:00+00:00",
+                        "last_updated": "2023-01-01T00:00:00+00:00",
+                        "state": "unknown",
+                    },
+                    "unit_of_measurement": None,
+                },
+                {
                     "original_name": "Koogeek-LS1-20833F",
                     "disabled": False,
                     "disabled_by": None,
@@ -505,7 +543,7 @@ async def test_device(hass: HomeAssistant, hass_client: ClientSession, utcnow):
                         "last_changed": "2023-01-01T00:00:00+00:00",
                         "last_updated": "2023-01-01T00:00:00+00:00",
                     },
-                }
+                },
             ],
         },
     }

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -89,6 +89,8 @@ async def test_temperature_sensor_not_added_twice(hass, utcnow):
     )
 
     for state in hass.states.async_all():
+        if state.entity_id.startswith("button"):
+            continue
         assert state.entity_id == helper.entity_id
 
 


### PR DESCRIPTION
## Proposed change

HomeKit has an "identify" API. This lets devices flash or beep so you know which power plug or sensor is which. This PR exposes it as a diagnostic button.

![Screenshot 2022-01-23 at 23 34 47](https://user-images.githubusercontent.com/11544/150702726-2f1fa387-f96c-4ff8-bde9-cd266de0b31a.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
