### PR TITLE
Fix error in Tuya diagnostics

### DIFF
--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -85,7 +85,7 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
     # Base device information, without sensitive information.
     data = {
         "name": device.name,
-        "model": device.product_id,
+        "model": f"{device.product_name} ({device.product_id})",
         "category": device.category,
         "product_id": device.product_id,
         "product_name": device.product_name,

--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -85,7 +85,7 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
     # Base device information, without sensitive information.
     data = {
         "name": device.name,
-        "model": {},
+        "model": device.model if hasattr(device, "model") else None,
         "category": device.category,
         "product_id": device.product_id,
         "product_name": device.product_name,

--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -84,8 +84,8 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
 
     # Base device information, without sensitive information.
     data = {
-        "name": device.model,
-        "model": device.model,
+        "name": device.name,
+        "model": device.product_id,
         "category": device.category,
         "product_id": device.product_id,
         "product_name": device.product_name,

--- a/homeassistant/components/tuya/diagnostics.py
+++ b/homeassistant/components/tuya/diagnostics.py
@@ -85,7 +85,7 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
     # Base device information, without sensitive information.
     data = {
         "name": device.name,
-        "model": f"{device.product_name} ({device.product_id})",
+        "model": {},
         "category": device.category,
         "product_id": device.product_id,
         "product_name": device.product_name,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix error in Tuya diagnostics

Debug before change:
````
2022-01-23 23:57:44 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_protocol.py", line 435, in _handle_request
    resp = await request_handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/workspaces/core/homeassistant/components/http/security_filter.py", line 60, in security_filter_middleware
    return await handler(request)
  File "/workspaces/core/homeassistant/components/http/forwarded.py", line 98, in forwarded_middleware
    return await handler(request)
  File "/workspaces/core/homeassistant/components/http/request_context.py", line 28, in request_context_middleware
    return await handler(request)
  File "/workspaces/core/homeassistant/components/http/ban.py", line 79, in ban_middleware
    return await handler(request)
  File "/workspaces/core/homeassistant/components/http/auth.py", line 219, in auth_middleware
    return await handler(request)
  File "/workspaces/core/homeassistant/components/http/view.py", line 137, in handle
    result = await result
  File "/workspaces/core/homeassistant/components/diagnostics/__init__.py", line 215, in get
    data = await info[d_type.value](hass, config_entry)
  File "/workspaces/core/homeassistant/components/tuya/diagnostics.py", line 32, in async_get_config_entry_diagnostics
    return _async_get_diagnostics(hass, entry)
  File "/workspaces/core/homeassistant/components/tuya/diagnostics.py", line 72, in _async_get_diagnostics
    devices=[
  File "/workspaces/core/homeassistant/components/tuya/diagnostics.py", line 73, in <listcomp>
    _async_device_as_dict(hass, device)
  File "/workspaces/core/homeassistant/components/tuya/diagnostics.py", line 87, in _async_device_as_dict
    "name": device.model,
AttributeError: 'TuyaDevice' object has no attribute 'model'
````
Diagnostics after the change:
````
{
        "name": "GT200-vdevo",
        "model": "p4FIRxzWha7NR1ev",
        "category": "sd",
        "product_id": "p4FIRxzWha7NR1ev",
        "product_name": "GT200",
        "online": true,
        "sub": false,
[...]
````
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
