### PR TITLE
Changing the Return to home in Tuya vacuum

### DIFF
--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -97,8 +97,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
         if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
             self._supported_features |= SUPPORT_RETURN_HOME
-        elif mode := self.find_dpcode(DPCode.MODE, dptype=DPType.ENUM):
-            if TUYA_MODE_RETURN_HOME in mode.range:
+        elif (enum_type := self.find_dpcode(DPCode.MODE, dptype=DPType.ENUM, prefer_function=True) and TUYA_MODE_RETURN_HOME in enum_type.range:
                 self._supported_features |= SUPPORT_RETURN_HOME
 
         if self.find_dpcode(DPCode.SEEK, prefer_function=True):

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantTuyaData
 from .base import EnumTypeData, IntegerTypeData, TuyaEntity
-from .const import DOMAIN, LOGGER, TUYA_DISCOVERY_NEW, DPCode, DPType
+from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, DPType
 
 TUYA_MODE_RETURN_HOME = "chargego"
 TUYA_STATUS_TO_HA = {
@@ -95,9 +95,9 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
             self._supported_features |= SUPPORT_PAUSE
 
-        if mode := self.find_dpcode(DPCode.MODE, dptype=DPType.ENUM):
+        if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
             self._supported_features |= SUPPORT_RETURN_HOME
-            LOGGER.debug("VACUUM: %s:", mode)
+        elif mode := self.find_dpcode(DPCode.MODE, dptype=DPType.ENUM):
             if TUYA_MODE_RETURN_HOME in mode.range:
                 self._supported_features |= SUPPORT_RETURN_HOME
 

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -95,9 +95,13 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
             self._supported_features |= SUPPORT_PAUSE
 
-        if mode := self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
+        if mode := self.find_dpcode(
+            DPCode.MODE, dptype=DPType.ENUM, prefer_function=True
+        ):
             self._supported_features |= SUPPORT_RETURN_HOME
             LOGGER.debug("VACUUM: %s:", mode)
+            if TUYA_MODE_RETURN_HOME in mode.range:
+                self._supported_features |= SUPPORT_RETURN_HOME
 
         if self.find_dpcode(DPCode.SEEK, prefer_function=True):
             self._supported_features |= SUPPORT_LOCATE

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -182,8 +182,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
     def return_to_base(self, **kwargs: Any) -> None:
         """Return device to dock."""
-        if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
-            self._send_command([{"code": DPCode.SWITCH_CHARGE, "value": True}])
+        self._send_command([{"code": DPCode.SWITCH_CHARGE, "value": True}])
         self._send_command([{"code": DPCode.MODE, "value": TUYA_MODE_RETURN_HOME}])
 
     def locate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -185,8 +185,12 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
     def return_to_base(self, **kwargs: Any) -> None:
         """Return device to dock."""
-        self._send_command([{"code": DPCode.SWITCH_CHARGE, "value": True}])
-        self._send_command([{"code": DPCode.MODE, "value": TUYA_MODE_RETURN_HOME}])
+        self._send_command(
+            [
+                {"code": DPCode.SWITCH_CHARGE, "value": True},
+                {"code": DPCode.MODE, "value": TUYA_MODE_RETURN_HOME},
+            ]
+        )
 
     def locate(self, **kwargs: Any) -> None:
         """Locate the device."""

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -97,9 +97,12 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
         if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
             self._supported_features |= SUPPORT_RETURN_HOME
-        elif mode := self.find_dpcode(DPCode.MODE, dptype=DPType.ENUM):
-            if TUYA_MODE_RETURN_HOME in mode.range:
-                self._supported_features |= SUPPORT_RETURN_HOME
+        elif (
+            enum_type := self.find_dpcode(
+                DPCode.MODE, dptype=DPType.ENUM, prefer_function=True
+            )
+        ) and TUYA_MODE_RETURN_HOME in enum_type.range:
+            self._supported_features |= SUPPORT_RETURN_HOME
 
         if self.find_dpcode(DPCode.SEEK, prefer_function=True):
             self._supported_features |= SUPPORT_LOCATE

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -33,6 +33,7 @@ from . import HomeAssistantTuyaData
 from .base import EnumTypeData, IntegerTypeData, TuyaEntity
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, DPType
 
+TUYA_MODE_RETURN_HOME = "chargego"
 TUYA_STATUS_TO_HA = {
     "charge_done": STATE_DOCKED,
     "chargecompleted": STATE_DOCKED,
@@ -94,7 +95,13 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
             self._supported_features |= SUPPORT_PAUSE
 
-        if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
+        if (
+            self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True)
+            or TUYA_MODE_RETURN_HOME
+            in EnumTypeData.from_json(
+                DPCode.MODE, device.status_range.get(DPCode.MODE).values
+            ).range
+        ):
             self._supported_features |= SUPPORT_RETURN_HOME
 
         if self.find_dpcode(DPCode.SEEK, prefer_function=True):
@@ -178,7 +185,9 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
     def return_to_base(self, **kwargs: Any) -> None:
         """Return device to dock."""
-        self._send_command([{"code": DPCode.MODE, "value": "chargego"}])
+        if self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
+            self._send_command([{"code": DPCode.SWITCH_CHARGE, "value": True}])
+        self._send_command([{"code": DPCode.MODE, "value": TUYA_MODE_RETURN_HOME}])
 
     def locate(self, **kwargs: Any) -> None:
         """Locate the device."""

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -95,9 +95,7 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
             self._supported_features |= SUPPORT_PAUSE
 
-        if mode := self.find_dpcode(
-            DPCode.MODE, dptype=DPType.ENUM, prefer_function=True
-        ):
+        if mode := self.find_dpcode(DPCode.MODE, dptype=DPType.ENUM):
             self._supported_features |= SUPPORT_RETURN_HOME
             LOGGER.debug("VACUUM: %s:", mode)
             if TUYA_MODE_RETURN_HOME in mode.range:

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantTuyaData
 from .base import EnumTypeData, IntegerTypeData, TuyaEntity
-from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, DPType
+from .const import DOMAIN, LOGGER, TUYA_DISCOVERY_NEW, DPCode, DPType
 
 TUYA_MODE_RETURN_HOME = "chargego"
 TUYA_STATUS_TO_HA = {
@@ -95,14 +95,9 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
             self._supported_features |= SUPPORT_PAUSE
 
-        if (
-            self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True)
-            or TUYA_MODE_RETURN_HOME
-            in EnumTypeData.from_json(
-                DPCode.MODE, device.status_range.get(DPCode.MODE).values
-            ).range
-        ):
+        if mode := self.find_dpcode(DPCode.SWITCH_CHARGE, prefer_function=True):
             self._supported_features |= SUPPORT_RETURN_HOME
+            LOGGER.debug("VACUUM: %s:", mode)
 
         if self.find_dpcode(DPCode.SEEK, prefer_function=True):
             self._supported_features |= SUPPORT_LOCATE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the [Tuya Vacuum documentation](https://developer.tuya.com/en/docs/iot/ssd?id=K9gf48qts32n0) there are two possibilities to trigger the return home. If the device has the `switch_charge`, just activate it and when this switch does not exist, you must set the mode to `charggo`.


Code | Name | Type | Description
-- | -- | -- | --
mode | Working mode | Enum | {“range”:[“standby”,“random”,“smart”,“wall_follow”,“mop”,“spiral”,“left_spiral”,“right_spiral”,“bow”,“left_bow”,“right_bow”,“partial_bow”,“chargego”,“single”,“zone”,“pose”,“point”,“part”,“pick_zone”]}
switch_charge | Recharge switch | Boolean | {}

This PR defines as two ways of selecting support `SUPPORT_RETURN_HOME` and for sending the command `return_to_base`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
