### PR TITLE
Update method names reflecting changes in UniFi library

### DIFF
--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
   "requirements": [
-    "aiounifi==29"
+    "aiounifi==30"
   ],
   "codeowners": [
     "@Kane610"
@@ -22,7 +22,7 @@
     {
       "manufacturer": "Ubiquiti Networks",
       "modelDescription": "UniFi Dream Machine SE"
-    }    
+    }
   ],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/unifi/services.py
+++ b/homeassistant/components/unifi/services.py
@@ -74,7 +74,7 @@ async def async_reconnect_client(hass, data) -> None:
         ):
             continue
 
-        await controller.api.clients.async_reconnect(mac)
+        await controller.api.clients.reconnect(mac)
 
 
 async def async_remove_clients(hass, data) -> None:

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -136,9 +136,9 @@ def add_poe_entities(controller, async_add_entities, clients, known_poe_clients)
         # If poe_enable is False we can't know if a POE client is available for control.
         if mac not in known_poe_clients and (
             mac in controller.wireless_clients
-            or client.sw_mac not in devices
-            or not devices[client.sw_mac].ports[client.sw_port].port_poe
-            or not devices[client.sw_mac].ports[client.sw_port].poe_enable
+            or client.switch_mac not in devices
+            or not devices[client.switch_mac].ports[client.switch_port].port_poe
+            or not devices[client.switch_mac].ports[client.switch_port].poe_enable
             or controller.mac == client.mac
         ):
             continue
@@ -153,8 +153,8 @@ def add_poe_entities(controller, async_add_entities, clients, known_poe_clients)
             if (
                 client2.is_wired
                 and client.mac != client2.mac
-                and client.sw_mac == client2.sw_mac
-                and client.sw_port == client2.sw_port
+                and client.switch_mac == client2.switch_mac
+                and client.switch_port == client2.switch_port
             ):
                 multi_clients_on_port = True
                 break
@@ -199,7 +199,7 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchEntity, RestoreEntity):
         super().__init__(client, controller)
 
         self.poe_mode = None
-        if client.sw_port and self.port.poe_mode != "off":
+        if client.switch_port and self.port.poe_mode != "off":
             self.poe_mode = self.port.poe_mode
 
     async def async_added_to_hass(self):
@@ -214,10 +214,10 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchEntity, RestoreEntity):
 
         self.poe_mode = state.attributes.get("poe_mode")
 
-        if not self.client.sw_mac:
+        if not self.client.switch_mac:
             self.client.raw["sw_mac"] = state.attributes.get("switch")
 
-        if not self.client.sw_port:
+        if not self.client.switch_port:
             self.client.raw["sw_port"] = state.attributes.get("port")
 
     @property
@@ -235,26 +235,26 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchEntity, RestoreEntity):
         return (
             self.poe_mode is not None
             and self.controller.available
-            and self.client.sw_port
-            and self.client.sw_mac
-            and self.client.sw_mac in self.controller.api.devices
+            and self.client.switch_port
+            and self.client.switch_mac
+            and self.client.switch_mac in self.controller.api.devices
         )
 
     async def async_turn_on(self, **kwargs):
         """Enable POE for client."""
-        await self.device.async_set_port_poe_mode(self.client.sw_port, self.poe_mode)
+        await self.device.set_port_poe_mode(self.client.switch_port, self.poe_mode)
 
     async def async_turn_off(self, **kwargs):
         """Disable POE for client."""
-        await self.device.async_set_port_poe_mode(self.client.sw_port, "off")
+        await self.device.set_port_poe_mode(self.client.switch_port, "off")
 
     @property
     def extra_state_attributes(self):
         """Return the device state attributes."""
         attributes = {
             "power": self.port.poe_power,
-            "switch": self.client.sw_mac,
-            "port": self.client.sw_port,
+            "switch": self.client.switch_mac,
+            "port": self.client.switch_port,
             "poe_mode": self.poe_mode,
         }
         return attributes
@@ -262,12 +262,12 @@ class UniFiPOEClientSwitch(UniFiClient, SwitchEntity, RestoreEntity):
     @property
     def device(self):
         """Shortcut to the switch that client is connected to."""
-        return self.controller.api.devices[self.client.sw_mac]
+        return self.controller.api.devices[self.client.switch_mac]
 
     @property
     def port(self):
         """Shortcut to the switch port that client is connected to."""
-        return self.device.ports[self.client.sw_port]
+        return self.device.ports[self.client.switch_port]
 
     async def options_updated(self) -> None:
         """Config entry options are updated, remove entity if option is disabled."""
@@ -307,11 +307,11 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn on connectivity for client."""
-        await self.controller.api.clients.async_unblock(self.client.mac)
+        await self.controller.api.clients.unblock(self.client.mac)
 
     async def async_turn_off(self, **kwargs):
         """Turn off connectivity for client."""
-        await self.controller.api.clients.async_block(self.client.mac)
+        await self.controller.api.clients.block(self.client.mac)
 
     @property
     def icon(self):
@@ -419,7 +419,7 @@ class UniFiDPIRestrictionSwitch(UniFiBase, SwitchEntity):
         """Restrict access of apps related to DPI group."""
         return await asyncio.gather(
             *[
-                self.controller.api.dpi_apps.async_enable(app_id)
+                self.controller.api.dpi_apps.enable(app_id)
                 for app_id in self._item.dpiapp_ids
             ]
         )
@@ -428,7 +428,7 @@ class UniFiDPIRestrictionSwitch(UniFiBase, SwitchEntity):
         """Remove restriction of apps related to DPI group."""
         return await asyncio.gather(
             *[
-                self.controller.api.dpi_apps.async_disable(app_id)
+                self.controller.api.dpi_apps.disable(app_id)
                 for app_id in self._item.dpiapp_ids
             ]
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -269,7 +269,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.2
 
 # homeassistant.components.unifi
-aiounifi==29
+aiounifi==30
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -204,7 +204,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.2
 
 # homeassistant.components.unifi
-aiounifi==29
+aiounifi==30
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cosmetic changes to naming in the library
https://github.com/Kane610/aiounifi/compare/v29...v30
Included with the library is also an addition to unifi power plugs which can be realised after this is merged

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
