### PR TITLE
Make sensor name consistent with other homekit_controller entity names

### DIFF
--- a/homeassistant/components/homekit_controller/diagnostics.py
+++ b/homeassistant/components/homekit_controller/diagnostics.py
@@ -60,6 +60,8 @@ def _async_get_diagnostics_for_device(
         include_disabled_entities=True,
     )
 
+    hass_entities.sort(key=lambda entry: entry.original_name)
+
     for entity_entry in hass_entities:
         state = hass.states.get(entity_entry.entity_id)
         state_dict = None

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -365,7 +365,7 @@ class SimpleSensor(CharacteristicEntity, SensorEntity):
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
-        return f"{super().name} - {self.entity_description.name}"
+        return f"{super().name} {self.entity_description.name}"
 
     @property
     def native_value(self):

--- a/tests/components/homekit_controller/specific_devices/test_arlo_baby.py
+++ b/tests/components/homekit_controller/specific_devices/test_arlo_baby.py
@@ -68,7 +68,7 @@ async def test_arlo_baby_setup(hass):
                     entity_id="sensor.arlobabya0_air_quality",
                     unique_id="homekit-00A0000000000-aid:1-sid:800-cid:802",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
-                    friendly_name="ArloBabyA0 - Air Quality",
+                    friendly_name="ArloBabyA0 Air Quality",
                     state="1",
                 ),
                 EntityTestInfo(

--- a/tests/components/homekit_controller/specific_devices/test_connectsense.py
+++ b/tests/components/homekit_controller/specific_devices/test_connectsense.py
@@ -36,7 +36,7 @@ async def test_connectsense_setup(hass):
             entities=[
                 EntityTestInfo(
                     entity_id="sensor.inwall_outlet_0394de_real_time_current",
-                    friendly_name="InWall Outlet-0394DE - Real Time Current",
+                    friendly_name="InWall Outlet-0394DE Real Time Current",
                     unique_id="homekit-1020301376-aid:1-sid:13-cid:18",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
@@ -44,7 +44,7 @@ async def test_connectsense_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.inwall_outlet_0394de_real_time_energy",
-                    friendly_name="InWall Outlet-0394DE - Real Time Energy",
+                    friendly_name="InWall Outlet-0394DE Real Time Energy",
                     unique_id="homekit-1020301376-aid:1-sid:13-cid:19",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=POWER_WATT,
@@ -52,7 +52,7 @@ async def test_connectsense_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.inwall_outlet_0394de_energy_kwh",
-                    friendly_name="InWall Outlet-0394DE - Energy kWh",
+                    friendly_name="InWall Outlet-0394DE Energy kWh",
                     unique_id="homekit-1020301376-aid:1-sid:13-cid:20",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=ENERGY_KILO_WATT_HOUR,
@@ -66,7 +66,7 @@ async def test_connectsense_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.inwall_outlet_0394de_real_time_current_2",
-                    friendly_name="InWall Outlet-0394DE - Real Time Current",
+                    friendly_name="InWall Outlet-0394DE Real Time Current",
                     unique_id="homekit-1020301376-aid:1-sid:25-cid:30",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
@@ -74,7 +74,7 @@ async def test_connectsense_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.inwall_outlet_0394de_real_time_energy_2",
-                    friendly_name="InWall Outlet-0394DE - Real Time Energy",
+                    friendly_name="InWall Outlet-0394DE Real Time Energy",
                     unique_id="homekit-1020301376-aid:1-sid:25-cid:31",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=POWER_WATT,
@@ -82,7 +82,7 @@ async def test_connectsense_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.inwall_outlet_0394de_energy_kwh_2",
-                    friendly_name="InWall Outlet-0394DE - Energy kWh",
+                    friendly_name="InWall Outlet-0394DE Energy kWh",
                     unique_id="homekit-1020301376-aid:1-sid:25-cid:32",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=ENERGY_KILO_WATT_HOUR,

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -123,7 +123,7 @@ async def test_ecobee3_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.homew_current_temperature",
-                    friendly_name="HomeW - Current Temperature",
+                    friendly_name="HomeW Current Temperature",
                     unique_id="homekit-123456789012-aid:1-sid:16-cid:19",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=TEMP_CELSIUS,

--- a/tests/components/homekit_controller/specific_devices/test_eve_degree.py
+++ b/tests/components/homekit_controller/specific_devices/test_eve_degree.py
@@ -49,7 +49,7 @@ async def test_eve_degree_setup(hass):
                 EntityTestInfo(
                     entity_id="sensor.eve_degree_aa11_air_pressure",
                     unique_id="homekit-AA00A0A00000-aid:1-sid:30-cid:32",
-                    friendly_name="Eve Degree AA11 - Air Pressure",
+                    friendly_name="Eve Degree AA11 Air Pressure",
                     unit_of_measurement=PRESSURE_HPA,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     state="1005.70001220703",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
@@ -38,7 +38,7 @@ async def test_koogeek_p1eu_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.koogeek_p1_a00aa0_real_time_energy",
-                    friendly_name="Koogeek-P1-A00AA0 - Real Time Energy",
+                    friendly_name="Koogeek-P1-A00AA0 Real Time Energy",
                     unique_id="homekit-EUCP03190xxxxx48-aid:1-sid:21-cid:22",
                     unit_of_measurement=POWER_WATT,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -44,7 +44,7 @@ async def test_koogeek_sw2_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.koogeek_sw2_187a91_real_time_energy",
-                    friendly_name="Koogeek-SW2-187A91 - Real Time Energy",
+                    friendly_name="Koogeek-SW2-187A91 Real Time Energy",
                     unique_id="homekit-CNNT061751001372-aid:1-sid:14-cid:18",
                     unit_of_measurement=POWER_WATT,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},

--- a/tests/components/homekit_controller/specific_devices/test_mysa_living.py
+++ b/tests/components/homekit_controller/specific_devices/test_mysa_living.py
@@ -46,7 +46,7 @@ async def test_mysa_living_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.mysa_85dda9_current_humidity",
-                    friendly_name="Mysa-85dda9 - Current Humidity",
+                    friendly_name="Mysa-85dda9 Current Humidity",
                     unique_id="homekit-AAAAAAA000-aid:1-sid:20-cid:27",
                     unit_of_measurement=PERCENTAGE,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
@@ -54,7 +54,7 @@ async def test_mysa_living_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.mysa_85dda9_current_temperature",
-                    friendly_name="Mysa-85dda9 - Current Temperature",
+                    friendly_name="Mysa-85dda9 Current Temperature",
                     unique_id="homekit-AAAAAAA000-aid:1-sid:20-cid:25",
                     unit_of_measurement=TEMP_CELSIUS,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
@@ -69,7 +69,7 @@ async def test_vocolinc_flowerbud_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.vocolinc_flowerbud_0d324b_current_humidity",
-                    friendly_name="VOCOlinc-Flowerbud-0d324b - Current Humidity",
+                    friendly_name="VOCOlinc-Flowerbud-0d324b Current Humidity",
                     unique_id="homekit-AM01121849000327-aid:1-sid:30-cid:33",
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},
                     unit_of_measurement=PERCENTAGE,

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_vp3.py
@@ -38,7 +38,7 @@ async def test_vocolinc_vp3_setup(hass):
                 ),
                 EntityTestInfo(
                     entity_id="sensor.vocolinc_vp3_123456_real_time_energy",
-                    friendly_name="VOCOlinc-VP3-123456 - Real Time Energy",
+                    friendly_name="VOCOlinc-VP3-123456 Real Time Energy",
                     unique_id="homekit-EU0121203xxxxx07-aid:1-sid:48-cid:97",
                     unit_of_measurement=POWER_WATT,
                     capabilities={"state_class": SensorStateClass.MEASUREMENT},

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -235,26 +235,6 @@ async def test_config_entry(hass: HomeAssistant, hass_client: ClientSession, utc
                 "hw_version": "",
                 "entities": [
                     {
-                        "device_class": None,
-                        "disabled": False,
-                        "disabled_by": None,
-                        "entity_category": "diagnostic",
-                        "icon": None,
-                        "original_device_class": None,
-                        "original_icon": None,
-                        "original_name": "Koogeek-LS1-20833F Identify",
-                        "state": {
-                            "attributes": {
-                                "friendly_name": "Koogeek-LS1-20833F Identify"
-                            },
-                            "entity_id": "button.koogeek_ls1_20833f_identify",
-                            "last_changed": "2023-01-01T00:00:00+00:00",
-                            "last_updated": "2023-01-01T00:00:00+00:00",
-                            "state": "unknown",
-                        },
-                        "unit_of_measurement": None,
-                    },
-                    {
                         "original_name": "Koogeek-LS1-20833F",
                         "disabled": False,
                         "disabled_by": None,
@@ -275,6 +255,26 @@ async def test_config_entry(hass: HomeAssistant, hass_client: ClientSession, utc
                             "last_changed": "2023-01-01T00:00:00+00:00",
                             "last_updated": "2023-01-01T00:00:00+00:00",
                         },
+                    },
+                    {
+                        "device_class": None,
+                        "disabled": False,
+                        "disabled_by": None,
+                        "entity_category": "diagnostic",
+                        "icon": None,
+                        "original_device_class": None,
+                        "original_icon": None,
+                        "original_name": "Koogeek-LS1-20833F Identify",
+                        "state": {
+                            "attributes": {
+                                "friendly_name": "Koogeek-LS1-20833F Identify"
+                            },
+                            "entity_id": "button.koogeek_ls1_20833f_identify",
+                            "last_changed": "2023-01-01T00:00:00+00:00",
+                            "last_updated": "2023-01-01T00:00:00+00:00",
+                            "state": "unknown",
+                        },
+                        "unit_of_measurement": None,
                     },
                 ],
             }
@@ -505,24 +505,6 @@ async def test_device(hass: HomeAssistant, hass_client: ClientSession, utcnow):
             "hw_version": "",
             "entities": [
                 {
-                    "device_class": None,
-                    "disabled": False,
-                    "disabled_by": None,
-                    "entity_category": "diagnostic",
-                    "icon": None,
-                    "original_device_class": None,
-                    "original_icon": None,
-                    "original_name": "Koogeek-LS1-20833F Identify",
-                    "state": {
-                        "attributes": {"friendly_name": "Koogeek-LS1-20833F Identify"},
-                        "entity_id": "button.koogeek_ls1_20833f_identify",
-                        "last_changed": "2023-01-01T00:00:00+00:00",
-                        "last_updated": "2023-01-01T00:00:00+00:00",
-                        "state": "unknown",
-                    },
-                    "unit_of_measurement": None,
-                },
-                {
                     "original_name": "Koogeek-LS1-20833F",
                     "disabled": False,
                     "disabled_by": None,
@@ -543,6 +525,24 @@ async def test_device(hass: HomeAssistant, hass_client: ClientSession, utcnow):
                         "last_changed": "2023-01-01T00:00:00+00:00",
                         "last_updated": "2023-01-01T00:00:00+00:00",
                     },
+                },
+                {
+                    "device_class": None,
+                    "disabled": False,
+                    "disabled_by": None,
+                    "entity_category": "diagnostic",
+                    "icon": None,
+                    "original_device_class": None,
+                    "original_icon": None,
+                    "original_name": "Koogeek-LS1-20833F Identify",
+                    "state": {
+                        "attributes": {"friendly_name": "Koogeek-LS1-20833F Identify"},
+                        "entity_id": "button.koogeek_ls1_20833f_identify",
+                        "last_changed": "2023-01-01T00:00:00+00:00",
+                        "last_updated": "2023-01-01T00:00:00+00:00",
+                        "state": "unknown",
+                    },
+                    "unit_of_measurement": None,
                 },
             ],
         },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This makes the name of characteristic based sensors consistent with number and button entity names, which also fixes the leading `-` in this screenshot:

![Screenshot 2022-01-24 at 07 48 01](https://user-images.githubusercontent.com/11544/150742162-0364c29c-ad5d-4dc3-b9be-09b37e3831ae.png)

While adding this I realised the sort order in my diagnostics test wasn't stable so was prone to breaking. I fixed that too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
