### PR TITLE
Add tests for LCN cover platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -587,7 +587,6 @@ omit =
     homeassistant/components/launch_library/sensor.py
     homeassistant/components/lcn/binary_sensor.py
     homeassistant/components/lcn/climate.py
-    homeassistant/components/lcn/cover.py
     homeassistant/components/lcn/helpers.py
     homeassistant/components/lcn/scene.py
     homeassistant/components/lcn/sensor.py

--- a/tests/components/lcn/fixtures/config.json
+++ b/tests/components/lcn/fixtures/config.json
@@ -77,6 +77,19 @@
         "address": "s0.g5",
         "output": "relay1"
       }
+    ],
+    "covers": [
+      {
+        "name": "Cover_Ouputs",
+        "address": "s0.m7",
+        "motor": "outputs",
+        "reverse_time": "rt1200"
+      },
+      {
+        "name": "Cover_Relays",
+        "address": "s0.m7",
+        "motor": "motor1"
+      }
     ]
   }
 }

--- a/tests/components/lcn/fixtures/config_entry_pchk.json
+++ b/tests/components/lcn/fixtures/config_entry_pchk.json
@@ -100,6 +100,26 @@
       "domain_data": {
         "output": "RELAY1"
       }
+    },
+    {
+      "address": [0, 7, false],
+      "name": "Cover_Outputs",
+      "resource": "outputs",
+      "domain": "cover",
+      "domain_data": {
+        "motor": "OUTPUTS",
+        "reverse_time": "RT1200"
+      }
+    },
+    {
+      "address": [0, 7, false],
+      "name": "Cover_Relays",
+      "resource": "motor1",
+      "domain": "cover",
+      "domain_data": {
+        "motor": "MOTOR1",
+        "reverse_time": "RT1200"
+      }
     }
   ]
 }

--- a/tests/components/lcn/test_cover.py
+++ b/tests/components/lcn/test_cover.py
@@ -1,0 +1,390 @@
+"""Test for the LCN cover platform."""
+from unittest.mock import patch
+
+from pypck.inputs import ModStatusOutput, ModStatusRelays
+from pypck.lcn_addr import LcnAddr
+from pypck.lcn_defs import MotorReverseTime, MotorStateModifier
+
+from homeassistant.components.cover import DOMAIN as DOMAIN_COVER
+from homeassistant.components.lcn.helpers import get_device_connection
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_STOP_COVER,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+    STATE_UNAVAILABLE,
+)
+
+from .conftest import MockModuleConnection
+
+
+async def test_setup_lcn_cover(hass, entry, lcn_connection):
+    """Test the setup of cover."""
+    for entity_id in (
+        "cover.cover_outputs",
+        "cover.cover_relays",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OPEN
+
+
+async def test_entity_attributes(hass, entry, lcn_connection):
+    """Test the attributes of an entity."""
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    entity_outputs = entity_registry.async_get("cover.cover_outputs")
+
+    assert entity_outputs
+    assert entity_outputs.unique_id == f"{entry.entry_id}-m000007-outputs"
+    assert entity_outputs.original_name == "Cover_Outputs"
+
+    entity_relays = entity_registry.async_get("cover.cover_relays")
+
+    assert entity_relays
+    assert entity_relays.unique_id == f"{entry.entry_id}-m000007-motor1"
+    assert entity_relays.original_name == "Cover_Relays"
+
+
+@patch.object(MockModuleConnection, "control_motors_outputs")
+async def test_outputs_open(control_motors_outputs, hass, lcn_connection):
+    """Test the outputs cover opens."""
+    state = hass.states.get("cover.cover_outputs")
+    state.state = STATE_CLOSED
+
+    # command failed
+    control_motors_outputs.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_outputs"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_outputs.assert_awaited_with(
+        MotorStateModifier.UP, MotorReverseTime.RT1200
+    )
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state != STATE_OPENING
+
+    # command success
+    control_motors_outputs.reset_mock(return_value=True)
+    control_motors_outputs.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_outputs"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_outputs.assert_awaited_with(
+        MotorStateModifier.UP, MotorReverseTime.RT1200
+    )
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state == STATE_OPENING
+
+
+@patch.object(MockModuleConnection, "control_motors_outputs")
+async def test_outputs_close(control_motors_outputs, hass, lcn_connection):
+    """Test the outputs cover closes."""
+    state = hass.states.get("cover.cover_outputs")
+    state.state = STATE_OPEN
+
+    # command failed
+    control_motors_outputs.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_outputs"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_outputs.assert_awaited_with(
+        MotorStateModifier.DOWN, MotorReverseTime.RT1200
+    )
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state != STATE_CLOSING
+
+    # command success
+    control_motors_outputs.reset_mock(return_value=True)
+    control_motors_outputs.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_outputs"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_outputs.assert_awaited_with(
+        MotorStateModifier.DOWN, MotorReverseTime.RT1200
+    )
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+
+@patch.object(MockModuleConnection, "control_motors_outputs")
+async def test_outputs_stop(control_motors_outputs, hass, lcn_connection):
+    """Test the outputs cover stops."""
+    state = hass.states.get("cover.cover_outputs")
+    state.state = STATE_CLOSING
+
+    # command failed
+    control_motors_outputs.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_outputs"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_outputs.assert_awaited_with(MotorStateModifier.STOP)
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+    # command success
+    control_motors_outputs.reset_mock(return_value=True)
+    control_motors_outputs.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_outputs"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_outputs.assert_awaited_with(MotorStateModifier.STOP)
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state not in (STATE_CLOSING, STATE_OPENING)
+
+
+@patch.object(MockModuleConnection, "control_motors_relays")
+async def test_relays_open(control_motors_relays, hass, lcn_connection):
+    """Test the relays cover opens."""
+    states = [MotorStateModifier.NOCHANGE] * 4
+    states[0] = MotorStateModifier.UP
+
+    state = hass.states.get("cover.cover_relays")
+    state.state = STATE_CLOSED
+
+    # command failed
+    control_motors_relays.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_relays"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_relays.assert_awaited_with(states)
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state != STATE_OPENING
+
+    # command success
+    control_motors_relays.reset_mock(return_value=True)
+    control_motors_relays.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_relays"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_relays.assert_awaited_with(states)
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state == STATE_OPENING
+
+
+@patch.object(MockModuleConnection, "control_motors_relays")
+async def test_relays_close(control_motors_relays, hass, lcn_connection):
+    """Test the relays cover closes."""
+    states = [MotorStateModifier.NOCHANGE] * 4
+    states[0] = MotorStateModifier.DOWN
+
+    state = hass.states.get("cover.cover_relays")
+    state.state = STATE_OPEN
+
+    # command failed
+    control_motors_relays.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_relays"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_relays.assert_awaited_with(states)
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state != STATE_CLOSING
+
+    # command success
+    control_motors_relays.reset_mock(return_value=True)
+    control_motors_relays.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_relays"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_relays.assert_awaited_with(states)
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+
+@patch.object(MockModuleConnection, "control_motors_relays")
+async def test_relays_stop(control_motors_relays, hass, lcn_connection):
+    """Test the relays cover stops."""
+    states = [MotorStateModifier.NOCHANGE] * 4
+    states[0] = MotorStateModifier.STOP
+
+    state = hass.states.get("cover.cover_relays")
+    state.state = STATE_CLOSING
+
+    # command failed
+    control_motors_relays.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_relays"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_relays.assert_awaited_with(states)
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+    # command success
+    control_motors_relays.reset_mock(return_value=True)
+    control_motors_relays.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_COVER,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: "cover.cover_relays"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_motors_relays.assert_awaited_with(states)
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state not in (STATE_CLOSING, STATE_OPENING)
+
+
+async def test_pushed_outputs_status_change(hass, entry, lcn_connection):
+    """Test the outputs cover changes its state on status received."""
+    device_connection = get_device_connection(hass, (0, 7, False), entry)
+    address = LcnAddr(0, 7, False)
+
+    state = hass.states.get("cover.cover_outputs")
+    state.state = STATE_CLOSED
+
+    # push status "open"
+    input = ModStatusOutput(address, 0, 100)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state == STATE_OPENING
+
+    # push status "stop"
+    input = ModStatusOutput(address, 0, 0)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state not in (STATE_OPENING, STATE_CLOSING)
+
+    # push status "close"
+    input = ModStatusOutput(address, 1, 100)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.cover_outputs")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+
+async def test_pushed_relays_status_change(hass, entry, lcn_connection):
+    """Test the relays cover changes its state on status received."""
+    device_connection = get_device_connection(hass, (0, 7, False), entry)
+    address = LcnAddr(0, 7, False)
+    states = [False] * 8
+
+    state = hass.states.get("cover.cover_relays")
+    state.state = STATE_CLOSED
+
+    # push status "open"
+    states[0:2] = [True, False]
+    input = ModStatusRelays(address, states)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state == STATE_OPENING
+
+    # push status "stop"
+    states[0] = False
+    input = ModStatusRelays(address, states)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state not in (STATE_OPENING, STATE_CLOSING)
+
+    # push status "close"
+    states[0:2] = [True, True]
+    input = ModStatusRelays(address, states)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.cover_relays")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+
+async def test_unload_config_entry(hass, entry, lcn_connection):
+    """Test the cover is removed when the config entry is unloaded."""
+    await hass.config_entries.async_unload(entry.entry_id)
+    assert hass.states.get("cover.cover_outputs").state == STATE_UNAVAILABLE
+    assert hass.states.get("cover.cover_relays").state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for LCN cover platform.
The tests are written according to PR #64741, which was recently merged.

There are two types of cover entities which have to be tested. One acts on output ports and the other on relay ports.
Tests are written for light platform setup, unloading, open/close/stop and state changes due to status messages received.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
