### PR TITLE
Add diagnostics to Nanoleaf

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -716,6 +716,7 @@ omit =
     homeassistant/components/nad/media_player.py
     homeassistant/components/nanoleaf/__init__.py
     homeassistant/components/nanoleaf/button.py
+    homeassistant/components/nanoleaf/diagnostics.py
     homeassistant/components/nanoleaf/entity.py
     homeassistant/components/nanoleaf/light.py
     homeassistant/components/neato/__init__.py

--- a/homeassistant/components/nanoleaf/diagnostics.py
+++ b/homeassistant/components/nanoleaf/diagnostics.py
@@ -1,0 +1,45 @@
+"""Diagnostics support for Nanoleaf."""
+from __future__ import annotations
+
+from aionanoleaf import Nanoleaf
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> dict:
+    """Return diagnostics for a config entry."""
+    device: Nanoleaf = hass.data[DOMAIN][config_entry.entry_id].device
+
+    return {
+        "info": async_redact_data(config_entry.as_dict(), (CONF_TOKEN, "title")),
+        "data": {
+            "brightness_max": device.brightness_max,
+            "brightness_min": device.brightness_min,
+            "brightness": device.brightness,
+            "color_mode": device.color_mode,
+            "color_temperature_max": device.color_temperature_max,
+            "color_temperature_min": device.color_temperature_min,
+            "color_temperature": device.color_temperature,
+            "effect": device.effect,
+            "effects_list": device.effects_list,
+            "firmware_version": device.firmware_version,
+            "hue_max": device.hue_max,
+            "hue_min": device.hue_min,
+            "hue": device.hue,
+            "is_on": device.is_on,
+            "manufacturer": device.manufacturer,
+            "port": device.port,
+            "saturation_max": device.saturation_max,
+            "saturation_min": device.saturation_min,
+            "saturation": device.saturation,
+            "serial_no": device.serial_no,
+        },
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics to Nanoleaf

<details>
<summary>Example output</summary>

```json
{
    "info": {
      "entry_id": "da5b71bd911494caf3de348168e9fdd6",
      "version": 1,
      "domain": "nanoleaf",
      "title": "**REDACTED**",
      "data": {
        "host": "192.168.100.70",
        "token": "**REDACTED**"
      },
      "options": {},
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": "Canvas 1CEF",
      "disabled_by": null
    },
    "data": {
      "brightness_max": 100,
      "brightness_min": 0,
      "brightness": 100,
      "color_mode": "effect",
      "color_temperature_max": 6500,
      "color_temperature_min": 1200,
      "color_temperature": 2700,
      "effect": "Galaxy",
      "effects_list": [
        "Bedtime",
        "Color Burst",
        "Falling Whites",
        "Fireworks",
        "Fireworks and Firecrackers",
        "Flames",
        "Forest",
        "Galaxy",
        "Inner Peace",
        "Meteor Shower",
        "Nemo",
        "Northern Lights",
        "Paint Splatter",
        "Pulse Pop Beats",
        "Radial Sound Bar",
        "Rhythmic Northern Lights",
        "Romantic",
        "Sound Bar",
        "Streaking Notes"
      ],
      "firmware_version": "6.2.3",
      "hue_max": 360,
      "hue_min": 0,
      "hue": 0,
      "is_on": true,
      "manufacturer": "Nanoleaf",
      "port": 16021,
      "saturation_max": 100,
      "saturation_min": 0,
      "saturation": 0,
      "serial_no": "S20484C0168"
    }
}
```

</details>



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
