### PR TITLE
Adjust pylint plugin to enforce platform type hints

### DIFF
--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -105,7 +105,7 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
-):
+) -> None:
     """Set up the Aussie Broadband sensor platform from a config entry."""
 
     async_add_entities(
@@ -116,7 +116,6 @@ async def async_setup_entry(
             if description.key in service["coordinator"].data
         ]
     )
-    return True
 
 
 class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):

--- a/homeassistant/components/demo/remote.py
+++ b/homeassistant/components/demo/remote.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 
 async def async_setup_entry(
@@ -25,7 +25,7 @@ def setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities_callback: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the demo remotes."""
     add_entities_callback(

--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -1,8 +1,6 @@
 """Demo platform that has a couple of fake sensors."""
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -20,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, StateType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
 from . import DOMAIN
 
@@ -29,7 +27,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Demo sensors."""
     async_add_entities(

--- a/homeassistant/components/eight_sleep/sensor.py
+++ b/homeassistant/components/eight_sleep/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import (
     CONF_SENSORS,
@@ -56,7 +56,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, list[tuple[str, str]]] = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the eight sleep sensors."""
     if discovery_info is None:

--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -1,8 +1,6 @@
 """This platform allows several binary sensor to be grouped into one binary sensor."""
 from __future__ import annotations
 
-from typing import Any
-
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -24,7 +22,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 
@@ -48,7 +46,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Group Binary Sensor platform."""
     async_add_entities(

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -46,7 +46,7 @@ from homeassistant.core import Event, HomeAssistant, State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 from .util import attribute_equal, reduce_attribute
@@ -71,7 +71,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Group Cover platform."""
     async_add_entities(

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -38,7 +38,7 @@ from homeassistant.core import Event, HomeAssistant, State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 from .util import (
@@ -68,7 +68,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Group Cover platform."""
     async_add_entities(

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -51,7 +51,7 @@ from homeassistant.core import Event, HomeAssistant, State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 from .util import find_state_attributes, mean_tuple, reduce_attribute
@@ -77,7 +77,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Initialize light.group platform."""
     async_add_entities(

--- a/homeassistant/components/gtfs/sensor.py
+++ b/homeassistant/components/gtfs/sensor.py
@@ -1,7 +1,6 @@
 """Support for GTFS (Google/General Transport Format Schema)."""
 from __future__ import annotations
 
-from collections.abc import Callable
 import datetime
 import logging
 import os
@@ -20,6 +19,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_OFFSET, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
@@ -480,7 +480,7 @@ def get_next_departure(
 def setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: Callable[[list], None],
+    add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the GTFS sensor."""

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.location import find_coordinates
-from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt
 
 _LOGGER = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ PLATFORM_SCHEMA = vol.All(
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: dict[str, str | bool],
+    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:

--- a/homeassistant/components/mqtt/light/__init__.py
+++ b/homeassistant/components/mqtt/light/__init__.py
@@ -1,12 +1,15 @@
 """Support for MQTT lights."""
+from __future__ import annotations
+
 import functools
 
 import voluptuous as vol
 
 from homeassistant.components import light
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .. import DOMAIN, PLATFORMS
 from ..mixins import async_setup_entry_helper
@@ -60,8 +63,11 @@ PLATFORM_SCHEMA = vol.All(
 
 
 async def async_setup_platform(
-    hass: HomeAssistant, config: ConfigType, async_add_entities, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Set up MQTT light through configuration.yaml."""
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     await _async_setup_entity(hass, async_add_entities, config)

--- a/homeassistant/components/tcp/binary_sensor.py
+++ b/homeassistant/components/tcp/binary_sensor.py
@@ -1,7 +1,7 @@
 """Provides a binary sensor which gets its values from a TCP socket."""
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Final
 
 from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .common import TCP_PLATFORM_SCHEMA, TcpEntity
 from .const import CONF_VALUE_ON
@@ -21,7 +21,7 @@ def setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the TCP binary sensor."""
     add_entities([TcpBinarySensor(hass, config)])

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -1,7 +1,7 @@
 """Support for TCP socket based sensors."""
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Final
 
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, StateType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
 from .common import TCP_PLATFORM_SCHEMA, TcpEntity
 
@@ -21,7 +21,7 @@ def setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the TCP Sensor."""
     add_entities([TcpSensor(hass, config)])

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -8,11 +8,12 @@ import voluptuous as vol
 
 from homeassistant.components.button import DEVICE_CLASSES_SCHEMA, ButtonEntity
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_UNIQUE_ID
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import DOMAIN
 from .template_entity import (
@@ -57,9 +58,9 @@ async def _async_create_entities(
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: Config,
+    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the template button."""
     if "coordinator" in discovery_info:

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -17,10 +17,11 @@ from homeassistant.components.number.const import (
     DOMAIN as NUMBER_DOMAIN,
 )
 from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_STATE, CONF_UNIQUE_ID
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
 from .const import DOMAIN
@@ -71,9 +72,9 @@ async def _async_create_entities(
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: Config,
+    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the template number."""
     if discovery_info is None:

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -13,10 +13,11 @@ from homeassistant.components.select.const import (
     DOMAIN as SELECT_DOMAIN,
 )
 from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_STATE, CONF_UNIQUE_ID
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
 from .const import DOMAIN
@@ -65,9 +66,9 @@ async def _async_create_entities(
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: Config,
+    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the template select."""
     if discovery_info is None:

--- a/homeassistant/components/websocket_api/sensor.py
+++ b/homeassistant/components/websocket_api/sensor.py
@@ -1,12 +1,10 @@
 """Entity to track connections to websocket API."""
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
     DATA_CONNECTIONS,
@@ -19,7 +17,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the API streams platform."""
     entity = APICount()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add platform methods to pylint plugin: `setup_platform`, `async_setup_platform` and `async_setup_entry`

As follow-up to #64313
Sample run with failures: https://github.com/home-assistant/core/runs/4922919630?check_suite_focus=true
```console
************* Module homeassistant.components.here_travel_time.sensor
Warning: homeassistant/components/here_travel_time/sensor.py:146:4: W0020: Argument 2 should be of type ConfigType (hass-argument-type)
************* Module homeassistant.components.tcp.binary_sensor
Warning: homeassistant/components/tcp/binary_sensor.py:24:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.tcp.sensor
Warning: homeassistant/components/tcp/sensor.py:24:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.eight_sleep.sensor
Warning: homeassistant/components/eight_sleep/sensor.py:59:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.mqtt.light
Warning: homeassistant/components/mqtt/light/__init__.py:63:45: W0020: Argument 3 should be of type AddEntitiesCallback (hass-argument-type)
Warning: homeassistant/components/mqtt/light/__init__.py:63:65: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
Warning: homeassistant/components/mqtt/light/__init__.py:62:0: W0021: Return type should be None (hass-return-type)
************* Module homeassistant.components.demo.remote
Warning: homeassistant/components/demo/remote.py:28:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.demo.sensor
Warning: homeassistant/components/demo/sensor.py:32:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.group.light
Warning: homeassistant/components/group/light.py:80:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.group.binary_sensor
Warning: homeassistant/components/group/binary_sensor.py:51:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.group.cover
Warning: homeassistant/components/group/cover.py:74:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.group.fan
Warning: homeassistant/components/group/fan.py:71:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.aussie_broadband.sensor
Warning: homeassistant/components/aussie_broadband/sensor.py:106:0: W0021: Return type should be None (hass-return-type)
************* Module homeassistant.components.gtfs.sensor
Warning: homeassistant/components/gtfs/sensor.py:483:4: W0020: Argument 3 should be of type AddEntitiesCallback (hass-argument-type)
************* Module homeassistant.components.template.number
Warning: homeassistant/components/template/number.py:76:4: W0020: Argument 2 should be of type ConfigType (hass-argument-type)
Warning: homeassistant/components/template/number.py:78:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.template.select
Warning: homeassistant/components/template/select.py:70:4: W0020: Argument 2 should be of type ConfigType (hass-argument-type)
Warning: homeassistant/components/template/select.py:72:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.template.button
Warning: homeassistant/components/template/button.py:70:4: W0020: Argument 2 should be of type ConfigType (hass-argument-type)
Warning: homeassistant/components/template/button.py:72:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.websocket_api.sensor
Warning: homeassistant/components/websocket_api/sensor.py:22:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
