### PR TITLE
Add event statistics to Sonos diagnostics

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -192,6 +192,8 @@ class SonosDiscoveryManager:
         return None
 
     async def _async_stop_event_listener(self, event: Event | None = None) -> None:
+        for speaker in self.data.discovered.values():
+            speaker.event_stats.log_report()
         await asyncio.gather(
             *(speaker.async_offline() for speaker in self.data.discovered.values())
         )

--- a/homeassistant/components/sonos/alarms.py
+++ b/homeassistant/components/sonos/alarms.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from soco import SoCo
 from soco.alarms import Alarm, Alarms
+from soco.events_base import Event as SonosEvent
 from soco.exceptions import SoCoException
 
-from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DATA_SONOS, SONOS_ALARMS_UPDATED, SONOS_CREATE_ALARM
 from .household_coordinator import SonosHouseholdCoordinator
+
+if TYPE_CHECKING:
+    from .speaker import SonosSpeaker
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,20 +58,18 @@ class SonosAlarms(SonosHouseholdCoordinator):
                 )
         async_dispatcher_send(self.hass, f"{SONOS_ALARMS_UPDATED}-{self.household_id}")
 
-    @callback
-    def async_handle_event(self, event_id: str, soco: SoCo) -> None:
-        """Create a task to update from an event callback."""
-        _, event_id = event_id.split(":")
-        event_id = int(event_id)
-        self.hass.async_create_task(self.async_process_event(event_id, soco))
-
-    async def async_process_event(self, event_id: str, soco: SoCo) -> None:
+    async def async_process_event(
+        self, event: SonosEvent, speaker: SonosSpeaker
+    ) -> None:
         """Process the event payload in an async lock and update entities."""
+        event_id = event.variables["alarm_list_version"].split(":")[-1]
+        event_id = int(event_id)
         async with self.cache_update_lock:
             if event_id <= self.last_processed_event_id:
                 # Skip updates if this event_id has already been seen
                 return
-            await self.async_update_entities(soco, event_id)
+            speaker.event_stats.process(event)
+            await self.async_update_entities(speaker.soco, event_id)
 
     def update_cache(self, soco: SoCo, update_id: int | None = None) -> bool:
         """Update cache of known alarms and return if cache has changed."""

--- a/homeassistant/components/sonos/diagnostics.py
+++ b/homeassistant/components/sonos/diagnostics.py
@@ -107,4 +107,5 @@ async def async_generate_speaker_info(
         payload[attrib] = get_contents(value)
 
     payload["media"] = await async_generate_media_info(hass, speaker)
+    payload["event_stats"] = speaker.event_stats.report()
     return payload

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -4,17 +4,20 @@ from __future__ import annotations
 from collections.abc import Iterator
 import logging
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from soco import SoCo
 from soco.data_structures import DidlFavorite
+from soco.events_base import Event as SonosEvent
 from soco.exceptions import SoCoException
 
-from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import SONOS_FAVORITES_UPDATED
 from .household_coordinator import SonosHouseholdCoordinator
+
+if TYPE_CHECKING:
+    from .speaker import SonosSpeaker
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,45 +54,41 @@ class SonosFavorites(SonosHouseholdCoordinator):
             self.hass, f"{SONOS_FAVORITES_UPDATED}-{self.household_id}"
         )
 
-    @callback
-    def async_handle_event(self, event_id: str, container_ids: str, soco: SoCo) -> None:
-        """Create a task to update from an event callback."""
+    async def async_process_event(
+        self, event: SonosEvent, speaker: SonosSpeaker
+    ) -> None:
+        """Process the event payload in an async lock and update entities."""
+        event_id = event.variables["favorites_update_id"]
+        container_ids = event.variables["container_update_i_ds"]
         if not (match := re.search(r"FV:2,(\d+)", container_ids)):
             return
 
         container_id = int(match.groups()[0])
         event_id = int(event_id.split(",")[-1])
 
-        self.hass.async_create_task(
-            self.async_process_event(event_id, container_id, soco)
-        )
-
-    async def async_process_event(
-        self, event_id: int, container_id: int, soco: SoCo
-    ) -> None:
-        """Process the event payload in an async lock and update entities."""
         async with self.cache_update_lock:
-            last_poll_id = self.last_polled_ids.get(soco.uid)
+            last_poll_id = self.last_polled_ids.get(speaker.uid)
             if (
                 self.last_processed_event_id
                 and event_id <= self.last_processed_event_id
             ):
                 # Skip updates if this event_id has already been seen
                 if not last_poll_id:
-                    self.last_polled_ids[soco.uid] = container_id
+                    self.last_polled_ids[speaker.uid] = container_id
                 return
 
             if last_poll_id and container_id <= last_poll_id:
                 return
 
+            speaker.event_stats.process(event)
             _LOGGER.debug(
                 "New favorites event %s from %s (was %s)",
                 event_id,
-                soco,
+                speaker.soco,
                 self.last_processed_event_id,
             )
             self.last_processed_event_id = event_id
-            await self.async_update_entities(soco, container_id)
+            await self.async_update_entities(speaker.soco, container_id)
 
     def update_cache(self, soco: SoCo, update_id: int | None = None) -> bool:
         """Update cache of known favorites and return if cache has changed."""

--- a/homeassistant/components/sonos/statistics.py
+++ b/homeassistant/components/sonos/statistics.py
@@ -1,0 +1,48 @@
+"""Class to track subscription event statistics."""
+from __future__ import annotations
+
+import logging
+
+from soco.data_structures_entry import from_didl_string
+from soco.events_base import Event as SonosEvent, parse_event_xml
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EventStatistics:
+    """Representation of Sonos event statistics."""
+
+    def __init__(self, zone_name: str) -> None:
+        """Initialize EventStatistics."""
+        self._stats = {}
+        self.zone_name = zone_name
+
+    def receive(self, event: SonosEvent) -> None:
+        """Mark a received event by subscription type."""
+        stats_entry = self._stats.setdefault(
+            event.service.service_type, {"received": 0, "duplicates": 0, "processed": 0}
+        )
+        stats_entry["received"] += 1
+
+    def duplicate(self, event: SonosEvent) -> None:
+        """Mark a duplicate event by subscription type."""
+        self._stats[event.service.service_type]["duplicates"] += 1
+
+    def process(self, event: SonosEvent) -> None:
+        """Mark a fully processed event by subscription type."""
+        self._stats[event.service.service_type]["processed"] += 1
+
+    def report(self) -> dict:
+        """Generate a report for use in diagnostics."""
+        payload = self._stats.copy()
+        payload["soco:from_didl_string"] = from_didl_string.cache_info()
+        payload["soco:parse_event_xml"] = parse_event_xml.cache_info()
+        return payload
+
+    def log_report(self) -> None:
+        """Log event statistics for this speaker."""
+        _LOGGER.debug(
+            "Event statistics for %s: %s",
+            self.zone_name,
+            self.report(),
+        )

--- a/tests/components/sonos/test_statistics.py
+++ b/tests/components/sonos/test_statistics.py
@@ -1,0 +1,30 @@
+"""Tests for the Sonos statistics."""
+from homeassistant.components.sonos.const import DATA_SONOS
+
+
+async def test_statistics_duplicate(
+    hass, async_autosetup_sonos, soco, device_properties_event
+):
+    """Test Sonos statistics."""
+    speaker = list(hass.data[DATA_SONOS].discovered.values())[0]
+
+    subscription = soco.deviceProperties.subscribe.return_value
+    sub_callback = subscription.callback
+
+    # Update the speaker with a callback event
+    sub_callback(device_properties_event)
+    await hass.async_block_till_done()
+
+    report = speaker.event_stats.report()
+    assert report["DeviceProperties"]["received"] == 1
+    assert report["DeviceProperties"]["duplicates"] == 0
+    assert report["DeviceProperties"]["processed"] == 1
+
+    # Ensure a duplicate is registered in the statistics
+    sub_callback(device_properties_event)
+    await hass.async_block_till_done()
+
+    report = speaker.event_stats.report()
+    assert report["DeviceProperties"]["received"] == 2
+    assert report["DeviceProperties"]["duplicates"] == 1
+    assert report["DeviceProperties"]["processed"] == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As a followup to #64722 I wanted to know how effective the duplicate event skipping strategies were without counting custom debug log entries. I was also curious how often we were able to abort processing early if we knew the payload contents were not interesting/applicable.

This PR writes event statistics per-speaker to diagnostics and debug log output on shutdown (to a new module so debug does not need to be enabled for the integration as a whole). It also writes statistics for `lru_cache` fixtures recently added to the underlying library which avoid re-parsing XML we've already encountered.

Hopefully this can give more insight into areas that can be optimized further.

```
2022-01-24 00:00:00 DEBUG (MainThread) [homeassistant.components.sonos.statistics] Event statistics for Kitchen: {'ContentDirectory': {'received': 6, 'duplicates': 0, 'processed': 0}, 'AVTransport': {'received': 7, 'duplicates': 0, 'processed': 6}, 'AlarmClock': {'received': 5, 'duplicates': 0, 'processed': 0}, 'ZoneGroupTopology': {'received': 5, 'duplicates': 0, 'processed': 1}, 'DeviceProperties': {'received': 13, 'duplicates': 0, 'processed': 13}, 'RenderingControl': {'received': 5, 'duplicates': 0, 'processed': 5}, 'soco:from_didl_string': CacheInfo(hits=165, misses=72, maxsize=128, currsize=72), 'soco:parse_event_xml': CacheInfo(hits=29, misses=139, maxsize=128, currsize=128)}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
