### PR TITLE
Add diagnostics to Launch Library

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -584,6 +584,7 @@ omit =
     homeassistant/components/lastfm/sensor.py
     homeassistant/components/launch_library/__init__.py
     homeassistant/components/launch_library/const.py
+    homeassistant/components/launch_library/diagnostics.py
     homeassistant/components/launch_library/sensor.py
     homeassistant/components/lcn/binary_sensor.py
     homeassistant/components/lcn/climate.py

--- a/homeassistant/components/launch_library/diagnostics.py
+++ b/homeassistant/components/launch_library/diagnostics.py
@@ -1,0 +1,24 @@
+"""Diagnostics support for Launch Library."""
+from __future__ import annotations
+
+from typing import Any
+
+from pylaunches.objects.launch import Launch
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: DataUpdateCoordinator[list[Launch]] = hass.data[DOMAIN]
+    next_launch = coordinator.data[0] if coordinator.data else None
+    return {
+        "next_launch": next_launch.raw_data_contents if next_launch else None,
+    }

--- a/homeassistant/components/launch_library/manifest.json
+++ b/homeassistant/components/launch_library/manifest.json
@@ -3,7 +3,7 @@
   "name": "Launch Library",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/launch_library",
-  "requirements": ["pylaunches==1.2.1"],
+  "requirements": ["pylaunches==1.2.2"],
   "codeowners": ["@ludeeus", "@DurgNomis-drol"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1633,7 +1633,7 @@ pylacrosse==0.4
 pylast==4.2.1
 
 # homeassistant.components.launch_library
-pylaunches==1.2.1
+pylaunches==1.2.2
 
 # homeassistant.components.lg_netcast
 pylgnetcast==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1020,7 +1020,7 @@ pykulersky==0.5.2
 pylast==4.2.1
 
 # homeassistant.components.launch_library
-pylaunches==1.2.1
+pylaunches==1.2.2
 
 # homeassistant.components.forked_daapd
 pylibrespot-java==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds diagnostics support

requirement bump diff <https://github.com/ludeeus/pylaunches/compare/1.2.1...1.2.2>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2022.2.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.13.0-27-generic",
    "run_as_root": true
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "launch_library",
    "name": "Launch Library",
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/launch_library",
    "requirements": [
      "pylaunches==1.2.2"
    ],
    "codeowners": [
      "@ludeeus",
      "@DurgNomis-drol"
    ],
    "iot_class": "cloud_polling",
    "is_built_in": true
  },
  "data": {
    "next_launch": {
      "id": "42f2c56f-19b9-403f-972d-5fd2282c298b",
      "url": "https://ll.thespacedevs.com/2.2.0/launch/42f2c56f-19b9-403f-972d-5fd2282c298b/",
      "launch_library_id": null,
      "slug": "long-march-4b-unknown",
      "name": "Long March 4B | Unknown",
      "status": {
        "id": 1,
        "name": "Go"
      },
      "net": "2022-01-25T23:40:00Z",
      "window_end": "2022-01-26T00:04:00Z",
      "window_start": "2022-01-25T23:34:00Z",
      "inhold": false,
      "tbdtime": false,
      "tbddate": false,
      "probability": null,
      "holdreason": "",
      "failreason": "",
      "hashtag": null,
      "launch_service_provider": {
        "id": 88,
        "url": "https://ll.thespacedevs.com/2.2.0/agencies/88/",
        "name": "China Aerospace Science and Technology Corporation",
        "type": "Government"
      },
      "rocket": {
        "id": 2415,
        "configuration": {
          "id": 10,
          "launch_library_id": 16,
          "url": "https://ll.thespacedevs.com/2.2.0/config/launcher/10/",
          "name": "Long March 4B",
          "family": "Long March 4",
          "full_name": "Long March 4B",
          "variant": "B"
        }
      },
      "mission": null,
      "pad": {
        "id": 22,
        "url": "https://ll.thespacedevs.com/2.2.0/pad/22/",
        "agency_id": null,
        "name": "Launch Area 4 (SLS-2 / 603)",
        "info_url": null,
        "wiki_url": "https://en.wikipedia.org/wiki/Jiuquan_Launch_Area_4",
        "map_url": "http://maps.google.com/maps?q=40.960556,100.298333",
        "latitude": "40.960556",
        "longitude": "100.298333",
        "location": {
          "id": 17,
          "url": "https://ll.thespacedevs.com/2.2.0/location/17/",
          "name": "Jiuquan, People's Republic of China",
          "country_code": "CHN",
          "map_image": "https://spacelaunchnow-prod-east.nyc3.digitaloceanspaces.com/media/launch_images/location_17_20200803142429.jpg",
          "total_launch_count": 156,
          "total_landing_count": 0
        },
        "map_image": "https://spacelaunchnow-prod-east.nyc3.digitaloceanspaces.com/media/launch_images/pad_22_20200803143437.jpg",
        "total_launch_count": 76
      },
      "webcast_live": false,
      "image": "https://spacelaunchnow-prod-east.nyc3.digitaloceanspaces.com/media/launcher_images/long2520march25204_image_20190430065008.jpg",
      "infographic": null,
      "program": []
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
