### PR TITLE
Include entity_id in Alexa state report error log

### DIFF
--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -177,7 +177,8 @@ async def async_send_changereport_message(
         await config.set_authorized(False)
 
     _LOGGER.error(
-        "Error when sending ChangeReport to Alexa: %s: %s",
+        "Error when sending ChangeReport to Alexa for %s: %s: %s",
+        alexa_entity.entity_id,
         response_json["payload"]["code"],
         response_json["payload"]["description"],
     )

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -150,7 +150,7 @@ async def async_send_changereport_message(
             )
 
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        _LOGGER.error("Timeout sending report to Alexa")
+        _LOGGER.error("Timeout sending report to Alexa for %s", alexa_entity.entity_id)
         return
 
     response_text = await response.text()
@@ -287,7 +287,7 @@ async def async_send_doorbell_event_message(hass, config, alexa_entity):
             )
 
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        _LOGGER.error("Timeout sending report to Alexa")
+        _LOGGER.error("Timeout sending report to Alexa for %s", alexa_entity.entity_id)
         return
 
     response_text = await response.text()
@@ -301,7 +301,8 @@ async def async_send_doorbell_event_message(hass, config, alexa_entity):
     response_json = json.loads(response_text)
 
     _LOGGER.error(
-        "Error when sending DoorbellPress event to Alexa: %s: %s",
+        "Error when sending DoorbellPress event for %s to Alexa: %s: %s",
+        alexa_entity.entity_id,
         response_json["payload"]["code"],
         response_json["payload"]["description"],
     )

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -177,7 +177,7 @@ async def async_send_changereport_message(
         await config.set_authorized(False)
 
     _LOGGER.error(
-        "Error when sending ChangeReport to Alexa for %s: %s: %s",
+        "Error when sending ChangeReport for %s to Alexa: %s: %s",
         alexa_entity.entity_id,
         response_json["payload"]["code"],
         response_json["payload"]["description"],

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -2,6 +2,7 @@
 import json
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 import pytest
 
 from homeassistant import core
@@ -81,9 +82,42 @@ async def test_report_state_fail(hass, aioclient_mock, caplog):
 
     # Check we log the entity id of the failing entity
     assert (
-        "Error when sending ChangeReport to Alexa for binary_sensor.test_contact: "
+        "Error when sending ChangeReport for binary_sensor.test_contact to Alexa: "
         "THROTTLING_EXCEPTION: Request could not be processed due to throttling"
     ) in caplog.text
+
+
+async def test_report_state_timeout(hass, aioclient_mock, caplog):
+    """Test proactive state retries once."""
+    aioclient_mock.post(
+        TEST_URL,
+        exc=aiohttp.ClientError(),
+    )
+
+    hass.states.async_set(
+        "binary_sensor.test_contact",
+        "on",
+        {"friendly_name": "Test Contact Sensor", "device_class": "door"},
+    )
+
+    await state_report.async_enable_proactive_mode(hass, get_default_config())
+
+    hass.states.async_set(
+        "binary_sensor.test_contact",
+        "off",
+        {"friendly_name": "Test Contact Sensor", "device_class": "door"},
+    )
+
+    # To trigger event listener
+    await hass.async_block_till_done()
+
+    # No retry on errors not related to expired access token
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # Check we log the entity id of the failing entity
+    assert (
+        "Timeout sending report to Alexa for binary_sensor.test_contact" in caplog.text
+    )
 
 
 async def test_report_state_retry(hass, aioclient_mock):
@@ -350,6 +384,81 @@ async def test_doorbell_event(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 2
+
+
+async def test_doorbell_event_fail(hass, aioclient_mock, caplog):
+    """Test proactive state retries once."""
+    aioclient_mock.post(
+        TEST_URL,
+        text=json.dumps(
+            {
+                "payload": {
+                    "code": "THROTTLING_EXCEPTION",
+                    "description": "Request could not be processed due to throttling",
+                }
+            }
+        ),
+        status=403,
+    )
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        "off",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    await state_report.async_enable_proactive_mode(hass, get_default_config())
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        "on",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    # To trigger event listener
+    await hass.async_block_till_done()
+
+    # No retry on errors not related to expired access token
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # Check we log the entity id of the failing entity
+    assert (
+        "Error when sending DoorbellPress event for binary_sensor.test_doorbell to Alexa: "
+        "THROTTLING_EXCEPTION: Request could not be processed due to throttling"
+    ) in caplog.text
+
+
+async def test_doorbell_event_timeout(hass, aioclient_mock, caplog):
+    """Test proactive state retries once."""
+    aioclient_mock.post(
+        TEST_URL,
+        exc=aiohttp.ClientError(),
+    )
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        "off",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    await state_report.async_enable_proactive_mode(hass, get_default_config())
+
+    hass.states.async_set(
+        "binary_sensor.test_doorbell",
+        "on",
+        {"friendly_name": "Test Doorbell Sensor", "device_class": "occupancy"},
+    )
+
+    # To trigger event listener
+    await hass.async_block_till_done()
+
+    # No retry on errors not related to expired access token
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # Check we log the entity id of the failing entity
+    assert (
+        "Timeout sending report to Alexa for binary_sensor.test_doorbell" in caplog.text
+    )
 
 
 async def test_proactive_mode_filter_states(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include `entity_id` in Alexa state report error log

Before this PR:
```
Error when sending ChangeReport to Alexa: THROTTLING_EXCEPTION: Request could not be processed due to throttling.
```

With this PR:
```
Error when sending ChangeReport to Alexa for light.ceiling: THROTTLING_EXCEPTION: Request could not be processed due to throttling.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/64860
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
