### PR TITLE
Adjust pylint plugin to enforce device_tracker type hints

### DIFF
--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 import logging
-from typing import Any, Final
+from typing import Final
 
 import bluetooth  # pylint: disable=import-error
 from bt_proximity import BluetoothRSSI
@@ -30,7 +30,7 @@ from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
     BT_PREFIX,
@@ -131,7 +131,7 @@ async def async_setup_scanner(
     hass: HomeAssistant,
     config: ConfigType,
     async_see: Callable[..., Awaitable[None]],
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> bool:
     """Set up the Bluetooth Scanner."""
     device_id: int = config[CONF_DEVICE_ID]

--- a/homeassistant/components/mysensors/device_tracker.py
+++ b/homeassistant/components/mysensors/device_tracker.py
@@ -1,13 +1,14 @@
 """Support for tracking MySensors devices."""
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from homeassistant.components import mysensors
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
 
 from .const import ATTR_GATEWAY_ID, DevId, DiscoveryInfo, GatewayId
@@ -16,9 +17,9 @@ from .helpers import on_unload
 
 async def async_setup_scanner(
     hass: HomeAssistant,
-    config: dict[str, Any],
-    async_see: Callable,
-    discovery_info: DiscoveryInfo | None = None,
+    config: ConfigType,
+    async_see: Callable[..., Awaitable[None]],
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> bool:
     """Set up the MySensors device scanner."""
     if not discovery_info:
@@ -27,7 +28,7 @@ async def async_setup_scanner(
     new_devices = mysensors.setup_mysensors_platform(
         hass,
         Platform.DEVICE_TRACKER,
-        discovery_info,
+        cast(DiscoveryInfo, discovery_info),
         MySensorsDeviceScanner,
         device_args=(hass, async_see),
     )

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import logging
-from typing import Any
 
 from pytile.tile import Tile
 
@@ -13,7 +12,7 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -55,7 +54,7 @@ async def async_setup_scanner(
     hass: HomeAssistant,
     config: ConfigType,
     async_see: Callable[..., Awaitable[None]],
-    discovery_info: dict[str, Any] | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> bool:
     """Detect a legacy configuration and import it."""
     hass.async_create_task(

--- a/tests/pylint/__init__.py
+++ b/tests/pylint/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pylint."""

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -1,0 +1,41 @@
+"""Tests for pylint hass_enforce_type_hints plugin."""
+# pylint:disable=protected-access
+
+from importlib.machinery import SourceFileLoader
+import re
+
+import pytest
+
+loader = SourceFileLoader(
+    "hass_enforce_type_hints", "pylint/plugins/hass_enforce_type_hints.py"
+)
+hass_enforce_type_hints = loader.load_module(None)
+_TYPE_HINT_MATCHERS: dict[str, re.Pattern] = hass_enforce_type_hints._TYPE_HINT_MATCHERS
+
+
+@pytest.mark.parametrize(
+    ("string", "expected_x", "expected_y", "expected_z"),
+    [
+        ("Callable[..., None]", "Callable", "...", "None"),
+        ("Callable[..., Awaitable[None]]", "Callable", "...", "Awaitable[None]"),
+    ],
+)
+def test_regex_x_of_y_comma_z(string, expected_x, expected_y, expected_z):
+    """Test x_of_y_comma_z regexes."""
+    assert (match := _TYPE_HINT_MATCHERS["x_of_y_comma_z"].match(string))
+    assert match.group(0) == string
+    assert match.group(1) == expected_x
+    assert match.group(2) == expected_y
+    assert match.group(3) == expected_z
+
+
+@pytest.mark.parametrize(
+    ("string", "expected_a", "expected_b"),
+    [("DiscoveryInfoType | None", "DiscoveryInfoType", "None")],
+)
+def test_regex_a_or_b(string, expected_a, expected_b):
+    """Test a_or_b regexes."""
+    assert (match := _TYPE_HINT_MATCHERS["a_or_b"].match(string))
+    assert match.group(0) == string
+    assert match.group(1) == expected_a
+    assert match.group(2) == expected_b


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add device_tracker methods to pylint plugin: `setup_scanner`, `async_setup_scanner`, `get_scanner` and `async_get_scanner`

As follow-up to #64313
Sample run with failures: https://github.com/home-assistant/core/runs/4936899685?check_suite_focus=true

```console
************* Module homeassistant.components.bluetooth_tracker.device_tracker
Warning: homeassistant/components/bluetooth_tracker/device_tracker.py:134:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.mysensors.device_tracker
Warning: homeassistant/components/mysensors/device_tracker.py:19:4: W0020: Argument 2 should be of type ConfigType (hass-argument-type)
Warning: homeassistant/components/mysensors/device_tracker.py:20:4: W0020: Argument 3 should be of type Callable[..., Awaitable[None]] (hass-argument-type)
Warning: homeassistant/components/mysensors/device_tracker.py:21:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
************* Module homeassistant.components.tile.device_tracker
Warning: homeassistant/components/tile/device_tracker.py:58:4: W0020: Argument 4 should be of type DiscoveryInfoType | None (hass-argument-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
