### PR TITLE
Add diagnostics to UptimeRobot

### DIFF
--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -57,6 +57,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator):
     """Data update coordinator for UptimeRobot."""
 
+    data: list[UptimeRobotMonitor]
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -69,17 +71,16 @@ class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             LOGGER,
             name=DOMAIN,
-            update_method=self._async_update_data,
             update_interval=COORDINATOR_UPDATE_INTERVAL,
         )
         self._config_entry_id = config_entry_id
         self._device_registry = dev_reg
-        self._api = api
+        self.api = api
 
     async def _async_update_data(self) -> list[UptimeRobotMonitor] | None:
         """Update data."""
         try:
-            response = await self._api.async_get_monitors()
+            response = await self.api.async_get_monitors()
         except UptimeRobotAuthenticationException as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except UptimeRobotException as exception:

--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -9,17 +9,19 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from . import UptimeRobotDataUpdateCoordinator
 from .const import DOMAIN
 from .entity import UptimeRobotEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the UptimeRobot binary_sensors."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: UptimeRobotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
             UptimeRobotBinarySensor(

--- a/homeassistant/components/uptimerobot/diagnostics.py
+++ b/homeassistant/components/uptimerobot/diagnostics.py
@@ -1,0 +1,45 @@
+"""Diagnostics support for UptimeRobot."""
+from __future__ import annotations
+
+from typing import Any
+
+from pyuptimerobot import UptimeRobotException
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from . import UptimeRobotDataUpdateCoordinator
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: UptimeRobotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    account: dict[str, Any] | str | None = None
+    try:
+        response = await coordinator.api.async_get_account_details()
+    except UptimeRobotException as err:
+        account = str(err)
+    else:
+        if (details := response.data) is not None:
+            account = {
+                "up_monitors": details.up_monitors,
+                "down_monitors": details.down_monitors,
+                "paused_monitors": details.paused_monitors,
+            }
+
+    return {
+        "account": account,
+        "monitors": [
+            {
+                "id": monitor.id,
+                "type": str(monitor.type),
+                "interval": monitor.interval,
+                "status": monitor.status,
+            }
+            for monitor in coordinator.data
+        ],
+    }

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -20,10 +20,15 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-MOCK_UPTIMEROBOT_API_KEY = "1234"
+MOCK_UPTIMEROBOT_API_KEY = "0242ac120003"
+MOCK_UPTIMEROBOT_EMAIL = "test@test.test"
 MOCK_UPTIMEROBOT_UNIQUE_ID = "1234567890"
 
-MOCK_UPTIMEROBOT_ACCOUNT = {"email": "test@test.test", "user_id": 1234567890}
+MOCK_UPTIMEROBOT_ACCOUNT = {
+    "email": MOCK_UPTIMEROBOT_EMAIL,
+    "user_id": 1234567890,
+    "up_monitors": 1,
+}
 MOCK_UPTIMEROBOT_ERROR = {"message": "test error from API."}
 MOCK_UPTIMEROBOT_MONITOR = {
     "id": 1234,
@@ -35,7 +40,7 @@ MOCK_UPTIMEROBOT_MONITOR = {
 
 MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA = {
     "domain": DOMAIN,
-    "title": "test@test.test",
+    "title": MOCK_UPTIMEROBOT_EMAIL,
     "data": {"platform": DOMAIN, "api_key": MOCK_UPTIMEROBOT_API_KEY},
     "unique_id": MOCK_UPTIMEROBOT_UNIQUE_ID,
     "source": config_entries.SOURCE_USER,

--- a/tests/components/uptimerobot/test_diagnostics.py
+++ b/tests/components/uptimerobot/test_diagnostics.py
@@ -1,0 +1,78 @@
+"""Test UptimeRobot diagnostics."""
+import json
+from unittest.mock import patch
+
+from aiohttp import ClientSession
+from pyuptimerobot import UptimeRobotException
+
+from homeassistant.core import HomeAssistant
+
+from .common import (
+    MOCK_UPTIMEROBOT_ACCOUNT,
+    MOCK_UPTIMEROBOT_API_KEY,
+    MOCK_UPTIMEROBOT_EMAIL,
+    MockApiResponseKey,
+    mock_uptimerobot_api_response,
+    setup_uptimerobot_integration,
+)
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+) -> None:
+    """Test config entry diagnostics."""
+    entry = await setup_uptimerobot_integration(hass)
+
+    with patch(
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        return_value=mock_uptimerobot_api_response(
+            key=MockApiResponseKey.ACCOUNT,
+            data=MOCK_UPTIMEROBOT_ACCOUNT,
+        ),
+    ):
+
+        result = await get_diagnostics_for_config_entry(
+            hass,
+            hass_client,
+            entry,
+        )
+
+    assert result["account"] == {
+        "down_monitors": 0,
+        "paused_monitors": 0,
+        "up_monitors": 1,
+    }
+
+    assert result["monitors"] == [
+        {"id": 1234, "interval": 0, "status": 2, "type": "MonitorType.HTTP"}
+    ]
+
+    assert list(result.keys()) == ["account", "monitors"]
+
+    result_dump = json.dumps(result)
+    assert MOCK_UPTIMEROBOT_EMAIL not in result_dump
+    assert MOCK_UPTIMEROBOT_API_KEY not in result_dump
+
+
+async def test_entry_diagnostics_exception(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+) -> None:
+    """Test config entry diagnostics with exception."""
+    entry = await setup_uptimerobot_integration(hass)
+
+    with patch(
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        side_effect=UptimeRobotException("Test exception"),
+    ):
+
+        result = await get_diagnostics_for_config_entry(
+            hass,
+            hass_client,
+            entry,
+        )
+
+    assert result["account"] == "Test exception"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics to uptime robot

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2022.2.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.13.0-27-generic",
    "run_as_root": true
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "uptimerobot",
    "name": "UptimeRobot",
    "documentation": "https://www.home-assistant.io/integrations/uptimerobot",
    "requirements": [
      "pyuptimerobot==21.11.0"
    ],
    "codeowners": [
      "@ludeeus"
    ],
    "quality_scale": "platinum",
    "iot_class": "cloud_polling",
    "config_flow": true,
    "is_built_in": true
  },
  "data": {
    "account": {
      "up_monitors": 5,
      "down_monitors": 0,
      "paused_monitors": 0
    },
    "monitors": [
      {
        "id": 788898718,
        "type": "MonitorType.HTTP",
        "interval": 300,
        "status": 2
      },
      {
        "id": 780901354,
        "type": "MonitorType.HTTP",
        "interval": 300,
        "status": 2
      },
      {
        "id": 780472770,
        "type": "MonitorType.HTTP",
        "interval": 300,
        "status": 2
      },
      {
        "id": 788889578,
        "type": "MonitorType.HTTP",
        "interval": 300,
        "status": 2
      },
      {
        "id": 789112505,
        "type": "MonitorType.HTTP",
        "interval": 300,
        "status": 2
      }
    ]
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
