### PR TITLE
Bump ZHA quirks to 0.0.66

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -7,7 +7,7 @@
     "bellows==0.29.0",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.65",
+    "zha-quirks==0.0.66",
     "zigpy-deconz==0.14.0",
     "zigpy==0.43.0",
     "zigpy-xbee==0.14.0",
@@ -15,14 +15,54 @@
     "zigpy-znp==0.7.0"
   ],
   "usb": [
-   {"vid":"10C4","pid":"EA60","description":"*2652*","known_devices":["slae.sh cc2652rb stick"]},
-   {"vid":"10C4","pid":"EA60","description":"*sonoff*plus*","known_devices":["sonoff zigbee dongle plus"]},
-   {"vid":"10C4","pid":"EA60","description":"*tubeszb*","known_devices":["TubesZB Coordinator"]},
-   {"vid":"1A86","pid":"7523","description":"*tubeszb*","known_devices":["TubesZB Coordinator"]},
-   {"vid":"1A86","pid":"7523","description":"*zigstar*","known_devices":["ZigStar Coordinators"]},
-   {"vid":"1CF1","pid":"0030","description":"*conbee*","known_devices":["Conbee II"]},
-   {"vid":"10C4","pid":"8A2A","description":"*zigbee*","known_devices":["Nortek HUSBZB-1"]},
-   {"vid":"10C4","pid":"8B34","description":"*bv 2010/10*","known_devices":["Bitron Video AV2010/10"]}
+    {
+      "vid": "10C4",
+      "pid": "EA60",
+      "description": "*2652*",
+      "known_devices": ["slae.sh cc2652rb stick"]
+    },
+    {
+      "vid": "10C4",
+      "pid": "EA60",
+      "description": "*sonoff*plus*",
+      "known_devices": ["sonoff zigbee dongle plus"]
+    },
+    {
+      "vid": "10C4",
+      "pid": "EA60",
+      "description": "*tubeszb*",
+      "known_devices": ["TubesZB Coordinator"]
+    },
+    {
+      "vid": "1A86",
+      "pid": "7523",
+      "description": "*tubeszb*",
+      "known_devices": ["TubesZB Coordinator"]
+    },
+    {
+      "vid": "1A86",
+      "pid": "7523",
+      "description": "*zigstar*",
+      "known_devices": ["ZigStar Coordinators"]
+    },
+    {
+      "vid": "1CF1",
+      "pid": "0030",
+      "description": "*conbee*",
+      "known_devices": ["Conbee II"]
+    },
+    {
+      "vid": "10C4",
+      "pid": "8A2A",
+      "description": "*zigbee*",
+      "known_devices": ["Nortek HUSBZB-1"]
+    },
+    {
+      "vid": "10C4",
+      "pid": "8B34",
+      "description": "*bv 2010/10*",
+      "known_devices": ["Bitron Video AV2010/10"]
+    }
   ],
   "codeowners": ["@dmulcahey", "@adminiuga"],
   "zeroconf": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2534,7 +2534,7 @@ zengge==0.2
 zeroconf==0.38.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.65
+zha-quirks==0.0.66
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1550,7 +1550,7 @@ youless-api==0.16
 zeroconf==0.38.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.65
+zha-quirks==0.0.66
 
 # homeassistant.components.zha
 zigpy-deconz==0.14.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps the ZHA quirks lib to 0.0.66 https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.66

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
