### PR TITLE
Add number platform for kostal_plenticore

### DIFF
--- a/homeassistant/components/kostal_plenticore/__init__.py
+++ b/homeassistant/components/kostal_plenticore/__init__.py
@@ -12,7 +12,7 @@ from .helper import Plenticore
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SELECT, Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/kostal_plenticore/const.py
+++ b/homeassistant/components/kostal_plenticore/const.py
@@ -795,13 +795,20 @@ SENSOR_PROCESS_DATA = [
 
 
 @dataclass
-class PlenticoreNumberEntityDescription(NumberEntityDescription):
-    """Describes a Plenticore number entity."""
+class PlenticoreNumberEntityDescriptionMixin:
+    """Define an entity description mixin for number entities."""
 
-    module_id: str = None
-    data_id: str = None
-    fmt_from: str = None
-    fmt_to: str = None
+    module_id: str
+    data_id: str
+    fmt_from: str
+    fmt_to: str
+
+
+@dataclass
+class PlenticoreNumberEntityDescription(
+    NumberEntityDescription, PlenticoreNumberEntityDescriptionMixin
+):
+    """Describes a Plenticore number entity."""
 
 
 NUMBER_SETTINGS_DATA = [

--- a/homeassistant/components/kostal_plenticore/const.py
+++ b/homeassistant/components/kostal_plenticore/const.py
@@ -1,6 +1,8 @@
 """Constants for the Kostal Plenticore Solar Inverter integration."""
+from dataclasses import dataclass
 from typing import NamedTuple
 
+from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -16,6 +18,7 @@ from homeassistant.const import (
     PERCENTAGE,
     POWER_WATT,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "kostal_plenticore"
 
@@ -790,31 +793,47 @@ SENSOR_PROCESS_DATA = [
     ),
 ]
 
-# Defines all entities for settings.
-#
-# Each entry is defined with a tuple of these values:
-#  - module id (str)
-#  - process data id (str)
-#  - entity name suffix (str)
-#  - sensor properties (dict)
-#  - value formatter (str)
-SENSOR_SETTINGS_DATA = [
-    (
-        "devices:local",
-        "Battery:MinHomeComsumption",
-        "Battery min Home Consumption",
-        {
-            ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
-            ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
-        },
-        "format_round",
+
+@dataclass
+class PlenticoreNumberEntityDescription(NumberEntityDescription):
+    """Describes a Plenticore number entity."""
+
+    module_id: str = None
+    data_id: str = None
+    fmt_from: str = None
+    fmt_to: str = None
+
+
+NUMBER_SETTINGS_DATA = [
+    PlenticoreNumberEntityDescription(
+        key="battery_min_soc",
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        icon="mdi:battery-negative",
+        name="Battery min SoC",
+        unit_of_measurement=PERCENTAGE,
+        max_value=100,
+        min_value=5,
+        step=5,
+        module_id="devices:local",
+        data_id="Battery:MinSoc",
+        fmt_from="format_round",
+        fmt_to="format_round_back",
     ),
-    (
-        "devices:local",
-        "Battery:MinSoc",
-        "Battery min Soc",
-        {ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE, ATTR_ICON: "mdi:battery-negative"},
-        "format_round",
+    PlenticoreNumberEntityDescription(
+        key="battery_min_home_consumption",
+        device_class=SensorDeviceClass.POWER,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        name="Battery min Home Consumption",
+        unit_of_measurement=POWER_WATT,
+        max_value=38000,
+        min_value=50,
+        step=1,
+        module_id="devices:local",
+        data_id="Battery:MinHomeComsumption",
+        fmt_from="format_round",
+        fmt_to="format_round_back",
     ),
 ]
 

--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -348,8 +348,10 @@ class PlenticoreDataFormatter:
     def format_round_back(value: float) -> str:
         """Return a rounded integer value from a float."""
         try:
-            if value.is_integer():
+            if isinstance(value, float) and value.is_integer():
                 int_value = int(value)
+            elif isinstance(value, int):
+                int_value = value
             else:
                 int_value = round(value)
 

--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta
 import logging
+from typing import Any
 
 from aiohttp.client_exceptions import ClientError
 from kostal.plenticore import (
@@ -332,7 +333,7 @@ class PlenticoreDataFormatter:
     }
 
     @classmethod
-    def get_method(cls, name: str) -> callable:
+    def get_method(cls, name: str) -> Callable[[Any], Any]:
         """Return a callable formatter of the given name."""
         return getattr(cls, name)
 

--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -122,7 +122,7 @@ class DataUpdateCoordinatorMixin:
     """Base implementation for read and write data."""
 
     async def async_read_data(self, module_id: str, data_id: str) -> list[str, bool]:
-        """Write settings back to Plenticore."""
+        """Read data from Plenticore."""
         if (client := self._plenticore.client) is None:
             return False
 
@@ -137,6 +137,10 @@ class DataUpdateCoordinatorMixin:
         """Write settings back to Plenticore."""
         if (client := self._plenticore.client) is None:
             return False
+
+        _LOGGER.debug(
+            "Setting value for %s in module %s to %s", self.name, module_id, value
+        )
 
         try:
             await client.set_setting_values(module_id, value)
@@ -339,6 +343,19 @@ class PlenticoreDataFormatter:
             return round(float(state))
         except (TypeError, ValueError):
             return state
+
+    @staticmethod
+    def format_round_back(value: float) -> str:
+        """Return a rounded integer value from a float."""
+        try:
+            if value.is_integer():
+                int_value = int(value)
+            else:
+                int_value = round(value)
+
+            return str(int_value)
+        except (TypeError, ValueError):
+            return ""
 
     @staticmethod
     def format_float(state: str) -> int | str:

--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -5,7 +5,7 @@ from abc import ABC
 from datetime import timedelta
 import logging
 
-from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -85,6 +85,7 @@ class PlenticoreDataNumber(CoordinatorEntity, NumberEntity, ABC):
         self._attr_device_info = device_info
         self._attr_unique_id = f"{self.entry_id}_{self.module_id}_{self.data_id}"
         self._attr_name = f"{platform_name} {description.name}"
+        self._attr_mode = NumberMode.BOX
 
         self._formatter = PlenticoreDataFormatter.get_method(description.fmt_from)
         self._formatter_back = PlenticoreDataFormatter.get_method(description.fmt_to)
@@ -124,7 +125,7 @@ class PlenticoreDataNumber(CoordinatorEntity, NumberEntity, ABC):
         """Return the current value."""
         if self.available:
             raw_value = self.coordinator.data[self.module_id][self.data_id]
-            return self._formatter(raw_value) if self._formatter else raw_value
+            return self._formatter(raw_value)
 
         return None
 
@@ -134,4 +135,4 @@ class PlenticoreDataNumber(CoordinatorEntity, NumberEntity, ABC):
         await self.coordinator.async_write_data(
             self.module_id, {self.data_id: str_value}
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -1,0 +1,137 @@
+"""Platform for Kostal Plenticore numbers."""
+from __future__ import annotations
+
+from abc import ABC
+from datetime import timedelta
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, NUMBER_SETTINGS_DATA, PlenticoreNumberEntityDescription
+from .helper import PlenticoreDataFormatter, SettingDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Add Kostal Plenticore Number entities."""
+    plenticore = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+
+    available_settings_data = await plenticore.client.get_settings()
+    settings_data_update_coordinator = SettingDataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        "Settings Data",
+        timedelta(seconds=30),
+        plenticore,
+    )
+
+    for description in NUMBER_SETTINGS_DATA:
+        if (
+            description.module_id not in available_settings_data
+            or description.data_id
+            not in (
+                setting.id for setting in available_settings_data[description.module_id]
+            )
+        ):
+            _LOGGER.debug(
+                "Skipping non existing setting data %s/%s",
+                description.module_id,
+                description.data_id,
+            )
+            continue
+
+        entities.append(
+            PlenticoreDataNumber(
+                settings_data_update_coordinator,
+                entry.entry_id,
+                entry.title,
+                plenticore.device_info,
+                description,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class PlenticoreDataNumber(CoordinatorEntity, NumberEntity, ABC):
+    """Representation of a Kostal Plenticore Number entity."""
+
+    entity_description: PlenticoreNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        platform_name: str,
+        device_info: DeviceInfo,
+        description: PlenticoreNumberEntityDescription,
+    ) -> None:
+        """Initialize the Plenticore Number entity."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self.entry_id = entry_id
+
+        self._attr_device_info = device_info
+        self._attr_unique_id = f"{self.entry_id}_{self.module_id}_{self.data_id}"
+        self._attr_name = f"{platform_name} {description.name}"
+
+        self._formatter = PlenticoreDataFormatter.get_method(description.fmt_from)
+        self._formatter_back = PlenticoreDataFormatter.get_method(description.fmt_to)
+
+    @property
+    def module_id(self) -> str:
+        """Return the plenticore module id of this entity."""
+        return self.entity_description.module_id
+
+    @property
+    def data_id(self) -> str:
+        """Return the plenticore data id for this entity."""
+        return self.entity_description.data_id
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            super().available
+            and self.coordinator.data is not None
+            and self.module_id in self.coordinator.data
+            and self.data_id in self.coordinator.data[self.module_id]
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register this entity on the Update Coordinator."""
+        await super().async_added_to_hass()
+        self.coordinator.start_fetch_data(self.module_id, self.data_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister this entity from the Update Coordinator."""
+        self.coordinator.stop_fetch_data(self.module_id, self.data_id)
+        await super().async_will_remove_from_hass()
+
+    @property
+    def value(self) -> float | None:
+        """Return the current value."""
+        if self.available:
+            raw_value = self.coordinator.data[self.module_id][self.data_id]
+            return self._formatter(raw_value) if self._formatter else raw_value
+
+        return None
+
+    async def async_set_value(self, value: float) -> None:
+        """Set a new value."""
+        str_value = self._formatter_back(value)
+        await self.coordinator.async_write_data(
+            self.module_id, {self.data_id: str_value}
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -78,10 +78,11 @@ class PlenticoreDataNumber(CoordinatorEntity, NumberEntity, ABC):
     """Representation of a Kostal Plenticore Number entity."""
 
     entity_description: PlenticoreNumberEntityDescription
+    coordinator: SettingDataUpdateCoordinator
 
     def __init__(
         self,
-        coordinator,
+        coordinator: SettingDataUpdateCoordinator,
         entry_id: str,
         platform_name: str,
         device_info: DeviceInfo,

--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from abc import ABC
 from datetime import timedelta
+from functools import partial
 import logging
 
 from kostal.plenticore import SettingsData
@@ -54,7 +55,7 @@ async def async_setup_entry(
 
         setting_data = next(
             filter(
-                lambda x: x.id == description.data_id,
+                partial(lambda id, sd: id == sd.id, description.data_id),
                 available_settings_data[description.module_id],
             )
         )

--- a/homeassistant/components/kostal_plenticore/sensor.py
+++ b/homeassistant/components/kostal_plenticore/sensor.py
@@ -14,17 +14,8 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTR_ENABLED_DEFAULT,
-    DOMAIN,
-    SENSOR_PROCESS_DATA,
-    SENSOR_SETTINGS_DATA,
-)
-from .helper import (
-    PlenticoreDataFormatter,
-    ProcessDataUpdateCoordinator,
-    SettingDataUpdateCoordinator,
-)
+from .const import ATTR_ENABLED_DEFAULT, DOMAIN, SENSOR_PROCESS_DATA
+from .helper import PlenticoreDataFormatter, ProcessDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,38 +58,6 @@ async def async_setup_entry(
                 PlenticoreDataFormatter.get_method(fmt),
                 plenticore.device_info,
                 None,
-            )
-        )
-
-    available_settings_data = await plenticore.client.get_settings()
-    settings_data_update_coordinator = SettingDataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        "Settings Data",
-        timedelta(seconds=300),
-        plenticore,
-    )
-    for module_id, data_id, name, sensor_data, fmt in SENSOR_SETTINGS_DATA:
-        if module_id not in available_settings_data or data_id not in (
-            setting.id for setting in available_settings_data[module_id]
-        ):
-            _LOGGER.debug(
-                "Skipping non existing setting data %s/%s", module_id, data_id
-            )
-            continue
-
-        entities.append(
-            PlenticoreDataSensor(
-                settings_data_update_coordinator,
-                entry.entry_id,
-                entry.title,
-                module_id,
-                data_id,
-                name,
-                sensor_data,
-                PlenticoreDataFormatter.get_method(fmt),
-                plenticore.device_info,
-                EntityCategory.DIAGNOSTIC,
             )
         )
 

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -35,7 +35,6 @@ def mock_plenticore() -> Generator[Plenticore, None, None]:
         plenticore = mock_api_class.return_value
         plenticore.async_setup = AsyncMock()
         plenticore.async_setup.return_value = True
-
         plenticore.device_info = DeviceInfo(
             configuration_url="http://192.168.1.2",
             identifiers={("kostal_plenticore", "12345")},

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -26,36 +26,8 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-<<<<<<< HEAD
 def mock_plenticore() -> Generator[Plenticore, None, None]:
     """Set up a Plenticore mock with some default values."""
-=======
-def mock_plenticore(hass: HomeAssistant) -> Generator[None, MagicMock, None]:
-    """Return a mocked Plenticore class."""
-    with patch(
-        "homeassistant.components.kostal_plenticore.Plenticore"
-    ) as mock_api_class:
-        # setup
-        plenticore = mock_api_class.return_value
-        plenticore.async_setup = AsyncMock()
-        plenticore.async_setup.return_value = True
-        plenticore.client = MagicMock()
-
-        plenticore.client.get_settings = AsyncMock()
-        plenticore.client.get_settings.return_value = []
-
-        plenticore.client.get_process_data = AsyncMock()
-        plenticore.client.get_process_data.return_value = []
-
-        yield plenticore
-
-
-@pytest.fixture
-async def init_integration(
-    hass: HomeAssistant,
-) -> Generator[None, MockConfigEntry, None]:
-    """Set up Kostal Plenticore integration for testing."""
->>>>>>> a091e51f8d (Fix test after rebaseing.)
     with patch(
         "homeassistant.components.kostal_plenticore.Plenticore", autospec=True
     ) as mock_api_class:

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -63,6 +63,7 @@ async def init_integration(
         plenticore = mock_api_class.return_value
         plenticore.async_setup = AsyncMock()
         plenticore.async_setup.return_value = True
+
         plenticore.device_info = DeviceInfo(
             configuration_url="http://192.168.1.2",
             identifiers={("kostal_plenticore", "12345")},

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -26,8 +26,36 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
+<<<<<<< HEAD
 def mock_plenticore() -> Generator[Plenticore, None, None]:
     """Set up a Plenticore mock with some default values."""
+=======
+def mock_plenticore(hass: HomeAssistant) -> Generator[None, MagicMock, None]:
+    """Return a mocked Plenticore class."""
+    with patch(
+        "homeassistant.components.kostal_plenticore.Plenticore"
+    ) as mock_api_class:
+        # setup
+        plenticore = mock_api_class.return_value
+        plenticore.async_setup = AsyncMock()
+        plenticore.async_setup.return_value = True
+        plenticore.client = MagicMock()
+
+        plenticore.client.get_settings = AsyncMock()
+        plenticore.client.get_settings.return_value = []
+
+        plenticore.client.get_process_data = AsyncMock()
+        plenticore.client.get_process_data.return_value = []
+
+        yield plenticore
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+) -> Generator[None, MockConfigEntry, None]:
+    """Set up Kostal Plenticore integration for testing."""
+>>>>>>> a091e51f8d (Fix test after rebaseing.)
     with patch(
         "homeassistant.components.kostal_plenticore.Plenticore", autospec=True
     ) as mock_api_class:

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -1,0 +1,121 @@
+"""Test Kostal Plenticore number."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from kostal.plenticore import SettingsData
+import pytest
+
+from homeassistant.components.kostal_plenticore.const import (
+    PlenticoreNumberEntityDescription,
+)
+from homeassistant.components.kostal_plenticore.number import PlenticoreDataNumber
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import async_get
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_coordinator() -> MagicMock:
+    """Return a mocked coordinator for tests."""
+    coordinator = MagicMock()
+    coordinator.async_write_data = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def mock_number_description() -> PlenticoreNumberEntityDescription:
+    """Return a PlenticoreNumberEntityDescription for tests."""
+    return PlenticoreNumberEntityDescription(
+        key="mock key",
+        module_id="moduleid",
+        data_id="dataid",
+        fmt_from="format_round",
+        fmt_to="format_round_back",
+    )
+
+
+async def test_setup_all_entries(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_plenticore: MagicMock
+):
+    """Test if all available entries are setup up."""
+    mock_plenticore.client.get_settings.return_value = {
+        "devices:local": [
+            SettingsData({"id": "Battery:MinSoc"}),
+            SettingsData({"id": "Battery:MinHomeComsumption"}),
+        ]
+    }
+
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    ent_reg = async_get(hass)
+    assert ent_reg.async_get("number.scb_battery_min_soc") is not None
+    assert ent_reg.async_get("number.scb_battery_min_home_consumption") is not None
+
+
+async def test_setup_no_entries(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_plenticore: MagicMock
+):
+    """Test that no entries are setup up."""
+    mock_plenticore.client.get_settings.return_value = []
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    ent_reg = async_get(hass)
+    assert ent_reg.async_get("number.scb_battery_min_soc") is None
+    assert ent_reg.async_get("number.scb_battery_min_home_consumption") is None
+
+
+def test_number_returns_value_if_available(
+    mock_coordinator: MagicMock,
+    mock_number_description: PlenticoreNumberEntityDescription,
+):
+    """Test if value property on PlenticoreDataNumber returns an int if available."""
+
+    mock_coordinator.data = {"moduleid": {"dataid": "42"}}
+
+    entity = PlenticoreDataNumber(
+        mock_coordinator, "42", "scb", None, mock_number_description
+    )
+
+    assert entity.value == 42
+    assert type(entity.value) == int
+
+
+def test_number_returns_none_if_unavailable(
+    mock_coordinator: MagicMock,
+    mock_number_description: PlenticoreNumberEntityDescription,
+):
+    """Test if value property on PlenticoreDataNumber returns none if unavailable."""
+
+    mock_coordinator.data = {}  # makes entity not available
+
+    entity = PlenticoreDataNumber(
+        mock_coordinator, "42", "scb", None, mock_number_description
+    )
+
+    assert entity.value is None
+
+
+async def test_set_value(
+    mock_coordinator: MagicMock,
+    mock_number_description: PlenticoreNumberEntityDescription,
+):
+    """Test if set value calls coordinator with new value."""
+
+    entity = PlenticoreDataNumber(
+        mock_coordinator, "42", "scb", None, mock_number_description
+    )
+
+    await entity.async_set_value(42)
+
+    mock_coordinator.async_write_data.assert_called_once_with(
+        "moduleid", {"dataid": "42"}
+    )
+    mock_coordinator.async_refresh.assert_called_once()

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -163,3 +163,35 @@ async def test_minmax_overwrite(
 
     assert entity.min_value == 5
     assert entity.max_value == 100
+
+
+async def test_added_to_hass(
+    mock_coordinator: MagicMock,
+    mock_number_description: PlenticoreNumberEntityDescription,
+    mock_setting_data: SettingsData,
+):
+    """Test if coordinator starts fetching after added to hass."""
+
+    entity = PlenticoreDataNumber(
+        mock_coordinator, "42", "scb", None, mock_number_description, mock_setting_data
+    )
+
+    await entity.async_added_to_hass()
+
+    mock_coordinator.start_fetch_data.assert_called_once_with("moduleid", "dataid")
+
+
+async def test_remove_from_hass(
+    mock_coordinator: MagicMock,
+    mock_number_description: PlenticoreNumberEntityDescription,
+    mock_setting_data: SettingsData,
+):
+    """Test if coordinator stops fetching after remove from hass."""
+
+    entity = PlenticoreDataNumber(
+        mock_coordinator, "42", "scb", None, mock_number_description, mock_setting_data
+    )
+
+    await entity.async_will_remove_from_hass()
+
+    mock_coordinator.stop_fetch_data.assert_called_once_with("moduleid", "dataid")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements the platform "number" for the Kostal Plenticore. Two existing sensor entities are promoted to this platform: Battery min Soc and Battery min Home Consumption.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64757
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21422

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
