### PR TITLE
Add tests for KNX diagnostic and expose

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -559,10 +559,8 @@ omit =
     homeassistant/components/knx/__init__.py
     homeassistant/components/knx/climate.py
     homeassistant/components/knx/cover.py
-    homeassistant/components/knx/diagnostics.py
     homeassistant/components/knx/expose.py
     homeassistant/components/knx/knx_entity.py
-    homeassistant/components/knx/light.py
     homeassistant/components/knx/notify.py
     homeassistant/components/knx/schema.py
     homeassistant/components/kodi/__init__.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -559,10 +559,7 @@ omit =
     homeassistant/components/knx/__init__.py
     homeassistant/components/knx/climate.py
     homeassistant/components/knx/cover.py
-    homeassistant/components/knx/expose.py
-    homeassistant/components/knx/knx_entity.py
     homeassistant/components/knx/notify.py
-    homeassistant/components/knx/schema.py
     homeassistant/components/kodi/__init__.py
     homeassistant/components/kodi/browse_media.py
     homeassistant/components/kodi/const.py

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -148,8 +148,6 @@ class KNXExposeSensor:
 
     async def _async_set_knx_value(self, value: StateType) -> None:
         """Set new value on xknx ExposeSensor."""
-        if value is None:
-            return
         await self.device.set(value)
 
 

--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -13,7 +13,7 @@ from xknx.telegram import Telegram, TelegramDirection
 from xknx.telegram.address import GroupAddress, IndividualAddress
 from xknx.telegram.apci import APCI, GroupValueRead, GroupValueResponse, GroupValueWrite
 
-from homeassistant.components.knx import ConnectionSchema
+from homeassistant.components.knx import ConnectionSchema, KNXModule
 from homeassistant.components.knx.const import (
     CONF_KNX_AUTOMATIC,
     CONF_KNX_CONNECTION_TYPE,
@@ -39,6 +39,11 @@ class KNXTestKit:
         # outgoing telegrams will be put in the Queue instead of sent to the interface
         # telegrams to an InternalGroupAddress won't be queued here
         self._outgoing_telegrams: asyncio.Queue = asyncio.Queue()
+
+    @property
+    def knx_module(self) -> KNXModule:
+        """Get the KNX module."""
+        return self.hass.data[KNX_DOMAIN]
 
     def assert_state(self, entity_id: str, state: str, **attributes) -> None:
         """Assert the state of an entity."""

--- a/tests/components/knx/test_diagnostic.py
+++ b/tests/components/knx/test_diagnostic.py
@@ -20,6 +20,8 @@ async def test_diagnostics(
     await knx.setup_integration({})
 
     with patch("homeassistant.config.async_hass_config_yaml", return_value={}):
+        # Overwrite the version for this test since we don't want to change this with every library bump
+        knx.xknx.version = "1.0.0"
         assert await get_diagnostics_for_config_entry(
             hass, hass_client, mock_config_entry
         ) == {
@@ -31,7 +33,7 @@ async def test_diagnostics(
             },
             "configuration_error": None,
             "configuration_yaml": None,
-            "xknx": {"current_address": "0.0.0", "version": "0.19.0"},
+            "xknx": {"current_address": "0.0.0", "version": "1.0.0"},
         }
 
 
@@ -48,6 +50,8 @@ async def test_diagnostic_config_error(
         "homeassistant.config.async_hass_config_yaml",
         return_value={"knx": {"wrong_key": {}}},
     ):
+        # Overwrite the version for this test since we don't want to change this with every library bump
+        knx.xknx.version = "1.0.0"
         assert await get_diagnostics_for_config_entry(
             hass, hass_client, mock_config_entry
         ) == {
@@ -59,5 +63,5 @@ async def test_diagnostic_config_error(
             },
             "configuration_error": "extra keys not allowed @ data['knx']['wrong_key']",
             "configuration_yaml": {"wrong_key": {}},
-            "xknx": {"current_address": "0.0.0", "version": "0.19.0"},
+            "xknx": {"current_address": "0.0.0", "version": "1.0.0"},
         }

--- a/tests/components/knx/test_diagnostic.py
+++ b/tests/components/knx/test_diagnostic.py
@@ -1,0 +1,63 @@
+"""Tests for the diagnostics data provided by the KNX integration."""
+from unittest.mock import patch
+
+from aiohttp import ClientSession
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.components.knx.conftest import KNXTestKit
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    mock_config_entry: MockConfigEntry,
+    knx: KNXTestKit,
+):
+    """Test diagnostics."""
+    await knx.setup_integration({})
+
+    with patch("homeassistant.config.async_hass_config_yaml", return_value={}):
+        assert await get_diagnostics_for_config_entry(
+            hass, hass_client, mock_config_entry
+        ) == {
+            "config_entry_data": {
+                "connection_type": "automatic",
+                "individual_address": "15.15.250",
+                "multicast_group": "224.0.23.12",
+                "multicast_port": 3671,
+            },
+            "configuration_error": None,
+            "configuration_yaml": None,
+            "xknx": {"current_address": "0.0.0", "version": "0.19.0"},
+        }
+
+
+async def test_diagnostic_config_error(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    mock_config_entry: MockConfigEntry,
+    knx: KNXTestKit,
+):
+    """Test diagnostics."""
+    await knx.setup_integration({})
+
+    with patch(
+        "homeassistant.config.async_hass_config_yaml",
+        return_value={"knx": {"wrong_key": {}}},
+    ):
+        assert await get_diagnostics_for_config_entry(
+            hass, hass_client, mock_config_entry
+        ) == {
+            "config_entry_data": {
+                "connection_type": "automatic",
+                "individual_address": "15.15.250",
+                "multicast_group": "224.0.23.12",
+                "multicast_port": 3671,
+            },
+            "configuration_error": "extra keys not allowed @ data['knx']['wrong_key']",
+            "configuration_yaml": {"wrong_key": {}},
+            "xknx": {"current_address": "0.0.0", "version": "0.19.0"},
+        }

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -142,8 +142,9 @@ async def test_expose_with_date(localtime, hass: HomeAssistant, knx: KNXTestKit)
     )
     assert not hass.states.async_all()
 
-    await knx.receive_read("1/1/8")
     await knx.assert_write("1/1/8", (0x7A, 0x1, 0x7, 0xE9, 0xD, 0xE, 0x20, 0x80))
+
+    await knx.receive_read("1/1/8")
     await knx.assert_response("1/1/8", (0x7A, 0x1, 0x7, 0xE9, 0xD, 0xE, 0x20, 0x80))
 
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -1,5 +1,8 @@
 """Test KNX expose."""
-from homeassistant.components.knx import CONF_KNX_EXPOSE, KNX_ADDRESS
+import time
+from unittest.mock import patch
+
+from homeassistant.components.knx import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
 from homeassistant.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_TYPE
 from homeassistant.core import HomeAssistant
@@ -123,3 +126,27 @@ async def test_expose_attribute_with_default(hass: HomeAssistant, knx: KNXTestKi
     # Change state to "off"; no attribute
     hass.states.async_set(entity_id, "off", {})
     await knx.assert_write("1/1/8", (0,))
+
+
+@patch("time.localtime")
+async def test_expose_with_date(localtime, hass: HomeAssistant, knx: KNXTestKit):
+    """Test an expose with a date."""
+    localtime.return_value = time.struct_time([2022, 1, 7, 9, 13, 14, 6, 0, 0])
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "datetime",
+                KNX_ADDRESS: "1/1/8",
+            }
+        },
+    )
+    assert not hass.states.async_all()
+
+    await knx.receive_read("1/1/8")
+    await knx.assert_write("1/1/8", (0x7A, 0x1, 0x7, 0xE9, 0xD, 0xE, 0x20, 0x80))
+    await knx.assert_response("1/1/8", (0x7A, 0x1, 0x7, 0xE9, 0xD, 0xE, 0x20, 0x80))
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+
+    assert await hass.config_entries.async_unload(entries[0].entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for KNX diagnostics and expose and cleanup coveragerc for KNX integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
