### PR TITLE
Decouple initial refreshes in setup for Environment Canada

### DIFF
--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -42,6 +42,8 @@ class ECCamera(CoordinatorEntity, Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
+        if not hasattr(self.radar_object, "timestamp"):
+            return None
         self.observation_time = self.radar_object.timestamp
         return self.radar_object.image
 

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -223,35 +223,35 @@ ALERT_TYPES: tuple[ECSensorEntityDescription, ...] = (
         key="advisories",
         name="Advisory",
         icon="mdi:bell-alert",
-        value_fn=lambda data: data.alerts.get("advisories", {}).get("value", []),
+        value_fn=lambda data: data.alerts.get("advisories", {}).get("value"),
         transform=len,
     ),
     ECSensorEntityDescription(
         key="endings",
         name="Endings",
         icon="mdi:alert-circle-check",
-        value_fn=lambda data: data.alerts.get("endings", {}).get("value", []),
+        value_fn=lambda data: data.alerts.get("endings", {}).get("value"),
         transform=len,
     ),
     ECSensorEntityDescription(
         key="statements",
         name="Statements",
         icon="mdi:bell-alert",
-        value_fn=lambda data: data.alerts.get("statements", {}).get("value", []),
+        value_fn=lambda data: data.alerts.get("statements", {}).get("value"),
         transform=len,
     ),
     ECSensorEntityDescription(
         key="warnings",
         name="Warnings",
         icon="mdi:alert-octagon",
-        value_fn=lambda data: data.alerts.get("warnings", {}).get("value", []),
+        value_fn=lambda data: data.alerts.get("warnings", {}).get("value"),
         transform=len,
     ),
     ECSensorEntityDescription(
         key="watches",
         name="Watches",
         icon="mdi:alert",
-        value_fn=lambda data: data.alerts.get("watches", {}).get("value", []),
+        value_fn=lambda data: data.alerts.get("watches", {}).get("value"),
         transform=len,
     ),
 )
@@ -283,13 +283,13 @@ class ECBaseSensor(CoordinatorEntity, SensorEntity):
         self._ec_data = coordinator.ec_data
         self._attr_attribution = self._ec_data.metadata["attribution"]
         self._attr_name = f"{coordinator.config_entry.title} {description.name}"
-        self._attr_unique_id = f"{self._ec_data.metadata['location']}-{description.key}"
+        self._attr_unique_id = f"{coordinator.config_entry.title}-{description.key}"
 
     @property
     def native_value(self):
         """Return the native value of the sensor."""
         value = self.entity_description.value_fn(self._ec_data)
-        if self.entity_description.transform:
+        if value and self.entity_description.transform:
             value = self.entity_description.transform(value)
         return value
 
@@ -313,6 +313,8 @@ class ECAlertSensor(ECBaseSensor):
     def extra_state_attributes(self):
         """Return the extra state attributes."""
         value = self.entity_description.value_fn(self._ec_data)
+        if not value:
+            return None
 
         extra_state_attrs = {
             ATTR_LOCATION: self._ec_data.metadata.get("location"),

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -289,7 +289,7 @@ class ECBaseSensor(CoordinatorEntity, SensorEntity):
     def native_value(self):
         """Return the native value of the sensor."""
         value = self.entity_description.value_fn(self._ec_data)
-        if value and self.entity_description.transform:
+        if value is not None and self.entity_description.transform:
             value = self.entity_description.transform(value)
         return value
 


### PR DESCRIPTION

## Proposed change

When the integration is being setup and if one of the coordinators is down (most often see radar not available) then the entire integration is unavailable, instead of just the one coordinator (of the three) that is down.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

There are two "parts" to this PR. The first bit is decoupling the `DataUpdateCoordinator` initial refreshes.  The second bit is to fix all the places in the entities that break because the initial refresh of the data failed. Most of those are pretty straight forward. The only one I want to highlight is that the `unique_id` for sensor is initialized from a different data source -- the `unique_id`s have not changed.

Big thank you to @thecode who helped me understand the options for how this is fixed.

We considered two approaches for this change. The approach that can be seen in the first commit in this PR was discarded as entities would show with unknown values when their corresponding `DataUpdateCoordinator` fails. The approach taken in the final PR show entities as Unavailable when their corresponding `DataUpdateCoordinator` fails.

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/64849
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
