### PR TITLE
Add switch platform to Z-Wave.Me integration

### DIFF
--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -5,10 +5,6 @@ from homeassistant.const import Platform
 # Base component constants
 DOMAIN = "zwave_me"
 
-ZWAVE_PLATFORMS = [
-    "switchMultilevel",
-]
+ZWAVE_PLATFORMS = ["switchMultilevel", "binarySwitch"]
 
-PLATFORMS = [
-    Platform.NUMBER,
-]
+PLATFORMS = [Platform.NUMBER, Platform.SWITCH]

--- a/homeassistant/components/zwave_me/manifest.json
+++ b/homeassistant/components/zwave_me/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/zwave_me",
   "iot_class": "local_push",
   "requirements": [
-    "zwave_me_ws==0.1.22",
+    "zwave_me_ws==0.1.23",
     "url-normalize==1.4.1"
   ],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/zwave_me/switch.py
+++ b/homeassistant/components/zwave_me/switch.py
@@ -1,0 +1,66 @@
+"""Representation of a switchBinary."""
+import logging
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import ZWaveMeEntity
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+DEVICE_NAME = "switchBinary"
+
+SWITCH_MAP: dict[str, SwitchEntityDescription] = {
+    "generic": SwitchEntityDescription(
+        key="generic",
+        device_class=SwitchDeviceClass.SWITCH,
+    )
+}
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the switch platform."""
+
+    @callback
+    def add_new_device(new_device):
+        controller = hass.data[DOMAIN][config_entry.entry_id]
+        switch = ZWaveMeSwitch(controller, new_device, SWITCH_MAP["generic"])
+
+        async_add_entities(
+            [
+                switch,
+            ]
+        )
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, f"ZWAVE_ME_NEW_{DEVICE_NAME.upper()}", add_new_device
+        )
+    )
+
+
+class ZWaveMeSwitch(ZWaveMeEntity, SwitchEntity):
+    """Representation of a ZWaveMe binary switch."""
+
+    def __init__(self, controller, device, description):
+        """Initialize the device."""
+        ZWaveMeEntity.__init__(self, controller, device)
+        self.entity_description = description
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the switch."""
+        return self.device.level == "on"
+
+    def turn_on(self, **kwargs) -> None:
+        """Turn the entity on."""
+        self.controller.zwave_api.send_command(self.device.id, "on")
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn the entity off."""
+        self.controller.zwave_api.send_command(self.device.id, "off")

--- a/homeassistant/components/zwave_me/switch.py
+++ b/homeassistant/components/zwave_me/switch.py
@@ -1,5 +1,6 @@
 """Representation of a switchBinary."""
 import logging
+from typing import Any
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -49,7 +50,7 @@ class ZWaveMeSwitch(ZWaveMeEntity, SwitchEntity):
 
     def __init__(self, controller, device, description):
         """Initialize the device."""
-        ZWaveMeEntity.__init__(self, controller, device)
+        super().__init__(controller, device)
         self.entity_description = description
 
     @property
@@ -57,10 +58,10 @@ class ZWaveMeSwitch(ZWaveMeEntity, SwitchEntity):
         """Return the state of the switch."""
         return self.device.level == "on"
 
-    def turn_on(self, **kwargs) -> None:
+    def turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         self.controller.zwave_api.send_command(self.device.id, "on")
 
-    def turn_off(self, **kwargs) -> None:
+    def turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self.controller.zwave_api.send_command(self.device.id, "off")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2565,4 +2565,4 @@ zm-py==0.5.2
 zwave-js-server-python==0.34.0
 
 # homeassistant.components.zwave_me
-zwave_me_ws==0.1.22
+zwave_me_ws==0.1.23

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1575,4 +1575,4 @@ zigpy==0.43.0
 zwave-js-server-python==0.34.0
 
 # homeassistant.components.zwave_me
-zwave_me_ws==0.1.22
+zwave_me_ws==0.1.23


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20684

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
