### PR TITLE
Adjust pylint plugin to enforce diagnostics type hints

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from http import HTTPStatus
 import json
 import logging
-from typing import Protocol
+from typing import Any, Protocol
 
 from aiohttp import web
 import voluptuous as vol
@@ -51,12 +51,12 @@ class DiagnosticsProtocol(Protocol):
 
     async def async_get_config_entry_diagnostics(
         self, hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> dict:
+    ) -> Any:
         """Return diagnostics for a config entry."""
 
     async def async_get_device_diagnostics(
         self, hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
-    ) -> dict:
+    ) -> Any:
         """Return diagnostics for a device."""
 
 
@@ -125,7 +125,7 @@ def handle_get(
 
 async def _async_get_json_file_response(
     hass: HomeAssistant,
-    data: dict | list,
+    data: Any,
     filename: str,
     domain: str,
     d_type: DiagnosticsType,

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -10,6 +10,7 @@ from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
 
 from homeassistant.const import Platform
+from homeassistant.helpers.typing import UNDEFINED
 
 
 @dataclass
@@ -178,7 +179,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigEntry",
         },
-        return_type=["dict", "dict[str, Any]"],
+        return_type=UNDEFINED,
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["diagnostics"],
@@ -188,13 +189,16 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             1: "ConfigEntry",
             2: "DeviceEntry",
         },
-        return_type=["dict", "dict[str, Any]"],
+        return_type=UNDEFINED,
     ),
 ]
 
 
 def _is_valid_type(expected_type: list[str] | str | None, node: astroid.NodeNG) -> bool:
     """Check the argument node against the expected type."""
+    if expected_type is UNDEFINED:
+        return True
+
     if isinstance(expected_type, list):
         for expected_type_item in expected_type:
             if _is_valid_type(expected_type_item, node):

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -39,9 +39,9 @@ _MODULE_FILTERS: dict[str, re.Pattern] = {
         f"^homeassistant\\.components\\.\\w+\\.({'|'.join([platform.value for platform in Platform])})$"
     ),
     # device_tracker matches only in the package root (device_tracker.py)
-    "device_tracker": re.compile(
-        f"^homeassistant\\.components\\.\\w+\\.({Platform.DEVICE_TRACKER.value})$"
-    ),
+    "device_tracker": re.compile(r"^homeassistant\.components\.\w+\.(device_tracker)$"),
+    # diagnostics matches only in the package root (diagnostics.py)
+    "diagnostics": re.compile(r"^homeassistant\.components\.\w+\.(diagnostics)$"),
 }
 
 _METHOD_MATCH: list[TypeHintMatch] = [
@@ -170,6 +170,25 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             1: "ConfigType",
         },
         return_type=["DeviceScanner", "DeviceScanner | None"],
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["diagnostics"],
+        function_name="async_get_config_entry_diagnostics",
+        arg_types={
+            0: "HomeAssistant",
+            1: "ConfigEntry",
+        },
+        return_type="dict",
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["diagnostics"],
+        function_name="async_get_device_diagnostics",
+        arg_types={
+            0: "HomeAssistant",
+            1: "ConfigEntry",
+            2: "DeviceEntry",
+        },
+        return_type="dict",
     ),
 ]
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -178,7 +178,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             0: "HomeAssistant",
             1: "ConfigEntry",
         },
-        return_type="dict",
+        return_type=["dict", "dict[str, Any]"],
     ),
     TypeHintMatch(
         module_filter=_MODULE_FILTERS["diagnostics"],
@@ -188,7 +188,7 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             1: "ConfigEntry",
             2: "DeviceEntry",
         },
-        return_type="dict",
+        return_type=["dict", "dict[str, Any]"],
     ),
 ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostics methods to pylint plugin: `async_get_config_entry_diagnostics`, `async_get_device_diagnostics`

As follow-up to #64313

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
