### PR TITLE
Add new yaml configuration to binary_sensor.command_line

### DIFF
--- a/homeassistant/components/command_line/__init__.py
+++ b/homeassistant/components/command_line/__init__.py
@@ -4,7 +4,70 @@ from __future__ import annotations
 import logging
 import subprocess
 
+from homeassistant import config as conf_util
+from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import Event, HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import discovery
+from homeassistant.helpers.reload import async_reload_integration_platforms
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import async_get_integration
+
+from .const import DOMAIN, PLATFORMS
+
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the command_line integration."""
+    if DOMAIN in config:
+        await _process_config(hass, config)
+
+    async def _reload_config(call: Event | ServiceCall) -> None:
+        """Reload top-level + platforms."""
+        try:
+            unprocessed_conf = await conf_util.async_hass_config_yaml(hass)
+        except HomeAssistantError as err:
+            _LOGGER.error(err)
+            return
+
+        conf = await conf_util.async_process_component_config(
+            hass, unprocessed_conf, await async_get_integration(hass, DOMAIN)
+        )
+
+        if conf is None:
+            return
+
+        await async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
+
+        if DOMAIN in conf:
+            await _process_config(hass, conf)
+
+        hass.bus.async_fire(f"event_{DOMAIN}_reloaded", context=call.context)
+
+    hass.helpers.service.async_register_admin_service(
+        DOMAIN, SERVICE_RELOAD, _reload_config
+    )
+
+    return True
+
+
+async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
+    """Process config."""
+    for conf_section in hass_config[DOMAIN]:
+        for platform_domain in PLATFORMS:
+            if platform_domain in conf_section:
+                hass.async_create_task(
+                    discovery.async_load_platform(
+                        hass,
+                        platform_domain,
+                        DOMAIN,
+                        {
+                            "entities": conf_section[platform_domain],
+                        },
+                        hass_config,
+                    )
+                )
 
 
 def call_shell_with_timeout(

--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -66,24 +66,24 @@ async def async_setup_platform(
     for entity in entities:
         command: str = entity[CONF_COMMAND]
         command_timeout: int = entity[CONF_COMMAND_TIMEOUT]
-        value_template: Template = entity[CONF_VALUE_TEMPLATE]
+        value_template: Template | None = entity.get(CONF_VALUE_TEMPLATE)
         if value_template is not None:
             value_template.hass = hass
 
-    add_entities(
-        [
-            CommandBinarySensor(
-                CommandSensorData(hass, command, command_timeout),
-                entity[CONF_NAME],
-                entity.get(CONF_DEVICE_CLASS),
-                entity[CONF_PAYLOAD_ON],
-                entity[CONF_PAYLOAD_OFF],
-                value_template,
-                entity[CONF_UNIQUE_ID],
-            )
-        ],
-        True,
-    )
+        add_entities(
+            [
+                CommandBinarySensor(
+                    CommandSensorData(hass, command, command_timeout),
+                    entity[CONF_NAME],
+                    entity.get(CONF_DEVICE_CLASS),
+                    entity[CONF_PAYLOAD_ON],
+                    entity[CONF_PAYLOAD_OFF],
+                    value_template,
+                    entity.get(CONF_UNIQUE_ID),
+                )
+            ],
+            True,
+        )
 
 
 class CommandBinarySensor(BinarySensorEntity):

--- a/homeassistant/components/command_line/config.py
+++ b/homeassistant/components/command_line/config.py
@@ -1,0 +1,47 @@
+"""Command Line config validator."""
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.config import async_log_exception, config_without_domain
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from . import binary_sensor as binary_sensor_platform
+from .const import DOMAIN
+
+PACKAGE_MERGE_HINT = "list"
+
+CONFIG_SECTION_SCHEMA = vol.Schema(
+    {
+        vol.Optional(BINARY_SENSOR_DOMAIN): vol.All(
+            cv.ensure_list, [binary_sensor_platform.BINARY_SENSOR_SCHEMA]
+        ),
+    }
+)
+
+
+async def async_validate_config(hass: HomeAssistant, config: ConfigType) -> ConfigType:
+    """Validate config."""
+    if DOMAIN not in config:
+        return config
+
+    config_sections = []
+
+    for cfg in cv.ensure_list(config[DOMAIN]):
+        try:
+            cfg = CONFIG_SECTION_SCHEMA(cfg)
+
+        except vol.Invalid as err:
+            async_log_exception(err, DOMAIN, cfg, hass)
+            continue
+
+        config_sections.append(cfg)
+
+    # Create a copy of the configuration with all config for current
+    # component removed and add validated config back in.
+    config = config_without_domain(config, DOMAIN)
+    config[DOMAIN] = config_sections
+
+    return config

--- a/tests/components/command_line/conftest.py
+++ b/tests/components/command_line/conftest.py
@@ -1,0 +1,50 @@
+"""command_line conftest."""
+import json
+
+import pytest
+
+from homeassistant.setup import async_setup_component
+
+from tests.common import assert_setup_component, async_mock_service
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+@pytest.fixture
+def config_addon():
+    """Add entra configuration items."""
+    return None
+
+
+@pytest.fixture
+async def start_ha(hass, domains, config_addon, config, caplog):
+    """Do setup of integration."""
+    if config_addon:
+        for key, value in config_addon.items():
+            config = config.replace(key, value)
+        config = json.loads(config)
+
+    async def setup_component():
+        for domain, count in domains:
+            with assert_setup_component(count, domain):
+                assert await async_setup_component(
+                    hass,
+                    domain,
+                    config,
+                )
+
+        await hass.async_block_till_done()
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    return setup_component
+
+
+@pytest.fixture
+async def caplog_setup_text(caplog):
+    """Return setup log of integration."""
+    yield caplog.text

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -1,35 +1,52 @@
 """The tests for the Command line Binary sensor platform."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Callable
 
-from homeassistant import setup
-from homeassistant.components.binary_sensor import DOMAIN
+import pytest
+
+from homeassistant.components.binary_sensor import DOMAIN as PLATFORM_DOMAIN
+from homeassistant.components.command_line import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 
-
-async def setup_test_entity(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
-    """Set up a test command line binary_sensor entity."""
-    assert await setup.async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {"platform": "command_line", "name": "Test", **config_dict}},
-    )
-    await hass.async_block_till_done()
+ENTITY_NAME = {"name": "Test"}
 
 
-async def test_setup(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(PLATFORM_DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: {
+                    "platform": DOMAIN,
+                    **ENTITY_NAME,
+                    "command": "echo 1",
+                    "payload_on": "1",
+                    "payload_off": "0",
+                },
+            },
+        ),
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        **ENTITY_NAME,
+                        "command": "echo 1",
+                        "payload_on": "1",
+                        "payload_off": "0",
+                    },
+                },
+            },
+        ),
+    ],
+)
+async def test_setup(hass: HomeAssistant, start_ha: Callable) -> None:
     """Test sensor setup."""
-    await setup_test_entity(
-        hass,
-        {
-            "command": "echo 1",
-            "payload_on": "1",
-            "payload_off": "0",
-        },
-    )
+    await start_ha()
 
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state
@@ -37,78 +54,148 @@ async def test_setup(hass: HomeAssistant) -> None:
     assert entity_state.name == "Test"
 
 
-async def test_template(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(PLATFORM_DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: {
+                    "platform": DOMAIN,
+                    **ENTITY_NAME,
+                    "command": "echo 10",
+                    "payload_on": "1.0",
+                    "payload_off": "0",
+                    "value_template": "{{ value | multiply(0.1) }}",
+                },
+            },
+        ),
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        **ENTITY_NAME,
+                        "command": "echo 10",
+                        "payload_on": "1.0",
+                        "payload_off": "0",
+                        "value_template": "{{ value | multiply(0.1) }}",
+                    },
+                },
+            },
+        ),
+    ],
+)
+async def test_template(hass: HomeAssistant, start_ha: Callable) -> None:
     """Test setting the state with a template."""
-
-    await setup_test_entity(
-        hass,
-        {
-            "command": "echo 10",
-            "payload_on": "1.0",
-            "payload_off": "0",
-            "value_template": "{{ value | multiply(0.1) }}",
-        },
-    )
+    await start_ha()
 
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state
     assert entity_state.state == STATE_ON
 
 
-async def test_sensor_off(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(PLATFORM_DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: {
+                    "platform": DOMAIN,
+                    **ENTITY_NAME,
+                    "command": "echo 0",
+                    "payload_on": "1",
+                    "payload_off": "0",
+                },
+            },
+        ),
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        **ENTITY_NAME,
+                        "command": "echo 0",
+                        "payload_on": "1",
+                        "payload_off": "0",
+                    },
+                },
+            },
+        ),
+    ],
+)
+async def test_sensor_off(hass: HomeAssistant, start_ha: Callable) -> None:
     """Test setting the state with a template."""
-    await setup_test_entity(
-        hass,
-        {
-            "command": "echo 0",
-            "payload_on": "1",
-            "payload_off": "0",
-        },
-    )
+    await start_ha()
+
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state
     assert entity_state.state == STATE_OFF
 
 
-async def test_unique_id(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(PLATFORM_DOMAIN, 3)],
+            {
+                PLATFORM_DOMAIN: [
+                    {
+                        "platform": DOMAIN,
+                        **ENTITY_NAME,
+                        "command": "echo 0",
+                        "unique_id": "unique",
+                    },
+                    {
+                        "platform": DOMAIN,
+                        **ENTITY_NAME,
+                        "command": "echo 1",
+                        "unique_id": "not-so-unique-anymore",
+                    },
+                    {
+                        "platform": DOMAIN,
+                        **ENTITY_NAME,
+                        "command": "echo 2",
+                        "unique_id": "not-so-unique-anymore",
+                    },
+                ],
+            },
+        ),
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: [
+                        {
+                            "command": "echo 0",
+                            "unique_id": "unique",
+                        },
+                        {
+                            "command": "echo 1",
+                            "unique_id": "not-so-unique-anymore",
+                        },
+                        {
+                            "command": "echo 2",
+                            "unique_id": "not-so-unique-anymore",
+                        },
+                    ],
+                },
+            },
+        ),
+    ],
+)
+async def test_unique_id(hass: HomeAssistant, start_ha: Callable) -> None:
     """Test unique_id option and if it only creates one binary sensor per id."""
-    assert await setup.async_setup_component(
-        hass,
-        DOMAIN,
-        {
-            DOMAIN: [
-                {
-                    "platform": "command_line",
-                    "unique_id": "unique",
-                    "command": "echo 0",
-                },
-                {
-                    "platform": "command_line",
-                    "unique_id": "not-so-unique-anymore",
-                    "command": "echo 1",
-                },
-                {
-                    "platform": "command_line",
-                    "unique_id": "not-so-unique-anymore",
-                    "command": "echo 2",
-                },
-            ]
-        },
-    )
-    await hass.async_block_till_done()
+    await start_ha()
 
     assert len(hass.states.async_all()) == 2
 
     ent_reg = entity_registry.async_get(hass)
 
     assert len(ent_reg.entities) == 2
+    assert ent_reg.async_get_entity_id(PLATFORM_DOMAIN, DOMAIN, "unique") is not None
     assert (
-        ent_reg.async_get_entity_id("binary_sensor", "command_line", "unique")
-        is not None
-    )
-    assert (
-        ent_reg.async_get_entity_id(
-            "binary_sensor", "command_line", "not-so-unique-anymore"
-        )
+        ent_reg.async_get_entity_id(PLATFORM_DOMAIN, DOMAIN, "not-so-unique-anymore")
         is not None
     )

--- a/tests/components/command_line/test_config.py
+++ b/tests/components/command_line/test_config.py
@@ -1,0 +1,71 @@
+"""The tests for the Command line sensor platform."""
+from __future__ import annotations
+
+from typing import Any, Callable
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.binary_sensor import DOMAIN as PLATFORM_DOMAIN
+from homeassistant.components.command_line import DOMAIN
+from homeassistant.const import SERVICE_RELOAD
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+ENTITY_NAME = {"name": "Test"}
+ENTITY_ID = "binary_sensor.test"
+
+
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        **ENTITY_NAME,
+                        "command": "echo 5",
+                    },
+                },
+            },
+        ),
+    ],
+)
+async def test_error_in_reload_config(
+    caplog: Any, hass: HomeAssistant, start_ha: Callable
+) -> None:
+    """Test Error during reload config service."""
+    await start_ha()
+    with patch(
+        "homeassistant.config.async_hass_config_yaml",
+        side_effect=HomeAssistantError("Error reloading config"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, {}, blocking=True)
+        assert "Error reloading config" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(DOMAIN, 0)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "commands": "echo 5",
+                    },
+                },
+            },
+        ),
+    ],
+)
+async def test_error_in_config(
+    caplog: Any, hass: HomeAssistant, start_ha: Callable
+) -> None:
+    """Test async_log_exception during config validation."""
+    await start_ha()
+    assert (
+        "Invalid config for [command_line]: [commands] is an invalid option for [command_line]."
+        in caplog.text
+    )


### PR DESCRIPTION
As suggested in https://github.com/home-assistant/core/pull/63840#issuecomment-1022529074 this is is the first part of the PR series for #63840 to add the new yaml configuration for the command_line platform.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds async_setup to the command_line integration and allows to
setup the platforms under integration domain key. This commit adds
support for the binary sensor platform.

e.g.
```yaml
command_line:
  - binary_sensor:
    - command: echo 0
```

With this commit this command_line platform supports both the old
legacy configuration under the platform key binary_sensor and the new
configuration under domain key.

Tests use parameterized tests to test both the old and new configuration
methods.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21350

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
