### PR TITLE
Improve Alexa error handling

### DIFF
--- a/homeassistant/components/alexa/errors.py
+++ b/homeassistant/components/alexa/errors.py
@@ -6,14 +6,6 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import API_TEMP_UNITS
 
 
-class UnsupportedInterface(HomeAssistantError):
-    """This entity does not support the requested Smart Home API interface."""
-
-
-class UnsupportedProperty(HomeAssistantError):
-    """This entity does not support the requested Smart Home API property."""
-
-
 class NoTokenAvailable(HomeAssistantError):
     """There is no access token available."""
 
@@ -51,11 +43,26 @@ class AlexaInvalidEndpointError(AlexaError):
         self.endpoint_id = endpoint_id
 
 
+class AlexaInternalError(AlexaError):
+    """Class to represent internal errors."""
+
+    namespace = "Alexa"
+    error_type = "INTERNAL_ERROR"
+
+
 class AlexaInvalidValueError(AlexaError):
     """Class to represent InvalidValue errors."""
 
     namespace = "Alexa"
     error_type = "INVALID_VALUE"
+
+
+class UnsupportedInterface(AlexaInvalidValueError):
+    """This entity does not support the requested Smart Home API interface."""
+
+
+class UnsupportedProperty(AlexaInvalidValueError):
+    """This entity does not support the requested Smart Home API property."""
 
 
 class AlexaUnsupportedThermostatModeError(AlexaError):

--- a/homeassistant/components/alexa/messages.py
+++ b/homeassistant/components/alexa/messages.py
@@ -87,7 +87,9 @@ class AlexaDirective:
         payload["type"] = error_type
         payload["message"] = error_message
 
-        _LOGGER.info(
+        meth = "error" if error_type == "INTERNAL_ERROR" else "info"
+
+        getattr(_LOGGER, meth)(
             "Request %s/%s error %s: %s",
             self._directive[API_HEADER]["namespace"],
             self._directive[API_HEADER]["name"],

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -50,6 +50,12 @@ async def async_handle_message(hass, config, request, context=None, enabled=True
         response = directive.error(
             error_type=err.error_type, error_message=err.error_message
         )
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception(
+            "Uncaught exception processing Alexa request (%s)",
+            directive.entity_id or "-",
+        )
+        response = directive.error(error_message="Unknown error")
 
     request_info = {"namespace": directive.namespace, "name": directive.name}
 

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -194,7 +194,7 @@ async def assert_scene_controller_works(
         assert re.search(pattern, response["event"]["payload"]["timestamp"])
 
 
-async def reported_properties(hass, endpoint):
+async def reported_properties(hass, endpoint, expect_error=None):
     """Use ReportState to get properties and return them.
 
     The result is a ReportedProperties instance, which has methods to make
@@ -203,7 +203,10 @@ async def reported_properties(hass, endpoint):
     request = get_new_request("Alexa", "ReportState", endpoint)
     msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
-    return ReportedProperties(msg["context"]["properties"])
+    if expect_error is None:
+        return ReportedProperties(msg["context"]["properties"])
+    assert msg["event"]["header"]["name"] == "ErrorResponse"
+    assert msg["event"]["payload"]["type"] == expect_error
 
 
 class ReportedProperties:

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.alexa import smart_home
-from homeassistant.components.alexa.errors import UnsupportedProperty
 from homeassistant.components.climate import const as climate
 from homeassistant.components.lock import STATE_JAMMED, STATE_LOCKING, STATE_UNLOCKING
 from homeassistant.components.media_player.const import (
@@ -677,16 +676,7 @@ async def test_report_climate_state(hass):
             ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
         },
     )
-    with pytest.raises(UnsupportedProperty):
-        properties = await reported_properties(hass, "climate.unsupported")
-        properties.assert_not_has_property(
-            "Alexa.ThermostatController", "thermostatMode"
-        )
-        properties.assert_equal(
-            "Alexa.TemperatureSensor",
-            "temperature",
-            {"value": 34.0, "scale": "CELSIUS"},
-        )
+    properties = await reported_properties(hass, "climate.unsupported", "INVALID_VALUE")
 
 
 async def test_temperature_sensor_sensor(hass):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -580,7 +580,7 @@ async def test_variable_fan_no_current_speed(hass, caplog):
             "fan.percentage",
         )
     assert (
-        "Request Alexa.RangeController/AdjustRangeValue error INVALID_VALUE: Unable to determine fan.test_3 current fan speed"
+        "Request Alexa.RangeController/AdjustRangeValue error INTERNAL_ERROR: Unexpected value for fan.test_3 percentage attribute: None"
         in caplog.text
     )
     caplog.clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate that the data we get from the state machine matches what the entity prescribes. Home Assistant currently doesn't validate this on demand. When it is unexpected (e.g. `brightness` is `None`), it would cause stacktraces. Now it will report to the user what entity is wrong and report to Alexa something went wrong.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
