### PR TITLE
Overkiz/address cover feedback

### DIFF
--- a/homeassistant/components/overkiz/cover_entities/awning.py
+++ b/homeassistant/components/overkiz/cover_entities/awning.py
@@ -55,9 +55,8 @@ class Awning(OverkizGenericCover):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        position = kwargs.get(ATTR_POSITION, 0)
         await self.executor.async_execute_command(
-            OverkizCommand.SET_DEPLOYMENT, position
+            OverkizCommand.SET_DEPLOYMENT, kwargs[ATTR_POSITION]
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/overkiz/cover_entities/awning.py
+++ b/homeassistant/components/overkiz/cover_entities/awning.py
@@ -7,11 +7,11 @@ from pyoverkiz.enums import OverkizCommand, OverkizState
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASS_AWNING,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
     SUPPORT_STOP,
+    CoverDeviceClass,
 )
 
 from .generic_cover import COMMANDS_STOP, OverkizGenericCover
@@ -20,7 +20,7 @@ from .generic_cover import COMMANDS_STOP, OverkizGenericCover
 class Awning(OverkizGenericCover):
     """Representation of an Overkiz awning."""
 
-    _attr_device_class = DEVICE_CLASS_AWNING
+    _attr_device_class = CoverDeviceClass.AWNING
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/overkiz/cover_entities/generic_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/generic_cover.py
@@ -63,7 +63,7 @@ class OverkizGenericCover(OverkizEntity, CoverEntity):
         if command := self.executor.select_command(*COMMANDS_SET_TILT_POSITION):
             await self.executor.async_execute_command(
                 command,
-                100 - kwargs.get(ATTR_TILT_POSITION, 0),
+                100 - kwargs[ATTR_TILT_POSITION],
             )
 
     @property

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -97,7 +97,7 @@ class VerticalCover(OverkizGenericCover):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        position = 100 - kwargs.get(ATTR_POSITION, 0)
+        position = 100 - kwargs[ATTR_POSITION]
         await self.executor.async_execute_command(OverkizCommand.SET_CLOSURE, position)
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -74,14 +74,16 @@ class VerticalCover(OverkizGenericCover):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        if current_position := self.executor.select_state(
+        position = self.executor.select_state(
             OverkizState.CORE_CLOSURE,
             OverkizState.CORE_CLOSURE_OR_ROCKER_POSITION,
             OverkizState.CORE_PEDESTRIAN_POSITION,
-        ):
-            return 100 - cast(int, current_position)
+        )
 
-        return None
+        if position is None:
+            return None
+
+        return 100 - cast(int, position)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -1,7 +1,7 @@
 """Support for Overkiz Vertical Covers."""
 from __future__ import annotations
 
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizState, UIClass, UIWidget
 
@@ -74,20 +74,14 @@ class VerticalCover(OverkizGenericCover):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        position = cast(
-            Union[int, None],
-            self.executor.select_state(
-                OverkizState.CORE_CLOSURE,
-                OverkizState.CORE_CLOSURE_OR_ROCKER_POSITION,
-                OverkizState.CORE_PEDESTRIAN_POSITION,
-            ),
-        )
+        if current_position := self.executor.select_state(
+            OverkizState.CORE_CLOSURE,
+            OverkizState.CORE_CLOSURE_OR_ROCKER_POSITION,
+            OverkizState.CORE_PEDESTRIAN_POSITION,
+        ):
+            return 100 - cast(int, current_position)
 
-        # Uno devices can have a position not in 0 to 100 range when unknown
-        if position is None or position < 0 or position > 100:
-            return None
-
-        return 100 - position
+        return None
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -7,17 +7,11 @@ from pyoverkiz.enums import OverkizCommand, OverkizState, UIClass, UIWidget
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASS_AWNING,
-    DEVICE_CLASS_BLIND,
-    DEVICE_CLASS_CURTAIN,
-    DEVICE_CLASS_GARAGE,
-    DEVICE_CLASS_GATE,
-    DEVICE_CLASS_SHUTTER,
-    DEVICE_CLASS_WINDOW,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
     SUPPORT_STOP,
+    CoverDeviceClass,
 )
 
 from .generic_cover import COMMANDS_STOP, OverkizGenericCover
@@ -26,16 +20,16 @@ COMMANDS_OPEN = [OverkizCommand.OPEN, OverkizCommand.UP, OverkizCommand.CYCLE]
 COMMANDS_CLOSE = [OverkizCommand.CLOSE, OverkizCommand.DOWN, OverkizCommand.CYCLE]
 
 OVERKIZ_DEVICE_TO_DEVICE_CLASS = {
-    UIClass.CURTAIN: DEVICE_CLASS_CURTAIN,
-    UIClass.EXTERIOR_SCREEN: DEVICE_CLASS_BLIND,
-    UIClass.EXTERIOR_VENETIAN_BLIND: DEVICE_CLASS_BLIND,
-    UIClass.GARAGE_DOOR: DEVICE_CLASS_GARAGE,
-    UIClass.GATE: DEVICE_CLASS_GATE,
-    UIWidget.MY_FOX_SECURITY_CAMERA: DEVICE_CLASS_SHUTTER,
-    UIClass.PERGOLA: DEVICE_CLASS_AWNING,
-    UIClass.ROLLER_SHUTTER: DEVICE_CLASS_SHUTTER,
-    UIClass.SWINGING_SHUTTER: DEVICE_CLASS_SHUTTER,
-    UIClass.WINDOW: DEVICE_CLASS_WINDOW,
+    UIClass.CURTAIN: CoverDeviceClass.CURTAIN,
+    UIClass.EXTERIOR_SCREEN: CoverDeviceClass.BLIND,
+    UIClass.EXTERIOR_VENETIAN_BLIND: CoverDeviceClass.BLIND,
+    UIClass.GARAGE_DOOR: CoverDeviceClass.GARAGE,
+    UIClass.GATE: CoverDeviceClass.GATE,
+    UIWidget.MY_FOX_SECURITY_CAMERA: CoverDeviceClass.SHUTTER,
+    UIClass.PERGOLA: CoverDeviceClass.AWNING,
+    UIClass.ROLLER_SHUTTER: CoverDeviceClass.SHUTTER,
+    UIClass.SWINGING_SHUTTER: CoverDeviceClass.SHUTTER,
+    UIClass.WINDOW: CoverDeviceClass.WINDOW,
 }
 
 
@@ -69,7 +63,7 @@ class VerticalCover(OverkizGenericCover):
             (
                 OVERKIZ_DEVICE_TO_DEVICE_CLASS.get(self.device.widget)
                 or OVERKIZ_DEVICE_TO_DEVICE_CLASS.get(self.device.ui_class)
-                or DEVICE_CLASS_BLIND
+                or CoverDeviceClass.BLIND
             ),
         )
 


### PR DESCRIPTION
## Proposed change
Addresses late feedback from MartinHjelmare in https://github.com/home-assistant/core/pull/64564#discussion_r793233983.

And since I can't reply to locked issues, some follow up comments here as well.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
