### PR TITLE
Add diagnostics support to P1 Monitor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -889,7 +889,6 @@ omit =
     homeassistant/components/pushover/notify.py
     homeassistant/components/pushsafer/notify.py
     homeassistant/components/pyload/sensor.py
-    homeassistant/components/p1_monitor/diagnostics.py
     homeassistant/components/qbittorrent/sensor.py
     homeassistant/components/qnap/sensor.py
     homeassistant/components/qrcode/image_processing.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -889,6 +889,7 @@ omit =
     homeassistant/components/pushover/notify.py
     homeassistant/components/pushsafer/notify.py
     homeassistant/components/pyload/sensor.py
+    homeassistant/components/p1_monitor/diagnostics.py
     homeassistant/components/qbittorrent/sensor.py
     homeassistant/components/qnap/sensor.py
     homeassistant/components/qrcode/image_processing.py

--- a/homeassistant/components/p1_monitor/diagnostics.py
+++ b/homeassistant/components/p1_monitor/diagnostics.py
@@ -1,0 +1,30 @@
+"""Diagnostics support for P1 Monitor."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from . import P1MonitorDataUpdateCoordinator
+from .const import DOMAIN, SERVICE_PHASES, SERVICE_SETTINGS, SERVICE_SMARTMETER
+
+TO_REDACT = {
+    CONF_HOST,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: P1MonitorDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    return {
+        "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "smartmeter": coordinator.data[SERVICE_SMARTMETER].__dict__,
+        "phases": coordinator.data[SERVICE_PHASES].__dict__,
+        "settings": coordinator.data[SERVICE_SETTINGS].__dict__,
+    }

--- a/homeassistant/components/p1_monitor/diagnostics.py
+++ b/homeassistant/components/p1_monitor/diagnostics.py
@@ -23,8 +23,13 @@ async def async_get_config_entry_diagnostics(
     coordinator: P1MonitorDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     return {
-        "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "smartmeter": coordinator.data[SERVICE_SMARTMETER].__dict__,
-        "phases": coordinator.data[SERVICE_PHASES].__dict__,
-        "settings": coordinator.data[SERVICE_SETTINGS].__dict__,
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(entry.data, TO_REDACT),
+        },
+        "data": {
+            "smartmeter": coordinator.data[SERVICE_SMARTMETER].__dict__,
+            "phases": coordinator.data[SERVICE_PHASES].__dict__,
+            "settings": coordinator.data[SERVICE_SETTINGS].__dict__,
+        },
     }

--- a/tests/components/p1_monitor/test_diagnostics.py
+++ b/tests/components/p1_monitor/test_diagnostics.py
@@ -1,0 +1,59 @@
+"""Tests for the diagnostics data provided by the P1 Monitor integration."""
+from aiohttp import ClientSession
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+    init_integration: MockConfigEntry,
+):
+    """Test diagnostics."""
+    assert await get_diagnostics_for_config_entry(
+        hass, hass_client, init_integration
+    ) == {
+        "entry": {
+            "title": "monitor",
+            "data": {
+                "host": REDACTED,
+            },
+        },
+        "data": {
+            "smartmeter": {
+                "gas_consumption": 2273.447,
+                "energy_tariff_period": "high",
+                "power_consumption": 877,
+                "energy_consumption_high": 2770.133,
+                "energy_consumption_low": 4988.071,
+                "power_production": 0,
+                "energy_production_high": 3971.604,
+                "energy_production_low": 1432.279,
+            },
+            "phases": {
+                "voltage_phase_l1": "233.6",
+                "voltage_phase_l2": "0.0",
+                "voltage_phase_l3": "233.0",
+                "current_phase_l1": "1.6",
+                "current_phase_l2": "4.44",
+                "current_phase_l3": "3.51",
+                "power_consumed_phase_l1": 315,
+                "power_consumed_phase_l2": 0,
+                "power_consumed_phase_l3": 624,
+                "power_produced_phase_l1": 0,
+                "power_produced_phase_l2": 0,
+                "power_produced_phase_l3": 0,
+            },
+            "settings": {
+                "gas_consumption_price": "0.64",
+                "energy_consumption_price_high": "0.20522",
+                "energy_consumption_price_low": "0.20522",
+                "energy_production_price_high": "0.20522",
+                "energy_production_price_low": "0.20522",
+            },
+        },
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to the P1 Monitor integration.

Example output:

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Core",
    "version": "2022.3.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.9.5",
    "docker": false,
    "arch": "x86_64",
    "timezone": "Europe/Amsterdam",
    "os_name": "Linux",
    "os_version": "5.4.0-1046-kvm",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "p1_monitor",
    "name": "P1 Monitor",
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/p1_monitor",
    "requirements": [
      "p1monitor==1.0.1"
    ],
    "codeowners": [
      "@klaasnicolaas"
    ],
    "quality_scale": "platinum",
    "iot_class": "local_polling",
    "is_built_in": true
  },
  "data": {
    "entry": {
      "title": "Huis",
      "data": {
        "host": "**REDACTED**"
      }
    },
    "data": {
      "smartmeter": {
        "gas_consumption": 3370.356,
        "energy_tariff_period": "low",
        "power_consumption": 916,
        "energy_consumption_high": 4349.623,
        "energy_consumption_low": 6853.735,
        "power_production": 0,
        "energy_production_high": 4588.617,
        "energy_production_low": 1640.0
      },
      "phases": {
        "voltage_phase_l1": "230.8",
        "voltage_phase_l2": "0.0",
        "voltage_phase_l3": "229.8",
        "current_phase_l1": "0.7",
        "current_phase_l2": "3.96",
        "current_phase_l3": "3.81",
        "power_consumed_phase_l1": 151,
        "power_consumed_phase_l2": 0,
        "power_consumed_phase_l3": 765,
        "power_produced_phase_l1": 0,
        "power_produced_phase_l2": 0,
        "power_produced_phase_l3": 0
      },
      "settings": {
        "gas_consumption_price": "0.64",
        "energy_consumption_price_high": "0.20522",
        "energy_consumption_price_low": "0.20522",
        "energy_production_price_high": "0.20522",
        "energy_production_price_low": "0.20522"
      }
    }
  }
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
