### PR TITLE
Report unmet dependencies for failing config flows

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -11,7 +11,7 @@ from homeassistant.auth.permissions.const import CAT_CONFIG_ENTRIES, POLICY_EDIT
 from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import DependencyError, Unauthorized
 from homeassistant.helpers.data_entry_flow import (
     FlowManagerIndexView,
     FlowManagerResourceView,
@@ -127,7 +127,13 @@ class ConfigManagerFlowIndexView(FlowManagerIndexView):
             raise Unauthorized(perm_category=CAT_CONFIG_ENTRIES, permission="add")
 
         # pylint: disable=no-value-for-parameter
-        return await super().post(request)
+        try:
+            return await super().post(request)
+        except DependencyError as exc:
+            return self.json_message(
+                f"Failed dependencies {exc.failed_dependencies}",
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
 
     def _prepare_result_json(self, result):
         """Convert result to JSON."""

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from http import HTTPStatus
 
+from aiohttp import web
 import aiohttp.web_exceptions
 import voluptuous as vol
 
@@ -130,9 +131,9 @@ class ConfigManagerFlowIndexView(FlowManagerIndexView):
         try:
             return await super().post(request)
         except DependencyError as exc:
-            return self.json_message(
-                f"Failed dependencies {exc.failed_dependencies}",
-                status_code=HTTPStatus.BAD_REQUEST,
+            return web.Response(
+                text=f"Failed dependencies {', '.join(exc.failed_dependencies)}",
+                status=HTTPStatus.BAD_REQUEST,
             )
 
     def _prepare_result_json(self, result):

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -199,3 +199,15 @@ class RequiredParameterMissing(HomeAssistantError):
             ),
         )
         self.parameter_names = parameter_names
+
+
+class DependencyError(HomeAssistantError):
+    """Raised when dependencies can not be setup."""
+
+    def __init__(self, failed_dependencies: list[str]) -> None:
+        """Initialize error."""
+        super().__init__(
+            self,
+            ("Could not setup dependencies " f"{', '.join(failed_dependencies)}"),
+        )
+        self.failed_dependencies = failed_dependencies

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -208,6 +208,6 @@ class DependencyError(HomeAssistantError):
         """Initialize error."""
         super().__init__(
             self,
-            ("Could not setup dependencies " f"{', '.join(failed_dependencies)}"),
+            f"Could not setup dependencies: {', '.join(failed_dependencies)}",
         )
         self.failed_dependencies = failed_dependencies

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -18,7 +18,7 @@ from .const import (
     Platform,
 )
 from .core import CALLBACK_TYPE
-from .exceptions import HomeAssistantError
+from .exceptions import DependencyError, HomeAssistantError
 from .helpers.typing import ConfigType
 from .util import dt as dt_util, ensure_unique_string
 
@@ -83,8 +83,11 @@ async def async_setup_component(
 
 async def _async_process_dependencies(
     hass: core.HomeAssistant, config: ConfigType, integration: loader.Integration
-) -> bool:
-    """Ensure all dependencies are set up."""
+) -> list[str]:
+    """Ensure all dependencies are set up.
+
+    Returns a list of dependencies which failed to set up.
+    """
     dependencies_tasks = {
         dep: hass.loop.create_task(async_setup_component(hass, dep, config))
         for dep in integration.dependencies
@@ -104,7 +107,7 @@ async def _async_process_dependencies(
             )
 
     if not dependencies_tasks and not after_dependencies_tasks:
-        return True
+        return []
 
     if dependencies_tasks:
         _LOGGER.debug(
@@ -135,8 +138,7 @@ async def _async_process_dependencies(
             ", ".join(failed),
         )
 
-        return False
-    return True
+    return failed
 
 
 async def _async_setup_component(
@@ -341,8 +343,9 @@ async def async_process_deps_reqs(
     elif integration.domain in processed:
         return
 
-    if not await _async_process_dependencies(hass, config, integration):
-        raise HomeAssistantError("Could not set up all dependencies.")
+    failed_deps = await _async_process_dependencies(hass, config, integration)
+    if failed_deps:
+        raise DependencyError(failed_deps)
 
     if not hass.config.skip_pip and integration.requirements:
         async with hass.timeout.async_freeze(integration.domain):

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -343,7 +343,7 @@ async def async_process_deps_reqs(
     elif integration.domain in processed:
         return
 
-    if failed_deps := await _async_process_dependencies(hass, config, integration)
+    if failed_deps := await _async_process_dependencies(hass, config, integration):
         raise DependencyError(failed_deps)
 
     if not hass.config.skip_pip and integration.requirements:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -343,8 +343,7 @@ async def async_process_deps_reqs(
     elif integration.domain in processed:
         return
 
-    failed_deps = await _async_process_dependencies(hass, config, integration)
-    if failed_deps:
+    if failed_deps := await _async_process_dependencies(hass, config, integration)
         raise DependencyError(failed_deps)
 
     if not hass.config.skip_pip and integration.requirements:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Report unmet dependencies for failing config flows.
A config flow initiated via `/api/config/config_entries/flow` will now fail with status 400, and an error message which includes the dependencies that could not be setup.

We already compiled a list of unmet dependencies, but the list was just discarded after printing it.
This PR wraps the list in a `DependencyError` which is a new subclass of `HomeAssistantError`.

Frontend support in https://github.com/home-assistant/frontend/pull/11499

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: 
  - #65153
  - https://www.reddit.com/r/homeassistant/comments/r232n3/config_flow_could_not_be_loaded/

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
