### PR TITLE
Add battery sensor for Tradfri blinds

### DIFF
--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
     api = coordinator_data[KEY_API]
 
     async_add_entities(
-        TradfriSensor(
+        TradfriBatterySensor(
             device_coordinator,
             api,
             gateway_id,
@@ -37,14 +37,13 @@ async def async_setup_entry(
         if (
             not device_coordinator.device.has_light_control
             and not device_coordinator.device.has_socket_control
-            and not device_coordinator.device.has_blind_control
             and not device_coordinator.device.has_signal_repeater_control
             and not device_coordinator.device.has_air_purifier_control
         )
     )
 
 
-class TradfriSensor(TradfriBaseEntity, SensorEntity):
+class TradfriBatterySensor(TradfriBaseEntity, SensorEntity):
     """The platform class required by Home Assistant."""
 
     _attr_device_class = SensorDeviceClass.BATTERY

--- a/tests/components/tradfri/test_sensor.py
+++ b/tests/components/tradfri/test_sensor.py
@@ -5,15 +5,12 @@ from unittest.mock import MagicMock, Mock
 from .common import setup_integration
 
 
-def mock_sensor(state_name: str, state_value: str, device_number=0):
+def mock_sensor(test_state: list, device_number=0):
     """Mock a tradfri sensor."""
     dev_info_mock = MagicMock()
     dev_info_mock.manufacturer = "manufacturer"
     dev_info_mock.model_number = "model"
     dev_info_mock.firmware_version = "1.2.3"
-
-    # Set state value, eg battery_level = 50
-    setattr(dev_info_mock, state_name, state_value)
 
     _mock_sensor = Mock(
         id=f"mock-sensor-id-{device_number}",
@@ -26,6 +23,11 @@ def mock_sensor(state_name: str, state_value: str, device_number=0):
         has_signal_repeater_control=False,
         has_air_purifier_control=False,
     )
+
+    # Set state value, eg battery_level = 50, or has_air_purifier_control=True
+    for state in test_state:
+        setattr(dev_info_mock, state["attribute"], state["value"])
+
     _mock_sensor.name = f"tradfri_sensor_{device_number}"
 
     return _mock_sensor
@@ -34,7 +36,7 @@ def mock_sensor(state_name: str, state_value: str, device_number=0):
 async def test_battery_sensor(hass, mock_gateway, mock_api_factory):
     """Test that a battery sensor is correctly added."""
     mock_gateway.mock_devices.append(
-        mock_sensor(state_name="battery_level", state_value=60)
+        mock_sensor(test_state=[{"attribute": "battery_level", "value": 60}])
     )
     await setup_integration(hass)
 
@@ -45,10 +47,27 @@ async def test_battery_sensor(hass, mock_gateway, mock_api_factory):
     assert sensor_1.attributes["device_class"] == "battery"
 
 
+async def test_cover_battery_sensor(hass, mock_gateway, mock_api_factory):
+    """Test that a battery sensor is correctly added for a cover (blind)."""
+    mock_gateway.mock_devices.append(
+        mock_sensor(
+            test_state=[
+                {"attribute": "battery_level", "value": 42, "has_blind_control": True}
+            ]
+        )
+    )
+    await setup_integration(hass)
+
+    sensor_1 = hass.states.get("sensor.tradfri_sensor_0")
+    assert sensor_1 is not None
+    assert sensor_1.state == "42"
+    assert sensor_1.attributes["unit_of_measurement"] == "%"
+    assert sensor_1.attributes["device_class"] == "battery"
+
+
 async def test_sensor_observed(hass, mock_gateway, mock_api_factory):
     """Test that sensors are correctly observed."""
-
-    sensor = mock_sensor(state_name="battery_level", state_value=60)
+    sensor = mock_sensor(test_state=[{"attribute": "battery_level", "value": 60}])
     mock_gateway.mock_devices.append(sensor)
     await setup_integration(hass)
     assert len(sensor.observe.mock_calls) > 0
@@ -56,11 +75,14 @@ async def test_sensor_observed(hass, mock_gateway, mock_api_factory):
 
 async def test_sensor_available(hass, mock_gateway, mock_api_factory):
     """Test sensor available property."""
-
-    sensor = mock_sensor(state_name="battery_level", state_value=60, device_number=1)
+    sensor = mock_sensor(
+        test_state=[{"attribute": "battery_level", "value": 60}], device_number=1
+    )
     sensor.reachable = True
 
-    sensor2 = mock_sensor(state_name="battery_level", state_value=60, device_number=2)
+    sensor2 = mock_sensor(
+        test_state=[{"attribute": "battery_level", "value": 60}], device_number=2
+    )
     sensor2.reachable = False
 
     mock_gateway.mock_devices.append(sensor)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds battery sensors for Tradfri's cover platform (known as blinds in the IKEA ecosystem). Caveat: I don't have any blinds so I can't test this, but they should have battery levels on the device level:
https://github.com/home-assistant-libs/pytradfri/blob/master/tests/test_blinds.py


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
