### PR TITLE
Guard browsing Spotify if setup failed

### DIFF
--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -4,6 +4,7 @@ import aiohttp
 from spotipy import Spotify, SpotifyException
 import voluptuous as vol
 
+from homeassistant.components.media_player import BrowseError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CREDENTIALS,
@@ -60,7 +61,9 @@ async def async_browse_media(
     hass, media_content_type, media_content_id, *, can_play_artist=True
 ):
     """Browse Spotify media."""
-    info = list(hass.data[DOMAIN].values())[0]
+    info = next(iter(hass.data[DOMAIN].values()), None)
+    if not info:
+        raise BrowseError("No Spotify accounts available")
     return await async_browse_media_internal(
         hass,
         info[DATA_SPOTIFY_CLIENT],

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -61,8 +61,7 @@ async def async_browse_media(
     hass, media_content_type, media_content_id, *, can_play_artist=True
 ):
     """Browse Spotify media."""
-    info = next(iter(hass.data[DOMAIN].values()), None)
-    if not info:
+    if not (info := next(iter(hass.data[DOMAIN].values()), None)):
         raise BrowseError("No Spotify accounts available")
     return await async_browse_media_internal(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If Spotify is configured but hasn't successfully loaded it can lead to errors when browsing from another integration (e.g., Sonos).

```
File "/usr/src/homeassistant/homeassistant/components/sonos/media_player.py", line 698, in async_browse_media
    return await media_browser.async_browse_media(
File "/usr/src/homeassistant/homeassistant/components/sonos/media_browser.py", line 109, in async_browse_media
    return await spotify.async_browse_media(hass, None, None, can_play_artist=False)
File "/usr/src/homeassistant/homeassistant/components/spotify/__init__.py", line 63, in async_browse_media
    info = list(hass.data[DOMAIN].values())[0]
KeyError: 'spotify'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
