### PR TITLE
Implement diagnostics for yale_smart_alarm

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1454,6 +1454,7 @@ omit =
     homeassistant/components/yale_smart_alarm/binary_sensor.py
     homeassistant/components/yale_smart_alarm/const.py
     homeassistant/components/yale_smart_alarm/coordinator.py
+    homeassistant/components/yale_smart_alarm/diagnostics.py
     homeassistant/components/yale_smart_alarm/entity.py
     homeassistant/components/yale_smart_alarm/lock.py
     homeassistant/components/yamaha_musiccast/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -980,6 +980,7 @@ tests/components/trace/* @home-assistant/core
 homeassistant/components/tractive/* @Danielhiversen @zhulik @bieniu
 tests/components/tractive/* @Danielhiversen @zhulik @bieniu
 homeassistant/components/trafikverket_train/* @endor-force @gjohansson-ST
+tests/components/trafikverket_train/* @endor-force @gjohansson-ST
 homeassistant/components/trafikverket_weatherstation/* @endor-force @gjohansson-ST
 tests/components/trafikverket_weatherstation/* @endor-force @gjohansson-ST
 homeassistant/components/transmission/* @engrbm87 @JPHutchins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -980,7 +980,6 @@ tests/components/trace/* @home-assistant/core
 homeassistant/components/tractive/* @Danielhiversen @zhulik @bieniu
 tests/components/tractive/* @Danielhiversen @zhulik @bieniu
 homeassistant/components/trafikverket_train/* @endor-force @gjohansson-ST
-tests/components/trafikverket_train/* @endor-force @gjohansson-ST
 homeassistant/components/trafikverket_weatherstation/* @endor-force @gjohansson-ST
 tests/components/trafikverket_weatherstation/* @endor-force @gjohansson-ST
 homeassistant/components/transmission/* @engrbm87 @JPHutchins

--- a/homeassistant/components/yale_smart_alarm/diagnostics.py
+++ b/homeassistant/components/yale_smart_alarm/diagnostics.py
@@ -1,0 +1,30 @@
+"""Diagnostics support for Yale Smart Alarm."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import COORDINATOR, DOMAIN
+from .coordinator import YaleDataUpdateCoordinator
+
+TO_REDACT = {
+    "address",
+    "name",
+    "mac",
+    "device_id",
+    "sensor_map",
+    "lock_map",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: YaleDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
+        COORDINATOR
+    ]
+    return async_redact_data(coordinator.data, TO_REDACT)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement new diagnostics feature for yale_smart_alarm

Example output:
```json
"data": {
    "alarm": "disarm",
    "locks": [
      {
        "area": "1",
        "no": "1",
        "rf": null,
        "address": "**REDACTED**",
        "type": "device_type.door_lock",
        "name": "**REDACTED**",
        "status1": "device_status.lock",
        "status2": null,
        "status_switch": null,
        "status_power": null,
        "status_temp": null,
        "status_humi": null,
        "status_dim_level": null,
        "status_lux": "",
        "status_hue": null,
        "status_saturation": null,
        "rssi": "9",
        "mac": "**REDACTED**",
        "scene_trigger": "0",
        "status_total_energy": null,
        "device_id2": "",
        "extension": null,
        "minigw_protocol": "DM",
        "minigw_syncing": "0",
        "minigw_configuration_data": "03FF000001000000000000000000001E000100",
        "minigw_product_data": "21020120",
        "minigw_lock_status": "35",
        "minigw_number_of_credentials_supported": "10",
        "sresp_button_3": null,
        "sresp_button_1": null,
        "sresp_button_2": null,
        "sresp_button_4": null,
        "ipcam_trigger_by_zone1": null,
        "ipcam_trigger_by_zone2": null,
        "ipcam_trigger_by_zone3": null,
        "ipcam_trigger_by_zone4": null,
        "scene_restore": null,
        "thermo_mode": null,
        "thermo_setpoint": null,
        "thermo_c_setpoint": null,
        "thermo_setpoint_away": null,
        "thermo_c_setpoint_away": null,
        "thermo_fan_mode": null,
        "thermo_schd_setting": null,
        "group_id": null,
        "group_name": null,
        "bypass": "0",
        "device_id": "**REDACTED**",
        "status_temp_format": "C",
        "type_no": "72",
        "device_group": "002",
        "status_fault": [],
        "status_open": [
          "device_status.lock"
        ],
        "trigger_by_zone": [],
        "_state": "locked",
        "_state2": "closed"
      }
    ],
    "door_windows": [],
    "status": "ok",
    "online": "online",
    "sensor_map": "**REDACTED**",
    "lock_map": "**REDACTED**"
  }
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
