### PR TITLE
Add button platform to Z-Wave.Me integration

### DIFF
--- a/homeassistant/components/zwave_me/button.py
+++ b/homeassistant/components/zwave_me/button.py
@@ -20,11 +20,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     @callback
     def add_new_device(new_device):
         controller = hass.data[DOMAIN][config_entry.entry_id]
-        switch = ZWaveMeButton(controller, new_device)
+        button = ZWaveMeButton(controller, new_device)
 
         async_add_entities(
             [
-                switch,
+                button,
             ]
         )
 

--- a/homeassistant/components/zwave_me/button.py
+++ b/homeassistant/components/zwave_me/button.py
@@ -1,0 +1,43 @@
+"""Representation of a toggleButton."""
+import logging
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import ZWaveMeEntity
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DEVICE_NAME = "toggleButton"
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the number platform."""
+
+    @callback
+    def add_new_device(new_device):
+        controller = hass.data[DOMAIN][config_entry.entry_id]
+        switch = ZWaveMeButton(controller, new_device)
+
+        async_add_entities(
+            [
+                switch,
+            ]
+        )
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, f"ZWAVE_ME_NEW_{DEVICE_NAME.upper()}", add_new_device
+        )
+    )
+
+
+class ZWaveMeButton(ZWaveMeEntity, ButtonEntity):
+    """Representation of a ZWaveMe button."""
+
+    def press(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        self.hass.data[DOMAIN].zwave_api.send_command(self.device.id, "on")

--- a/homeassistant/components/zwave_me/button.py
+++ b/homeassistant/components/zwave_me/button.py
@@ -1,5 +1,4 @@
 """Representation of a toggleButton."""
-import logging
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity
@@ -8,8 +7,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import ZWaveMeEntity
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 DEVICE_NAME = "toggleButton"
 

--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -5,6 +5,6 @@ from homeassistant.const import Platform
 # Base component constants
 DOMAIN = "zwave_me"
 
-ZWAVE_PLATFORMS = ["switchMultilevel", "binarySwitch"]
+ZWAVE_PLATFORMS = ["switchMultilevel", "binarySwitch", "toggleButton"]
 
-PLATFORMS = [Platform.NUMBER, Platform.SWITCH]
+PLATFORMS = [Platform.NUMBER, Platform.SWITCH, Platform.BUTTON]

--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -7,4 +7,4 @@ DOMAIN = "zwave_me"
 
 ZWAVE_PLATFORMS = ["switchMultilevel", "binarySwitch", "toggleButton"]
 
-PLATFORMS = [Platform.NUMBER, Platform.SWITCH, Platform.BUTTON]
+PLATFORMS = [Platform.BUTTON, Platform.NUMBER, Platform.SWITCH]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20684

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
