### PR TITLE
Add diagnostics support to onewire

### DIFF
--- a/homeassistant/components/onewire/diagnostics.py
+++ b/homeassistant/components/onewire/diagnostics.py
@@ -1,0 +1,33 @@
+"""Diagnostics support for 1-Wire."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .onewirehub import OneWireHub
+
+TO_REDACT = {CONF_HOST}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    onewirehub: OneWireHub = hass.data[DOMAIN][entry.entry_id]
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(entry.data, TO_REDACT),
+            "options": {**entry.options},
+        },
+        "devices": [asdict(device_details) for device_details in onewirehub.devices]
+        if onewirehub.devices
+        else [],
+    }

--- a/tests/components/onewire/test_diagnostics.py
+++ b/tests/components/onewire/test_diagnostics.py
@@ -1,0 +1,61 @@
+"""Test 1-Wire diagnostics."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from . import setup_owproxy_mock_devices
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+@pytest.fixture(autouse=True)
+def override_platforms():
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.onewire.PLATFORMS", [Platform.SWITCH]):
+        yield
+
+
+DEVICE_DETAILS = {
+    "device_info": {
+        "identifiers": [["onewire", "EF.111111111113"]],
+        "manufacturer": "Hobby Boards",
+        "model": "HB_HUB",
+        "name": "EF.111111111113",
+    },
+    "family": "EF",
+    "id": "EF.111111111113",
+    "path": "/EF.111111111113/",
+    "type": "HB_HUB",
+}
+
+
+@pytest.mark.parametrize("device_id", ["EF.111111111113"], indirect=True)
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    hass_client,
+    owproxy: MagicMock,
+    device_id: str,
+):
+    """Test config entry diagnostics."""
+    setup_owproxy_mock_devices(owproxy, Platform.SENSOR, [device_id])
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+        "entry": {
+            "data": {
+                "host": REDACTED,
+                "port": 1234,
+                "type": "OWServer",
+            },
+            "options": {},
+            "title": "Mock Title",
+        },
+        "devices": [DEVICE_DETAILS],
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add diagnostics support to onewire

Sample output:
```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2022.3.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "UTC",
    "os_name": "Linux",
    "os_version": "5.10.16.3-microsoft-standard-WSL2",
    "run_as_root": true
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "onewire",
    "name": "1-Wire",
    "documentation": "https://www.home-assistant.io/integrations/onewire",
    "config_flow": true,
    "requirements": [
      "pyownet==0.10.0.post1",
      "pi1wire==0.1.0"
    ],
    "codeowners": [
      "@garbled1",
      "@epenet"
    ],
    "iot_class": "local_polling",
    "is_built_in": true
  },
  "data": {
    "entry": {
      "title": "OWServer",
      "data": {
        "type": "OWServer",
        "host": "**REDACTED**",
        "port": 4304
      },
      "options": {
        "clear_device_config": false,
        "ds18b20_device_selection": [
          "28.E33966040000",
          "28.067566040000",
          "28.30DB77040000"
        ],
        "sensor_precision": {
          "28.30DB77040000": "9 Bits",
          "28.067566040000": "9 Bits",
          "28.E33966040000": "9 Bits"
        }
      }
    },
    "devices": [
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.A05966040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.A05966040000"
        },
        "family": "28",
        "id": "28.A05966040000",
        "path": "/28.A05966040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.30DB77040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.30DB77040000"
        },
        "family": "28",
        "id": "28.30DB77040000",
        "path": "/28.30DB77040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.F43666040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.F43666040000"
        },
        "family": "28",
        "id": "28.F43666040000",
        "path": "/28.F43666040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.067566040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.067566040000"
        },
        "family": "28",
        "id": "28.067566040000",
        "path": "/28.067566040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.464366040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.464366040000"
        },
        "family": "28",
        "id": "28.464366040000",
        "path": "/28.464366040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.A3FC85050000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.A3FC85050000"
        },
        "family": "28",
        "id": "28.A3FC85050000",
        "path": "/28.A3FC85050000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.E33966040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.E33966040000"
        },
        "family": "28",
        "id": "28.E33966040000",
        "path": "/28.E33966040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "28.676466040000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS18B20",
          "name": "28.676466040000"
        },
        "family": "28",
        "id": "28.676466040000",
        "path": "/28.676466040000/",
        "type": "DS18B20"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "12.A4EBA0000000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS2406",
          "name": "12.A4EBA0000000"
        },
        "family": "12",
        "id": "12.A4EBA0000000",
        "path": "/12.A4EBA0000000/",
        "type": "DS2406"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "12.8CF1A0000000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS2406",
          "name": "12.8CF1A0000000"
        },
        "family": "12",
        "id": "12.8CF1A0000000",
        "path": "/12.8CF1A0000000/",
        "type": "DS2406"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "26.0B691D020000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS2438",
          "name": "26.0B691D020000"
        },
        "family": "26",
        "id": "26.0B691D020000",
        "path": "/26.0B691D020000/",
        "type": "DS2438"
      },
      {
        "device_info": {
          "identifiers": [
            [
              "onewire",
              "29.48CC22000000"
            ]
          ],
          "manufacturer": "Maxim Integrated",
          "model": "DS2408",
          "name": "29.48CC22000000"
        },
        "family": "29",
        "id": "29.48CC22000000",
        "path": "/29.48CC22000000/",
        "type": "DS2408"
      }
    ]
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
