### PR TITLE
Add diagnostics for rtsp_to_webrtc

### DIFF
--- a/homeassistant/components/rtsp_to_webrtc/diagnostics.py
+++ b/homeassistant/components/rtsp_to_webrtc/diagnostics.py
@@ -1,0 +1,17 @@
+"""Diagnostics support for Nest."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rtsp_to_webrtc import client
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return dict(client.get_diagnostics())

--- a/tests/components/rtsp_to_webrtc/conftest.py
+++ b/tests/components/rtsp_to_webrtc/conftest.py
@@ -1,0 +1,98 @@
+"""Tests for RTSPtoWebRTC inititalization."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+from typing import Any, TypeVar
+from unittest.mock import patch
+
+import pytest
+import rtsp_to_webrtc
+
+from homeassistant.components import camera
+from homeassistant.components.rtsp_to_webrtc import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+STREAM_SOURCE = "rtsp://example.com"
+SERVER_URL = "http://127.0.0.1:8083"
+
+CONFIG_ENTRY_DATA = {"server_url": SERVER_URL}
+
+# Typing helpers
+ComponentSetup = Callable[[], Awaitable[None]]
+T = TypeVar("T")
+YieldFixture = Generator[T, None, None]
+
+
+@pytest.fixture(autouse=True)
+async def webrtc_server() -> None:
+    """Patch client library to force usage of RTSPtoWebRTC server."""
+    with patch(
+        "rtsp_to_webrtc.client.WebClient.heartbeat",
+        side_effect=rtsp_to_webrtc.exceptions.ResponseError(),
+    ):
+        yield
+
+
+@pytest.fixture
+async def mock_camera(hass) -> AsyncGenerator[None, None]:
+    """Initialize a demo camera platform."""
+    assert await async_setup_component(
+        hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.demo.camera.Path.read_bytes",
+        return_value=b"Test",
+    ), patch(
+        "homeassistant.components.camera.Camera.stream_source",
+        return_value=STREAM_SOURCE,
+    ), patch(
+        "homeassistant.components.camera.Camera.supported_features",
+        return_value=camera.SUPPORT_STREAM,
+    ):
+        yield
+
+
+@pytest.fixture
+async def config_entry_data() -> dict[str, Any]:
+    """Fixture for MockConfigEntry data."""
+    return CONFIG_ENTRY_DATA
+
+
+@pytest.fixture
+async def config_entry(config_entry_data: dict[str, Any]) -> MockConfigEntry:
+    """Fixture for MockConfigEntry."""
+    return MockConfigEntry(domain=DOMAIN, data=config_entry_data)
+
+
+@pytest.fixture
+async def rtsp_to_webrtc_client() -> None:
+    """Fixture for mock rtsp_to_webrtc client."""
+    with patch("rtsp_to_webrtc.client.Client.heartbeat"):
+        yield
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> YieldFixture[ComponentSetup]:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    async def func() -> None:
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    yield func
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    await hass.config_entries.async_unload(entries[0].entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.data.get(DOMAIN)
+    assert entries[0].state is ConfigEntryState.NOT_LOADED

--- a/tests/components/rtsp_to_webrtc/test_diagnostics.py
+++ b/tests/components/rtsp_to_webrtc/test_diagnostics.py
@@ -1,0 +1,29 @@
+"""Test nest diagnostics."""
+
+from typing import Any
+
+from .conftest import ComponentSetup
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+THERMOSTAT_TYPE = "sdm.devices.types.THERMOSTAT"
+
+
+async def test_entry_diagnostics(
+    hass,
+    hass_client,
+    config_entry: MockConfigEntry,
+    rtsp_to_webrtc_client: Any,
+    setup_integration: ComponentSetup,
+):
+    """Test config entry diagnostics."""
+    await setup_integration()
+
+    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+        {
+            "discovery": {"attempt": 1, "web.failure": 1, "webrtc.success": 1},
+            "web": {},
+            "webrtc": {},
+        }
+    }

--- a/tests/components/rtsp_to_webrtc/test_diagnostics.py
+++ b/tests/components/rtsp_to_webrtc/test_diagnostics.py
@@ -21,9 +21,7 @@ async def test_entry_diagnostics(
     await setup_integration()
 
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
-        {
-            "discovery": {"attempt": 1, "web.failure": 1, "webrtc.success": 1},
-            "web": {},
-            "webrtc": {},
-        }
+        "discovery": {"attempt": 1, "web.failure": 1, "webrtc.success": 1},
+        "web": {},
+        "webrtc": {},
     }

--- a/tests/components/rtsp_to_webrtc/test_init.py
+++ b/tests/components/rtsp_to_webrtc/test_init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import patch
 
@@ -11,132 +11,72 @@ import aiohttp
 import pytest
 import rtsp_to_webrtc
 
-from homeassistant.components import camera
 from homeassistant.components.rtsp_to_webrtc import DOMAIN
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from .conftest import SERVER_URL, STREAM_SOURCE, ComponentSetup
+
 from tests.test_util.aiohttp import AiohttpClientMocker
 
-STREAM_SOURCE = "rtsp://example.com"
 # The webrtc component does not inspect the details of the offer and answer,
 # and is only a pass through.
 OFFER_SDP = "v=0\r\no=carol 28908764872 28908764872 IN IP4 100.3.6.6\r\n..."
 ANSWER_SDP = "v=0\r\no=bob 2890844730 2890844730 IN IP4 host.example.com\r\n..."
 
-SERVER_URL = "http://127.0.0.1:8083"
 
-CONFIG_ENTRY_DATA = {"server_url": SERVER_URL}
-
-
-@pytest.fixture(autouse=True)
-async def webrtc_server() -> None:
-    """Patch client library to force usage of RTSPtoWebRTC server."""
-    with patch(
-        "rtsp_to_webrtc.client.WebClient.heartbeat",
-        side_effect=rtsp_to_webrtc.exceptions.ResponseError(),
-    ):
-        yield
-
-
-@pytest.fixture
-async def mock_camera(hass) -> AsyncGenerator[None, None]:
-    """Initialize a demo camera platform."""
-    assert await async_setup_component(
-        hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
-    )
-    await hass.async_block_till_done()
-    with patch(
-        "homeassistant.components.demo.camera.Path.read_bytes",
-        return_value=b"Test",
-    ), patch(
-        "homeassistant.components.camera.Camera.stream_source",
-        return_value=STREAM_SOURCE,
-    ), patch(
-        "homeassistant.components.camera.Camera.supported_features",
-        return_value=camera.SUPPORT_STREAM,
-    ):
-        yield
-
-
-async def async_setup_rtsp_to_webrtc(hass: HomeAssistant) -> None:
-    """Set up the component."""
-    return await async_setup_component(hass, DOMAIN, {})
-
-
-async def test_setup_success(hass: HomeAssistant) -> None:
+async def test_setup_success(
+    hass: HomeAssistant, rtsp_to_webrtc_client: Any, setup_integration: ComponentSetup
+) -> None:
     """Test successful setup and unload."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
-    config_entry.add_to_hass(hass)
-
-    with patch("rtsp_to_webrtc.client.Client.heartbeat"):
-        assert await async_setup_rtsp_to_webrtc(hass)
-        await hass.async_block_till_done()
+    await setup_integration()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.LOADED
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
-    await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
-    assert config_entry.state is ConfigEntryState.NOT_LOADED
-
-
-async def test_invalid_config_entry(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("config_entry_data", [{}])
+async def test_invalid_config_entry(
+    hass: HomeAssistant, rtsp_to_webrtc_client: Any, setup_integration: ComponentSetup
+) -> None:
     """Test a config entry with missing required fields."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={})
-    config_entry.add_to_hass(hass)
-
-    assert await async_setup_rtsp_to_webrtc(hass)
+    await setup_integration()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_server_failure(hass: HomeAssistant) -> None:
+async def test_setup_server_failure(
+    hass: HomeAssistant, setup_integration: ComponentSetup
+) -> None:
     """Test server responds with a failure on startup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
-    config_entry.add_to_hass(hass)
-
     with patch(
         "rtsp_to_webrtc.client.Client.heartbeat",
         side_effect=rtsp_to_webrtc.exceptions.ResponseError(),
     ):
-        assert await async_setup_rtsp_to_webrtc(hass)
-        await hass.async_block_till_done()
+        await setup_integration()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_RETRY
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
-    await hass.async_block_till_done()
 
-
-async def test_setup_communication_failure(hass: HomeAssistant) -> None:
+async def test_setup_communication_failure(
+    hass: HomeAssistant, setup_integration: ComponentSetup
+) -> None:
     """Test unable to talk to server on startup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
-    config_entry.add_to_hass(hass)
-
     with patch(
         "rtsp_to_webrtc.client.Client.heartbeat",
         side_effect=rtsp_to_webrtc.exceptions.ClientError(),
     ):
-        assert await async_setup_rtsp_to_webrtc(hass)
-        await hass.async_block_till_done()
+        await setup_integration()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_RETRY
-
-    await hass.config_entries.async_unload(config_entry.entry_id)
-    await hass.async_block_till_done()
 
 
 async def test_offer_for_stream_source(
@@ -144,14 +84,11 @@ async def test_offer_for_stream_source(
     aioclient_mock: AiohttpClientMocker,
     hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
     mock_camera: Any,
+    rtsp_to_webrtc_client: Any,
+    setup_integration: ComponentSetup,
 ) -> None:
     """Test successful response from RTSPtoWebRTC server."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
-    config_entry.add_to_hass(hass)
-
-    with patch("rtsp_to_webrtc.client.Client.heartbeat"):
-        assert await async_setup_rtsp_to_webrtc(hass)
-        await hass.async_block_till_done()
+    await setup_integration()
 
     aioclient_mock.post(
         f"{SERVER_URL}/stream",
@@ -188,14 +125,11 @@ async def test_offer_failure(
     aioclient_mock: AiohttpClientMocker,
     hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
     mock_camera: Any,
+    rtsp_to_webrtc_client: Any,
+    setup_integration: ComponentSetup,
 ) -> None:
     """Test a transient failure talking to RTSPtoWebRTC server."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_ENTRY_DATA)
-    config_entry.add_to_hass(hass)
-
-    with patch("rtsp_to_webrtc.client.Client.heartbeat"):
-        assert await async_setup_rtsp_to_webrtc(hass)
-        await hass.async_block_till_done()
+    await setup_integration()
 
     aioclient_mock.post(
         f"{SERVER_URL}/stream",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add initial version of diagnostics from the rtsp_to_webrtc client library that tracks
counters and various RPC error codes.

See client library diagnostics implementation in https://github.com/allenporter/rtsp-to-webrtc-client/blob/main/rtsp_to_webrtc/diagnostics.py which is effectively a set of counters for setup code and various RPCs, based on the client library that was used.

Moved test setup code to shared fixtures to facilitate testing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
