### PR TITLE
Update nest diagnostics

### DIFF
--- a/homeassistant/components/nest/diagnostics.py
+++ b/homeassistant/components/nest/diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from google_nest_sdm import diagnostics
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import InfoTrait
 from google_nest_sdm.exceptions import ApiException
@@ -30,22 +31,14 @@ async def async_get_config_entry_diagnostics(
         return {"error": str(err)}
 
     return {
+        **diagnostics.get_diagnostics(),
         "devices": [
             get_device_data(device) for device in device_manager.devices.values()
-        ]
+        ],
     }
 
 
 def get_device_data(device: Device) -> dict[str, Any]:
     """Return diagnostic information about a device."""
-    # Return a simplified view of the API object, but skipping any id fields or
-    # traits that include unique identifiers or personally identifiable information.
-    # See https://developers.google.com/nest/device-access/traits for API details
-    return {
-        "type": device.type,
-        "traits": {
-            trait: data
-            for trait, data in device.raw_data.get("traits", {}).items()
-            if trait not in REDACT_DEVICE_TRAITS
-        },
-    }
+    # Library performs its own redaction for device data
+    return device.get_diagnostics()

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -1,6 +1,7 @@
 """Common libraries for test setup."""
 from __future__ import annotations
 
+from collections.abc import Generator
 import copy
 import shutil
 from typing import Any
@@ -8,6 +9,7 @@ from unittest.mock import patch
 import uuid
 
 import aiohttp
+from google_nest_sdm import diagnostics
 from google_nest_sdm.auth import AbstractAuth
 from google_nest_sdm.device_manager import DeviceManager
 import pytest
@@ -234,3 +236,10 @@ async def setup_platform(
 ) -> PlatformSetup:
     """Fixture to setup the integration platform and subscriber."""
     return setup_base_platform
+
+
+@pytest.fixture(autouse=True)
+def reset_diagnostics() -> Generator[None, None, None]:
+    """Fixture to reset client library diagnostic counters."""
+    yield
+    diagnostics.reset()

--- a/tests/components/nest/test_diagnostics.py
+++ b/tests/components/nest/test_diagnostics.py
@@ -56,13 +56,21 @@ async def test_entry_diagnostics(hass, hass_client):
     assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
         "devices": [
             {
-                "traits": {
-                    "sdm.devices.traits.Humidity": {"ambientHumidityPercent": 35.0},
-                    "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.1
+                "data": {
+                    "assignee": "**REDACTED**",
+                    "name": "**REDACTED**",
+                    "parentRelations": [
+                        {"displayName": "**REDACTED**", "parent": "**REDACTED**"}
+                    ],
+                    "traits": {
+                        "sdm.devices.traits.Info": {"customName": "**REDACTED**"},
+                        "sdm.devices.traits.Humidity": {"ambientHumidityPercent": 35.0},
+                        "sdm.devices.traits.Temperature": {
+                            "ambientTemperatureCelsius": 25.1
+                        },
                     },
-                },
-                "type": "sdm.devices.types.THERMOSTAT",
+                    "type": "sdm.devices.types.THERMOSTAT",
+                }
             }
         ],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update nest diagnostics to use the diagnostics provided by the client library that provides
support for event counters, redacting device fields, and other subscriber data.

This test does not exercise many counters to keep it from being brittle, however you can see the full set of diffs including redaction logic (copied from home assistant) for diagnostics provided here:
https://github.com/allenporter/python-google-nest-sdm/compare/1.5.1...1.6.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
