### PR TITLE
Add WS API to adjust incorrect energy statistics

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -89,6 +89,7 @@ _LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+
 SERVICE_PURGE = "purge"
 SERVICE_PURGE_ENTITIES = "purge_entities"
 SERVICE_ENABLE = "enable"

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -89,12 +89,10 @@ _LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-
-SERVICE_ADJUST_STATISTICS = "adjust_statistics"
-SERVICE_DISABLE = "disable"
-SERVICE_ENABLE = "enable"
 SERVICE_PURGE = "purge"
 SERVICE_PURGE_ENTITIES = "purge_entities"
+SERVICE_ENABLE = "enable"
+SERVICE_DISABLE = "disable"
 
 ATTR_KEEP_DAYS = "keep_days"
 ATTR_REPACK = "repack"
@@ -121,23 +119,6 @@ SERVICE_PURGE_ENTITIES_SCHEMA = vol.Schema(
 ).extend(cv.ENTITY_SERVICE_FIELDS)
 SERVICE_ENABLE_SCHEMA = vol.Schema({})
 SERVICE_DISABLE_SCHEMA = vol.Schema({})
-
-ATTR_SUM_ADJUSTMENT = "sum_adjustment"
-ATTR_START_TIME = "start_time"
-ATTR_STATISTIC_ID = "statistic_id"
-ATTR_TABLE = "table"
-SERVICE_ADJUST_STATISTICS_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_STATISTIC_ID, "id"): vol.Any(
-            statistics.validate_statistic_id, cv.entity_id
-        ),
-        vol.Required(ATTR_START_TIME): cv.datetime,
-        vol.Required(ATTR_SUM_ADJUSTMENT): vol.Coerce(float),
-        vol.Optional(ATTR_TABLE, default="statistics"): vol.In(
-            ("statistics", "statistics_short_term")
-        ),
-    }
-)
 
 DEFAULT_URL = "sqlite:///{hass_config_path}"
 DEFAULT_DB_FILE = "home-assistant_v2.db"
@@ -370,22 +351,6 @@ def _async_register_services(hass, instance):
         schema=SERVICE_DISABLE_SCHEMA,
     )
 
-    async def async_handle_adjust_statistics(service: ServiceCall) -> None:
-        """Handle calls to the adjust statistics service."""
-        statistic_id = service.data[ATTR_STATISTIC_ID]
-        start_time = service.data[ATTR_START_TIME]
-        sum_adjustment = service.data[ATTR_SUM_ADJUSTMENT]
-        table = service.data[ATTR_TABLE]
-
-        instance.do_adjust_statistics(statistic_id, start_time, sum_adjustment, table)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ADJUST_STATISTICS,
-        async_handle_adjust_statistics,
-        schema=SERVICE_ADJUST_STATISTICS_SCHEMA,
-    )
-
 
 class RecorderTask(abc.ABC):
     """ABC for recorder tasks."""
@@ -503,7 +468,6 @@ class AdjustStatisticsTask(RecorderTask):
     statistic_id: str
     start_time: datetime
     sum_adjustment: float
-    table: str
 
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
@@ -512,13 +476,12 @@ class AdjustStatisticsTask(RecorderTask):
             self.statistic_id,
             self.start_time,
             self.sum_adjustment,
-            self.table,
         ):
             return
         # Schedule a new adjust statistics task if this one didn't finish
         instance.queue.put(
             AdjustStatisticsTask(
-                self.statistic_id, self.start_time, self.sum_adjustment, self.table
+                self.statistic_id, self.start_time, self.sum_adjustment
             )
         )
 
@@ -737,12 +700,6 @@ class Recorder(threading.Thread):
             start = statistics.get_start_time()
         self.queue.put(StatisticsTask(start))
 
-    def do_adjust_statistics(self, statistic_id, start_time, sum_adjustment, table):
-        """Adjust statistics."""
-        self.queue.put(
-            AdjustStatisticsTask(statistic_id, start_time, sum_adjustment, table)
-        )
-
     @callback
     def async_register(self, shutdown_task, hass_started):
         """Post connection initialize."""
@@ -827,6 +784,11 @@ class Recorder(threading.Thread):
         """Trigger the hourly statistics run."""
         start = statistics.get_start_time()
         self.queue.put(StatisticsTask(start))
+
+    @callback
+    def async_adjust_statistics(self, statistic_id, start_time, sum_adjustment):
+        """Adjust statistics."""
+        self.queue.put(AdjustStatisticsTask(statistic_id, start_time, sum_adjustment))
 
     @callback
     def async_clear_statistics(self, statistic_ids):

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1306,7 +1306,6 @@ def adjust_statistics(
     statistic_id: str,
     start_time: datetime,
     sum_adjustment: float,
-    table: str,
 ) -> bool:
     """Process an add_statistics job."""
 
@@ -1317,12 +1316,17 @@ def adjust_statistics(
         if statistic_id not in metadata:
             return True
 
-        _adjust_sum_statistics(
-            session,
-            Statistics if table == "statistics" else StatisticsShortTerm,
-            metadata[statistic_id][0],
-            start_time,
-            sum_adjustment,
+        tables: tuple[type[Statistics | StatisticsShortTerm], ...] = (
+            Statistics,
+            StatisticsShortTerm,
         )
+        for table in tables:
+            _adjust_sum_statistics(
+                session,
+                table,
+                metadata[statistic_id][0],
+                start_time,
+                sum_adjustment,
+            )
 
     return True

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1309,7 +1309,7 @@ def adjust_statistics(
 ) -> bool:
     """Process an add_statistics job."""
 
-    with session_scope(session=instance.get_session()) as session:  # type: ignore
+    with session_scope(session=instance.get_session()) as session:  # type: ignore[misc]
         metadata = get_metadata_with_session(
             instance.hass, session, statistic_ids=(statistic_id,)
         )

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -113,7 +113,7 @@ def ws_update_statistics_metadata(
         vol.Required("type"): "recorder/adjust_sum_statistics",
         vol.Required("statistic_id"): str,
         vol.Required("start_time"): str,
-        vol.Required("adjustment"): float,
+        vol.Required("adjustment"): vol.Any(float, int),
     }
 )
 @callback
@@ -126,7 +126,7 @@ def ws_adjust_sum_statistics(
     if start_time := dt_util.parse_datetime(start_time_str):
         start_time = dt_util.as_utc(start_time)
     else:
-        connection.send_error(msg["id"], "invalid_start_time", "Invalid start_time")
+        connection.send_error(msg["id"], "invalid_start_time", "Invalid start time")
         return
 
     hass.data[DATA_INSTANCE].async_adjust_statistics(

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -23,14 +23,14 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 @callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the recorder websocket API."""
-    websocket_api.async_register_command(hass, ws_adjust_sum_statistics)
-    websocket_api.async_register_command(hass, ws_backup_end)
-    websocket_api.async_register_command(hass, ws_backup_start)
+    websocket_api.async_register_command(hass, ws_validate_statistics)
     websocket_api.async_register_command(hass, ws_clear_statistics)
     websocket_api.async_register_command(hass, ws_get_statistics_metadata)
     websocket_api.async_register_command(hass, ws_update_statistics_metadata)
     websocket_api.async_register_command(hass, ws_info)
-    websocket_api.async_register_command(hass, ws_validate_statistics)
+    websocket_api.async_register_command(hass, ws_backup_end)
+    websocket_api.async_register_command(hass, ws_backup_start)
+    websocket_api.async_register_command(hass, ws_adjust_sum_statistics)
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.util import dt as dt_util
 
 from .const import DATA_INSTANCE, MAX_QUEUE_BACKLOG
 from .statistics import list_statistic_ids, validate_statistics
@@ -22,13 +23,14 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 @callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the recorder websocket API."""
-    websocket_api.async_register_command(hass, ws_validate_statistics)
+    websocket_api.async_register_command(hass, ws_adjust_sum_statistics)
+    websocket_api.async_register_command(hass, ws_backup_end)
+    websocket_api.async_register_command(hass, ws_backup_start)
     websocket_api.async_register_command(hass, ws_clear_statistics)
     websocket_api.async_register_command(hass, ws_get_statistics_metadata)
     websocket_api.async_register_command(hass, ws_update_statistics_metadata)
     websocket_api.async_register_command(hass, ws_info)
-    websocket_api.async_register_command(hass, ws_backup_start)
-    websocket_api.async_register_command(hass, ws_backup_end)
+    websocket_api.async_register_command(hass, ws_validate_statistics)
 
 
 @websocket_api.websocket_command(
@@ -101,6 +103,34 @@ def ws_update_statistics_metadata(
     """Update statistics metadata for a statistic_id."""
     hass.data[DATA_INSTANCE].async_update_statistics_metadata(
         msg["statistic_id"], msg["unit_of_measurement"]
+    )
+    connection.send_result(msg["id"])
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "recorder/adjust_sum_statistics",
+        vol.Required("statistic_id"): str,
+        vol.Required("start_time"): str,
+        vol.Required("adjustment"): float,
+    }
+)
+@callback
+def ws_adjust_sum_statistics(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Adjust sum statistics."""
+    start_time_str = msg["start_time"]
+
+    if start_time := dt_util.parse_datetime(start_time_str):
+        start_time = dt_util.as_utc(start_time)
+    else:
+        connection.send_error(msg["id"], "invalid_start_time", "Invalid start_time")
+        return
+
+    hass.data[DATA_INSTANCE].async_adjust_statistics(
+        msg["statistic_id"], start_time, msg["adjustment"]
     )
     connection.send_result(msg["id"])
 

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -28,8 +28,8 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_get_statistics_metadata)
     websocket_api.async_register_command(hass, ws_update_statistics_metadata)
     websocket_api.async_register_command(hass, ws_info)
-    websocket_api.async_register_command(hass, ws_backup_end)
     websocket_api.async_register_command(hass, ws_backup_start)
+    websocket_api.async_register_command(hass, ws_backup_end)
     websocket_api.async_register_command(hass, ws_adjust_sum_statistics)
 
 

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -34,7 +34,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import get_test_home_assistant, mock_registry
+from .common import async_wait_recording_done_without_instance
+
+from tests.common import (
+    async_init_recorder_component,
+    get_test_home_assistant,
+    mock_registry,
+)
 from tests.components.recorder.common import wait_recording_done
 
 ORIG_TZ = dt_util.DEFAULT_TIME_ZONE
@@ -327,10 +333,11 @@ def test_statistics_duplicated(hass_recorder, caplog):
         caplog.clear()
 
 
-def test_external_statistics(hass_recorder, caplog):
+async def test_external_statistics(hass, hass_ws_client, caplog):
     """Test inserting external statistics."""
-    hass = hass_recorder()
-    wait_recording_done(hass)
+    client = await hass_ws_client()
+    await async_init_recorder_component(hass)
+
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
 
@@ -363,7 +370,7 @@ def test_external_statistics(hass_recorder, caplog):
     async_add_external_statistics(
         hass, external_metadata, (external_statistics1, external_statistics2)
     )
-    wait_recording_done(hass)
+    await async_wait_recording_done_without_instance(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
         "test:total_energy_import": [
@@ -439,7 +446,7 @@ def test_external_statistics(hass_recorder, caplog):
         "sum": 6,
     }
     async_add_external_statistics(hass, external_metadata, (external_statistics,))
-    wait_recording_done(hass)
+    await async_wait_recording_done_without_instance(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
         "test:total_energy_import": [
@@ -479,7 +486,7 @@ def test_external_statistics(hass_recorder, caplog):
         "sum": 5,
     }
     async_add_external_statistics(hass, external_metadata, (external_statistics,))
-    wait_recording_done(hass)
+    await async_wait_recording_done_without_instance(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
         "test:total_energy_import": [
@@ -508,18 +515,19 @@ def test_external_statistics(hass_recorder, caplog):
         ]
     }
 
-    # Adjust the inserted statistics
-    hass.services.call(
-        "recorder",
-        "adjust_statistics",
+    await client.send_json(
         {
+            "id": 1,
+            "type": "recorder/adjust_sum_statistics",
             "statistic_id": "test:total_energy_import",
             "start_time": period2.isoformat(),
-            "sum_adjustment": 1000,
-        },
-        blocking=True,
+            "adjustment": 1000.0,
+        }
     )
-    wait_recording_done(hass)
+    response = await client.receive_json()
+    assert response["success"]
+
+    await async_wait_recording_done_without_instance(hass)
     stats = statistics_during_period(hass, zero, period="hour")
     assert stats == {
         "test:total_energy_import": [

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -508,6 +508,46 @@ def test_external_statistics(hass_recorder, caplog):
         ]
     }
 
+    # Adjust the inserted statistics
+    hass.services.call(
+        "recorder",
+        "adjust_statistics",
+        {
+            "statistic_id": "test:total_energy_import",
+            "start_time": period2.isoformat(),
+            "sum_adjustment": 1000,
+        },
+        blocking=True,
+    )
+    wait_recording_done(hass)
+    stats = statistics_during_period(hass, zero, period="hour")
+    assert stats == {
+        "test:total_energy_import": [
+            {
+                "statistic_id": "test:total_energy_import",
+                "start": period1.isoformat(),
+                "end": (period1 + timedelta(hours=1)).isoformat(),
+                "max": approx(1.0),
+                "mean": approx(2.0),
+                "min": approx(3.0),
+                "last_reset": None,
+                "state": approx(4.0),
+                "sum": approx(5.0),
+            },
+            {
+                "statistic_id": "test:total_energy_import",
+                "start": period2.isoformat(),
+                "end": (period2 + timedelta(hours=1)).isoformat(),
+                "max": None,
+                "mean": None,
+                "min": None,
+                "last_reset": None,
+                "state": approx(1.0),
+                "sum": approx(1003.0),
+            },
+        ]
+    }
+
 
 def test_external_statistics_errors(hass_recorder, caplog):
     """Test validation of external statistics."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS API `recorder/adjust_sum_statistics` which allows adjusting incorrect energy statistics.

The API accepts a statistic id (same as entity_id in most cases), a start time and an adjustment.

All statistics created at or later than the given start time is adjusted by the requested amount.

Note that no unit conversion is done; the adjustment must be in the unit used by the database:
- kWh for energy
- m³ for gas

Example to adjust sum statistics for sensor.total_energy up by 7MWh, starting at midnight new year's eve:
```json
{
    "type": "recorder/adjust_sum_statistics",
    "statistic_id": "sensor.total_energy",
    "start_time": "2022-01-01 00:00:00Z",
    "adjustment": 7000.0
}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
