### PR TITLE
Ensure diagnostics redaction can handle lists of lists

### DIFF
--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -2,17 +2,17 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import Any, TypeVar
+from typing import Any
 
 from homeassistant.core import callback
 
 from .const import REDACTED
 
-T = TypeVar("T")
-
 
 @callback
-def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
+def async_redact_data(
+    data: list | dict[str, Any], to_redact: Iterable[Any]
+) -> list | dict[str, Any]:
     """Redact sensitive data in a dict."""
     if not isinstance(data, (Mapping, list)):
         return data

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
-from typing import Any
+from typing import Any, TypeVar
 
 from homeassistant.core import callback
 
 from .const import REDACTED
 
+T = TypeVar("T")
+
 
 @callback
-def async_redact_data(data: Mapping, to_redact: Iterable[Any]) -> Mapping[Any, Any]:
+def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
     """Redact sensitive data in a dict."""
     if not isinstance(data, (Mapping, list)):
         return data

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from homeassistant.core import callback
 
 from .const import REDACTED
 
-T = TypeVar("T", list, dict[str, Any])
+T = TypeVar("T")
 
 
 @callback
@@ -18,7 +18,7 @@ def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
         return data
 
     if isinstance(data, list):
-        return [async_redact_data(val, to_redact) for val in data]
+        return cast(T, [async_redact_data(val, to_redact) for val in data])
 
     redacted = {**data}
 
@@ -30,4 +30,4 @@ def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
         elif isinstance(value, list):
             redacted[key] = [async_redact_data(item, to_redact) for item in value]
 
-    return redacted
+    return cast(T, redacted)

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from copy import deepcopy
 from typing import Any, TypeVar
 
 from homeassistant.core import callback
@@ -18,17 +17,17 @@ def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
     if not isinstance(data, (Mapping, list)):
         return data
 
-    redacted = deepcopy(data)
-
-    if isinstance(redacted, dict):
-        for key, value in redacted.items():
-            if key in to_redact:
-                redacted[key] = REDACTED
-            elif isinstance(value, dict):
-                redacted[key] = async_redact_data(value, to_redact)
-            elif isinstance(value, list):
-                redacted[key] = [async_redact_data(item, to_redact) for item in value]
-    elif isinstance(redacted, list):
+    if isinstance(data, list):
         return [async_redact_data(val, to_redact) for val in data]
+
+    redacted = {**data}
+
+    for key, value in redacted.items():
+        if key in to_redact:
+            redacted[key] = REDACTED
+        elif isinstance(value, dict):
+            redacted[key] = async_redact_data(value, to_redact)
+        elif isinstance(value, list):
+            redacted[key] = [async_redact_data(item, to_redact) for item in value]
 
     return redacted

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -2,17 +2,17 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import Any, TypeVar
 
 from homeassistant.core import callback
 
 from .const import REDACTED
 
+T = TypeVar("T")
+
 
 @callback
-def async_redact_data(
-    data: list | dict[str, Any], to_redact: Iterable[Any]
-) -> list | dict[str, Any]:
+def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
     """Redact sensitive data in a dict."""
     if not isinstance(data, (Mapping, list)):
         return data

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -12,7 +12,7 @@ T = TypeVar("T")
 
 
 @callback
-def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
+def async_redact_data(data: type[T], to_redact: Iterable[Any]) -> type[T]:
     """Redact sensitive data in a dict."""
     if not isinstance(data, (Mapping, list)):
         return data

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -12,7 +12,7 @@ T = TypeVar("T")
 
 
 @callback
-def async_redact_data(data: type[T], to_redact: Iterable[Any]) -> type[T]:
+def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
     """Redact sensitive data in a dict."""
     if not isinstance(data, (Mapping, list)):
         return data

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -8,7 +8,7 @@ from homeassistant.core import callback
 
 from .const import REDACTED
 
-T = TypeVar("T")
+T = TypeVar("T", list, dict[str, Any])
 
 
 @callback

--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -29,7 +29,6 @@ def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
             elif isinstance(value, list):
                 redacted[key] = [async_redact_data(item, to_redact) for item in value]
     elif isinstance(redacted, list):
-        for idx, value in enumerate(redacted):
-            redacted[idx] = async_redact_data(value, to_redact)
+        return [async_redact_data(val, to_redact) for val in data]
 
     return redacted

--- a/tests/components/diagnostics/test_util.py
+++ b/tests/components/diagnostics/test_util.py
@@ -1,0 +1,33 @@
+"""Test Diagnostics utils."""
+from homeassistant.components.diagnostics import REDACTED, async_redact_data
+
+
+def test_redact():
+    """Test the async_redact_data helper."""
+    data = {
+        "key1": "value1",
+        "key2": ["value2_a", "value2_b"],
+        "key3": [["value_3a", "value_3b"], ["value_3c", "value_3d"]],
+        "key4": {
+            "key4_1": "value4_1",
+            "key4_2": ["value4_2a", "value4_2b"],
+            "key4_3": [["value4_3a", "value4_3b"], ["value4_3c", "value4_3d"]],
+        },
+    }
+
+    to_redact = {
+        "key1",
+        "key3",
+        "key4_1",
+    }
+
+    assert async_redact_data(data, to_redact) == {
+        "key1": REDACTED,
+        "key2": ["value2_a", "value2_b"],
+        "key3": REDACTED,
+        "key4": {
+            "key4_1": REDACTED,
+            "key4_2": ["value4_2a", "value4_2b"],
+            "key4_3": [["value4_3a", "value4_3b"], ["value4_3c", "value4_3d"]],
+        },
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While building diagnostics for SimpliSafe, I noticed that its API can return lists of lists – for example:

```python
{
    "rssi": [
        [
            1600935204,
            -43,
        ],
    ],
}
```

This type of data structure causes `homeassistant.components.diagnostics.async_redact_data` to fail. This PR adjusts the logic to account for this scenario.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
