### PR TITLE
Add state classes to AdGuard Home sensors

### DIFF
--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, TIME_MILLISECONDS
 from homeassistant.core import HomeAssistant
@@ -114,6 +114,8 @@ class AdGuardHomeDNSQueriesSensor(AdGuardHomeSensor):
 class AdGuardHomeBlockedFilteringSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home blocked by filtering sensor."""
 
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
         super().__init__(
@@ -154,6 +156,8 @@ class AdGuardHomePercentageBlockedSensor(AdGuardHomeSensor):
 class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home replaced by parental control sensor."""
 
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
         super().__init__(
@@ -172,6 +176,8 @@ class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
 
 class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home replaced by safe browsing sensor."""
+
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
@@ -192,6 +198,8 @@ class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
 class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home replaced by safe search sensor."""
 
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
         super().__init__(
@@ -210,6 +218,8 @@ class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
 
 class AdGuardHomeAverageProcessingTimeSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home average processing time sensor."""
+
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
@@ -230,6 +240,8 @@ class AdGuardHomeAverageProcessingTimeSensor(AdGuardHomeSensor):
 
 class AdGuardHomeRulesCountSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home rules count sensor."""
+
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -114,7 +114,7 @@ class AdGuardHomeDNSQueriesSensor(AdGuardHomeSensor):
 class AdGuardHomeBlockedFilteringSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home blocked by filtering sensor."""
 
-    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
@@ -156,7 +156,7 @@ class AdGuardHomePercentageBlockedSensor(AdGuardHomeSensor):
 class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home replaced by parental control sensor."""
 
-    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
@@ -177,7 +177,7 @@ class AdGuardHomeReplacedParentalSensor(AdGuardHomeSensor):
 class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home replaced by safe browsing sensor."""
 
-    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""
@@ -198,7 +198,7 @@ class AdGuardHomeReplacedSafeBrowsingSensor(AdGuardHomeSensor):
 class AdGuardHomeReplacedSafeSearchSensor(AdGuardHomeSensor):
     """Defines a AdGuard Home replaced by safe search sensor."""
 
-    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
 
     def __init__(self, adguard: AdGuardHome, entry: ConfigEntry) -> None:
         """Initialize AdGuard Home sensor."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `_attr_state_class` to suitable Adguard sensors to enable long-term statistics for them.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io


An off-topic question but I don't know where is the best place to ask: I found out the sensors for Adguard are updated separately calling the `adguard.stats.*` API, but some of them are redundant since the APIs just retrieve results from `/stats` endpoint and extracts the requested fields. We could perhaps share a `AdguardHomeData` object across all sensors that is responsible for updating all stats and cache the results so some API calls can be avoided. If it's worth doing I can create PRs for refactors.

Also, it seems that we can remove some boilerplate code (`AdguardHomeXXXXSensor`) by creating a list of `SensorEntityDescription` object and pass this to a more generic `AdguardHomeSensor` to set the descriptions, something like [apcupsd](https://github.com/home-assistant/core/blob/545e321002fd4edd349083a4a6aa057e42280ea7/homeassistant/components/apcupsd/sensor.py#L34-L386).

