### PR TITLE
Make `this` variable available in template entities

### DIFF
--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -27,7 +27,11 @@ from homeassistant.helpers.event import (
     TrackTemplateResult,
     async_track_template_result,
 )
-from homeassistant.helpers.template import Template, result_as_boolean
+from homeassistant.helpers.template import (
+    Template,
+    TemplateStateFromEntityId,
+    result_as_boolean,
+)
 
 from .const import (
     CONF_ATTRIBUTE_TEMPLATES,
@@ -365,7 +369,7 @@ class TemplateEntity(Entity):
         template_var_tups = []
         has_availability_template = False
 
-        values = {ATTR_ENTITY_ID: self.entity_id}
+        values = {"this": TemplateStateFromEntityId(self.hass, self.entity_id)}
 
         for template, attributes in self._template_attrs.items():
             template_var_tup = TrackTemplate(template, values)

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -364,12 +364,11 @@ class TemplateEntity(Entity):
     async def _async_template_startup(self, *_) -> None:
         template_var_tups = []
         has_availability_template = False
-        this = None
-        if state := self.hass.states.get(self.entity_id):
-            this = state.as_dict()
-        variables = {"this": this}
+
+        values = {ATTR_ENTITY_ID: self.entity_id}
+
         for template, attributes in self._template_attrs.items():
-            template_var_tup = TrackTemplate(template, variables)
+            template_var_tup = TrackTemplate(template, values)
             is_availability_template = False
             for attribute in attributes:
                 # pylint: disable-next=protected-access

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -364,8 +364,12 @@ class TemplateEntity(Entity):
     async def _async_template_startup(self, *_) -> None:
         template_var_tups = []
         has_availability_template = False
+        this = None
+        if state := self.hass.states.get(self.entity_id):
+            this = state.as_dict()
+        variables = {"this": this}
         for template, attributes in self._template_attrs.items():
-            template_var_tup = TrackTemplate(template, None)
+            template_var_tup = TrackTemplate(template, variables)
             is_availability_template = False
             for attribute in attributes:
                 # pylint: disable-next=protected-access

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -819,10 +819,6 @@ class TemplateStateBase(State):
         self._collect_state()
         return self._state.__eq__(other)
 
-    def __repr__(self) -> str:
-        """Representation of Template State."""
-        return f"<template TemplateState({self._state.__repr__()})>"
-
 
 class TemplateState(TemplateStateBase):
     """Class to represent a state object in a template."""
@@ -835,6 +831,10 @@ class TemplateState(TemplateStateBase):
         """Initialize template state."""
         super().__init__(hass, collect, state.entity_id)
         self._state = state
+
+    def __repr__(self) -> str:
+        """Representation of Template State."""
+        return f"<template TemplateState({self._state.__repr__()})>"
 
 
 class TemplateStateFromEntityId(TemplateStateBase):
@@ -851,6 +851,10 @@ class TemplateStateFromEntityId(TemplateStateBase):
         state = self._hass.states.get(self._entity_id)
         assert state
         return state
+
+    def __repr__(self) -> str:
+        """Representation of Template State."""
+        return f"<template TemplateStateFromEntityId({self._entity_id})>"
 
 
 def _collect_state(hass: HomeAssistant, entity_id: str) -> None:

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -632,7 +632,7 @@ async def test_sun_renders_once_per_sensor(hass, start_ha):
                 "platform": "template",
                 "sensors": {
                     "test_template_sensor": {
-                        "value_template": "{{ state_attr(entity_id, 'test') }}: {{ entity_id }}",
+                        "value_template": "{{ this.attributes.test }}: {{ this.entity_id }}",
                         "attribute_templates": {
                             "test": "It {{ states.sensor.test_state.state }}"
                         },
@@ -642,7 +642,7 @@ async def test_sun_renders_once_per_sensor(hass, start_ha):
         },
     ],
 )
-async def test_entity_id_variable(hass, start_ha):
+async def test_this_variable(hass, start_ha):
     """Test template."""
     assert hass.states.get(TEST_NAME).state == "It: " + TEST_NAME
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -631,6 +631,35 @@ async def test_sun_renders_once_per_sensor(hass, start_ha):
             "sensor": {
                 "platform": "template",
                 "sensors": {
+                    "test_template_sensor": {
+                        "value_template": "{{ state_attr(entity_id, 'test') }}: {{ entity_id }}",
+                        "attribute_templates": {
+                            "test": "It {{ states.sensor.test_state.state }}"
+                        },
+                    }
+                },
+            },
+        },
+    ],
+)
+async def test_entity_id_variable(hass, start_ha):
+    """Test template."""
+    assert hass.states.get(TEST_NAME).state == "It: " + TEST_NAME
+
+    hass.states.async_set("sensor.test_state", "Works")
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert hass.states.get(TEST_NAME).state == "It Works: " + TEST_NAME
+
+
+@pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "sensor": {
+                "platform": "template",
+                "sensors": {
                     "test": {
                         "value_template": "{{ ((states.sensor.test.state or 0) | int) + 1 }}",
                     },


### PR DESCRIPTION
## Proposed change
This PR makes the variable `this` available in template entities, which simplifies the use of self-referencing template entities.
Because, without this, we have to repeat the entity id every time.
If we can solve this without explicitly spelling the entity id, code can be re-used much better.

As a side-effect, this will allow to use `variables`-like patterns,
where attributes can be used as variables to calculate subsequent attributes or state.

Example:
```yaml
template:
  sensor:
    - name: test
      state: "{{ this.attributes.test }}"
      # not: "{{ state_attr('sensor.test', 'test' }}"
      attributes:
        test: "{{ now() }}"
```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22211

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
