### PR TITLE
Fix tradfri coordinator error handling

### DIFF
--- a/homeassistant/components/tradfri/coordinator.py
+++ b/homeassistant/components/tradfri/coordinator.py
@@ -51,8 +51,6 @@ class TradfriDeviceDataUpdateCoordinator(DataUpdateCoordinator[Device]):
     @callback
     def _observe_update(self, device: Device) -> None:
         """Update the coordinator for a device when a change is detected."""
-        self.update_interval = timedelta(seconds=SCAN_INTERVAL)  # Reset update interval
-
         self.async_set_updated_data(data=device)
 
     @callback
@@ -90,8 +88,11 @@ class TradfriDeviceDataUpdateCoordinator(DataUpdateCoordinator[Device]):
                     duration=0,
                 )
                 await self.api(cmd)
-            except RequestError as exc:
-                await self._handle_exception(exc)
+            except RequestError as err:
+                raise UpdateFailed(f"Error communicating with API: {err}.") from err
+
+            # Reset update interval
+            self.update_interval = timedelta(seconds=SCAN_INTERVAL)
 
         return self.device
 

--- a/homeassistant/components/tradfri/coordinator.py
+++ b/homeassistant/components/tradfri/coordinator.py
@@ -80,10 +80,7 @@ class TradfriDeviceDataUpdateCoordinator(DataUpdateCoordinator[Device]):
                 self._exception = None  # Clear stored exception
                 raise exc  # pylint: disable-msg=raising-bad-type
         except RequestError as err:
-            raise UpdateFailed(
-                f"Error communicating with API: {err}. Try unplugging and replugging your "
-                f"IKEA gateway."
-            ) from err
+            raise UpdateFailed(f"Error communicating with API: {err}.") from err
 
         if not self.data or not self.last_update_success:  # Start subscription
             try:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix the observation error callback parameters. It had the wrong signature.
- Raise UpdateFailed inside coordinator update method on error.
- Do not advice user to restart gateway on error as that may not be the problem when a single device fails.
- Clean up some comments and move interval reset.
- Note that this should not go out in core-2022.2 since the coordinator is only on dev.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
