### PR TITLE
Add activity statistics to Sonos diagnostics

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -193,6 +193,7 @@ class SonosDiscoveryManager:
 
     async def _async_stop_event_listener(self, event: Event | None = None) -> None:
         for speaker in self.data.discovered.values():
+            speaker.activity_stats.log_report()
             speaker.event_stats.log_report()
         await asyncio.gather(
             *(speaker.async_offline() for speaker in self.data.discovered.values())

--- a/homeassistant/components/sonos/diagnostics.py
+++ b/homeassistant/components/sonos/diagnostics.py
@@ -130,5 +130,6 @@ async def async_generate_speaker_info(
         if s is speaker
     }
     payload["media"] = await async_generate_media_info(hass, speaker)
+    payload["activity_stats"] = speaker.activity_stats.report()
     payload["event_stats"] = speaker.event_stats.report()
     return payload

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -62,7 +62,7 @@ from .const import (
 )
 from .favorites import SonosFavorites
 from .helpers import soco_error
-from .statistics import EventStatistics
+from .statistics import ActivityStatistics, EventStatistics
 
 NEVER_TIME = -1200.0
 EVENT_CHARGING = {
@@ -177,6 +177,7 @@ class SonosSpeaker:
         self._event_dispatchers: dict[str, Callable] = {}
         self._last_activity: float = NEVER_TIME
         self._last_event_cache: dict[str, Any] = {}
+        self.activity_stats: ActivityStatistics = ActivityStatistics(self.zone_name)
         self.event_stats: EventStatistics = EventStatistics(self.zone_name)
 
         # Scheduled callback handles
@@ -528,6 +529,7 @@ class SonosSpeaker:
         """Track the last activity on this speaker, set availability and resubscribe."""
         _LOGGER.debug("Activity on %s from %s", self.zone_name, source)
         self._last_activity = time.monotonic()
+        self.activity_stats.activity(source, self._last_activity)
         was_available = self.available
         self.available = True
         if not was_available:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar to #64845, this adds statistics on the types of activity seen on a given Sonos speaker. This activity determines if a speaker should be marked available. Previous issue reports have mentioned speakers being unexpectedly marked as both available/unavailable and I hope this will provide more insight.

Example payload addition (per speaker):
```json
            "activity_stats" : {
               "AVTransport subscription" : {
                  "count" : 1,
                  "last_seen" : 1748035.87648851
               },
               "AlarmClock subscription" : {
                  "count" : 1,
                  "last_seen" : 1748035.91362103
               },
               "ContentDirectory subscription" : {
                  "count" : 1,
                  "last_seen" : 1748035.85474241
               },
               "DeviceProperties subscription" : {
                  "count" : 1,
                  "last_seen" : 1748035.83606669
               },
               "RenderingControl subscription" : {
                  "count" : 1,
                  "last_seen" : 1748035.85869822
               },
               "SonosSpeaker.update_media" : {
                  "count" : 1,
                  "last_seen" : 1748035.91147692
               },
               "SonosSpeaker.update_volume" : {
                  "count" : 1,
                  "last_seen" : 1748035.67688027
               },
               "ZoneGroupTopology subscription" : {
                  "count" : 1,
                  "last_seen" : 1748035.81670208
               },
               "discovery" : {
                  "count" : 1,
                  "last_seen" : 1748052.0931729
               }
            },
```
The `last_seen` timestamp logged per activity type can be directly compared to the aggregate `_last_activity` timestamp per-speaker and also the `current_timestamp` provided at the root of the diagnostics payload.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
