### PR TITLE
Add events on cloud connect and disconnect

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -1,6 +1,6 @@
 """Component to integrate the Home Assistant cloud."""
 import asyncio
-from typing import Final
+from enum import Enum
 
 from hass_nabucasa import Cloud
 import voluptuous as vol
@@ -47,9 +47,6 @@ from .const import (
     MODE_PROD,
 )
 from .prefs import CloudPreferences
-
-EVENT_CLOUD_CONNECTED: Final = "cloud_connected"
-EVENT_CLOUD_DISCONNECTED: Final = "cloud_disconnected"
 
 DEFAULT_MODE = MODE_PROD
 
@@ -192,6 +189,13 @@ def is_cloudhook_request(request):
     return isinstance(request, MockRequest)
 
 
+class CloudConnectionState(Enum):
+    """Cloud connection state."""
+
+    CLOUD_CONNECTED = "cloud_connected"
+    CLOUD_DISCONNECTED = "cloud_disconnected"
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Initialize the Home Assistant cloud."""
     # Process configs
@@ -256,11 +260,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             Platform.TTS, DOMAIN, {}, config
         )
 
-        client.async_notify_connection_change(EVENT_CLOUD_CONNECTED)
+        client.async_notify_connection_change(CloudConnectionState.CLOUD_CONNECTED)
 
     async def _on_disconnect():
         """Handle cloud disconnect."""
-        client.async_notify_connection_change(EVENT_CLOUD_DISCONNECTED)
+        client.async_notify_connection_change(CloudConnectionState.CLOUD_DISCONNECTED)
 
     async def _on_initialized():
         """Update preferences."""

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -256,11 +256,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             Platform.TTS, DOMAIN, {}, config
         )
 
-        hass.bus.async_fire(EVENT_CLOUD_CONNECTED)
+        client.async_notify_connection_change(EVENT_CLOUD_CONNECTED)
 
     async def _on_disconnect():
         """Handle cloud disconnect."""
-        hass.bus.async_fire(EVENT_CLOUD_DISCONNECTED)
+        client.async_notify_connection_change(EVENT_CLOUD_DISCONNECTED)
 
     async def _on_initialized():
         """Update preferences."""

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -151,10 +151,9 @@ def async_is_connected(hass: HomeAssistant) -> bool:
     return DOMAIN in hass.data and hass.data[DOMAIN].iot.connected
 
 
-@bind_hass
 @callback
 def async_listen_connection_change(
-    hass: HomeAssistant, target: Callable[..., Any]
+    hass: HomeAssistant, target: Callable[[CloudConnectionState], None]
 ) -> Callable[[], None]:
     """Notify on connection state changes."""
     return async_dispatcher_connect(hass, SIGNAL_CLOUD_CONNECTION_STATE, target)

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 from collections.abc import Callable
 from enum import Enum
-from typing import Any
 
 from hass_nabucasa import Cloud
 import voluptuous as vol

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -47,7 +47,6 @@ class CloudClient(Interface):
         self._google_config: google_config.CloudGoogleConfig | None = None
         self._alexa_config_init_lock = asyncio.Lock()
         self._google_config_init_lock = asyncio.Lock()
-        self._listeners = []
 
     @property
     def base_path(self) -> Path:

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -256,14 +256,3 @@ class CloudClient(Interface):
     async def async_cloudhooks_update(self, data: dict[str, dict[str, str]]) -> None:
         """Update local list of cloudhooks."""
         await self._prefs.async_update(cloudhooks=data)
-
-    @callback
-    def async_listen_connection_change(self, listener):
-        """Listen for connection state changes."""
-        self._listeners.append(listener)
-
-    @callback
-    def async_notify_connection_change(self, state):
-        """Notify listeners about connections state changes."""
-        for listener in self._listeners:
-            listener(state)

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -47,6 +47,7 @@ class CloudClient(Interface):
         self._google_config: google_config.CloudGoogleConfig | None = None
         self._alexa_config_init_lock = asyncio.Lock()
         self._google_config_init_lock = asyncio.Lock()
+        self._listeners = []
 
     @property
     def base_path(self) -> Path:
@@ -255,3 +256,14 @@ class CloudClient(Interface):
     async def async_cloudhooks_update(self, data: dict[str, dict[str, str]]) -> None:
         """Update local list of cloudhooks."""
         await self._prefs.async_update(cloudhooks=data)
+
+    @callback
+    def async_listen_connection_change(self, listener):
+        """Listen for connection state changes."""
+        self._listeners.append(listener)
+
+    @callback
+    def async_notify_connection_change(self, state):
+        """Notify listeners about connections state changes."""
+        for listener in self._listeners:
+            listener(state)

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -158,7 +158,14 @@ async def test_on_connect(hass, mock_cloud_fixture):
     assert len(mock_load.mock_calls) == 0
 
     assert len(events) == 1
-    assert events[0] == cloud.EVENT_CLOUD_CONNECTED
+    assert events[-1] == cloud.EVENT_CLOUD_CONNECTED
+
+    assert len(cl.iot._on_disconnect) == 2
+    assert "async_setup" in str(cl.iot._on_disconnect[-1])
+    await cl.iot._on_disconnect[-1]()
+
+    assert len(events) == 2
+    assert events[-1] == cloud.EVENT_CLOUD_DISCONNECTED
 
 
 async def test_remote_ui_url(hass, mock_cloud_fixture):

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -137,13 +137,13 @@ async def test_on_connect(hass, mock_cloud_fixture):
 
     assert len(hass.states.async_entity_ids("binary_sensor")) == 0
 
-    events = []
+    cloud_states = []
 
-    def handle_event(event):
-        nonlocal events
-        events.append(event)
+    def handle_state(cloud_state):
+        nonlocal cloud_states
+        cloud_states.append(cloud_state)
 
-    cl.client.async_listen_connection_change(handle_event)
+    cl.client.async_listen_connection_change(handle_state)
 
     assert "async_setup" in str(cl.iot._on_connect[-1])
     await cl.iot._on_connect[-1]()
@@ -157,15 +157,15 @@ async def test_on_connect(hass, mock_cloud_fixture):
 
     assert len(mock_load.mock_calls) == 0
 
-    assert len(events) == 1
-    assert events[-1] == cloud.EVENT_CLOUD_CONNECTED
+    assert len(cloud_states) == 1
+    assert cloud_states[-1] == cloud.EVENT_CLOUD_CONNECTED
 
     assert len(cl.iot._on_disconnect) == 2
     assert "async_setup" in str(cl.iot._on_disconnect[-1])
     await cl.iot._on_disconnect[-1]()
 
-    assert len(events) == 2
-    assert events[-1] == cloud.EVENT_CLOUD_DISCONNECTED
+    assert len(cloud_states) == 2
+    assert cloud_states[-1] == cloud.EVENT_CLOUD_DISCONNECTED
 
 
 async def test_remote_ui_url(hass, mock_cloud_fixture):

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -8,9 +8,11 @@ from homeassistant.components import cloud
 from homeassistant.components.cloud.const import DOMAIN
 from homeassistant.components.cloud.prefs import STORAGE_KEY
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Context, callback
+from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import async_setup_component
+
+from tests.common import async_capture_events
 
 
 async def test_constructor_loads_info_from_config(hass):
@@ -137,13 +139,7 @@ async def test_on_connect(hass, mock_cloud_fixture):
 
     assert len(hass.states.async_entity_ids("binary_sensor")) == 0
 
-    all_events = []
-
-    @callback
-    def capture_events(ev):
-        all_events.append(ev.event_type)
-
-    hass.bus.async_listen(cloud.EVENT_CLOUD_CONNECTED, capture_events)
+    events = async_capture_events(hass, cloud.EVENT_CLOUD_CONNECTED)
 
     assert "async_setup" in str(cl.iot._on_connect[-1])
     await cl.iot._on_connect[-1]()
@@ -157,7 +153,8 @@ async def test_on_connect(hass, mock_cloud_fixture):
 
     assert len(mock_load.mock_calls) == 0
 
-    assert all_events == [cloud.EVENT_CLOUD_CONNECTED]
+    assert len(events) == 1
+    assert events[0].event_type == cloud.EVENT_CLOUD_CONNECTED
 
 
 async def test_remote_ui_url(hass, mock_cloud_fixture):

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -158,14 +158,14 @@ async def test_on_connect(hass, mock_cloud_fixture):
     assert len(mock_load.mock_calls) == 0
 
     assert len(cloud_states) == 1
-    assert cloud_states[-1] == cloud.EVENT_CLOUD_CONNECTED
+    assert cloud_states[-1] == cloud.CloudConnectionState.CLOUD_CONNECTED
 
     assert len(cl.iot._on_disconnect) == 2
     assert "async_setup" in str(cl.iot._on_disconnect[-1])
     await cl.iot._on_disconnect[-1]()
 
     assert len(cloud_states) == 2
-    assert cloud_states[-1] == cloud.EVENT_CLOUD_DISCONNECTED
+    assert cloud_states[-1] == cloud.CloudConnectionState.CLOUD_DISCONNECTED
 
 
 async def test_remote_ui_url(hass, mock_cloud_fixture):

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -143,7 +143,7 @@ async def test_on_connect(hass, mock_cloud_fixture):
         nonlocal cloud_states
         cloud_states.append(cloud_state)
 
-    cl.client.async_listen_connection_change(handle_state)
+    cloud.async_listen_connection_change(hass, handle_state)
 
     assert "async_setup" in str(cl.iot._on_connect[-1])
     await cl.iot._on_connect[-1]()
@@ -163,6 +163,7 @@ async def test_on_connect(hass, mock_cloud_fixture):
     assert len(cl.iot._on_disconnect) == 2
     assert "async_setup" in str(cl.iot._on_disconnect[-1])
     await cl.iot._on_disconnect[-1]()
+    await hass.async_block_till_done()
 
     assert len(cloud_states) == 2
     assert cloud_states[-1] == cloud.CloudConnectionState.CLOUD_DISCONNECTED


### PR DESCRIPTION
Signed-off-by: cgtobi <cgtobi@gmail.com>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provide a mechanism for cloud dependent integrations to react upon connection changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
