### PR TITLE
Improve google calendar test coverage to 97%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -405,7 +405,6 @@ omit =
     homeassistant/components/goodwe/number.py
     homeassistant/components/goodwe/select.py
     homeassistant/components/goodwe/sensor.py
-    homeassistant/components/google/__init__.py
     homeassistant/components/google_cloud/tts.py
     homeassistant/components/google_maps/device_tracker.py
     homeassistant/components/google_pubsub/__init__.py

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -263,7 +263,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 def check_correct_scopes(hass, token_file, config):
     """Check for the correct scopes in file."""
-    creds = Storage(hass.config.path(TOKEN_FILE)).get()
+    creds = Storage(token_file).get()
     if not creds or not creds.scopes:
         return False
     target_scope = config[CONF_CALENDAR_ACCESS].scope

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -194,6 +194,7 @@ def do_authentication(hass, hass_config, config):
 
     def step2_exchange(now):
         """Keep trying to validate the user_code until it expires."""
+        _LOGGER.debug("Attempting to validate user code")
 
         # For some reason, oauth.step1_get_device_and_user_codes() returns a datetime
         # object without tzinfo. For the comparison below to work, it needs one.
@@ -251,6 +252,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         do_authentication(hass, config, conf)
     else:
         if not check_correct_scopes(token_file, conf):
+            _LOGGER.debug("Existing scopes are not sufficient, re-authenticating")
             do_authentication(hass, config, conf)
         else:
             do_setup(hass, config, conf)
@@ -365,6 +367,7 @@ def setup_services(
 
 def do_setup(hass, hass_config, config):
     """Run the setup after we have everything configured."""
+    _LOGGER.debug("Setting up integration")
     # Load calendars the user has configured
     hass.data[DATA_INDEX] = load_config(hass.config.path(YAML_DEVICES))
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -249,6 +249,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     token_file = hass.config.path(TOKEN_FILE)
     if not os.path.isfile(token_file):
+        _LOGGER.debug("Token file does not exist, authenticating for first time")
         do_authentication(hass, config, conf)
     else:
         if not check_correct_scopes(token_file, conf):

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -266,7 +266,7 @@ def check_correct_scopes(hass, token_file, config):
     creds = Storage(hass.config.path(TOKEN_FILE)).get()
     if not creds or not creds.scopes:
         return False
-    target_scope = config.get(CONF_CALENDAR_ACCESS).scope
+    target_scope = config[CONF_CALENDAR_ACCESS].scope
     return target_scope in creds.scopes
 
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -208,6 +208,7 @@ def do_authentication(hass, hass_config, config):
                 notification_id=NOTIFICATION_ID,
             )
             listener()
+            return
 
         try:
             credentials = oauth.step2_exchange(device_flow_info=dev_flow)

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -1,10 +1,24 @@
 """Test configuration and mocks for the google integration."""
-from unittest.mock import patch
+from collections.abc import Callable
+import os
+from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 
+from homeassistant.components.google import (
+    TOKEN_FILE,
+    YAML_DEVICES,
+    GoogleCalendarService,
+)
+from homeassistant.core import HomeAssistant
+
+ApiResult = Callable[[dict[str, Any]], None]
+
+CALENDAR_ID = "qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com"
+
 TEST_CALENDAR = {
-    "id": "qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com",
+    "id": CALENDAR_ID,
     "etag": '"3584134138943410"',
     "timeZone": "UTC",
     "accessRole": "reader",
@@ -34,3 +48,55 @@ def mock_next_event():
     )
     with patch_google_cal as google_cal_data:
         yield google_cal_data
+
+
+@pytest.fixture(autouse=True)
+def cleanup_files(hass: HomeAssistant) -> None:
+    """Test cleanup, remove any token files created during the test."""
+    yield
+    if os.path.exists(hass.config.path(TOKEN_FILE)):
+        os.remove(hass.config.path(TOKEN_FILE))
+    if os.path.exists(hass.config.path(YAML_DEVICES)):
+        os.remove(hass.config.path(YAML_DEVICES))
+
+
+@pytest.fixture
+def mock_events_list(
+    google_service: GoogleCalendarService,
+) -> Callable[[dict[str, Any]], None]:
+    """Fixture to construct a fake event list API response."""
+
+    def _put_result(response: dict[str, Any]) -> None:
+        google_service.return_value.get.return_value.events.return_value.list.return_value.execute.return_value = (
+            response
+        )
+        return
+
+    return _put_result
+
+
+@pytest.fixture
+def mock_calendars_list(
+    google_service: GoogleCalendarService,
+) -> ApiResult:
+    """Fixture to construct a fake calendar list API response."""
+
+    def _put_result(response: dict[str, Any]) -> None:
+        google_service.return_value.get.return_value.calendarList.return_value.list.return_value.execute.return_value = (
+            response
+        )
+        return
+
+    return _put_result
+
+
+@pytest.fixture
+def mock_insert_event(
+    google_service: GoogleCalendarService,
+) -> Mock:
+    """Fixture to create a mock to capture new events added to the API."""
+    insert_mock = Mock()
+    google_service.return_value.get.return_value.events.return_value.insert = (
+        insert_mock
+    )
+    return insert_mock

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -1,15 +1,11 @@
 """Test configuration and mocks for the google integration."""
 from collections.abc import Callable
-from pathlib import Path
-import shutil
 from typing import Any, Generator, TypeVar
 from unittest.mock import Mock, patch
-import uuid
 
 import pytest
 
 from homeassistant.components.google import GoogleCalendarService
-from homeassistant.core import HomeAssistant
 
 ApiResult = Callable[[dict[str, Any]], None]
 T = TypeVar("T")
@@ -48,31 +44,6 @@ def mock_next_event():
     )
     with patch_google_cal as google_cal_data:
         yield google_cal_data
-
-
-@pytest.fixture(autouse=True)
-def config_path(hass: HomeAssistant) -> Path:
-    """Test cleanup, remove any token files created during the test."""
-    path = Path(hass.config.path(str(uuid.uuid4())))
-    path.mkdir()
-    yield path
-    shutil.rmtree(path)
-
-
-@pytest.fixture(autouse=True)
-def token_filename(config_path: Path) -> YieldFixture[Path]:
-    """Test token filename."""
-    filename = config_path / "token"
-    with patch("homeassistant.components.google.TOKEN_FILE", new=filename):
-        yield filename
-
-
-@pytest.fixture(autouse=True)
-def yaml_devices_filename(config_path: Path) -> YieldFixture[Path]:
-    """Test token filename."""
-    filename = config_path / "google_calendars.yaml"
-    with patch("homeassistant.components.google.YAML_DEVICES", new=filename):
-        yield filename
 
 
 @pytest.fixture

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import copy
 from http import HTTPStatus
 from typing import Any
@@ -22,7 +21,6 @@ from homeassistant.components.google import (
     CONF_TRACK,
     DEVICE_SCHEMA,
     SERVICE_SCAN_CALENDARS,
-    GoogleCalendarService,
     do_setup,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -356,21 +354,6 @@ async def test_http_event_api_failure(hass, hass_client, google_service):
     # A failure to talk to the server results in an empty list of events
     events = await response.json()
     assert events == []
-
-
-@pytest.fixture
-def mock_events_list(
-    google_service: GoogleCalendarService,
-) -> Callable[[dict[str, Any]], None]:
-    """Fixture to construct a fake event list API response."""
-
-    def _put_result(response: dict[str, Any]) -> None:
-        google_service.return_value.get.return_value.events.return_value.list.return_value.execute.return_value = (
-            response
-        )
-        return
-
-    return _put_result
 
 
 async def test_http_api_event(hass, hass_client, google_service, mock_events_list):

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -1,11 +1,171 @@
 """The tests for the Google Calendar component."""
-from unittest.mock import patch
+from collections.abc import Awaitable, Callable
+import datetime
+import os
+from typing import Any, Generator, TypeVar
+from unittest.mock import Mock, call, patch
 
+from oauth2client.client import (
+    FlowExchangeError,
+    OAuth2Credentials,
+    OAuth2DeviceCodeError,
+)
+from oauth2client.file import Storage
+
+# from google.oauth2.credentials import Credentials
 import pytest
+import yaml
 
 import homeassistant.components.google as google
+from homeassistant.components.google import (
+    DOMAIN,
+    SERVICE_ADD_EVENT,
+    TOKEN_FILE,
+    YAML_DEVICES,
+    GoogleCalendarService,
+)
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
+
+from .conftest import CALENDAR_ID, ApiResult
+
+from tests.common import async_fire_time_changed
+
+# Typing helpers
+ComponentSetup = Callable[[], Awaitable[bool]]
+T = TypeVar("T")
+YieldFixture = Generator[T, None, None]
+
+
+CODE_CHECK_INTERVAL = 1
+CODE_CHECK_TIMEDELTA = datetime.timedelta(seconds=CODE_CHECK_INTERVAL)
+
+
+@pytest.fixture
+async def code_expiration_delta() -> datetime.timedelta:
+    """Fixture for code expiration time, defaulting to the future."""
+    return datetime.timedelta(minutes=3)
+
+
+@pytest.fixture
+async def mock_code_flow(
+    code_expiration_delta: datetime.timedelta,
+) -> YieldFixture[Mock]:
+    """Fixture for initiating OAuth flow."""
+    with patch(
+        "oauth2client.client.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+    ) as mock_flow:
+        mock_flow.return_value.user_code_expiry = utcnow() + code_expiration_delta
+        mock_flow.return_value.interval = CODE_CHECK_INTERVAL
+        yield mock_flow
+
+
+@pytest.fixture
+async def token_scopes() -> list[str]:
+    """Fixture for scopes used during test."""
+    return ["https://www.googleapis.com/auth/calendar"]
+
+
+@pytest.fixture
+async def creds(token_scopes: list[str]) -> OAuth2Credentials:
+    """Fixture that defines creds used in the test."""
+    token_expiry = utcnow() + datetime.timedelta(days=7)
+    return OAuth2Credentials(
+        access_token="ACCESS_TOKEN",
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_token="REFRESH_TOKEN",
+        token_expiry=token_expiry,
+        token_uri="http://example.com",
+        user_agent="n/a",
+        scopes=token_scopes,
+    )
+
+
+@pytest.fixture
+async def mock_exchange(creds: OAuth2Credentials) -> YieldFixture[Mock]:
+    """Fixture for mocking out the exchange for credentials."""
+    with patch(
+        "oauth2client.client.OAuth2WebServerFlow.step2_exchange", return_value=creds
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+async def token_file(hass: HomeAssistant, creds: OAuth2Credentials) -> None:
+    """Fixture to populate an existing token file."""
+    storage = Storage(hass.config.path(TOKEN_FILE))
+    storage.put(creds)
+
+
+@pytest.fixture
+async def calendars_config() -> list[dict[str, Any]]:
+    """Fixture for tests to override default calendar configuration."""
+    return [
+        {
+            "cal_id": CALENDAR_ID,
+            "entities": [
+                {
+                    "device_id": "backyard_light",
+                    "name": "Backyard Light",
+                    "search": "#Backyard",
+                    "track": True,
+                }
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+async def calendars_yaml(
+    hass: HomeAssistant, calendars_config: list[dict[str, Any]]
+) -> None:
+    """Fixture that prepares the calendars.yaml file."""
+    with open(hass.config.path(YAML_DEVICES), "w") as out:
+        yaml.dump(calendars_config, out)
+
+
+@pytest.fixture
+async def mock_load_platform() -> YieldFixture[Mock]:
+    """Fixture that counts when calendars are loaded, to exercise success case."""
+    with patch("homeassistant.components.google.discovery.load_platform") as mock:
+        yield mock
+
+
+@pytest.fixture
+async def mock_notification() -> YieldFixture[Mock]:
+    """Fixture for capturing persistent notifications."""
+    with patch("homeassistant.components.persistent_notification.create") as mock:
+        yield mock
+
+
+@pytest.fixture
+async def config() -> dict[str, Any]:
+    """Fixture for overriding component config."""
+    return {DOMAIN: {CONF_CLIENT_ID: "client-id", CONF_CLIENT_SECRET: "client-ecret"}}
+
+
+@pytest.fixture
+async def component_setup(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> ComponentSetup:
+    """Fixture for setting up the integration."""
+
+    async def _setup_func() -> bool:
+        result = await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+        return result
+
+    return _setup_func
+
+
+@pytest.fixture
+async def google_service() -> YieldFixture[GoogleCalendarService]:
+    """Fixture to capture service calls."""
+    with patch("homeassistant.components.google.GoogleCalendarService") as mock:
+        yield mock
 
 
 @pytest.fixture(name="google_setup")
@@ -23,11 +183,18 @@ def mock_google_setup(hass):
         yield
 
 
-async def test_setup_component(hass, google_setup):
-    """Test setup component."""
-    config = {"google": {CONF_CLIENT_ID: "id", CONF_CLIENT_SECRET: "secret"}}
+async def fire_alarm(hass, point_in_time):
+    """Fire an alarm and wait for callbacks to run."""
+    with patch("homeassistant.util.dt.utcnow", return_value=point_in_time):
+        async_fire_time_changed(hass, point_in_time)
+        await hass.async_block_till_done()
 
-    assert await async_setup_component(hass, "google", config)
+
+# async def test_setup_component(hass, google_setup):
+#    """Test setup component."""
+#    config = {"google": {CONF_CLIENT_ID: "id", CONF_CLIENT_SECRET: "secret"}}
+#
+#    assert await async_setup_component(hass, "google", config)
 
 
 async def test_get_calendar_info(hass, test_calendar):
@@ -48,20 +215,381 @@ async def test_get_calendar_info(hass, test_calendar):
     }
 
 
-async def test_found_calendar(hass, google_setup, mock_next_event, test_calendar):
-    """Test when a calendar is found."""
-    config = {
-        "google": {
-            CONF_CLIENT_ID: "id",
-            CONF_CLIENT_SECRET: "secret",
-            "track_new_calendar": True,
-        }
-    }
-    assert await async_setup_component(hass, "google", config)
+# async def test_found_calendar(hass, google_setup, mock_next_event, test_calendar):
+#    """Test when a calendar is found."""
+#    config = {
+#        "google": {
+#            CONF_CLIENT_ID: "id",
+#            CONF_CLIENT_SECRET: "secret",
+#            "track_new_calendar": True,
+#        }
+#    }
+#    assert await async_setup_component(hass, "google", config)
+#    assert hass.data[google.DATA_INDEX] == {}
+#
+#    await hass.services.async_call(
+#        "google", google.SERVICE_FOUND_CALENDARS, test_calendar, blocking=True
+#    )
+#
+#    assert hass.data[google.DATA_INDEX].get(test_calendar["id"]) is not None
+
+
+@pytest.mark.parametrize("config", [{}])
+async def test_setup_config_empty(
+    hass: HomeAssistant, component_setup: ComponentSetup, mock_notification: Mock
+):
+    """Test setup component with an empty configuruation."""
+    assert await component_setup()
     assert hass.data[google.DATA_INDEX] == {}
 
-    await hass.services.async_call(
-        "google", google.SERVICE_FOUND_CALENDARS, test_calendar, blocking=True
+    mock_notification.assert_not_called()
+
+
+async def test_init_success(
+    hass: HomeAssistant,
+    google_service: GoogleCalendarService,
+    mock_code_flow: Mock,
+    mock_exchange: Mock,
+    mock_notification: Mock,
+    mock_load_platform: Mock,
+    calendars_yaml: None,
+    component_setup: ComponentSetup,
+) -> None:
+    """Test successful creds setup."""
+    assert await component_setup()
+
+    # Run one tick to invoke the credential exchange check
+    now = utcnow()
+    await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+    assert len(mock_exchange.mock_calls) == 1
+
+    mock_load_platform.assert_called_once()
+
+    # One calendar configured
+    assert len(hass.data[google.DATA_INDEX]) == 1
+
+    mock_notification.assert_called()
+    assert "We are all setup now" in mock_notification.call_args[0][1]
+
+    # Credentials persisted
+    assert os.path.exists(hass.config.path(TOKEN_FILE))
+
+
+async def test_code_error(
+    hass: HomeAssistant,
+    mock_code_flow: Mock,
+    component_setup: ComponentSetup,
+    mock_notification: Mock,
+) -> None:
+    """Test loading the integration with no existing credentials."""
+
+    with patch(
+        "oauth2client.client.OAuth2WebServerFlow.step1_get_device_and_user_codes",
+        side_effect=OAuth2DeviceCodeError("Test Failure"),
+    ):
+        assert await component_setup()
+
+    mock_notification.assert_called()
+    assert "Error: Test Failure" in mock_notification.call_args[0][1]
+    # No credentials persisted
+    assert not os.path.exists(hass.config.path(TOKEN_FILE))
+
+
+# assert "In order to authorize Home-Assistant to view your" in mock_notification.call_args[0][1]
+
+
+@pytest.mark.parametrize("code_expiration_delta", [datetime.timedelta(minutes=-5)])
+async def test_expired_after_exchange(
+    hass: HomeAssistant,
+    mock_code_flow: Mock,
+    component_setup: ComponentSetup,
+    mock_notification: Mock,
+) -> None:
+    """Test loading the integration with no existing credentials."""
+
+    assert await component_setup()
+
+    now = utcnow()
+    await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+    assert len(mock_code_flow.mock_calls) == 4
+
+    mock_notification.assert_called()
+    assert (
+        "Authentication code expired, please restart Home-Assistant and try again"
+        in mock_notification.call_args[0][1]
     )
 
-    assert hass.data[google.DATA_INDEX].get(test_calendar["id"]) is not None
+    # No credentials persisted
+    assert not os.path.exists(hass.config.path(TOKEN_FILE))
+
+
+async def test_exchange_error(
+    hass: HomeAssistant,
+    mock_code_flow: Mock,
+    component_setup: ComponentSetup,
+    mock_notification: Mock,
+) -> None:
+    """Test an error while exchanging the code for credentials."""
+
+    with patch(
+        "oauth2client.client.OAuth2WebServerFlow.step2_exchange",
+        side_effect=FlowExchangeError(),
+    ):
+        assert await component_setup()
+
+        now = utcnow()
+        await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+        assert len(mock_code_flow.mock_calls) == 4
+
+    mock_notification.assert_called()
+    assert "In order to authorize Home-Assistant" in mock_notification.call_args[0][1]
+    # No credentials persisted
+    assert not os.path.exists(hass.config.path(TOKEN_FILE))
+
+
+async def test_existing_token(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    mock_load_platform: Mock,
+    google_service: GoogleCalendarService,
+    calendars_yaml: None,
+    mock_notification: Mock,
+) -> None:
+    """Test setup with an existing token file."""
+    assert await component_setup()
+
+    mock_load_platform.assert_called_once()
+
+    # One calendar configured
+    assert len(hass.data[google.DATA_INDEX]) == 1
+
+    # No notifications on success
+    mock_notification.assert_not_called()
+
+    # Credentials persisted
+    assert os.path.exists(hass.config.path(TOKEN_FILE))
+
+
+@pytest.mark.parametrize(
+    "token_scopes", ["https://www.googleapis.com/auth/calendar.readonly"]
+)
+async def test_existing_token_missing_scope(
+    hass: HomeAssistant,
+    token_scopes: list[str],
+    token_file: None,
+    component_setup: ComponentSetup,
+    mock_load_platform: Mock,
+    google_service: GoogleCalendarService,
+    calendars_yaml: None,
+    mock_notification: Mock,
+    mock_code_flow: Mock,
+    mock_exchange: Mock,
+) -> None:
+    """Test setup where existing token does not have sufficient scopes."""
+    assert await component_setup()
+
+    # Run one tick to invoke the credential exchange check
+    now = utcnow()
+    await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+    assert len(mock_exchange.mock_calls) == 1
+
+    mock_load_platform.assert_called_once()
+
+    # One calendar configured
+    assert len(hass.data[google.DATA_INDEX]) == 1
+
+    # No notifications on success
+    mock_notification.assert_called()
+    assert "We are all setup now" in mock_notification.call_args[0][1]
+
+    # Credentials persisted
+    assert os.path.exists(hass.config.path(TOKEN_FILE))
+
+
+@pytest.mark.parametrize("calendars_config", [[{"cal_id": "invalid-schema"}]])
+async def test_calendar_yaml_missing_required_fields(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    mock_load_platform: Mock,
+    google_service: GoogleCalendarService,
+    calendars_config: list[dict[str, Any]],
+    calendars_yaml: None,
+    mock_notification: Mock,
+) -> None:
+    """Test setup with a missing schema fields, ignores the error and continues."""
+    assert await component_setup()
+
+    mock_load_platform.assert_not_called()
+    mock_notification.assert_not_called()
+    assert hass.data[google.DATA_INDEX] == {}
+
+
+@pytest.mark.parametrize("calendars_config", [[{"missing-cal_id": "invalid-schema"}]])
+async def test_invalid_calendar_yaml(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    mock_load_platform: Mock,
+    google_service: GoogleCalendarService,
+    calendars_config: list[dict[str, Any]],
+    calendars_yaml: None,
+    mock_notification: Mock,
+) -> None:
+    """Test setup with missing entity id fields fails to setup the integration."""
+
+    # Integration fails to setup
+    assert not await component_setup()
+
+    mock_load_platform.assert_not_called()
+    mock_notification.assert_not_called()
+    assert hass.data[google.DATA_INDEX] == {}
+
+
+async def test_invalid_calendar_config_format(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    mock_load_platform: Mock,
+    google_service: GoogleCalendarService,
+    calendars_config: list[dict[str, Any]],
+    calendars_yaml: None,
+    mock_notification: Mock,
+) -> None:
+    """Test setup when the yaml file does not contain yaml."""
+
+    # Write arbitrary binary data that isn't yaml
+    with open(hass.config.path(YAML_DEVICES), "wb") as out:
+        out.write(bytearray(range(1, 100)))
+
+    assert not await component_setup()
+
+    mock_load_platform.assert_not_called()
+    mock_notification.assert_not_called()
+    assert hass.data[google.DATA_INDEX] == {}
+
+
+async def test_found_calendar(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    google_service: GoogleCalendarService,
+    mock_calendars_list: ApiResult,
+    test_calendar: dict[str, Any],
+) -> None:
+    """Test finding a calendar from the API."""
+
+    mock_calendars_list({"items": [test_calendar]})
+
+    assert await component_setup()
+
+    # One calendar loaded from the API
+    assert len(hass.data[google.DATA_INDEX]) == 1
+
+
+async def test_add_event(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    google_service: GoogleCalendarService,
+    mock_calendars_list: ApiResult,
+    test_calendar: dict[str, Any],
+    mock_insert_event: Mock,
+) -> None:
+    """Test service call that adds an event."""
+
+    mock_calendars_list({"items": [test_calendar]})
+    assert await component_setup()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_EVENT,
+        {
+            "calendar_id": CALENDAR_ID,
+            "summary": "Summary",
+            "description": "Description",
+        },
+        blocking=True,
+    )
+    mock_insert_event.assert_called()
+    assert mock_insert_event.mock_calls[0] == call(
+        calendarId=CALENDAR_ID,
+        body={
+            "summary": "Summary",
+            "description": "Description",
+            "start": {},
+            "end": {},
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "date_fields,start_timedelta,end_timedelta",
+    [
+        (
+            {"in": {"days": 3}},
+            datetime.timedelta(days=3),
+            datetime.timedelta(days=4),
+        ),
+        (
+            {"in": {"weeks": 1}},
+            datetime.timedelta(days=7),
+            datetime.timedelta(days=8),
+        ),
+        (
+            {
+                "start_date": datetime.date.today().isoformat(),
+                "end_date": (
+                    datetime.date.today() + datetime.timedelta(days=2)
+                ).isoformat(),
+            },
+            datetime.timedelta(days=0),
+            datetime.timedelta(days=2),
+        ),
+    ],
+    ids=["in_days", "in_weeks", "explit_date"],
+)
+async def test_add_event_date_ranges(
+    hass: HomeAssistant,
+    token_file: None,
+    component_setup: ComponentSetup,
+    google_service: GoogleCalendarService,
+    mock_calendars_list: ApiResult,
+    test_calendar: dict[str, Any],
+    mock_insert_event: Mock,
+    date_fields: dict[str, Any],
+    start_timedelta: datetime.timedelta,
+    end_timedelta: datetime.timedelta,
+) -> None:
+    """Test service call that adds an event with various time ranges."""
+
+    mock_calendars_list({"items": [test_calendar]})
+    assert await component_setup()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_EVENT,
+        {
+            "calendar_id": CALENDAR_ID,
+            "summary": "Summary",
+            "description": "Description",
+            **date_fields,
+        },
+        blocking=True,
+    )
+    mock_insert_event.assert_called()
+
+    now = datetime.datetime.now()
+    start_date = now + start_timedelta
+    end_date = now + end_timedelta
+
+    assert mock_insert_event.mock_calls[0] == call(
+        calendarId=CALENDAR_ID,
+        body={
+            "summary": "Summary",
+            "description": "Description",
+            "start": {"date": start_date.date().isoformat()},
+            "end": {"date": end_date.date().isoformat()},
+        },
+    )

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -37,7 +37,7 @@ YieldFixture = Generator[T, None, None]
 
 
 CODE_CHECK_INTERVAL = 1
-CODE_CHECK_TIMEDELTA = datetime.timedelta(seconds=CODE_CHECK_INTERVAL)
+CODE_CHECK_ALARM_TIMEDELTA = datetime.timedelta(seconds=CODE_CHECK_INTERVAL * 2)
 
 
 @pytest.fixture
@@ -198,7 +198,7 @@ async def test_init_success(
 
     # Run one tick to invoke the credential exchange check
     now = utcnow()
-    await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+    await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
     assert len(mock_exchange.mock_calls) == 1
 
     mock_load_platform.assert_called_once()
@@ -240,7 +240,7 @@ async def test_expired_after_exchange(
     assert await component_setup()
 
     now = utcnow()
-    await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+    await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
 
     mock_notification.assert_called()
     assert (
@@ -264,7 +264,7 @@ async def test_exchange_error(
         assert await component_setup()
 
         now = utcnow()
-        await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+        await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
 
     mock_notification.assert_called()
     assert "In order to authorize Home-Assistant" in mock_notification.call_args[0][1]
@@ -311,7 +311,7 @@ async def test_existing_token_missing_scope(
 
     # Run one tick to invoke the credential exchange check
     now = utcnow()
-    await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
+    await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
     assert len(mock_exchange.mock_calls) == 1
 
     mock_load_platform.assert_called_once()

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -162,7 +162,9 @@ async def component_setup(
 @pytest.fixture
 async def google_service() -> YieldFixture[GoogleCalendarService]:
     """Fixture to capture service calls."""
-    with patch("homeassistant.components.google.GoogleCalendarService") as mock:
+    with patch("homeassistant.components.google.GoogleCalendarService") as mock, patch(
+        "homeassistant.components.google.calendar.GoogleCalendarService", mock
+    ):
         yield mock
 
 
@@ -204,6 +206,7 @@ async def test_init_success(
     await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
 
     state = hass.states.get("calendar.backyard_light")
+    assert state
     assert state.name == "Backyard Light"
     assert state.state == STATE_OFF
 
@@ -289,6 +292,7 @@ async def test_existing_token(
     assert await component_setup()
 
     state = hass.states.get("calendar.backyard_light")
+    assert state
     assert state.name == "Backyard Light"
     assert state.state == STATE_OFF
 
@@ -318,6 +322,7 @@ async def test_existing_token_missing_scope(
     assert len(mock_exchange.mock_calls) == 1
 
     state = hass.states.get("calendar.backyard_light")
+    assert state
     assert state.name == "Backyard Light"
     assert state.state == STATE_OFF
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -1,7 +1,6 @@
 """The tests for the Google Calendar component."""
 from collections.abc import Awaitable, Callable
 import datetime
-import os
 from typing import Any, Generator, TypeVar
 from unittest.mock import Mock, call, patch
 
@@ -210,9 +209,6 @@ async def test_init_success(
     mock_notification.assert_called()
     assert "We are all setup now" in mock_notification.call_args[0][1]
 
-    # Credentials persisted
-    assert os.path.exists(hass.config.path(TOKEN_FILE))
-
 
 async def test_code_error(
     hass: HomeAssistant,
@@ -230,8 +226,6 @@ async def test_code_error(
 
     mock_notification.assert_called()
     assert "Error: Test Failure" in mock_notification.call_args[0][1]
-    # No credentials persisted
-    assert not os.path.exists(hass.config.path(TOKEN_FILE))
 
 
 @pytest.mark.parametrize("code_expiration_delta", [datetime.timedelta(minutes=-5)])
@@ -255,9 +249,6 @@ async def test_expired_after_exchange(
         in mock_notification.call_args[0][1]
     )
 
-    # No credentials persisted
-    assert not os.path.exists(hass.config.path(TOKEN_FILE))
-
 
 async def test_exchange_error(
     hass: HomeAssistant,
@@ -279,8 +270,6 @@ async def test_exchange_error(
 
     mock_notification.assert_called()
     assert "In order to authorize Home-Assistant" in mock_notification.call_args[0][1]
-    # No credentials persisted
-    assert not os.path.exists(hass.config.path(TOKEN_FILE))
 
 
 async def test_existing_token(
@@ -302,9 +291,6 @@ async def test_existing_token(
 
     # No notifications on success
     mock_notification.assert_not_called()
-
-    # Credentials persisted
-    assert os.path.exists(hass.config.path(TOKEN_FILE))
 
 
 @pytest.mark.parametrize(
@@ -338,9 +324,6 @@ async def test_existing_token_missing_scope(
     # No notifications on success
     mock_notification.assert_called()
     assert "We are all setup now" in mock_notification.call_args[0][1]
-
-    # Credentials persisted
-    assert os.path.exists(hass.config.path(TOKEN_FILE))
 
 
 @pytest.mark.parametrize("calendars_config", [[{"cal_id": "invalid-schema"}]])

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -11,8 +11,6 @@ from oauth2client.client import (
     OAuth2DeviceCodeError,
 )
 from oauth2client.file import Storage
-
-# from google.oauth2.credentials import Credentials
 import pytest
 import yaml
 
@@ -168,70 +166,11 @@ async def google_service() -> YieldFixture[GoogleCalendarService]:
         yield mock
 
 
-@pytest.fixture(name="google_setup")
-def mock_google_setup(hass):
-    """Mock the google set up functions."""
-    p_auth = patch(
-        "homeassistant.components.google.do_authentication", side_effect=google.do_setup
-    )
-    p_service = patch("homeassistant.components.google.GoogleCalendarService.get")
-    p_discovery = patch("homeassistant.components.google.discovery.load_platform")
-    p_load = patch("homeassistant.components.google.load_config", return_value={})
-    p_save = patch("homeassistant.components.google.update_config")
-
-    with p_auth, p_load, p_service, p_discovery, p_save:
-        yield
-
-
 async def fire_alarm(hass, point_in_time):
     """Fire an alarm and wait for callbacks to run."""
     with patch("homeassistant.util.dt.utcnow", return_value=point_in_time):
         async_fire_time_changed(hass, point_in_time)
         await hass.async_block_till_done()
-
-
-# async def test_setup_component(hass, google_setup):
-#    """Test setup component."""
-#    config = {"google": {CONF_CLIENT_ID: "id", CONF_CLIENT_SECRET: "secret"}}
-#
-#    assert await async_setup_component(hass, "google", config)
-
-
-async def test_get_calendar_info(hass, test_calendar):
-    """Test getting the calendar info."""
-    calendar_info = await hass.async_add_executor_job(
-        google.get_calendar_info, hass, test_calendar
-    )
-    assert calendar_info == {
-        "cal_id": "qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com",
-        "entities": [
-            {
-                "device_id": "we_are_we_are_a_test_calendar",
-                "name": "We are, we are, a... Test Calendar",
-                "track": True,
-                "ignore_availability": True,
-            }
-        ],
-    }
-
-
-# async def test_found_calendar(hass, google_setup, mock_next_event, test_calendar):
-#    """Test when a calendar is found."""
-#    config = {
-#        "google": {
-#            CONF_CLIENT_ID: "id",
-#            CONF_CLIENT_SECRET: "secret",
-#            "track_new_calendar": True,
-#        }
-#    }
-#    assert await async_setup_component(hass, "google", config)
-#    assert hass.data[google.DATA_INDEX] == {}
-#
-#    await hass.services.async_call(
-#        "google", google.SERVICE_FOUND_CALENDARS, test_calendar, blocking=True
-#    )
-#
-#    assert hass.data[google.DATA_INDEX].get(test_calendar["id"]) is not None
 
 
 @pytest.mark.parametrize("config", [{}])
@@ -293,9 +232,6 @@ async def test_code_error(
     assert "Error: Test Failure" in mock_notification.call_args[0][1]
     # No credentials persisted
     assert not os.path.exists(hass.config.path(TOKEN_FILE))
-
-
-# assert "In order to authorize Home-Assistant to view your" in mock_notification.call_args[0][1]
 
 
 @pytest.mark.parametrize("code_expiration_delta", [datetime.timedelta(minutes=-5)])
@@ -470,7 +406,7 @@ async def test_invalid_calendar_config_format(
     assert hass.data[google.DATA_INDEX] == {}
 
 
-async def test_found_calendar(
+async def test_found_calendar_from_api(
     hass: HomeAssistant,
     token_file: None,
     component_setup: ComponentSetup,

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -241,7 +241,6 @@ async def test_expired_after_exchange(
 
     now = utcnow()
     await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
-    assert len(mock_code_flow.mock_calls) == 4
 
     mock_notification.assert_called()
     assert (
@@ -266,7 +265,6 @@ async def test_exchange_error(
 
         now = utcnow()
         await fire_alarm(hass, now + CODE_CHECK_TIMEDELTA)
-        assert len(mock_code_flow.mock_calls) == 4
 
     mock_notification.assert_called()
     assert "In order to authorize Home-Assistant" in mock_notification.call_args[0][1]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve google calendar test coverage to 97% and fix one error on setup found from tests. There are additional error cases that appear to have inconsistencies or unintended bugs (e.g. missing keys not handled gracefully), but they can be fixed in follow ups.

Removed tests that were not exercising public entity APIs.
Removed tests that were mocking out large parts of the code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
