### PR TITLE
Flag Tradfri groups and YAML as deprecated

### DIFF
--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -127,8 +127,19 @@ async def async_setup_entry(
             gateway.get_devices(), timeout=TIMEOUT_API
         )
         devices: list[Device] = await api(devices_commands, timeout=TIMEOUT_API)
-        groups_commands: Command = await api(gateway.get_groups(), timeout=TIMEOUT_API)
-        groups: list[Group] = await api(groups_commands, timeout=TIMEOUT_API)
+
+        if entry.data[CONF_IMPORT_GROUPS]:
+            # Note: we should update this page when deprecating:
+            # https://www.home-assistant.io/integrations/tradfri/
+            _LOGGER.warning(
+                "Importing of Tradfri groups has been deprecated due to stability issues "
+                "and will be removed in Home Assistant core 2022.4"
+            )
+            # No need to load groups if the user hasn't requested it
+            groups_commands: Command = await api(
+                gateway.get_groups(), timeout=TIMEOUT_API
+            )
+            groups: list[Group] = await api(groups_commands, timeout=TIMEOUT_API)
 
     except PytradfriError as exc:
         await factory.shutdown()

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -57,12 +57,18 @@ LISTENERS = "tradfri_listeners"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_HOST): cv.string,
-                vol.Optional(
-                    CONF_ALLOW_TRADFRI_GROUPS, default=DEFAULT_ALLOW_TRADFRI_GROUPS
-                ): cv.boolean,
-            }
+            vol.All(
+                cv.deprecated(CONF_HOST),
+                cv.deprecated(
+                    CONF_ALLOW_TRADFRI_GROUPS,
+                ),
+                {
+                    vol.Optional(CONF_HOST): cv.string,
+                    vol.Optional(
+                        CONF_ALLOW_TRADFRI_GROUPS, default=DEFAULT_ALLOW_TRADFRI_GROUPS
+                    ): cv.boolean,
+                },
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -120,6 +126,7 @@ async def async_setup_entry(
 
     api = factory.request
     gateway = Gateway()
+    groups: list[Group] = []
 
     try:
         gateway_info = await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
@@ -139,7 +146,7 @@ async def async_setup_entry(
             groups_commands: Command = await api(
                 gateway.get_groups(), timeout=TIMEOUT_API
             )
-            groups: list[Group] = await api(groups_commands, timeout=TIMEOUT_API)
+            groups = await api(groups_commands, timeout=TIMEOUT_API)
 
     except PytradfriError as exc:
         await factory.shutdown()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The native IKEA Tradfri groups are now deprecated and this feature will be removed from the integration in a future release. Tradfri groups rely on sending frequent requests (polling) to the gateway to check the states of the groups. Continuously polling the gateway causes stability issues of the gateway, sometimes causing it to crash and requiring a restart. We propose using [light groups](https://www.home-assistant.io/integrations/light.group/) instead.

Configuring IKEA Tradfri via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Any remaining YAML configuration has been automatically imported since a long time and thus can be safely removed from your YAML configuration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tradfri groups use polling to update their state. Polling the IKEA gateway causes instability and has therefore been an opt-in for the past thee years. We should deprecate groups alltogether, as suggested by this PR.

![image](https://user-images.githubusercontent.com/21142447/151689412-68e8eedc-e1ff-4eea-bcd9-115f11b8b49b.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21403

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
