### PR TITLE
Fix webostv live TV source missing when configuring sources

### DIFF
--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import async_control_connect
 from .const import CONF_SOURCES, DEFAULT_NAME, DOMAIN, WEBOSTV_EXCEPTIONS
+from .helpers import async_get_sources
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -198,20 +199,3 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="init", data_schema=options_schema, errors=errors
         )
-
-
-async def async_get_sources(host: str, key: str) -> list[str]:
-    """Construct sources list."""
-    try:
-        client = await async_control_connect(host, key)
-    except WEBOSTV_EXCEPTIONS:
-        return []
-
-    return list(
-        dict.fromkeys(  # Preserve order when filtering duplicates
-            [
-                *(app["title"] for app in client.apps.values()),
-                *(app["label"] for app in client.inputs.values()),
-            ]
-        )
-    )

--- a/homeassistant/components/webostv/helpers.py
+++ b/homeassistant/components/webostv/helpers.py
@@ -6,8 +6,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from . import WebOsClientWrapper
-from .const import DATA_CONFIG_ENTRY, DOMAIN
+from . import WebOsClientWrapper, async_control_connect
+from .const import DATA_CONFIG_ENTRY, DOMAIN, LIVE_TV_APP_ID, WEBOSTV_EXCEPTIONS
 
 
 @callback
@@ -81,3 +81,29 @@ def async_get_client_wrapper_by_device_entry(
         )
 
     return wrapper
+
+
+async def async_get_sources(host: str, key: str) -> list[str]:
+    """Construct sources list."""
+    try:
+        client = await async_control_connect(host, key)
+    except WEBOSTV_EXCEPTIONS:
+        return []
+
+    sources = []
+    found_live_tv = False
+    for app in client.apps.values():
+        sources.append(app["title"])
+        if app["id"] == LIVE_TV_APP_ID:
+            found_live_tv = True
+
+    for source in client.inputs.values():
+        sources.append(source["label"])
+        if source["appId"] == LIVE_TV_APP_ID:
+            found_live_tv = True
+
+    if not found_live_tv:
+        sources.append("Live TV")
+
+    # Preserve order when filtering duplicates
+    return list(dict.fromkeys(sources))

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -11,26 +11,9 @@ from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
+from .const import CLIENT_KEY, FAKE_UUID, HOST, MOCK_CLIENT_KEYS, TV_NAME
+
 from tests.common import MockConfigEntry
-
-FAKE_UUID = "some-fake-uuid"
-TV_NAME = "fake_webos"
-ENTITY_ID = f"{MP_DOMAIN}.{TV_NAME}"
-HOST = "1.2.3.4"
-CLIENT_KEY = "some-secret"
-MOCK_CLIENT_KEYS = {HOST: CLIENT_KEY}
-MOCK_JSON = '{"1.2.3.4": "some-secret"}'
-
-CHANNEL_1 = {
-    "channelNumber": "1",
-    "channelName": "Channel 1",
-    "channelId": "ch1id",
-}
-CHANNEL_2 = {
-    "channelNumber": "20",
-    "channelName": "Channel Name 2",
-    "channelId": "ch2id",
-}
 
 
 async def setup_webostv(hass, unique_id=FAKE_UUID):

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.components.webostv.const import LIVE_TV_APP_ID
 from homeassistant.helpers import entity_registry
 
-from . import CHANNEL_1, CHANNEL_2, CLIENT_KEY, FAKE_UUID
+from .const import CHANNEL_1, CHANNEL_2, CLIENT_KEY, FAKE_UUID, MOCK_APPS, MOCK_INPUTS
 
 from tests.common import async_mock_service
 
@@ -28,18 +28,8 @@ def client_fixture():
         client.software_info = {"major_ver": "major", "minor_ver": "minor"}
         client.system_info = {"modelName": "TVFAKE"}
         client.client_key = CLIENT_KEY
-        client.apps = {
-            LIVE_TV_APP_ID: {
-                "title": "Live TV",
-                "id": LIVE_TV_APP_ID,
-                "largeIcon": "large-icon",
-                "icon": "icon",
-            },
-        }
-        client.inputs = {
-            "in1": {"label": "Input01", "id": "in1", "appId": "app0"},
-            "in2": {"label": "Input02", "id": "in2", "appId": "app1"},
-        }
+        client.apps = MOCK_APPS
+        client.inputs = MOCK_INPUTS
         client.current_app_id = LIVE_TV_APP_ID
 
         client.channels = [CHANNEL_1, CHANNEL_2]

--- a/tests/components/webostv/const.py
+++ b/tests/components/webostv/const.py
@@ -1,0 +1,36 @@
+"""Constants for LG webOS Smart TV tests."""
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.webostv.const import LIVE_TV_APP_ID
+
+FAKE_UUID = "some-fake-uuid"
+TV_NAME = "fake_webos"
+ENTITY_ID = f"{MP_DOMAIN}.{TV_NAME}"
+HOST = "1.2.3.4"
+CLIENT_KEY = "some-secret"
+MOCK_CLIENT_KEYS = {HOST: CLIENT_KEY}
+MOCK_JSON = '{"1.2.3.4": "some-secret"}'
+
+CHANNEL_1 = {
+    "channelNumber": "1",
+    "channelName": "Channel 1",
+    "channelId": "ch1id",
+}
+CHANNEL_2 = {
+    "channelNumber": "20",
+    "channelName": "Channel Name 2",
+    "channelId": "ch2id",
+}
+
+MOCK_APPS = {
+    LIVE_TV_APP_ID: {
+        "title": "Live TV",
+        "id": LIVE_TV_APP_ID,
+        "largeIcon": "large-icon",
+        "icon": "icon",
+    },
+}
+
+MOCK_INPUTS = {
+    "in1": {"label": "Input01", "id": "in1", "appId": "app0"},
+    "in2": {"label": "Input02", "id": "in2", "appId": "app1"},
+}

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -24,7 +24,8 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from . import CLIENT_KEY, FAKE_UUID, HOST, TV_NAME, setup_webostv
+from . import setup_webostv
+from .const import CLIENT_KEY, FAKE_UUID, HOST, MOCK_APPS, MOCK_INPUTS, TV_NAME
 
 MOCK_YAML_CONFIG = {
     CONF_HOST: HOST,
@@ -153,26 +154,23 @@ async def test_form(hass, client):
     "apps, inputs",
     [
         # Live TV in apps (default)
-        (None, None),
+        (MOCK_APPS, MOCK_INPUTS),
         # Live TV in inputs
         (
             {},
             {
-                "in1": {"label": "Input01", "id": "in1", "appId": "app0"},
-                "in2": {"label": "Input02", "id": "in2", "appId": "app1"},
+                **MOCK_INPUTS,
                 "livetv": {"label": "Live TV", "id": "livetv", "appId": LIVE_TV_APP_ID},
             },
         ),
         # Live TV not found
-        ({}, None),
+        ({}, MOCK_INPUTS),
     ],
 )
 async def test_options_flow_live_tv_in_apps(hass, client, apps, inputs):
     """Test options config flow Live TV found in apps."""
-    if apps is not None:
-        client.apps = apps
-    if inputs is not None:
-        client.inputs = inputs
+    client.apps = apps
+    client.inputs = inputs
     entry = await setup_webostv(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -11,7 +11,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
 
-from . import ENTITY_ID, FAKE_UUID, setup_webostv
+from . import setup_webostv
+from .const import ENTITY_ID, FAKE_UUID
 
 from tests.common import MockConfigEntry, async_get_device_automations
 

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -8,11 +8,11 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.webostv import DOMAIN
 
 from . import (
-    MOCK_JSON,
     create_memory_sqlite_engine,
     is_entity_unique_id_updated,
     setup_legacy_component,
 )
+from .const import MOCK_JSON
 
 
 async def test_missing_keys_file_abort(hass, client, caplog):

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -64,7 +64,8 @@ from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
-from . import CHANNEL_2, ENTITY_ID, TV_NAME, setup_webostv
+from . import setup_webostv
+from .const import CHANNEL_2, ENTITY_ID, TV_NAME
 
 from tests.common import async_fire_time_changed
 

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -9,7 +9,8 @@ from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import CONF_ICON, CONF_SERVICE_DATA
 from homeassistant.setup import async_setup_component
 
-from . import TV_NAME, setup_webostv
+from . import setup_webostv
+from .const import TV_NAME
 
 ICON_PATH = "/some/path"
 MESSAGE = "one, two, testing, testing"

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -7,7 +7,8 @@ from homeassistant.const import SERVICE_RELOAD
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
 
-from . import ENTITY_ID, FAKE_UUID, setup_webostv
+from . import setup_webostv
+from .const import ENTITY_ID, FAKE_UUID
 
 from tests.common import MockEntity, MockEntityPlatform
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Live TV source missing when configuring sources, Live TV source may be either an app, an input source and may be missing.
Copy the same logic from [Media player update sources](https://github.com/home-assistant/core/blob/77ef86faee0c7eac3a418dc5784a0aa9d2c769c7/homeassistant/components/webostv/media_player.py#L179)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/65196
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
