### PR TITLE
Fix flux_led not generating unique ids when discovery fails

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import (
     async_track_time_change,
@@ -88,6 +88,31 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+async def _async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Migrate entities when the mac address gets discovered."""
+    unique_id = entry.unique_id
+    if not unique_id:
+        return
+    entry_id = entry.entry_id
+
+    @callback
+    def _async_migrator(entity_entry: er.RegistryEntry) -> dict[str, Any] | None:
+        # Old format {entry_id}.....
+        # New format {unique_id}....
+        entity_unique_id = entity_entry.unique_id
+        if not entity_unique_id.startswith(entry_id):
+            return None
+        new_unique_id = f"{unique_id}{entity_unique_id[len(entry_id):]}"
+        _LOGGER.info(
+            "Migrating unique_id from [%s] to [%s]",
+            entity_unique_id,
+            new_unique_id,
+        )
+        return {"new_unique_id": new_unique_id}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _async_migrator)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Flux LED/MagicLight from a config entry."""
     host = entry.data[CONF_HOST]
@@ -134,6 +159,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Only update the entry once we have verified the unique id
         # is either missing or we have verified it matches
         async_update_entry_from_discovery(hass, entry, discovery, device.model_num)
+
+    await _async_migrate_unique_ids(hass, entry)
 
     coordinator = FluxLedUpdateCoordinator(hass, device, entry)
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/flux_led/button.py
+++ b/homeassistant/components/flux_led/button.py
@@ -64,8 +64,8 @@ class FluxButton(FluxBaseEntity, ButtonEntity):
         self.entity_description = description
         super().__init__(device, entry)
         self._attr_name = f"{entry.data[CONF_NAME]} {description.name}"
-        if entry.unique_id:
-            self._attr_unique_id = f"{entry.unique_id}_{description.key}"
+        base_unique_id = entry.unique_id or entry.entry_id
+        self._attr_unique_id = f"{base_unique_id}_{description.key}"
 
     async def async_press(self) -> None:
         """Send out a command."""

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -177,7 +177,7 @@ async def async_setup_entry(
         [
             FluxLight(
                 coordinator,
-                entry.unique_id,
+                entry.unique_id or entry.entry_id,
                 entry.data[CONF_NAME],
                 list(custom_effect_colors),
                 options.get(CONF_CUSTOM_EFFECT_SPEED_PCT, DEFAULT_EFFECT_SPEED),
@@ -195,14 +195,14 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
     def __init__(
         self,
         coordinator: FluxLedUpdateCoordinator,
-        unique_id: str | None,
+        base_unique_id: str,
         name: str,
         custom_effect_colors: list[tuple[int, int, int]],
         custom_effect_speed_pct: int,
         custom_effect_transition: str,
     ) -> None:
         """Initialize the light."""
-        super().__init__(coordinator, unique_id, name, None)
+        super().__init__(coordinator, base_unique_id, name, None)
         self._attr_min_mireds = color_temperature_kelvin_to_mired(self._device.max_temp)
         self._attr_max_mireds = color_temperature_kelvin_to_mired(self._device.min_temp)
         self._attr_supported_color_modes = _hass_color_modes(self._device)

--- a/homeassistant/components/flux_led/number.py
+++ b/homeassistant/components/flux_led/number.py
@@ -51,26 +51,28 @@ async def async_setup_entry(
         | FluxMusicSegmentsNumber
     ] = []
     name = entry.data[CONF_NAME]
-    unique_id = entry.unique_id
+    base_unique_id = entry.unique_id or entry.entry_id
 
     if device.pixels_per_segment is not None:
         entities.append(
             FluxPixelsPerSegmentNumber(
                 coordinator,
-                unique_id,
+                base_unique_id,
                 f"{name} Pixels Per Segment",
                 "pixels_per_segment",
             )
         )
     if device.segments is not None:
         entities.append(
-            FluxSegmentsNumber(coordinator, unique_id, f"{name} Segments", "segments")
+            FluxSegmentsNumber(
+                coordinator, base_unique_id, f"{name} Segments", "segments"
+            )
         )
     if device.music_pixels_per_segment is not None:
         entities.append(
             FluxMusicPixelsPerSegmentNumber(
                 coordinator,
-                unique_id,
+                base_unique_id,
                 f"{name} Music Pixels Per Segment",
                 "music_pixels_per_segment",
             )
@@ -78,12 +80,12 @@ async def async_setup_entry(
     if device.music_segments is not None:
         entities.append(
             FluxMusicSegmentsNumber(
-                coordinator, unique_id, f"{name} Music Segments", "music_segments"
+                coordinator, base_unique_id, f"{name} Music Segments", "music_segments"
             )
         )
     if device.effect_list and device.effect_list != [EFFECT_RANDOM]:
         entities.append(
-            FluxSpeedNumber(coordinator, unique_id, f"{name} Effect Speed", None)
+            FluxSpeedNumber(coordinator, base_unique_id, f"{name} Effect Speed", None)
         )
 
     if entities:
@@ -131,12 +133,12 @@ class FluxConfigNumber(FluxEntity, CoordinatorEntity, NumberEntity):
     def __init__(
         self,
         coordinator: FluxLedUpdateCoordinator,
-        unique_id: str | None,
+        base_unique_id: str,
         name: str,
         key: str | None,
     ) -> None:
         """Initialize the flux number."""
-        super().__init__(coordinator, unique_id, name, key)
+        super().__init__(coordinator, base_unique_id, name, key)
         self._debouncer: Debouncer | None = None
         self._pending_value: int | None = None
 

--- a/homeassistant/components/flux_led/select.py
+++ b/homeassistant/components/flux_led/select.py
@@ -54,28 +54,28 @@ async def async_setup_entry(
         | FluxWhiteChannelSelect
     ] = []
     name = entry.data[CONF_NAME]
-    unique_id = entry.unique_id
+    base_unique_id = entry.unique_id or entry.entry_id
 
     if device.device_type == DeviceType.Switch:
         entities.append(FluxPowerStateSelect(coordinator.device, entry))
     if device.operating_modes:
         entities.append(
             FluxOperatingModesSelect(
-                coordinator, unique_id, f"{name} Operating Mode", "operating_mode"
+                coordinator, base_unique_id, f"{name} Operating Mode", "operating_mode"
             )
         )
     if device.wirings:
         entities.append(
-            FluxWiringsSelect(coordinator, unique_id, f"{name} Wiring", "wiring")
+            FluxWiringsSelect(coordinator, base_unique_id, f"{name} Wiring", "wiring")
         )
     if device.ic_types:
         entities.append(
-            FluxICTypeSelect(coordinator, unique_id, f"{name} IC Type", "ic_type")
+            FluxICTypeSelect(coordinator, base_unique_id, f"{name} IC Type", "ic_type")
         )
     if device.remote_config:
         entities.append(
             FluxRemoteConfigSelect(
-                coordinator, unique_id, f"{name} Remote Config", "remote_config"
+                coordinator, base_unique_id, f"{name} Remote Config", "remote_config"
             )
         )
     if FLUX_COLOR_MODE_RGBW in device.color_modes:
@@ -111,8 +111,8 @@ class FluxPowerStateSelect(FluxConfigAtStartSelect, SelectEntity):
         """Initialize the power state select."""
         super().__init__(device, entry)
         self._attr_name = f"{entry.data[CONF_NAME]} Power Restored"
-        if entry.unique_id:
-            self._attr_unique_id = f"{entry.unique_id}_power_restored"
+        base_unique_id = entry.unique_id or entry.entry_id
+        self._attr_unique_id = f"{base_unique_id}_power_restored"
         self._async_set_current_option_from_device()
 
     @callback
@@ -201,12 +201,12 @@ class FluxRemoteConfigSelect(FluxConfigSelect):
     def __init__(
         self,
         coordinator: FluxLedUpdateCoordinator,
-        unique_id: str | None,
+        base_unique_id: str,
         name: str,
         key: str,
     ) -> None:
         """Initialize the remote config type select."""
-        super().__init__(coordinator, unique_id, name, key)
+        super().__init__(coordinator, base_unique_id, name, key)
         assert self._device.remote_config is not None
         self._name_to_state = {
             _human_readable_option(option.name): option for option in RemoteConfig
@@ -238,8 +238,8 @@ class FluxWhiteChannelSelect(FluxConfigAtStartSelect):
         """Initialize the white channel select."""
         super().__init__(device, entry)
         self._attr_name = f"{entry.data[CONF_NAME]} White Channel"
-        if entry.unique_id:
-            self._attr_unique_id = f"{entry.unique_id}_white_channel"
+        base_unique_id = entry.unique_id or entry.entry_id
+        self._attr_unique_id = f"{base_unique_id}_white_channel"
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/flux_led/sensor.py
+++ b/homeassistant/components/flux_led/sensor.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
             [
                 FluxPairedRemotes(
                     coordinator,
-                    entry.unique_id,
+                    entry.unique_id or entry.entry_id,
                     f"{entry.data[CONF_NAME]} Paired Remotes",
                     "paired_remotes",
                 )

--- a/homeassistant/components/flux_led/switch.py
+++ b/homeassistant/components/flux_led/switch.py
@@ -34,18 +34,18 @@ async def async_setup_entry(
     """Set up the Flux lights."""
     coordinator: FluxLedUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[FluxSwitch | FluxRemoteAccessSwitch | FluxMusicSwitch] = []
-    unique_id = entry.unique_id
+    base_unique_id = entry.unique_id or entry.entry_id
     name = entry.data[CONF_NAME]
 
     if coordinator.device.device_type == DeviceType.Switch:
-        entities.append(FluxSwitch(coordinator, unique_id, name, None))
+        entities.append(FluxSwitch(coordinator, base_unique_id, name, None))
 
     if entry.data.get(CONF_REMOTE_ACCESS_HOST):
         entities.append(FluxRemoteAccessSwitch(coordinator.device, entry))
 
     if coordinator.device.microphone:
         entities.append(
-            FluxMusicSwitch(coordinator, unique_id, f"{name} Music", "music")
+            FluxMusicSwitch(coordinator, base_unique_id, f"{name} Music", "music")
         )
 
     if entities:
@@ -74,8 +74,8 @@ class FluxRemoteAccessSwitch(FluxBaseEntity, SwitchEntity):
         """Initialize the light."""
         super().__init__(device, entry)
         self._attr_name = f"{entry.data[CONF_NAME]} Remote Access"
-        if entry.unique_id:
-            self._attr_unique_id = f"{entry.unique_id}_remote_access"
+        base_unique_id = entry.unique_id or entry.entry_id
+        self._attr_unique_id = f"{base_unique_id}_remote_access"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the remote access on."""

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -7,10 +7,16 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import flux_led
-from homeassistant.components.flux_led.const import DOMAIN
+from homeassistant.components.flux_led.const import (
+    CONF_REMOTE_ACCESS_ENABLED,
+    CONF_REMOTE_ACCESS_HOST,
+    CONF_REMOTE_ACCESS_PORT,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -156,3 +162,46 @@ async def test_time_sync_startup_and_next_day(hass: HomeAssistant) -> None:
     async_fire_time_changed(hass, utcnow() + timedelta(hours=24))
     await hass.async_block_till_done()
     assert len(bulb.async_set_time.mock_calls) == 2
+
+
+async def test_unique_id_migrate_when_mac_discovered(hass: HomeAssistant) -> None:
+    """Test unique id migrated when mac discovered."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_REMOTE_ACCESS_HOST: "any",
+            CONF_REMOTE_ACCESS_ENABLED: True,
+            CONF_REMOTE_ACCESS_PORT: 1234,
+            CONF_HOST: IP_ADDRESS,
+            CONF_NAME: DEFAULT_ENTRY_TITLE,
+        },
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    with _patch_discovery(no_device=True), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    assert not config_entry.unique_id
+    entity_registry = er.async_get(hass)
+    assert (
+        entity_registry.async_get("light.bulb_rgbcw_ddeeff").unique_id
+        == config_entry.entry_id
+    )
+    assert (
+        entity_registry.async_get("switch.bulb_rgbcw_ddeeff_remote_access").unique_id
+        == f"{config_entry.entry_id}_remote_access"
+    )
+
+    with _patch_discovery(), _patch_wifibulb(device=bulb):
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get("light.bulb_rgbcw_ddeeff").unique_id
+        == config_entry.unique_id
+    )
+    assert (
+        entity_registry.async_get("switch.bulb_rgbcw_ddeeff_remote_access").unique_id
+        == f"{config_entry.unique_id}_remote_access"
+    )

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -137,8 +137,8 @@ async def test_light_goes_unavailable_and_recovers(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
 
 
-async def test_light_no_unique_id(hass: HomeAssistant) -> None:
-    """Test a light without a unique id."""
+async def test_light_mac_address_not_found(hass: HomeAssistant) -> None:
+    """Test a light when we cannot discover the mac address."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE}
     )
@@ -150,7 +150,7 @@ async def test_light_no_unique_id(hass: HomeAssistant) -> None:
 
     entity_id = "light.bulb_rgbcw_ddeeff"
     entity_registry = er.async_get(hass)
-    assert entity_registry.async_get(entity_id) is None
+    assert entity_registry.async_get(entity_id).unique_id == config_entry.entry_id
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 

--- a/tests/components/flux_led/test_number.py
+++ b/tests/components/flux_led/test_number.py
@@ -41,7 +41,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_number_unique_id(hass: HomeAssistant) -> None:
+async def test_effects_speed_unique_id(hass: HomeAssistant) -> None:
     """Test a number unique id."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -57,6 +57,23 @@ async def test_number_unique_id(hass: HomeAssistant) -> None:
     entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
     entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
+
+
+async def test_effects_speed_unique_id_no_discovery(hass: HomeAssistant) -> None:
+    """Test a number unique id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    with _patch_discovery(no_device=True), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(entity_id).unique_id == config_entry.entry_id
 
 
 async def test_rgb_light_effect_speed(hass: HomeAssistant) -> None:

--- a/tests/components/flux_led/test_select.py
+++ b/tests/components/flux_led/test_select.py
@@ -14,6 +14,7 @@ from homeassistant.components.flux_led.const import CONF_WHITE_CHANNEL_TYPE, DOM
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import (
@@ -64,6 +65,47 @@ async def test_switch_power_restore_state(hass: HomeAssistant) -> None:
     )
     switch.async_set_power_restore.assert_called_once_with(
         channel1=PowerRestoreState.ALWAYS_ON
+    )
+
+
+async def test_power_restored_unique_id(hass: HomeAssistant) -> None:
+    """Test a select unique id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    switch = _mocked_switch()
+    with _patch_discovery(), _patch_wifibulb(device=switch):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.bulb_rgbcw_ddeeff_power_restored"
+    entity_registry = er.async_get(hass)
+    assert (
+        entity_registry.async_get(entity_id).unique_id
+        == f"{MAC_ADDRESS}_power_restored"
+    )
+
+
+async def test_power_restored_unique_id_no_discovery(hass: HomeAssistant) -> None:
+    """Test a select unique id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+    )
+    config_entry.add_to_hass(hass)
+    switch = _mocked_switch()
+    with _patch_discovery(no_device=True), _patch_wifibulb(device=switch):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "select.bulb_rgbcw_ddeeff_power_restored"
+    entity_registry = er.async_get(hass)
+    assert (
+        entity_registry.async_get(entity_id).unique_id
+        == f"{config_entry.entry_id}_power_restored"
     )
 
 


### PR DESCRIPTION
Found while testing https://github.com/home-assistant/core/pull/65222

This is likely unreported since it only affects beta


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The unique id would be set to `None_remote_access_enabled`
for entities that added to the unique id because the base class
did not check if the unique id was `None`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
