### PR TITLE
Netgear coordinator

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -81,7 +81,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["router"])
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.unique_id)

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # ensure the coordinator keeps updating to discover new devices
     @callback
     def dummy_coordinator_callback() -> None:
-        """Dummy coordiantor callback to ensure discovery of new devices."""
+        """Callback ensuring discovery of new devices."""
 
     remove_dummy_update = coordinator.async_add_listener(dummy_coordinator_callback)
 

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, PLATFORMS
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, PLATFORMS, PLATFORMS_UNLOAD
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -83,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["router"])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS_UNLOAD)
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.unique_id)

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, PLATFORMS, PLATFORMS_UNLOAD
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, PLATFORMS
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -55,10 +55,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         configuration_url=f"http://{entry.data[CONF_HOST]}/",
     )
 
-    async def async_update_data():
+    async def async_update_data() -> None:
         """Fetch data from the router."""
         await router.async_update_device_trackers()
-        return
 
     # Create update coordinator
     coordinator = DataUpdateCoordinator(
@@ -84,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS_UNLOAD
+        entry, PLATFORMS
     )
 
     if unload_ok:

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -28,7 +28,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Netgear component."""
     router = NetgearRouter(hass, entry)
     try:
-        await router.async_setup()
+        if not await router.async_setup():
+            raise ConfigEntryNotReady
     except CannotLoginException as ex:
         raise ConfigEntryNotReady from ex
 

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -4,12 +4,18 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, KEY_NEW_DEVICE_LISTENERS, PLATFORMS
+from .const import (
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_NEW_DEVICE_LISTENERS,
+    KEY_ROUTER,
+    PLATFORMS,
+)
 from .errors import CannotLoginException
 from .router import NetgearRouter
 

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -1,7 +1,6 @@
 """Support for Netgear routers."""
-import logging
-
 from datetime import timedelta
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
@@ -10,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, PLATFORMS, KEY_ROUTER, KEY_COORDINATOR
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, PLATFORMS
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -65,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        name=name,
+        name=router.device_name,
         update_method=async_update_data,
         update_interval=SCAN_INTERVAL,
     )

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -9,13 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    DOMAIN,
-    KEY_COORDINATOR,
-    KEY_NEW_DEVICE_LISTENERS,
-    KEY_ROUTER,
-    PLATFORMS,
-)
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, PLATFORMS
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -81,7 +75,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.unique_id] = {
         KEY_ROUTER: router,
         KEY_COORDINATOR: coordinator,
-        KEY_NEW_DEVICE_LISTENERS: [],
     }
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
@@ -92,11 +85,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    # remove new device listeners from the coordinator
-    new_device_listeners = hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS]
-    for new_device_listener in new_device_listeners:
-        new_device_listener()
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.unique_id)

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -69,6 +69,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=SCAN_INTERVAL,
     )
 
+    await coordinator.async_config_entry_first_refresh()
+
     hass.data[DOMAIN][entry.unique_id] = {
         KEY_ROUTER: router,
         KEY_COORDINATOR: coordinator,

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -82,9 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.unique_id)

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.unique_id] = {
+    hass.data[DOMAIN][entry.entry_id] = {
         KEY_ROUTER: router,
         KEY_COORDINATOR: coordinator,
     }
@@ -87,7 +87,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.unique_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
 

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -83,7 +83,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS_UNLOAD)
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        entry, PLATFORMS_UNLOAD
+    )
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.unique_id)

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -11,7 +11,6 @@ KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
-PLATFORMS_UNLOAD = [KEY_ROUTER]
 
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -9,7 +9,6 @@ CONF_CONSIDER_HOME = "consider_home"
 
 KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
-KEY_NEW_DEVICE_LISTENERS = "new_device_listeners"
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -5,13 +5,13 @@ from homeassistant.const import Platform
 
 DOMAIN = "netgear"
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
-PLATFORMS_UNLOAD = ["router"]
-
 CONF_CONSIDER_HOME = "consider_home"
 
 KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
+
+PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
+PLATFORMS_UNLOAD = [KEY_ROUTER]
 
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -9,7 +9,7 @@ CONF_CONSIDER_HOME = "consider_home"
 
 KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
-KEY_STOP_COORDINATOR = "stop_coordinator"
+KEY_NEW_DEVICE_LISTENERS = "new_device_listeners"
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -9,6 +9,7 @@ CONF_CONSIDER_HOME = "consider_home"
 
 KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
+KEY_STOP_COORDINATOR = "stop_coordinator"
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -9,6 +9,9 @@ PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 
 CONF_CONSIDER_HOME = "consider_home"
 
+KEY_ROUTER = "router"
+KEY_COORDINATOR = "coordinator"
+
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -6,6 +6,7 @@ from homeassistant.const import Platform
 DOMAIN = "netgear"
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
+PLATFORMS_UNLOAD = ["router"]
 
 CONF_CONSIDER_HOME = "consider_home"
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -8,6 +8,7 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DEVICE_ICONS
 from .router import NetgearDeviceEntity, NetgearRouter, async_setup_netgear_entry
@@ -20,8 +21,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up device tracker for Netgear component."""
 
-    def generate_classes(router: NetgearRouter, device: dict):
-        return [NetgearScannerEntity(router, device)]
+    def generate_classes(coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict):
+        return [NetgearScannerEntity(coordinator, router, device)]
 
     async_setup_netgear_entry(hass, entry, async_add_entities, generate_classes)
 
@@ -29,9 +30,9 @@ async def async_setup_entry(
 class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
     """Representation of a device connected to a Netgear router."""
 
-    def __init__(self, router: NetgearRouter, device: dict) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict) -> None:
         """Initialize a Netgear device."""
-        super().__init__(router, device)
+        super().__init__(coordinator, router, device)
         self._hostname = self.get_hostname()
         self._icon = DEVICE_ICONS.get(device["device_type"], "mdi:help-network")
 
@@ -48,8 +49,6 @@ class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
         self._device = self._router.devices[self._mac]
         self._active = self._device["active"]
         self._icon = DEVICE_ICONS.get(self._device["device_type"], "mdi:help-network")
-
-        self.async_write_ha_state()
 
     @property
     def is_connected(self):

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -21,7 +21,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up device tracker for Netgear component."""
 
-    def generate_classes(coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict):
+    def generate_classes(
+        coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+    ):
         return [NetgearScannerEntity(coordinator, router, device)]
 
     async_setup_netgear_entry(hass, entry, async_add_entities, generate_classes)
@@ -30,7 +32,9 @@ async def async_setup_entry(
 class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
     """Representation of a device connected to a Netgear router."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict) -> None:
+    def __init__(
+        self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+    ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator, router, device)
         self._hostname = self.get_hostname()

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -20,8 +20,8 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up device tracker for Netgear component."""
-    router = hass.data[DOMAIN][entry.unique_id][KEY_ROUTER]
-    coordinator = hass.data[DOMAIN][entry.unique_id][KEY_COORDINATOR]
+    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
+    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
     tracked = set()
 
     @callback

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
             async_add_entities(new_entities, update_before_add=True)
 
     remove_new_device_listener = coordinator.async_add_listener(new_device_callback)
-    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].add(
+    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].append(
         remove_new_device_listener
     )
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -10,7 +10,13 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DEVICE_ICONS, DOMAIN, KEY_COORDINATOR, KEY_ROUTER, KEY_NEW_DEVICE_LISTENERS
+from .const import (
+    DEVICE_ICONS,
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_NEW_DEVICE_LISTENERS,
+    KEY_ROUTER,
+)
 from .router import NetgearDeviceEntity, NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +32,7 @@ async def async_setup_entry(
 
     @callback
     def new_device_callback() -> None:
-        """Callback adding new devices if needed."""
+        """Add new devices if needed."""
         if not coordinator.data:
             return
 
@@ -36,15 +42,17 @@ async def async_setup_entry(
             if mac in tracked:
                 continue
 
-            new_entities.add(NetgearScannerEntity(coordinator, router, device))
+            new_entities.append(NetgearScannerEntity(coordinator, router, device))
             tracked.add(mac)
 
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
     remove_new_device_listener = coordinator.async_add_listener(new_device_callback)
-    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].add(remove_new_device_listener)
-    
+    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].add(
+        remove_new_device_listener
+    )
+
     new_device_callback()
 
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DEVICE_ICONS, DOMAIN, KEY_COORDINATOR, KEY_ROUTER
-from .router import NetgearDeviceEntity, NetgearRouter
+from .router import NetgearBaseEntity, NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ async def async_setup_entry(
     new_device_callback()
 
 
-class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
+class NetgearScannerEntity(NetgearBaseEntity, ScannerEntity):
     """Representation of a device connected to a Netgear router."""
 
     def __init__(

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
             tracked.add(mac)
 
         if new_entities:
-            async_add_entities(new_entities, update_before_add=True)
+            async_add_entities(new_entities)
 
     entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -53,6 +53,7 @@ async def async_setup_entry(
         remove_new_device_listener
     )
 
+    coordinator.data = True
     new_device_callback()
 
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -10,13 +10,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    DEVICE_ICONS,
-    DOMAIN,
-    KEY_COORDINATOR,
-    KEY_NEW_DEVICE_LISTENERS,
-    KEY_ROUTER,
-)
+from .const import DEVICE_ICONS, DOMAIN, KEY_COORDINATOR, KEY_ROUTER
 from .router import NetgearDeviceEntity, NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,10 +42,7 @@ async def async_setup_entry(
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
-    remove_new_device_listener = coordinator.async_add_listener(new_device_callback)
-    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].append(
-        remove_new_device_listener
-    )
+    entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
 
     coordinator.data = True
     new_device_callback()

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Callable
 from datetime import timedelta
 import logging
 
@@ -19,12 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
 from homeassistant.helpers.entity import DeviceInfo, Entity
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -36,8 +30,6 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_NAME,
     DOMAIN,
-    KEY_COORDINATOR,
-    KEY_ROUTER,
     MODELS_V2,
 )
 from .errors import CannotLoginException

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -25,8 +25,10 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -34,9 +36,9 @@ from .const import (
     DEFAULT_CONSIDER_HOME,
     DEFAULT_NAME,
     DOMAIN,
-    MODELS_V2,
-    KEY_ROUTER,
     KEY_COORDINATOR,
+    KEY_ROUTER,
+    MODELS_V2,
 )
 from .errors import CannotLoginException
 
@@ -64,7 +66,9 @@ def async_setup_netgear_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    entity_class_generator: Callable[[DataUpdateCoordinator, NetgearRouter, dict], list],
+    entity_class_generator: Callable[
+        [DataUpdateCoordinator, NetgearRouter, dict], list
+    ],
 ) -> None:
     """Set up device tracker for Netgear component."""
     router = hass.data[DOMAIN][entry.unique_id][KEY_ROUTER]
@@ -86,7 +90,9 @@ def async_setup_netgear_entry(
 
 
 @callback
-def async_add_new_entities(coordinator, router, async_add_entities, tracked, entity_class_generator):
+def async_add_new_entities(
+    coordinator, router, async_add_entities, tracked, entity_class_generator
+):
     """Add new tracker entities from the router."""
     new_tracked = []
 
@@ -247,7 +253,9 @@ class NetgearRouter:
 class NetgearDeviceEntity(CoordinatorEntity, Entity):
     """Base class for a device connected to a Netgear router."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict) -> None:
+    def __init__(
+        self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+    ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator)
         self._router = router

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -197,7 +197,7 @@ class NetgearRouter:
         return self._api.ssl
 
 
-class NetgearBaseEntity(CoordinatorEntity, Entity):
+class NetgearBaseEntity(CoordinatorEntity):
     """Base class for a device connected to a Netgear router."""
 
     def __init__(

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -192,9 +192,6 @@ class NetgearRouter:
                 "conn_ap_mac": None,
             }
 
-        await self.async_update_device_trackers()
-        async_dispatcher_send(self.hass, self.signal_device_new)
-
     async def async_get_attached_devices(self) -> list:
         """Get the devices connected to the router."""
         if self.method_version == 1:

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -95,6 +95,9 @@ class NetgearRouter:
         )
 
         self._info = self._api.get_info()
+        if self._info is None:
+            return False
+
         self.device_name = self._info.get("DeviceName", DEFAULT_NAME)
         self.model = self._info.get("ModelName")
         self.firmware_version = self._info.get("Firmwareversion")
@@ -111,9 +114,12 @@ class NetgearRouter:
                 )
                 self.method_version = 1
 
-    async def async_setup(self) -> None:
+        return True
+
+    async def async_setup(self) -> bool:
         """Set up a Netgear router."""
-        await self.hass.async_add_executor_job(self._setup)
+        if not await self.hass.async_add_executor_job(self._setup):
+            return False
 
         # set already known devices to away instead of unavailable
         device_registry = dr.async_get(self.hass)
@@ -137,6 +143,8 @@ class NetgearRouter:
                 "ssid": None,
                 "conn_ap_mac": None,
             }
+
+        return True
 
     async def async_get_attached_devices(self) -> list:
         """Get the devices connected to the router."""

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -197,7 +197,7 @@ class NetgearRouter:
         return self._api.ssl
 
 
-class NetgearDeviceEntity(CoordinatorEntity, Entity):
+class NetgearBaseEntity(CoordinatorEntity, Entity):
     """Base class for a device connected to a Netgear router."""
 
     def __init__(
@@ -210,7 +210,6 @@ class NetgearDeviceEntity(CoordinatorEntity, Entity):
         self._mac = device["mac"]
         self._name = self.get_device_name()
         self._device_name = self._name
-        self._unique_id = self._mac
         self._active = device["active"]
 
     def get_device_name(self):
@@ -233,14 +232,25 @@ class NetgearDeviceEntity(CoordinatorEntity, Entity):
         super()._handle_coordinator_update()
 
     @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return self._unique_id
-
-    @property
     def name(self) -> str:
         """Return the name."""
         return self._name
+
+
+class NetgearDeviceEntity(NetgearBaseEntity):
+    """Base class for a device connected to a Netgear router."""
+
+    def __init__(
+        self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+    ) -> None:
+        """Initialize a Netgear device."""
+        super().__init__(coordinator, router, device)
+        self._unique_id = self._mac
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -50,12 +50,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up device tracker for Netgear component."""
 
-    def generate_sensor_classes(coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict):
+    def generate_sensor_classes(
+        coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+    ):
         sensors = ["type", "link_rate", "signal"]
         if router.method_version == 2:
             sensors.extend(["ssid", "conn_ap_mac"])
 
-        return [NetgearSensorEntity(coordinator, router, device, attribute) for attribute in sensors]
+        return [
+            NetgearSensorEntity(coordinator, router, device, attribute)
+            for attribute in sensors
+        ]
 
     async_setup_netgear_entry(hass, entry, async_add_entities, generate_sensor_classes)
 
@@ -65,7 +70,13 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
 
     _attr_entity_registry_enabled_default = False
 
-    def __init__(self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict, attribute: str) -> None:
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        router: NetgearRouter,
+        device: dict,
+        attribute: str,
+    ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator, router, device)
         self._attribute = attribute

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER, KEY_NEW_DEVICE_LISTENERS
+from .const import DOMAIN, KEY_COORDINATOR, KEY_NEW_DEVICE_LISTENERS, KEY_ROUTER
 from .router import NetgearDeviceEntity, NetgearRouter
 
 SENSOR_TYPES = {
@@ -53,14 +53,14 @@ async def async_setup_entry(
     router = hass.data[DOMAIN][entry.unique_id][KEY_ROUTER]
     coordinator = hass.data[DOMAIN][entry.unique_id][KEY_COORDINATOR]
     tracked = set()
-    
+
     sensors = ["type", "link_rate", "signal"]
     if router.method_version == 2:
         sensors.extend(["ssid", "conn_ap_mac"])
 
     @callback
     def new_device_callback() -> None:
-        """Callback adding new devices if needed."""
+        """Add new devices if needed."""
         if not coordinator.data:
             return
 
@@ -69,19 +69,23 @@ async def async_setup_entry(
         for mac, device in router.devices.items():
             if mac in tracked:
                 continue
-            
-            new_entities.extend([
-                NetgearSensorEntity(coordinator, router, device, attribute)
-                for attribute in sensors
-            ])
+
+            new_entities.extend(
+                [
+                    NetgearSensorEntity(coordinator, router, device, attribute)
+                    for attribute in sensors
+                ]
+            )
             tracked.add(mac)
 
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
     remove_new_device_listener = coordinator.async_add_listener(new_device_callback)
-    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].add(remove_new_device_listener)
-    
+    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].add(
+        remove_new_device_listener
+    )
+
     new_device_callback()
 
 

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_NEW_DEVICE_LISTENERS, KEY_ROUTER
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
 from .router import NetgearDeviceEntity, NetgearRouter
 
 SENSOR_TYPES = {
@@ -81,10 +81,7 @@ async def async_setup_entry(
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
-    remove_new_device_listener = coordinator.async_add_listener(new_device_callback)
-    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].append(
-        remove_new_device_listener
-    )
+    entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
 
     coordinator.data = True
     new_device_callback()

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -82,7 +82,7 @@ async def async_setup_entry(
             async_add_entities(new_entities, update_before_add=True)
 
     remove_new_device_listener = coordinator.async_add_listener(new_device_callback)
-    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].add(
+    hass.data[DOMAIN][entry.unique_id][KEY_NEW_DEVICE_LISTENERS].append(
         remove_new_device_listener
     )
 

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -79,7 +79,7 @@ async def async_setup_entry(
             tracked.add(mac)
 
         if new_entities:
-            async_add_entities(new_entities, update_before_add=True)
+            async_add_entities(new_entities)
 
     entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
 

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -50,8 +50,8 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up device tracker for Netgear component."""
-    router = hass.data[DOMAIN][entry.unique_id][KEY_ROUTER]
-    coordinator = hass.data[DOMAIN][entry.unique_id][KEY_COORDINATOR]
+    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
+    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
     tracked = set()
 
     sensors = ["type", "link_rate", "signal"]

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -86,6 +86,7 @@ async def async_setup_entry(
         remove_new_device_listener
     )
 
+    coordinator.data = True
     new_device_callback()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert Netgear entity to use Data Update Coordinator instead of using signaling for device updates.
1) this allows users to disable updates and configure there own update intervall through an automation
2) the entity update method will actually work
3) prepares the integration for further development in which other router functions can be polled (like traffic meter data)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
