### PR TITLE
Add support to reprompt user

### DIFF
--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -166,7 +166,10 @@ async def async_handle_intent(hass, message):
             alexa_response.add_speech(
                 alexa_speech, intent_response.speech[intent_speech]["speech"]
             )
-            break
+        if intent_speech in intent_response.reprompt:
+            alexa_response.add_reprompt(
+                alexa_speech, intent_response.reprompt[intent_speech]["reprompt"]
+            )
 
     if "simple" in intent_response.card:
         alexa_response.add_card(
@@ -267,10 +270,9 @@ class AlexaResponse:
 
         key = "ssml" if speech_type == SpeechType.ssml else "text"
 
-        self.reprompt = {
-            "type": speech_type.value,
-            key: text.async_render(self.variables, parse_result=False),
-        }
+        self.should_end_session = False
+
+        self.reprompt = {"type": speech_type.value, key: text}
 
     def as_dict(self):
         """Return response in an Alexa valid dict."""

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -12,6 +12,7 @@ DOMAIN = "intent_script"
 
 CONF_INTENTS = "intents"
 CONF_SPEECH = "speech"
+CONF_REPROMPT = "reprompt"
 
 CONF_ACTION = "action"
 CONF_CARD = "card"
@@ -36,6 +37,10 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Required(CONF_CONTENT): cv.template,
                 },
                 vol.Optional(CONF_SPEECH): {
+                    vol.Optional(CONF_TYPE, default="plain"): cv.string,
+                    vol.Required(CONF_TEXT): cv.template,
+                },
+                vol.Optional(CONF_REPROMPT): {
                     vol.Optional(CONF_TYPE, default="plain"): cv.string,
                     vol.Required(CONF_TEXT): cv.template,
                 },
@@ -72,6 +77,7 @@ class ScriptIntentHandler(intent.IntentHandler):
     async def async_handle(self, intent_obj):
         """Handle the intent."""
         speech = self.config.get(CONF_SPEECH)
+        reprompt = self.config.get(CONF_REPROMPT)
         card = self.config.get(CONF_CARD)
         action = self.config.get(CONF_ACTION)
         is_async_action = self.config.get(CONF_ASYNC_ACTION)
@@ -91,6 +97,12 @@ class ScriptIntentHandler(intent.IntentHandler):
             response.async_set_speech(
                 speech[CONF_TEXT].async_render(slots, parse_result=False),
                 speech[CONF_TYPE],
+            )
+
+        if reprompt is not None and reprompt[CONF_TEXT].template:
+            response.async_set_reprompt(
+                reprompt[CONF_TEXT].async_render(slots, parse_result=False),
+                reprompt[CONF_TYPE],
             )
 
         if card is not None:

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -276,4 +276,8 @@ class IntentResponse:
     @callback
     def as_dict(self) -> dict[str, dict[str, dict[str, Any]]]:
         """Return a dictionary representation of an intent response."""
-        return {"speech": self.speech, "reprompt": self.reprompt, "card": self.card}
+        return (
+            {"speech": self.speech, "reprompt": self.reprompt, "card": self.card}
+            if self.reprompt
+            else {"speech": self.speech, "card": self.card}
+        )

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -249,6 +249,7 @@ class IntentResponse:
         """Initialize an IntentResponse."""
         self.intent = intent
         self.speech: dict[str, dict[str, Any]] = {}
+        self.reprompt: dict[str, dict[str, Any]] = {}
         self.card: dict[str, dict[str, str]] = {}
 
     @callback
@@ -259,13 +260,20 @@ class IntentResponse:
         self.speech[speech_type] = {"speech": speech, "extra_data": extra_data}
 
     @callback
+    def async_set_reprompt(
+        self, speech: str, speech_type: str = "plain", extra_data: Any | None = None
+    ) -> None:
+        """Set reprompt response."""
+        self.reprompt[speech_type] = {"reprompt": speech, "extra_data": extra_data}
+
+    @callback
     def async_set_card(
         self, title: str, content: str, card_type: str = "simple"
     ) -> None:
-        """Set speech response."""
+        """Set card response."""
         self.card[card_type] = {"title": title, "content": content}
 
     @callback
     def as_dict(self) -> dict[str, dict[str, dict[str, Any]]]:
         """Return a dictionary representation of an intent response."""
-        return {"speech": self.speech, "card": self.card}
+        return {"speech": self.speech, "reprompt": self.reprompt, "card": self.card}

--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -40,3 +40,48 @@ async def test_intent_script(hass):
 
     assert response.card["simple"]["title"] == "Hello Paulus"
     assert response.card["simple"]["content"] == "Content for Paulus"
+
+
+async def test_intent_script_wait_response(hass):
+    """Test intent scripts work."""
+    calls = async_mock_service(hass, "test", "service")
+
+    await async_setup_component(
+        hass,
+        "intent_script",
+        {
+            "intent_script": {
+                "HelloWorldWaitResponse": {
+                    "action": {
+                        "service": "test.service",
+                        "data_template": {"hello": "{{ name }}"},
+                    },
+                    "card": {
+                        "title": "Hello {{ name }}",
+                        "content": "Content for {{ name }}",
+                    },
+                    "speech": {"text": "Good morning {{ name }}"},
+                    "reprompt": {
+                        "text": "I didn't hear you, {{ name }}... I said good morning!"
+                    },
+                }
+            }
+        },
+    )
+
+    response = await intent.async_handle(
+        hass, "test", "HelloWorldWaitResponse", {"name": {"value": "Paulus"}}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data["hello"] == "Paulus"
+
+    assert response.speech["plain"]["speech"] == "Good morning Paulus"
+
+    assert (
+        response.reprompt["plain"]["reprompt"]
+        == "I didn't hear you, Paulus... I said good morning!"
+    )
+
+    assert response.card["simple"]["title"] == "Hello Paulus"
+    assert response.card["simple"]["content"] == "Content for Paulus"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Added "reprompt" for the intent response


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Tests executed:
tox -e py39 -- tests/components/alexa/test_intent.py
tox -e py39 -- tests/components/conversation/test_init.py
tox -e py39 -- tests/components/intent/test_init.py
tox -e py39 -- tests/components/intent_script/test_init.py
tox -e py39 -- tests/helpers/test_intent.py

https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#response-object

"The object containing the outputSpeech to use if a re-prompt is necessary.

Used if your service keeps the session open after sending the response (shouldEndSession is false), but the user doesn't respond with anything that maps to an intent defined in your voice interface while the microphone is open. The user has a few seconds to respond to the reprompt before Alexa closes the session.

If the reprompt doesn't have a value, Alexa doesn't reprompt the user."

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1200

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
