### PR TITLE
Migrate powerwall from using ip address as unique id

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -223,7 +223,7 @@ def call_base_info(power_wall):
     # Make sure the serial numbers always have the same order
     gateway_din = None
     with contextlib.suppress((AssertionError, PowerwallError)):
-        gateway_din = power_wall.get_gateway_din()
+        gateway_din = power_wall.get_gateway_din().upper()
     return {
         POWERWALL_API_SITE_INFO: power_wall.get_site_info(),
         POWERWALL_API_STATUS: power_wall.get_status(),

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -1,4 +1,5 @@
 """The Tesla Powerwall integration."""
+import contextlib
 from datetime import timedelta
 import logging
 
@@ -7,6 +8,7 @@ from tesla_powerwall import (
     AccessDeniedError,
     MissingAttributeError,
     Powerwall,
+    PowerwallError,
     PowerwallUnreachableError,
 )
 
@@ -18,12 +20,14 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util.network import is_ip_address
 
 from .const import (
     DOMAIN,
     POWERWALL_API_CHANGED,
     POWERWALL_API_CHARGE,
     POWERWALL_API_DEVICE_TYPE,
+    POWERWALL_API_GATEWAY_DIN,
     POWERWALL_API_GRID_SERVICES_ACTIVE,
     POWERWALL_API_GRID_STATUS,
     POWERWALL_API_METERS,
@@ -116,6 +120,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryAuthFailed from err
 
     await _migrate_old_unique_ids(hass, entry_id, powerwall_data)
+
+    gateway_din = powerwall_data[POWERWALL_API_GATEWAY_DIN]
+    if gateway_din and entry.unique_id is not None and is_ip_address(entry.unique_id):
+        hass.config_entries.async_update_entry(entry, unique_id=gateway_din)
+
     login_failed_count = 0
 
     runtime_data = hass.data[DOMAIN][entry.entry_id] = {
@@ -211,14 +220,16 @@ def _login_and_fetch_base_info(power_wall: Powerwall, password: str):
 
 def call_base_info(power_wall):
     """Wrap powerwall properties to be a callable."""
-    serial_numbers = power_wall.get_serial_numbers()
     # Make sure the serial numbers always have the same order
-    serial_numbers.sort()
+    gateway_din = None
+    with contextlib.suppress((AssertionError, PowerwallError)):
+        gateway_din = power_wall.get_gateway_din()
     return {
         POWERWALL_API_SITE_INFO: power_wall.get_site_info(),
         POWERWALL_API_STATUS: power_wall.get_status(),
         POWERWALL_API_DEVICE_TYPE: power_wall.get_device_type(),
-        POWERWALL_API_SERIAL_NUMBERS: serial_numbers,
+        POWERWALL_API_SERIAL_NUMBERS: sorted(power_wall.get_serial_numbers()),
+        POWERWALL_API_GATEWAY_DIN: gateway_din,
     }
 
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -93,6 +93,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if errors:
             if CONF_PASSWORD in errors:
                 # The default password is the gateway din last 5
+                # if it does not work, we have to ask
                 return await self.async_step_user()
             return self.async_abort(reason="cannot_connect")
         assert info is not None

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -87,6 +87,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "name": gateway_din,
             "ip_address": self.ip_address,
         }
+        errors, info = await self._async_try_connect(
+            {CONF_IP_ADDRESS: self.ip_address, CONF_PASSWORD: gateway_din[-5:]}
+        )
+        if errors:
+            return await self.async_step_user()
+        assert info is not None
+        self.title = info["title"]
         return await self.async_step_confirm_discovery()
 
     async def _async_try_connect(
@@ -123,13 +130,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        errors, info = await self._async_try_connect(
-            {CONF_IP_ADDRESS: self.ip_address, CONF_PASSWORD: self.unique_id[-5:]}
-        )
-        if errors:
-            return await self.async_step_user()
-        assert info is not None
-        self.title = info["title"]
         self._set_confirm_only()
         self.context["title_placeholders"] = {
             "name": self.title,

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.components import dhcp
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.util.network import is_ip_address
 
 from .const import DOMAIN
 
@@ -72,7 +73,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # The hostname is the gateway_din (unique_id)
         await self.async_set_unique_id(gateway_din)
         self._abort_if_unique_id_configured(updates={CONF_IP_ADDRESS: self.ip_address})
-        self._async_abort_entries_match({CONF_IP_ADDRESS: self.ip_address})
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data[CONF_IP_ADDRESS] == discovery_info.ip:
+                if entry.unique_id is not None and is_ip_address(entry.unique_id):
+                    if self.hass.config_entries.async_update_entry(
+                        entry, unique_id=gateway_din
+                    ):
+                        self.hass.async_create_task(
+                            self.hass.config_entries.async_reload(entry.entry_id)
+                        )
+                return self.async_abort(reason="already_configured")
         self.context["title_placeholders"] = {
             "name": gateway_din,
             "ip_address": self.ip_address,

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -91,7 +91,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {CONF_IP_ADDRESS: self.ip_address, CONF_PASSWORD: gateway_din[-5:]}
         )
         if errors:
-            return await self.async_step_user()
+            if CONF_PASSWORD in errors:
+                # The default password is the gateway din last 5
+                return await self.async_step_user()
+            return self.async_abort(reason="cannot_connect")
         assert info is not None
         self.title = info["title"]
         return await self.async_step_confirm_discovery()

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -152,7 +152,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 assert info is not None
                 if info["unique_id"]:
-                    await self.async_set_unique_id(info["unique_id"])
+                    await self.async_set_unique_id(
+                        info["unique_id"], raise_on_progress=False
+                    )
                     self._abort_if_unique_id_configured(
                         updates={CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS]}
                     )

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -68,11 +68,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle dhcp discovery."""
         self.ip_address = discovery_info.ip
+        gateway_din = discovery_info.hostname.upper()
         # The hostname is the gateway_din (unique_id)
-        await self.async_set_unique_id(discovery_info.hostname.upper())
+        await self.async_set_unique_id(gateway_din)
         self._abort_if_unique_id_configured(updates={CONF_IP_ADDRESS: self.ip_address})
         self._async_abort_entries_match({CONF_IP_ADDRESS: self.ip_address})
-        self.context["title_placeholders"] = {CONF_IP_ADDRESS: self.ip_address}
+        self.context["title_placeholders"] = {
+            "name": gateway_din,
+            "ip_address": self.ip_address,
+        }
         return await self.async_step_confirm_discovery()
 
     async def _async_try_connect(
@@ -117,11 +121,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         assert info is not None
         self.title = info["title"]
         self._set_confirm_only()
+        self.context["title_placeholders"] = {
+            "name": self.title,
+            "ip_address": self.ip_address,
+        }
         return self.async_show_form(
             step_id="confirm_discovery",
             data_schema=vol.Schema({}),
             description_placeholders={
-                "gateway_din": self.unique_id,
+                "name": self.title,
                 "ip_address": self.ip_address,
             },
         )

--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -26,6 +26,7 @@ POWERWALL_API_STATUS = "status"
 POWERWALL_API_DEVICE_TYPE = "device_type"
 POWERWALL_API_SITE_INFO = "site_info"
 POWERWALL_API_SERIAL_NUMBERS = "serial_numbers"
+POWERWALL_API_GATEWAY_DIN = "gateway_din"
 
 POWERWALL_HTTP_SESSION = "http_session"
 

--- a/homeassistant/components/powerwall/manifest.json
+++ b/homeassistant/components/powerwall/manifest.json
@@ -3,6 +3,7 @@
   "name": "Tesla Powerwall",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/powerwall",
+  "requirements": ["tesla-powerwall==0.3.15"],
   "codeowners": ["@bdraco", "@jrester"],
   "dhcp": [
     {

--- a/homeassistant/components/powerwall/manifest.json
+++ b/homeassistant/components/powerwall/manifest.json
@@ -3,16 +3,10 @@
   "name": "Tesla Powerwall",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/powerwall",
-  "requirements": ["tesla-powerwall==0.3.12"],
   "codeowners": ["@bdraco", "@jrester"],
   "dhcp": [
     {
-      "hostname": "1118431-*",
-      "macaddress": "88DA1A*"
-    },
-    {
-      "hostname": "1118431-*",
-      "macaddress": "000145*"
+      "hostname": "1118431-*"
     }
   ],
   "iot_class": "local_polling",

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -9,6 +9,17 @@
           "ip_address": "[%key:common::config_flow::data::ip%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confim": {
+        "title": "Reauthenticate the powerwall",
+        "description": "[%key:component::powerwall::config::step::user::description%]",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },      
+      "confirm_discovery": {
+        "title": "[%key:component::powerwall::config::step::user::title%]",
+        "description": "Do you want to setup {gateway_din} ({ip_address})?"
       }
     },
     "error": {

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -29,6 +29,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "{ip_address}",
+    "flow_title": "{name} ({ip_address})",
     "step": {
       "user": {
         "title": "Connect to the powerwall",
@@ -19,7 +19,7 @@
       },      
       "confirm_discovery": {
         "title": "[%key:component::powerwall::config::step::user::title%]",
-        "description": "Do you want to setup {gateway_din} ({ip_address})?"
+        "description": "Do you want to setup {name} ({ip_address})?"
       }
     },
     "error": {

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -2,6 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
+            "cannot_connect": "Failed to connect",
             "reauth_successful": "Re-authentication was successful"
         },
         "error": {

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -10,8 +10,19 @@
             "unknown": "Unexpected error",
             "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved."
         },
-        "flow_title": "{ip_address}",
+        "flow_title": "{name} ({ip_address})",
         "step": {
+            "confirm_discovery": {
+                "description": "Do you want to setup {name} ({ip_address})?",
+                "title": "Connect to the powerwall"
+            },
+            "reauth_confim": {
+                "data": {
+                    "password": "Password"
+                },
+                "description": "The password is usually the last 5 characters of the serial number for Backup Gateway and can be found in the Tesla app or the last 5 characters of the password found inside the door for Backup Gateway 2.",
+                "title": "Reauthenticate the powerwall"
+            },
             "user": {
                 "data": {
                     "ip_address": "IP Address",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -218,13 +218,7 @@ DHCP = [
     },
     {
         "domain": "powerwall",
-        "hostname": "1118431-*",
-        "macaddress": "88DA1A*"
-    },
-    {
-        "domain": "powerwall",
-        "hostname": "1118431-*",
-        "macaddress": "000145*"
+        "hostname": "1118431-*"
     },
     {
         "domain": "rachio",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2340,6 +2340,9 @@ temperusb==1.5.3
 # homeassistant.components.tensorflow
 # tensorflow==2.5.0
 
+# homeassistant.components.powerwall
+tesla-powerwall==0.3.15
+
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2340,9 +2340,6 @@ temperusb==1.5.3
 # homeassistant.components.tensorflow
 # tensorflow==2.5.0
 
-# homeassistant.components.powerwall
-tesla-powerwall==0.3.12
-
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.0.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1428,9 +1428,6 @@ tailscale==0.1.6
 # homeassistant.components.tellduslive
 tellduslive==0.10.11
 
-# homeassistant.components.powerwall
-tesla-powerwall==0.3.12
-
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.0.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1428,6 +1428,9 @@ tailscale==0.1.6
 # homeassistant.components.tellduslive
 tellduslive==0.10.11
 
+# homeassistant.components.powerwall
+tesla-powerwall==0.3.15
+
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.0.1
 

--- a/tests/components/powerwall/mocks.py
+++ b/tests/components/powerwall/mocks.py
@@ -16,6 +16,8 @@ from tesla_powerwall import (
 
 from tests.common import load_fixture
 
+MOCK_GATEWAY_DIN = "111-0----2-000000000FFA"
+
 
 async def _mock_powerwall_with_fixtures(hass):
     """Mock data used to build powerwall state."""
@@ -70,6 +72,7 @@ async def _mock_powerwall_site_name(hass, site_name):
     # Sets site_info_resp.site_name to return site_name
     site_info_resp.response["site_name"] = site_name
     powerwall_mock.get_site_info = Mock(return_value=site_info_resp)
+    powerwall_mock.get_gateway_din = Mock(return_value=MOCK_GATEWAY_DIN)
 
     return powerwall_mock
 

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -12,8 +12,13 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT
 
-from .mocks import _mock_powerwall_side_effect, _mock_powerwall_site_name
+from .mocks import (
+    MOCK_GATEWAY_DIN,
+    _mock_powerwall_side_effect,
+    _mock_powerwall_site_name,
+)
 
 from tests.common import MockConfigEntry
 
@@ -174,22 +179,26 @@ async def test_already_configured_with_ignored(hass):
     assert result["type"] == "form"
 
 
-async def test_dhcp_discovery(hass):
-    """Test we can process the discovery from dhcp."""
+async def test_dhcp_discovery_manual_configure(hass):
+    """Test we can process the discovery from dhcp and manually configure."""
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
-            ip="1.1.1.1",
-            macaddress="AA:BB:CC:DD:EE:FF",
-            hostname="any",
-        ),
-    )
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall.login",
+        side_effect=AccessDeniedError("xyz"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                ip="1.1.1.1",
+                macaddress="AA:BB:CC:DD:EE:FF",
+                hostname="any",
+            ),
+        )
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
     with patch(
         "homeassistant.components.powerwall.config_flow.Powerwall",
         return_value=mock_powerwall,
@@ -209,18 +218,59 @@ async def test_dhcp_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_dhcp_discovery_auto_configure(hass):
+    """Test we can process the discovery from dhcp and auto configure."""
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                ip="1.1.1.1",
+                macaddress="AA:BB:CC:DD:EE:FF",
+                hostname="00GGX",
+            ),
+        )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ), patch(
+        "homeassistant.components.powerwall.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Some site"
+    assert result2["data"] == {"ip_address": "1.1.1.1", "password": "00GGX"}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_form_reauth(hass):
     """Test reauthenticate."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=VALID_CONFIG,
-        unique_id="1.2.3.4",
+        unique_id=MOCK_GATEWAY_DIN,
     )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=entry.data
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
     )
     assert result["type"] == "form"
     assert result["errors"] == {}
@@ -237,7 +287,6 @@ async def test_form_reauth(hass):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_IP_ADDRESS: "1.2.3.4",
                 CONF_PASSWORD: "new-test-password",
             },
         )
@@ -246,3 +295,68 @@ async def test_form_reauth(hass):
     assert result2["type"] == "abort"
     assert result2["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_dhcp_discovery_update_ip_address(hass):
+    """Test we can update the ip address from dhcp."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id=MOCK_GATEWAY_DIN,
+    )
+    entry.add_to_hass(hass)
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ), patch(
+        "homeassistant.components.powerwall.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                ip="1.1.1.1",
+                macaddress="AA:BB:CC:DD:EE:FF",
+                hostname=MOCK_GATEWAY_DIN.lower(),
+            ),
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_IP_ADDRESS] == "1.1.1.1"
+
+
+async def test_dhcp_discovery_updates_unique_id(hass):
+    """Test we can update the unique id from dhcp."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+        unique_id="1.2.3.4",
+    )
+    entry.add_to_hass(hass)
+    mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
+
+    with patch(
+        "homeassistant.components.powerwall.config_flow.Powerwall",
+        return_value=mock_powerwall,
+    ), patch(
+        "homeassistant.components.powerwall.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                ip="1.2.3.4",
+                macaddress="AA:BB:CC:DD:EE:FF",
+                hostname=MOCK_GATEWAY_DIN.lower(),
+            ),
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_IP_ADDRESS] == "1.2.3.4"
+    assert entry.unique_id == MOCK_GATEWAY_DIN


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Migrate powerwall from using ip address as unique id

This integration was created a while ago before we realized we shouldn't use ip address for unique id.

Changelog: https://github.com/jrester/tesla_powerwall/compare/v0.3.12...v0.3.15

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
