### PR TITLE
Remove deprecated helper functions from homekit_controller pairing flow

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -48,36 +48,6 @@ def valid_serial_number(serial):
         return True
 
 
-def get_accessory_information(accessory):
-    """Obtain the accessory information service of a HomeKit device."""
-    result = {}
-    for service in accessory["services"]:
-        stype = service["type"].upper()
-        if ServicesTypes.get_short(stype) != "accessory-information":
-            continue
-        for characteristic in service["characteristics"]:
-            ctype = CharacteristicsTypes.get_short(characteristic["type"])
-            if "value" in characteristic:
-                result[ctype] = characteristic["value"]
-    return result
-
-
-def get_bridge_information(accessories):
-    """Return the accessory info for the bridge."""
-    for accessory in accessories:
-        if accessory["aid"] == 1:
-            return get_accessory_information(accessory)
-    return get_accessory_information(accessories[0])
-
-
-def get_accessory_name(accessory_info):
-    """Return the name field of an accessory."""
-    for field in ("name", "model", "manufacturer"):
-        if field in accessory_info:
-            return accessory_info[field]
-    return None
-
-
 class HKDevice:
     """HomeKit device."""
 
@@ -642,13 +612,3 @@ class HKDevice:
         This id is random and will change if a device undergoes a hard reset.
         """
         return self.pairing_data["AccessoryPairingID"]
-
-    @property
-    def connection_info(self):
-        """Return accessory information for the main accessory."""
-        return get_bridge_information(self.accessories)
-
-    @property
-    def name(self):
-        """Name of the bridge accessory."""
-        return get_accessory_name(self.connection_info) or self.unique_id

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -180,6 +180,7 @@ def setup_mock_accessory(controller):
         serial_number="12345",
         firmware_revision="1.1",
     )
+    accessory.aid = 1
 
     service = accessory.add_service(ServicesTypes.LIGHTBULB)
     on_char = service.add_char(CharacteristicsTypes.ON)


### PR DESCRIPTION
## Proposed change

I want to make some enum-like classes in aiohomekit actually enums (so we can using them in typing). To do that I need to remove some old aiohomekit cruft.

The recent device registry improvements got rid of most uses of `get_accessory_information` and its friends, there was just one use left in the config entry code. As they use `get_short` (which means they use free form strings and not the enums), I need to get rid of them. Which is what this PR does.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
