### PR TITLE
Use upstream constants when defining homekit service to platform mapping

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -494,7 +494,11 @@ class HKDevice:
         tasks = []
         for accessory in self.accessories:
             for service in accessory["services"]:
-                stype = ServicesTypes.get_short(service["type"].upper())
+                try:
+                    stype = ServicesTypes.get_short_uuid(service["type"].upper())
+                except KeyError:
+                    stype = service["type"].upper()
+
                 if stype in HOMEKIT_ACCESSORY_DISPATCH:
                     platform = HOMEKIT_ACCESSORY_DISPATCH[stype]
                     if platform not in self.platforms:

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -2,6 +2,7 @@
 from typing import Final
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 
 DOMAIN = "homekit_controller"
 
@@ -20,33 +21,33 @@ IDENTIFIER_LEGACY_ACCESSORY_ID = "accessory-id"
 
 # Mapping from Homekit type to component.
 HOMEKIT_ACCESSORY_DISPATCH = {
-    "lightbulb": "light",
-    "outlet": "switch",
-    "switch": "switch",
-    "thermostat": "climate",
-    "heater-cooler": "climate",
-    "security-system": "alarm_control_panel",
-    "garage-door-opener": "cover",
-    "window": "cover",
-    "window-covering": "cover",
-    "lock-mechanism": "lock",
-    "contact": "binary_sensor",
-    "motion": "binary_sensor",
-    "carbon-dioxide": "sensor",
-    "humidity": "sensor",
-    "humidifier-dehumidifier": "humidifier",
-    "light": "sensor",
-    "temperature": "sensor",
-    "battery": "sensor",
-    "smoke": "binary_sensor",
-    "carbon-monoxide": "binary_sensor",
-    "leak": "binary_sensor",
-    "fan": "fan",
-    "fanv2": "fan",
-    "occupancy": "binary_sensor",
-    "television": "media_player",
-    "valve": "switch",
-    "camera-rtp-stream-management": "camera",
+    ServicesTypes.LIGHTBULB: "light",
+    ServicesTypes.OUTLET: "switch",
+    ServicesTypes.SWITCH: "switch",
+    ServicesTypes.THERMOSTAT: "climate",
+    ServicesTypes.HEATER_COOLER: "climate",
+    ServicesTypes.SECURITY_SYSTEM: "alarm_control_panel",
+    ServicesTypes.GARAGE_DOOR_OPENER: "cover",
+    ServicesTypes.WINDOW: "cover",
+    ServicesTypes.WINDOW_COVERING: "cover",
+    ServicesTypes.LOCK_MECHANISM: "lock",
+    ServicesTypes.CONTACT_SENSOR: "binary_sensor",
+    ServicesTypes.MOTION_SENSOR: "binary_sensor",
+    ServicesTypes.CARBON_DIOXIDE_SENSOR: "sensor",
+    ServicesTypes.HUMIDITY_SENSOR: "sensor",
+    ServicesTypes.HUMIDIFIER_DEHUMIDIFIER: "humidifier",
+    ServicesTypes.LIGHT_SENSOR: "sensor",
+    ServicesTypes.TEMPERATURE_SENSOR: "sensor",
+    ServicesTypes.BATTERY_SERVICE: "sensor",
+    ServicesTypes.SMOKE_SENSOR: "binary_sensor",
+    ServicesTypes.CARBON_MONOXIDE_SENSOR: "binary_sensor",
+    ServicesTypes.LEAK_SENSOR: "binary_sensor",
+    ServicesTypes.FAN: "fan",
+    ServicesTypes.FAN_V2: "fan",
+    ServicesTypes.OCCUPANCY_SENSOR: "binary_sensor",
+    ServicesTypes.TELEVISION: "media_player",
+    ServicesTypes.VALVE: "switch",
+    ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT: "camera",
 }
 
 CHARACTERISTIC_PLATFORMS = {

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -230,7 +230,7 @@ async def setup_test_component(hass, setup_accessory, capitalize=False, suffix=N
 
     domain = None
     for service in accessory.services:
-        service_name = ServicesTypes.get_short(service.type)
+        service_name = ServicesTypes.get_short_uuid(service.type)
         if service_name in HOMEKIT_ACCESSORY_DISPATCH:
             domain = HOMEKIT_ACCESSORY_DISPATCH[service_name]
             break


### PR DESCRIPTION
## Proposed change

I want to make some enum-like classes in aiohomekit actually enums (so we can using them in typing). To do that I need to remove some old aiohomekit cruft.

This changes the mappings in const.py for linking a HomeKit service to a Home Assistant platform from using bare strings to using the ServicesTypes constants. In doing so we get rid of a call to the deprecated `ServicesTypes.get_short`  👍 👍 👍 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
