### PR TITLE
Fix flick_electric auth failures

### DIFF
--- a/homeassistant/components/flick_electric/__init__.py
+++ b/homeassistant/components/flick_electric/__init__.py
@@ -1,7 +1,9 @@
 """The Flick Electric integration."""
 
 from datetime import datetime as dt
+import logging
 
+import jwt
 from pyflick import FlickAPI
 from pyflick.authentication import AbstractFlickAuth
 from pyflick.const import DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET
@@ -18,7 +20,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_TOKEN_EXPIRES_IN, CONF_TOKEN_EXPIRY, DOMAIN
+from .const import CONF_TOKEN_EXPIRY, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_ID_TOKEN = "id_token"
 
@@ -69,6 +73,8 @@ class HassFlickAuth(AbstractFlickAuth):
         return self._entry.data[CONF_ACCESS_TOKEN]
 
     async def _update_token(self):
+        _LOGGER.debug("Fetching new access token")
+
         token = await self.get_new_token(
             username=self._entry.data[CONF_USERNAME],
             password=self._entry.data[CONF_PASSWORD],
@@ -78,15 +84,17 @@ class HassFlickAuth(AbstractFlickAuth):
             ),
         )
 
-        # Reduce expiry by an hour to avoid API being called after expiry
-        expiry = dt.now().timestamp() + int(token[CONF_TOKEN_EXPIRES_IN] - 3600)
+        _LOGGER.debug("New token: %s", token)
+
+        # Flick will send the same token, but expiry is relative - so grab it from the token
+        token_decoded = jwt.decode(token, options={"verify_signature": False})
 
         self._hass.config_entries.async_update_entry(
             self._entry,
             data={
                 **self._entry.data,
                 CONF_ACCESS_TOKEN: token,
-                CONF_TOKEN_EXPIRY: expiry,
+                CONF_TOKEN_EXPIRY: token_decoded["exp"],
             },
         )
 

--- a/homeassistant/components/flick_electric/__init__.py
+++ b/homeassistant/components/flick_electric/__init__.py
@@ -87,7 +87,9 @@ class HassFlickAuth(AbstractFlickAuth):
         _LOGGER.debug("New token: %s", token)
 
         # Flick will send the same token, but expiry is relative - so grab it from the token
-        token_decoded = jwt.decode(token, options={"verify_signature": False})
+        token_decoded = jwt.decode(
+            token[CONF_ID_TOKEN], options={"verify_signature": False}
+        )
 
         self._hass.config_entries.async_update_entry(
             self._entry,

--- a/homeassistant/components/flick_electric/const.py
+++ b/homeassistant/components/flick_electric/const.py
@@ -2,7 +2,6 @@
 
 DOMAIN = "flick_electric"
 
-CONF_TOKEN_EXPIRES_IN = "expires_in"
 CONF_TOKEN_EXPIRY = "expires"
 
 ATTR_START_AT = "start_at"

--- a/homeassistant/components/flick_electric/sensor.py
+++ b/homeassistant/components/flick_electric/sensor.py
@@ -15,8 +15,6 @@ from homeassistant.util.dt import utcnow
 from .const import ATTR_COMPONENTS, ATTR_END_AT, ATTR_START_AT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-_AUTH_URL = "https://api.flick.energy/identity/oauth/token"
-_RESOURCE = "https://api.flick.energy/customer/mobile_provider/price"
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
@@ -70,6 +68,8 @@ class FlickPricingSensor(SensorEntity):
 
         async with async_timeout.timeout(60):
             self._price = await self._api.getPricing()
+
+        _LOGGER.debug("Pricing data: %s", self._price)
 
         self._attributes[ATTR_START_AT] = self._price.start_at
         self._attributes[ATTR_END_AT] = self._price.end_at


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes autentication issues for `flick_electric` - in short, the API returns the same token until it expires, which caused HA to incorrectly think it's renewed the token when it hadn't.

I've also added a couple debug logs to make things easier to debug in future, and cleaned up a few unused constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60477
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
