### PR TITLE
Increase august timeout and make failure to sync at startup non-fatal

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -1,6 +1,5 @@
 """Support for August devices."""
 import asyncio
-import contextlib
 from itertools import chain
 import logging
 
@@ -154,18 +153,16 @@ class AugustData(AugustSubscriberMixin):
         # We don't care if this fails because we only want to wake
         # locks that are actually online anyways and they will be
         # awake when they come back online
-        with contextlib.suppress(
-            (asyncio.TimeoutError, ClientResponseError, CannotConnect)
-        ):
-            await asyncio.gather(
-                *[
-                    self.async_status_async(
-                        device_id, bool(detail.bridge and detail.bridge.hyper_bridge)
-                    )
-                    for device_id, detail in self._device_detail_by_id.items()
-                    if device_id in self._locks_by_id
-                ]
-            )
+        await asyncio.gather(
+            *[
+                self.async_status_async(
+                    device_id, bool(detail.bridge and detail.bridge.hyper_bridge)
+                )
+                for device_id, detail in self._device_detail_by_id.items()
+                if device_id in self._locks_by_id
+            ],
+            return_exceptions=True,
+        )
 
     @callback
     def async_pubnub_message(self, device_id, date_time, message):

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -1,5 +1,6 @@
 """Support for August devices."""
 import asyncio
+import contextlib
 from itertools import chain
 import logging
 
@@ -43,7 +44,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return await async_setup_august(hass, entry, august_gateway)
     except (RequireValidation, InvalidAuth) as err:
         raise ConfigEntryAuthFailed from err
-    except (ClientResponseError, CannotConnect, asyncio.TimeoutError) as err:
+    except asyncio.TimeoutError as err:
+        raise ConfigEntryNotReady("Timed out connecting to august api") from err
+    except (ClientResponseError, CannotConnect) as err:
         raise ConfigEntryNotReady from err
 
 
@@ -141,15 +144,28 @@ class AugustData(AugustSubscriberMixin):
         self._pubnub_unsub = async_create_pubnub(user_data["UserID"], pubnub)
 
         if self._locks_by_id:
-            tasks = []
-            for lock_id in self._locks_by_id:
-                detail = self._device_detail_by_id[lock_id]
-                tasks.append(
+            # Do not prevent setup as the sync can timeout
+            # but it is not a fatal error as the lock
+            # will recover automatically when it comes back online.
+            asyncio.create_task(self._async_initial_sync())
+
+    async def _async_initial_sync(self):
+        """Attempt to request an initial sync."""
+        # We don't care if this fails because we only want to wake
+        # locks that are actually online anyways and they will be
+        # awake when they come back online
+        with contextlib.suppress(
+            (asyncio.TimeoutError, ClientResponseError, CannotConnect)
+        ):
+            await asyncio.gather(
+                *[
                     self.async_status_async(
-                        lock_id, bool(detail.bridge and detail.bridge.hyper_bridge)
+                        device_id, bool(detail.bridge and detail.bridge.hyper_bridge)
                     )
-                )
-            await asyncio.gather(*tasks)
+                    for device_id, detail in self._device_detail_by_id.items()
+                    if device_id in self._locks_by_id
+                ]
+            )
 
     @callback
     def async_pubnub_message(self, device_id, date_time, message):

--- a/homeassistant/components/august/const.py
+++ b/homeassistant/components/august/const.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from homeassistant.const import Platform
 
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 15
 
 CONF_ACCESS_TOKEN_CACHE_FILE = "access_token_cache_file"
 CONF_LOGIN_METHOD = "login_method"

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.19"],
+  "requirements": ["yalexs==1.1.20"],
   "codeowners": ["@bdraco"],
   "dhcp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2513,7 +2513,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.3.7
 
 # homeassistant.components.august
-yalexs==1.1.19
+yalexs==1.1.20
 
 # homeassistant.components.yeelight
 yeelight==0.7.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1544,7 +1544,7 @@ xmltodict==0.12.0
 yalesmartalarmclient==0.3.7
 
 # homeassistant.components.august
-yalexs==1.1.19
+yalexs==1.1.20
 
 # homeassistant.components.yeelight
 yeelight==0.7.8

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -30,6 +30,26 @@ from tests.components.august.mocks import (
 )
 
 
+async def test_august_api_is_failing(hass):
+    """Config entry state is SETUP_RETRY when august api is failing."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=_mock_get_config()[DOMAIN],
+        title="August august",
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
+        side_effect=ClientResponseError(None, None, status=500),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
 async def test_august_is_offline(hass):
     """Config entry state is SETUP_RETRY when august is offline."""
 


### PR DESCRIPTION
Replaces #65278 since the CI keeps failing on that one

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Increase timeout

- If initial sync fails do not fail to setup as it can recover later

Changelog: https://github.com/bdraco/yalexs/compare/v1.1.19...v1.1.20


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65277
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
