### PR TITLE
Add support Mqtt switch for unkown state

### DIFF
--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import functools
-from xmlrpc.client import boolean
 
 import voluptuous as vol
 
@@ -176,7 +175,7 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
             self._state = last_state.state == STATE_ON
 
     @property
-    def is_on(self) -> boolean | None:
+    def is_on(self) -> bool | None:
         """Return true if device is on."""
         return self._state
 

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -132,9 +132,6 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
             config[CONF_OPTIMISTIC] or config.get(CONF_STATE_TOPIC) is None
         )
 
-        if self._optimistic:
-            self._state = False
-
         self._value_template = MqttValueTemplate(
             self._config.get(CONF_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -128,7 +128,9 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
         state_off = config.get(CONF_STATE_OFF)
         self._state_off = state_off if state_off else config[CONF_PAYLOAD_OFF]
 
-        self._optimistic = config[CONF_OPTIMISTIC]
+        self._optimistic = (
+            config[CONF_OPTIMISTIC] or config.get(CONF_STATE_TOPIC) is None
+        )
 
         if self._optimistic:
             self._state = False

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -14,9 +14,9 @@ from homeassistant.components.mqtt.abbreviations import (
 from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED, async_start
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
-    STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 
@@ -649,7 +649,7 @@ async def test_discovery_expansion(hass, mqtt_mock, caplog):
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "test_topic/some/base/topic", "ON")
 
@@ -699,7 +699,7 @@ async def test_discovery_expansion_2(hass, mqtt_mock, caplog):
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.no_fail_on_log_exception
@@ -773,7 +773,7 @@ async def test_discovery_expansion_without_encoding_and_value_template_1(
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "some/base/topic/avail_item1", b"\x00")
 
@@ -819,7 +819,7 @@ async def test_discovery_expansion_without_encoding_and_value_template_2(
     assert state is not None
     assert state.name == "DiscoveryExpansionTest1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "some/base/topic/avail_item1", b"\x00")
 
@@ -895,13 +895,13 @@ async def test_no_implicit_state_topic_switch(hass, mqtt_mock, caplog):
     assert state is not None
     assert state.name == "Test1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes["assumed_state"] is True
 
     async_fire_mqtt_message(hass, "homeassistant/switch/bla/state", "ON")
 
     state = hass.states.get("switch.Test1")
-    assert state.state == "off"
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -14,6 +14,7 @@ from homeassistant.components.mqtt.abbreviations import (
 from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED, async_start
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
+    STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -895,13 +896,13 @@ async def test_no_implicit_state_topic_switch(hass, mqtt_mock, caplog):
     assert state is not None
     assert state.name == "Test1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_OFF
     assert state.attributes["assumed_state"] is True
 
     async_fire_mqtt_message(hass, "homeassistant/switch/bla/state", "ON")
 
     state = hass.states.get("switch.Test1")
-    assert state.state == STATE_UNKNOWN
+    assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -14,7 +14,6 @@ from homeassistant.components.mqtt.abbreviations import (
 from homeassistant.components.mqtt.discovery import ALREADY_DISCOVERED, async_start
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
-    STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -896,13 +895,13 @@ async def test_no_implicit_state_topic_switch(hass, mqtt_mock, caplog):
     assert state is not None
     assert state.name == "Test1"
     assert ("switch", "bla") in hass.data[ALREADY_DISCOVERED]
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes["assumed_state"] is True
 
     async_fire_mqtt_message(hass, "homeassistant/switch/bla/state", "ON")
 
     state = hass.states.get("switch.Test1")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -138,6 +138,26 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state == STATE_OFF
 
 
+async def test_sending_inital_state_and_optimistic(hass, mqtt_mock):
+    """Test the initial state in optimistic mode."""
+    assert await async_setup_component(
+        hass,
+        switch.DOMAIN,
+        {
+            switch.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test")
+    assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_ASSUMED_STATE)
+
+
 async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
     """Test the controlling state via topic and JSON message."""
     assert await async_setup_component(

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -154,7 +154,7 @@ async def test_sending_inital_state_and_optimistic(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -71,7 +72,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_DEVICE_CLASS) == "switch"
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -84,6 +85,11 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "state-topic", "None")
+
+    state = hass.states.get("switch.test")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
@@ -152,7 +158,7 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "state-topic", '{"val":"beer on"}')
 
@@ -163,6 +169,11 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "state-topic", '{"val": null}')
+
+    state = hass.states.get("switch.test")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_availability_when_connection_lost(hass, mqtt_mock):
@@ -236,7 +247,7 @@ async def test_custom_state_payload(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "state-topic", "HIGH")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The initial state for MQTT switch will become `unknown`. This could break existing automation's.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for MQTT switch that enables to have an `unknown` state.
If the switch is not in optimistic mode the initial state will be `unknown`.
Additional the state will be reset to `unknown` if a `None` payload is received at `state_topic`.

The PR fixes also a bug that the MQTT switch does not assume optimistic mode when `state_stopic` is not configured.
With this PR explicit configuring `optimistic` is no longer needed.

This is a follow up for #64621

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21414

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
