### PR TITLE
Allow HomeWizard devices with disabled api to show up in discovery

### DIFF
--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.data_entry_flow import AbortFlow, FlowResult
 
 from .const import (
     CONF_API_ENABLED,
+    CONF_PATH,
     CONF_PRODUCT_NAME,
     CONF_PRODUCT_TYPE,
     CONF_SERIAL,
@@ -103,33 +104,33 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Validate doscovery entry
         if (
-            "api_enabled" not in discovery_info.properties
-            or "path" not in discovery_info.properties
-            or "product_name" not in discovery_info.properties
-            or "product_type" not in discovery_info.properties
-            or "serial" not in discovery_info.properties
+            CONF_API_ENABLED not in discovery_info.properties
+            or CONF_PATH not in discovery_info.properties
+            or CONF_PRODUCT_NAME not in discovery_info.properties
+            or CONF_PRODUCT_TYPE not in discovery_info.properties
+            or CONF_SERIAL not in discovery_info.properties
         ):
             return self.async_abort(reason="invalid_discovery_parameters")
 
-        if (discovery_info.properties["path"]) != "/api/v1":
+        if (discovery_info.properties[CONF_PATH]) != "/api/v1":
             return self.async_abort(reason="unsupported_api_version")
 
         # Sets unique ID and aborts if it is already exists
         await self._async_set_and_check_unique_id(
             {
                 CONF_IP_ADDRESS: discovery_info.host,
-                CONF_PRODUCT_TYPE: discovery_info.properties["product_type"],
-                CONF_SERIAL: discovery_info.properties["serial"],
+                CONF_PRODUCT_TYPE: discovery_info.properties[CONF_PRODUCT_TYPE],
+                CONF_SERIAL: discovery_info.properties[CONF_SERIAL],
             }
         )
 
         # Pass parameters
         self.config = {
-            CONF_API_ENABLED: discovery_info.properties["api_enabled"],
+            CONF_API_ENABLED: discovery_info.properties[CONF_API_ENABLED],
             CONF_IP_ADDRESS: discovery_info.host,
-            CONF_PRODUCT_TYPE: discovery_info.properties["product_type"],
-            CONF_PRODUCT_NAME: discovery_info.properties["product_name"],
-            CONF_SERIAL: discovery_info.properties["serial"],
+            CONF_PRODUCT_TYPE: discovery_info.properties[CONF_PRODUCT_TYPE],
+            CONF_PRODUCT_NAME: discovery_info.properties[CONF_PRODUCT_NAME],
+            CONF_SERIAL: discovery_info.properties[CONF_SERIAL],
         }
         return await self.async_step_discovery_confirm()
 

--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -35,7 +35,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the HomeWizard config flow."""
         self.config: dict[str, str | int] = {}
 
-    async def async_step_import(self, import_config: dict) -> FlowResult:
+    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
         """Handle a flow initiated by older `homewizard_energy` component."""
         _LOGGER.debug("config_flow async_step_import")
 

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -19,6 +19,7 @@ CONF_PRODUCT_NAME = "product_name"
 CONF_PRODUCT_TYPE = "product_type"
 CONF_DEVICE = "device"
 CONF_DATA = "data"
+CONF_API_ENABLED = "api_enabled"
 
 UPDATE_INTERVAL = timedelta(seconds=5)
 

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -14,12 +14,13 @@ DOMAIN = "homewizard"
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 
 # Platform config.
-CONF_SERIAL = "serial"
+CONF_API_ENABLED = "api_enabled"
+CONF_DATA = "data"
+CONF_DEVICE = "device"
+CONF_PATH = "path"
 CONF_PRODUCT_NAME = "product_name"
 CONF_PRODUCT_TYPE = "product_type"
-CONF_DEVICE = "device"
-CONF_DATA = "data"
-CONF_API_ENABLED = "api_enabled"
+CONF_SERIAL = "serial"
 
 UPDATE_INTERVAL = timedelta(seconds=5)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow a device with a disabled API to show up in discovered devices. The user will be informed how to enable the API.
Also a plus: Devices that have a disabled API won't receive requests to its API

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration) (ish)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
