### PR TITLE
Add siren platform to Overkiz

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -876,6 +876,7 @@ omit =
     homeassistant/components/overkiz/scene.py
     homeassistant/components/overkiz/select.py
     homeassistant/components/overkiz/sensor.py
+    homeassistant/components/overkiz/siren.py
     homeassistant/components/overkiz/switch.py
     homeassistant/components/ovo_energy/__init__.py
     homeassistant/components/ovo_energy/const.py

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -27,6 +27,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SCENE,
     Platform.SENSOR,
+    Platform.SIREN,
     Platform.SWITCH,
 ]
 
@@ -36,7 +37,7 @@ IGNORED_OVERKIZ_DEVICES: list[UIClass | UIWidget] = [
 ]
 
 # Used to map the Somfy widget and ui_class to the Home Assistant platform
-OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
+OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIClass.ADJUSTABLE_SLATS_ROLLER_SHUTTER: Platform.COVER,
     UIClass.AWNING: Platform.COVER,
     UIClass.CURTAIN: Platform.COVER,
@@ -51,6 +52,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIClass.ROLLER_SHUTTER: Platform.COVER,
     UIClass.SCREEN: Platform.COVER,
     UIClass.SHUTTER: Platform.COVER,
+    UIClass.SIREN: Platform.SIREN,
     UIClass.SWIMMING_POOL: Platform.SWITCH,
     UIClass.SWINGING_SHUTTER: Platform.COVER,
     UIClass.VENETIAN_BLIND: Platform.COVER,
@@ -60,6 +62,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIWidget.RTD_INDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIWidget.RTD_OUTDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIWidget.RTS_GENERIC: Platform.COVER,  # widgetName, uiClass is Generic (not supported)
+    UIWidget.SIREN_STATUS: None,  # widgetName, uiClass is Siren (siren)
     UIWidget.STATELESS_ALARM_CONTROLLER: Platform.SWITCH,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.STATELESS_EXTERIOR_HEATING: Platform.SWITCH,  # widgetName, uiClass is ExteriorHeatingSystem (not supported)
 }

--- a/homeassistant/components/overkiz/siren.py
+++ b/homeassistant/components/overkiz/siren.py
@@ -58,7 +58,8 @@ class OverkizSiren(OverkizEntity, SirenEntity):
         duration_in_ms = duration * 1000
 
         await self.executor.async_execute_command(
-            OverkizCommand.RING_WITH_SINGLE_SIMPLE_SEQUENCE,  # https://www.tahomalink.com/enduser-mobile-web/steer-html5-client/vendor/somfy/io/siren/const.js
+            # https://www.tahomalink.com/enduser-mobile-web/steer-html5-client/vendor/somfy/io/siren/const.js
+            OverkizCommand.RING_WITH_SINGLE_SIMPLE_SEQUENCE,
             duration_in_ms,  # duration
             75,  # 90 seconds bip, 30 seconds silence
             2,  # repeat 3 times

--- a/homeassistant/components/overkiz/siren.py
+++ b/homeassistant/components/overkiz/siren.py
@@ -1,0 +1,70 @@
+"""Support for Overkiz sirens."""
+from typing import Any, cast
+
+from pyoverkiz.enums import OverkizState
+from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam
+
+from homeassistant.components.siren import SirenEntity
+from homeassistant.components.siren.const import (
+    ATTR_DURATION,
+    SUPPORT_DURATION,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import HomeAssistantOverkizData
+from .const import DOMAIN
+from .entity import OverkizEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Overkiz sirens from a config entry."""
+    data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        OverkizSiren(device.device_url, data.coordinator)
+        for device in data.platforms[Platform.SIREN]
+    )
+
+
+class OverkizSiren(OverkizEntity, SirenEntity):
+    """Representation an Overkiz Siren."""
+
+    _attr_supported_features = SUPPORT_TURN_OFF | SUPPORT_TURN_ON | SUPPORT_DURATION
+
+    @property
+    def is_on(self) -> bool:
+        """Get whether the siren is in on state."""
+        return (
+            self.executor.select_state(OverkizState.CORE_ON_OFF)
+            == OverkizCommandParam.ON
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Send the on command."""
+        if kwargs.get(ATTR_DURATION):
+            duration = cast(int, kwargs.get(ATTR_DURATION))
+        else:
+            duration = 2 * 60  # 2 minutes
+
+        duration_in_ms = duration * 1000
+
+        await self.executor.async_execute_command(
+            OverkizCommand.RING_WITH_SINGLE_SIMPLE_SEQUENCE,  # https://www.tahomalink.com/enduser-mobile-web/steer-html5-client/vendor/somfy/io/siren/const.js
+            duration_in_ms,  # duration
+            75,  # 90 seconds bip, 30 seconds silence
+            2,  # repeat 3 times
+            OverkizCommandParam.MEMORIZED_VOLUME,
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Send the off command."""
+        await self.executor.async_execute_command(OverkizCommand.OFF)

--- a/homeassistant/components/overkiz/siren.py
+++ b/homeassistant/components/overkiz/siren.py
@@ -1,5 +1,5 @@
 """Support for Overkiz sirens."""
-from typing import Any, cast
+from typing import Any
 
 from pyoverkiz.enums import OverkizState
 from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam
@@ -51,7 +51,7 @@ class OverkizSiren(OverkizEntity, SirenEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the on command."""
         if kwargs.get(ATTR_DURATION):
-            duration = cast(int, kwargs.get(ATTR_DURATION))
+            duration = kwargs[ATTR_DURATION]
         else:
             duration = 2 * 60  # 2 minutes
 


### PR DESCRIPTION
## Proposed change

Adds support for Overkiz (io) Sirens. Support for stateless sirens has been added already, and this PR adds support for stateful sirens.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
