### PR TITLE
Add MQTT light unknown state support

### DIFF
--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -109,6 +109,8 @@ CONF_WHITE_VALUE_STATE_TOPIC = "white_value_state_topic"
 CONF_WHITE_VALUE_TEMPLATE = "white_value_template"
 CONF_ON_COMMAND_TYPE = "on_command_type"
 
+PAYLOAD_NONE = "None"
+
 MQTT_LIGHT_ATTRIBUTES_BLOCKED = frozenset(
     {
         ATTR_COLOR_MODE,
@@ -257,7 +259,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         self._rgb_color = None
         self._rgbw_color = None
         self._rgbww_color = None
-        self._state = False
+        self._state = None
         self._supported_color_modes = None
         self._white_value = None
         self._xy_color = None
@@ -350,6 +352,8 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             optimistic or topic[CONF_COLOR_MODE_STATE_TOPIC] is None
         )
         self._optimistic = optimistic or topic[CONF_STATE_TOPIC] is None
+        if self._optimistic:
+            self._state = False
         self._optimistic_rgb_color = optimistic or topic[CONF_RGB_STATE_TOPIC] is None
         self._optimistic_rgbw_color = optimistic or topic[CONF_RGBW_STATE_TOPIC] is None
         self._optimistic_rgbww_color = (
@@ -445,9 +449,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         @log_messages(self.hass, self.entity_id)
         def state_received(msg):
             """Handle new MQTT messages."""
-            payload = self._value_templates[CONF_STATE_VALUE_TEMPLATE](
-                msg.payload, None
-            )
+            payload = self._value_templates[CONF_STATE_VALUE_TEMPLATE](msg.payload)
             if not payload:
                 _LOGGER.debug("Ignoring empty state message from '%s'", msg.topic)
                 return
@@ -456,6 +458,8 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 self._state = True
             elif payload == self._payload["off"]:
                 self._state = False
+            elif payload == PAYLOAD_NONE:
+                self._state = None
             self.async_write_ha_state()
 
         if self._topic[CONF_STATE_TOPIC] is not None:

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -352,8 +352,6 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             optimistic or topic[CONF_COLOR_MODE_STATE_TOPIC] is None
         )
         self._optimistic = optimistic or topic[CONF_STATE_TOPIC] is None
-        if self._optimistic:
-            self._state = False
         self._optimistic_rgb_color = optimistic or topic[CONF_RGB_STATE_TOPIC] is None
         self._optimistic_rgbw_color = optimistic or topic[CONF_RGBW_STATE_TOPIC] is None
         self._optimistic_rgbww_color = (

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -212,8 +212,6 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
         }
         optimistic = config[CONF_OPTIMISTIC]
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
-        if self._optimistic:
-            self._state = False
 
         self._flash_times = {
             key: config.get(key)

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -100,6 +100,8 @@ CONF_FLASH_TIME_SHORT = "flash_time_short"
 CONF_MAX_MIREDS = "max_mireds"
 CONF_MIN_MIREDS = "min_mireds"
 
+PAYLOAD_NONE = "None"
+
 
 def valid_color_configuration(config):
     """Test color_mode is not combined with deprecated config."""
@@ -179,7 +181,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
 
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize MQTT JSON light."""
-        self._state = False
+        self._state = None
         self._supported_features = 0
 
         self._topic = None
@@ -210,6 +212,8 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
         }
         optimistic = config[CONF_OPTIMISTIC]
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
+        if self._optimistic:
+            self._state = False
 
         self._flash_times = {
             key: config.get(key)
@@ -318,6 +322,8 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                 self._state = True
             elif values["state"] == "OFF":
                 self._state = False
+            elif values["state"] is None:
+                self._state = None
 
             if self._supported_features and SUPPORT_COLOR and "color" in values:
                 if values["color"] is None:

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -67,6 +67,8 @@ CONF_MIN_MIREDS = "min_mireds"
 CONF_RED_TEMPLATE = "red_template"
 CONF_WHITE_VALUE_TEMPLATE = "white_value_template"
 
+PAYLOAD_NONE = "None"
+
 PLATFORM_SCHEMA_TEMPLATE = (
     mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
         {
@@ -109,7 +111,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
 
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize a MQTT Template light."""
-        self._state = False
+        self._state = None
 
         self._topics = None
         self._templates = None
@@ -155,6 +157,8 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             or self._topics[CONF_STATE_TOPIC] is None
             or self._templates[CONF_STATE_TEMPLATE] is None
         )
+        if self._optimistic:
+            self._state = False
 
     async def _subscribe_topics(self):  # noqa: C901
         """(Re)Subscribe to topics."""
@@ -175,6 +179,8 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
                 self._state = True
             elif state == STATE_OFF:
                 self._state = False
+            elif state == PAYLOAD_NONE:
+                self._state = None
             else:
                 _LOGGER.warning("Invalid state value received")
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -157,8 +157,6 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             or self._topics[CONF_STATE_TOPIC] is None
             or self._templates[CONF_STATE_TEMPLATE] is None
         )
-        if self._optimistic:
-            self._state = False
 
     async def _subscribe_topics(self):  # noqa: C901
         """(Re)Subscribe to topics."""

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -1471,7 +1471,7 @@ async def test_sending_mqtt_rgb_command_with_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", rgb_color=[255, 128, 64])
 
@@ -1508,7 +1508,7 @@ async def test_sending_mqtt_rgbw_command_with_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", rgbw_color=[255, 128, 64, 32])
 
@@ -1545,7 +1545,7 @@ async def test_sending_mqtt_rgbww_command_with_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", rgbww_color=[255, 128, 64, 32, 16])
 
@@ -1581,7 +1581,7 @@ async def test_sending_mqtt_color_temp_command_with_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", color_temp=100)
 
@@ -1614,7 +1614,7 @@ async def test_on_command_first(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=50)
 
@@ -1649,7 +1649,7 @@ async def test_on_command_last(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=50)
 
@@ -1686,7 +1686,7 @@ async def test_on_command_brightness(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     # Turn on w/ no brightness - should set to max
     await common.async_turn_on(hass, "light.test")
@@ -1742,7 +1742,7 @@ async def test_on_command_brightness_scaled(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     # Turn on w/ no brightness - should set to max
     await common.async_turn_on(hass, "light.test")
@@ -1810,7 +1810,7 @@ async def test_legacy_on_command_rgb(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=127)
 
@@ -1900,7 +1900,7 @@ async def test_on_command_rgb(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=127)
 
@@ -1990,7 +1990,7 @@ async def test_on_command_rgbw(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=127)
 
@@ -2080,7 +2080,7 @@ async def test_on_command_rgbww(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=127)
 
@@ -2171,7 +2171,7 @@ async def test_on_command_rgb_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=127)
 
@@ -2208,8 +2208,7 @@ async def test_on_command_rgbw_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
-
+    assert state.state == STATE_UNKNOWN
     await common.async_turn_on(hass, "light.test", brightness=127)
 
     # Should get the following MQTT messages.
@@ -2245,7 +2244,7 @@ async def test_on_command_rgbww_template(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", brightness=127)
 
@@ -2294,7 +2293,7 @@ async def test_on_command_white(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) is None
@@ -2654,7 +2653,7 @@ async def test_effect(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test", effect="rainbow")
 

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -177,6 +177,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -269,7 +270,7 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(hass, mqt
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
@@ -297,6 +298,16 @@ async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(hass, mqt
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) == "onoff"
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == ["onoff"]
+
+    async_fire_mqtt_message(hass, "test_light_rgb/status", "OFF")
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "test_light_rgb/status", "None")
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_legacy_controlling_state_via_topic(hass, mqtt_mock):
@@ -332,7 +343,7 @@ async def test_legacy_controlling_state_via_topic(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
@@ -463,7 +474,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
@@ -581,7 +592,7 @@ async def test_legacy_invalid_state_via_topic(hass, mqtt_mock, caplog):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
@@ -700,7 +711,7 @@ async def test_invalid_state_via_topic(hass, mqtt_mock, caplog):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") is None
@@ -823,7 +834,7 @@ async def test_brightness_controlling_scale(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -869,7 +880,7 @@ async def test_brightness_from_rgb_controlling_scale(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -909,7 +920,7 @@ async def test_legacy_white_value_controlling_scale(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("white_value") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -969,7 +980,7 @@ async def test_legacy_controlling_state_via_topic_with_templates(hass, mqtt_mock
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("rgb_color") is None
 
@@ -1016,6 +1027,10 @@ async def test_legacy_controlling_state_via_topic_with_templates(hass, mqtt_mock
     state = hass.states.get("light.test")
     assert state.attributes.get("xy_color") == (0.14, 0.131)
 
+    async_fire_mqtt_message(hass, "test_light_rgb/status", '{"hello": null}')
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
+
 
 async def test_controlling_state_via_topic_with_templates(hass, mqtt_mock):
     """Test the setting of the state with a template."""
@@ -1058,7 +1073,7 @@ async def test_controlling_state_via_topic_with_templates(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("rgb_color") is None
 
@@ -2364,7 +2379,7 @@ async def test_explicit_color_mode(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
@@ -2505,7 +2520,7 @@ async def test_explicit_color_mode_templated(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("hs_color") is None
@@ -2591,7 +2606,7 @@ async def test_white_state_update(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) is None

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -102,6 +102,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -268,7 +269,7 @@ async def test_no_color_brightness_color_temp_white_val_if_no_topics(hass, mqtt_
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = light.SUPPORT_FLASH | light.SUPPORT_TRANSITION
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
     assert state.attributes.get("rgb_color") is None
@@ -290,6 +291,16 @@ async def test_no_color_brightness_color_temp_white_val_if_no_topics(hass, mqtt_
     assert state.attributes.get("white_value") is None
     assert state.attributes.get("xy_color") is None
     assert state.attributes.get("hs_color") is None
+
+    async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"OFF"}')
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "test_light_rgb", '{"state": null}')
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_controlling_state_via_topic(hass, mqtt_mock):
@@ -318,7 +329,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = (
         light.SUPPORT_BRIGHTNESS
         | light.SUPPORT_COLOR
@@ -446,7 +457,7 @@ async def test_controlling_state_via_topic2(hass, mqtt_mock, caplog):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = (
         light.SUPPORT_BRIGHTNESS
         | light.SUPPORT_COLOR
@@ -1529,7 +1540,7 @@ async def test_brightness_scale(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("brightness") is None
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
@@ -1573,7 +1584,7 @@ async def test_invalid_values(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = (
         light.SUPPORT_BRIGHTNESS
         | light.SUPPORT_COLOR

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -971,7 +971,7 @@ async def test_sending_hs_color(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     mqtt_mock.reset_mock()
     await common.async_turn_on(
@@ -1034,7 +1034,7 @@ async def test_sending_rgb_color_no_brightness(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
@@ -1089,7 +1089,7 @@ async def test_sending_rgb_color_no_brightness2(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
@@ -1166,7 +1166,7 @@ async def test_sending_rgb_color_with_brightness(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
@@ -1237,7 +1237,7 @@ async def test_sending_rgb_color_with_scaled_brightness(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
@@ -1307,7 +1307,7 @@ async def test_sending_xy_color(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(
         hass, "light.test", brightness=50, xy_color=[0.123, 0.123]
@@ -1370,7 +1370,7 @@ async def test_effect(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = (
         light.SUPPORT_EFFECT | light.SUPPORT_FLASH | light.SUPPORT_TRANSITION
     )
@@ -1433,7 +1433,7 @@ async def test_flash_short_and_long(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = light.SUPPORT_FLASH | light.SUPPORT_TRANSITION
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
 
@@ -1492,7 +1492,7 @@ async def test_transition(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = light.SUPPORT_FLASH | light.SUPPORT_TRANSITION
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == expected_features
     await common.async_turn_on(hass, "light.test", transition=15)

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -172,7 +172,7 @@ async def test_rgb_light(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     expected_features = (
         light.SUPPORT_TRANSITION
         | light.SUPPORT_COLOR
@@ -646,7 +646,7 @@ async def test_effect(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 44
 
     await common.async_turn_on(hass, "light.test")
@@ -697,7 +697,7 @@ async def test_flash(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 40
 
     await common.async_turn_on(hass, "light.test")
@@ -745,7 +745,7 @@ async def test_transition(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 40
 

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -40,6 +40,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
@@ -171,6 +172,7 @@ async def test_rgb_light(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
+    assert state.state == STATE_OFF
     expected_features = (
         light.SUPPORT_TRANSITION
         | light.SUPPORT_COLOR
@@ -208,7 +210,7 @@ async def test_state_change_via_topic(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
@@ -223,6 +225,16 @@ async def test_state_change_via_topic(hass, mqtt_mock):
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("white_value") is None
+
+    async_fire_mqtt_message(hass, "test_light_rgb", "off")
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_OFF
+
+    async_fire_mqtt_message(hass, "test_light_rgb", "None")
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_state_brightness_color_effect_temp_white_change_via_topic(
@@ -264,7 +276,7 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("effect") is None
@@ -282,6 +294,12 @@ async def test_state_brightness_color_effect_temp_white_change_via_topic(
     assert state.attributes.get("color_temp") == 145
     assert state.attributes.get("white_value") == 123
     assert state.attributes.get("effect") is None
+
+    # make the light state unknown
+    async_fire_mqtt_message(hass, "test_light_rgb", "None")
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_UNKNOWN
 
     # turn the light off
     async_fire_mqtt_message(hass, "test_light_rgb", "off")
@@ -514,7 +532,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert not state.attributes.get("brightness")
     assert not state.attributes.get("hs_color")
     assert not state.attributes.get("effect")
@@ -528,7 +546,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     await common.async_turn_on(hass, "light.test")
     mqtt_mock.async_publish.assert_called_once_with(
@@ -536,7 +554,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
 
     # Set color_temp
     await common.async_turn_on(hass, "light.test", color_temp=70)
@@ -545,7 +563,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert not state.attributes.get("color_temp")
 
     # Set full brightness
@@ -555,7 +573,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert not state.attributes.get("brightness")
 
     # Full brightness - no scaling of RGB values sent over MQTT
@@ -567,7 +585,7 @@ async def test_sending_mqtt_commands_non_optimistic_brightness_template(
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert not state.attributes.get("white_value")
     assert not state.attributes.get("rgb_color")
 
@@ -783,7 +801,7 @@ async def test_invalid_values(hass, mqtt_mock):
         await hass.async_block_till_done()
 
     state = hass.states.get("light.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get("rgb_color") is None
     assert state.attributes.get("brightness") is None
     assert state.attributes.get("color_temp") is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The initial state of a MQTT light will be `unknown`. This could break existing automation's.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for `unknown` state for MQTT light (schema: `basic`, `json` and `template`).
The state can be reset to `unknown` by the device using a `None` payload.

This is a follow up for #64621

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21419

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
