### PR TITLE
Alexa to handle brightness and catch exceptions

### DIFF
--- a/homeassistant/components/alexa/errors.py
+++ b/homeassistant/components/alexa/errors.py
@@ -1,6 +1,8 @@
 """Alexa related errors."""
 from __future__ import annotations
 
+from typing import Literal
+
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import API_TEMP_UNITS
@@ -56,6 +58,30 @@ class AlexaInvalidValueError(AlexaError):
 
     namespace = "Alexa"
     error_type = "INVALID_VALUE"
+
+
+class AlexaInteralError(AlexaError):
+    """Class to represent internal errors."""
+
+    namespace = "Alexa"
+    error_type = "INTERNAL_ERROR"
+
+
+class AlexaNotSupportedInCurrentMode(AlexaError):
+    """The device is not in the correct mode to support this command."""
+
+    namespace = "Alexa"
+    error_type = "NOT_SUPPORTED_IN_CURRENT_MODE"
+
+    def __init__(
+        self,
+        endpoint_id: str,
+        current_mode: Literal["COLOR", "ASLEEP", "NOT_PROVISIONED", "OTHER"],
+    ) -> None:
+        """Initialize invalid endpoint error."""
+        msg = f"Not supported while in {current_mode} mode"
+        AlexaError.__init__(self, msg, {"currentDeviceMode": current_mode})
+        self.endpoint_id = endpoint_id
 
 
 class AlexaUnsupportedThermostatModeError(AlexaError):

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -212,20 +212,14 @@ async def async_api_adjust_brightness(hass, config, directive, context):
     entity = directive.entity
     brightness_delta = int(directive.payload["brightnessDelta"])
 
-    # read current state
-    try:
-        current = math.floor(
-            int(entity.attributes.get(light.ATTR_BRIGHTNESS)) / 255 * 100
-        )
-    except ZeroDivisionError:
-        current = 0
-
     # set brightness
-    brightness = max(0, brightness_delta + current)
     await hass.services.async_call(
         entity.domain,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity.entity_id, light.ATTR_BRIGHTNESS_PCT: brightness},
+        {
+            ATTR_ENTITY_ID: entity.entity_id,
+            light.ATTR_BRIGHTNESS_STEP_PCT: brightness_delta,
+        },
         blocking=False,
         context=context,
     )

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -48,8 +48,18 @@ async def async_handle_message(hass, config, request, context=None, enabled=True
             response = directive.error()
     except AlexaError as err:
         response = directive.error(
-            error_type=err.error_type, error_message=err.error_message
+            error_type=err.error_type,
+            error_message=err.error_message,
+            payload=err.payload,
         )
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception(
+            "Uncaught exception processing Alexa %s/%s request (%s)",
+            directive.namespace,
+            directive.name,
+            directive.entity_id or "-",
+        )
+        response = directive.error(error_message="Unknown error")
 
     request_info = {"namespace": directive.namespace, "name": directive.name}
 

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -194,7 +194,7 @@ async def assert_scene_controller_works(
         assert re.search(pattern, response["event"]["payload"]["timestamp"])
 
 
-async def reported_properties(hass, endpoint):
+async def reported_properties(hass, endpoint, return_full_response=False):
     """Use ReportState to get properties and return them.
 
     The result is a ReportedProperties instance, which has methods to make
@@ -203,6 +203,8 @@ async def reported_properties(hass, endpoint):
     request = get_new_request("Alexa", "ReportState", endpoint)
     msg = await smart_home.async_handle_message(hass, get_default_config(), request)
     await hass.async_block_till_done()
+    if return_full_response:
+        return msg
     return ReportedProperties(msg["context"]["properties"])
 
 

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.alexa import smart_home
-from homeassistant.components.alexa.errors import UnsupportedProperty
 from homeassistant.components.climate import const as climate
 from homeassistant.components.lock import STATE_JAMMED, STATE_LOCKING, STATE_UNLOCKING
 from homeassistant.components.media_player.const import (
@@ -39,8 +38,8 @@ from . import (
 from tests.common import async_mock_service
 
 
-@pytest.mark.parametrize("result,adjust", [(25, "-5"), (35, "5"), (0, "-80")])
-async def test_api_adjust_brightness(hass, result, adjust):
+@pytest.mark.parametrize("adjust", ["-5", "5", "-80"])
+async def test_api_adjust_brightness(hass, adjust):
     """Test api adjust brightness process."""
     request = get_new_request(
         "Alexa.BrightnessController", "AdjustBrightness", "light#test"
@@ -64,7 +63,7 @@ async def test_api_adjust_brightness(hass, result, adjust):
 
     assert len(call_light) == 1
     assert call_light[0].data["entity_id"] == "light.test"
-    assert call_light[0].data["brightness_pct"] == result
+    assert call_light[0].data["brightness_step_pct"] == int(adjust)
     assert msg["header"]["name"] == "Response"
 
 
@@ -677,16 +676,9 @@ async def test_report_climate_state(hass):
             ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
         },
     )
-    with pytest.raises(UnsupportedProperty):
-        properties = await reported_properties(hass, "climate.unsupported")
-        properties.assert_not_has_property(
-            "Alexa.ThermostatController", "thermostatMode"
-        )
-        properties.assert_equal(
-            "Alexa.TemperatureSensor",
-            "temperature",
-            {"value": 34.0, "scale": "CELSIUS"},
-        )
+    msg = await reported_properties(hass, "climate.unsupported", True)
+    assert msg["event"]["header"]["name"] == "ErrorResponse"
+    assert msg["event"]["payload"]["type"] == "INTERNAL_ERROR"
 
 
 async def test_temperature_sensor_sensor(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Slimmed down version of #65029. Alexa adjust brightness can't raise errors anymore and exceptions raised are now reported correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
