### PR TITLE
Improve debugging and error handling in Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -1,11 +1,7 @@
 """Support for AVM Fritz!Box functions."""
 import logging
 
-from fritzconnection.core.exceptions import (
-    FritzConnectionException,
-    FritzSecurityError,
-    FritzServiceError,
-)
+from fritzconnection.core.exceptions import FritzSecurityError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
@@ -13,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .common import AvmWrapper, FritzData
-from .const import DATA_FRITZ, DOMAIN, PLATFORMS
+from .const import DATA_FRITZ, DOMAIN, FRITZ_EXCEPTIONS, PLATFORMS
 from .services import async_setup_services, async_unload_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await avm_wrapper.async_setup(entry.options)
     except FritzSecurityError as ex:
         raise ConfigEntryAuthFailed from ex
-    except (FritzConnectionException, FritzServiceError) as ex:
+    except FRITZ_EXCEPTIONS as ex:
         raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -3,8 +3,8 @@ import logging
 
 from fritzconnection.core.exceptions import (
     FritzConnectionException,
-    FritzResourceError,
     FritzSecurityError,
+    FritzServiceError,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -34,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await avm_wrapper.async_setup(entry.options)
     except FritzSecurityError as ex:
         raise ConfigEntryAuthFailed from ex
-    except (FritzConnectionException, FritzResourceError) as ex:
+    except (FritzConnectionException, FritzServiceError) as ex:
         raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -188,9 +188,26 @@ class FritzBoxTools(update_coordinator.DataUpdateCoordinator):
             _LOGGER.error("Unable to establish a connection with %s", self.host)
             return
 
+        _LOGGER.debug(
+            "detected services on %s %s",
+            self.host,
+            list(self.connection.services.keys()),
+        )
+
         self.fritz_hosts = FritzHosts(fc=self.connection)
         self.fritz_status = FritzStatus(fc=self.connection)
         info = self.connection.call_action("DeviceInfo:1", "GetInfo")
+
+        _LOGGER.debug(
+            "gathered device info of %s %s",
+            self.host,
+            {
+                **info,
+                "NewDeviceLog": "***omitted***",
+                "NewSerialNumber": "***omitted***",
+            },
+        )
+
         if not self._unique_id:
             self._unique_id = info["NewSerialNumber"]
 

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -12,10 +12,7 @@ from typing import Any, TypedDict, cast
 from fritzconnection import FritzConnection
 from fritzconnection.core.exceptions import (
     FritzActionError,
-    FritzActionFailedError,
     FritzConnectionException,
-    FritzInternalError,
-    FritzLookUpError,
     FritzSecurityError,
     FritzServiceError,
 )
@@ -46,6 +43,7 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_USERNAME,
     DOMAIN,
+    FRITZ_EXCEPTIONS,
     SERVICE_CLEANUP,
     SERVICE_REBOOT,
     SERVICE_RECONNECT,
@@ -540,13 +538,7 @@ class AvmWrapper(FritzBoxTools):
                 "Authorization Error: Please check the provided credentials and verify that you can log into the web interface",
                 exc_info=True,
             )
-        except (
-            FritzActionError,
-            FritzActionFailedError,
-            FritzInternalError,
-            FritzServiceError,
-            FritzLookUpError,
-        ):
+        except FRITZ_EXCEPTIONS:
             _LOGGER.error(
                 "Service/Action Error: cannot execute service %s with action %s",
                 service_name,

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -2,6 +2,14 @@
 
 from typing import Literal
 
+from fritzconnection.core.exceptions import (
+    FritzActionError,
+    FritzActionFailedError,
+    FritzInternalError,
+    FritzLookUpError,
+    FritzServiceError,
+)
+
 from homeassistant.backports.enum import StrEnum
 from homeassistant.const import Platform
 
@@ -47,3 +55,11 @@ SWITCH_TYPE_PORTFORWARD = "PortForward"
 SWITCH_TYPE_WIFINETWORK = "WiFiNetwork"
 
 UPTIME_DEVIATION = 5
+
+FRITZ_EXCEPTIONS = (
+    FritzActionError,
+    FritzActionFailedError,
+    FritzInternalError,
+    FritzServiceError,
+    FritzLookUpError,
+)

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -94,16 +94,15 @@ class FritzConnectionMock:  # pylint: disable=too-few-public-methods
 
     def __init__(self):
         """Inint Mocking class."""
-        type(self).modelname = mock.PropertyMock(return_value=self.MODELNAME)
+        self.modelname = self.MODELNAME
         self.call_action = mock.Mock(side_effect=self._side_effect_call_action)
         type(self).action_names = mock.PropertyMock(
             side_effect=self._side_effect_action_names
         )
-        services = {
+        self.services = {
             srv: None
             for srv, _ in list(self.FRITZBOX_DATA) + list(self.FRITZBOX_DATA_INDEXED)
         }
-        type(self).services = mock.PropertyMock(side_effect=[services])
 
     def _side_effect_call_action(self, service, action, **kwargs):
         if kwargs:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add some additional debug logging and replace the only lib internal used `FritzResourceError` by `FritzServiceError` during setup.

Example debug logs

`2022-01-31 18:46:18 DEBUG (SyncWorker_3) [homeassistant.components.fritz.common] detected services on 192.168.1.1 ['any1', 'WANCommonIFC1', 'WANDSLLinkC1', 'WANIPConn1', 'WANIPv6Firewall1', 'DeviceInfo1', 'DeviceConfig1', 'Layer3Forwarding1', 'LANConfigSecurity1', 'ManagementServer1', 'Time1', 'UserInterface1', 'X_AVM-DE_Storage1', 'X_AVM-DE_WebDAVClient1', 'X_AVM-DE_UPnP1', 'X_AVM-DE_Speedtest1', 'X_AVM-DE_RemoteAccess1', 'X_AVM-DE_MyFritz1', 'X_VoIP1', 'X_AVM-DE_OnTel1', 'X_AVM-DE_Dect1', 'X_AVM-DE_TAM1', 'X_AVM-DE_AppSetup1', 'X_AVM-DE_Homeauto1', 'X_AVM-DE_Homeplug1', 'X_AVM-DE_Filelinks1', 'X_AVM-DE_Auth1', 'X_AVM-DE_HostFilter1', 'WLANConfiguration1', 'WLANConfiguration2', 'WLANConfiguration3', 'Hosts1', 'LANEthernetInterfaceConfig1', 'LANHostConfigManagement1', 'WANCommonInterfaceConfig1', 'WANDSLInterfaceConfig1', 'WANDSLLinkConfig1', 'WANEthernetLinkConfig1', 'WANPPPConnection1', 'WANIPConnection1']`

`2022-01-31 18:46:18 DEBUG (SyncWorker_3) [homeassistant.components.fritz.common] gathered device info of 192.168.1.1 {'NewManufacturerName': 'AVM', 'NewManufacturerOUI': '00040E', 'NewModelName': 'FRITZ!Box 7530 AX', 'NewDescription': 'FRITZ!Box 7530 AX 256.07.29', 'NewProductClass': 'FRITZ!Box', 'NewSerialNumber': '***omitted***', 'NewSoftwareVersion': '256.07.29', 'NewHardwareVersion': 'FRITZ!Box 7530 AX', 'NewSpecVersion': '1.0', 'NewProvisioningCode': '012.000.000.000', 'NewUpTime': 781897, 'NewDeviceLog': '***omitted***'}`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
