### PR TITLE
Refactor homekit_controller to prepare for more typing information

### DIFF
--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if service.short_type != ServicesTypes.SECURITY_SYSTEM:
+        if service.type != ServicesTypes.SECURITY_SYSTEM:
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitAlarmControlPanelEntity(conn, info)], True)

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -124,7 +124,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if not (entity_class := ENTITY_TYPES.get(service.short_type)):
+        if not (entity_class := ENTITY_TYPES.get(service.type)):
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)

--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -31,15 +31,15 @@ class HomeKitButtonEntityDescription(ButtonEntityDescription):
 
 
 BUTTON_ENTITIES: dict[str, HomeKitButtonEntityDescription] = {
-    CharacteristicsTypes.Vendor.HAA_SETUP: HomeKitButtonEntityDescription(
-        key=CharacteristicsTypes.Vendor.HAA_SETUP,
+    CharacteristicsTypes.VENDOR_HAA_SETUP: HomeKitButtonEntityDescription(
+        key=CharacteristicsTypes.VENDOR_HAA_SETUP,
         name="Setup",
         icon="mdi:cog",
         entity_category=EntityCategory.CONFIG,
         write_value="#HAA@trcmd",
     ),
-    CharacteristicsTypes.Vendor.HAA_UPDATE: HomeKitButtonEntityDescription(
-        key=CharacteristicsTypes.Vendor.HAA_UPDATE,
+    CharacteristicsTypes.VENDOR_HAA_UPDATE: HomeKitButtonEntityDescription(
+        key=CharacteristicsTypes.VENDOR_HAA_UPDATE,
         name="Update",
         device_class=ButtonDeviceClass.UPDATE,
         entity_category=EntityCategory.CONFIG,
@@ -52,16 +52,6 @@ BUTTON_ENTITIES: dict[str, HomeKitButtonEntityDescription] = {
         write_value=True,
     ),
 }
-
-
-# For legacy reasons, "built-in" characteristic types are in their short form
-# And vendor types don't have a short form
-# This means long and short forms get mixed up in this dict, and comparisons
-# don't work!
-# We call get_uuid on *every* type to normalise them to the long form
-# Eventually aiohomekit will use the long form exclusively amd this can be removed.
-for k, v in list(BUTTON_ENTITIES.items()):
-    BUTTON_ENTITIES[CharacteristicsTypes.get_uuid(k)] = BUTTON_ENTITIES.pop(k)
 
 
 async def async_setup_entry(
@@ -155,5 +145,5 @@ class HomeKitEcobeeClearHoldButton(CharacteristicEntity, ButtonEntity):
 
 
 BUTTON_ENTITY_CLASSES: dict[str, type] = {
-    CharacteristicsTypes.Vendor.ECOBEE_CLEAR_HOLD: HomeKitEcobeeClearHoldButton,
+    CharacteristicsTypes.VENDOR_ECOBEE_CLEAR_HOLD: HomeKitEcobeeClearHoldButton,
 }

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -95,7 +95,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if not (entity_class := ENTITY_TYPES.get(service.short_type)):
+        if not (entity_class := ENTITY_TYPES.get(service.type)):
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -11,6 +11,7 @@ from aiohomekit.exceptions import (
 from aiohomekit.model import Accessories, Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
+from aiohomekit.uuid import normalize_uuid
 
 from homeassistant.const import ATTR_VIA_DEVICE
 from homeassistant.core import callback
@@ -495,7 +496,7 @@ class HKDevice:
         for accessory in self.accessories:
             for service in accessory["services"]:
                 try:
-                    stype = ServicesTypes.get_short_uuid(service["type"].upper())
+                    stype = normalize_uuid(service["type"])
                 except KeyError:
                     stype = service["type"].upper()
 

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -51,33 +51,33 @@ HOMEKIT_ACCESSORY_DISPATCH = {
 }
 
 CHARACTERISTIC_PLATFORMS = {
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_WATT: "sensor",
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_AMPS: "sensor",
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_AMPS_20: "sensor",
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_KW_HOUR: "sensor",
-    CharacteristicsTypes.Vendor.AQARA_GATEWAY_VOLUME: "number",
-    CharacteristicsTypes.Vendor.AQARA_E1_GATEWAY_VOLUME: "number",
-    CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE: "switch",
-    CharacteristicsTypes.Vendor.AQARA_E1_PAIRING_MODE: "switch",
-    CharacteristicsTypes.Vendor.ECOBEE_HOME_TARGET_COOL: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_HOME_TARGET_HEAT: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_SLEEP_TARGET_COOL: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_SLEEP_TARGET_HEAT: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_AWAY_TARGET_COOL: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_AWAY_TARGET_HEAT: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE: "select",
-    CharacteristicsTypes.Vendor.EVE_ENERGY_WATT: "sensor",
-    CharacteristicsTypes.Vendor.EVE_DEGREE_AIR_PRESSURE: "sensor",
-    CharacteristicsTypes.Vendor.EVE_DEGREE_ELEVATION: "number",
-    CharacteristicsTypes.Vendor.HAA_SETUP: "button",
-    CharacteristicsTypes.Vendor.HAA_UPDATE: "button",
-    CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY: "sensor",
-    CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2: "sensor",
-    CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: "number",
-    CharacteristicsTypes.Vendor.VOCOLINC_OUTLET_ENERGY: "sensor",
-    CharacteristicsTypes.Vendor.ECOBEE_CLEAR_HOLD: "button",
-    CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: "number",
-    CharacteristicsTypes.Vendor.ECOBEE_SET_HOLD_SCHEDULE: "number",
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_WATT: "sensor",
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_AMPS: "sensor",
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_AMPS_20: "sensor",
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_KW_HOUR: "sensor",
+    CharacteristicsTypes.VENDOR_AQARA_GATEWAY_VOLUME: "number",
+    CharacteristicsTypes.VENDOR_AQARA_E1_GATEWAY_VOLUME: "number",
+    CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE: "switch",
+    CharacteristicsTypes.VENDOR_AQARA_E1_PAIRING_MODE: "switch",
+    CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_COOL: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_HEAT: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_COOL: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_HEAT: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_COOL: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_HEAT: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE: "select",
+    CharacteristicsTypes.VENDOR_EVE_ENERGY_WATT: "sensor",
+    CharacteristicsTypes.VENDOR_EVE_DEGREE_AIR_PRESSURE: "sensor",
+    CharacteristicsTypes.VENDOR_EVE_DEGREE_ELEVATION: "number",
+    CharacteristicsTypes.VENDOR_HAA_SETUP: "button",
+    CharacteristicsTypes.VENDOR_HAA_UPDATE: "button",
+    CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY: "sensor",
+    CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY_2: "sensor",
+    CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: "number",
+    CharacteristicsTypes.VENDOR_VOCOLINC_OUTLET_ENERGY: "sensor",
+    CharacteristicsTypes.VENDOR_ECOBEE_CLEAR_HOLD: "button",
+    CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: "number",
+    CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: "number",
     CharacteristicsTypes.TEMPERATURE_CURRENT: "sensor",
     CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT: "sensor",
     CharacteristicsTypes.AIR_QUALITY: "sensor",
@@ -89,16 +89,6 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.DENSITY_VOC: "sensor",
     CharacteristicsTypes.IDENTIFY: "button",
 }
-
-# For legacy reasons, "built-in" characteristic types are in their short form
-# And vendor types don't have a short form
-# This means long and short forms get mixed up in this dict, and comparisons
-# don't work!
-# We call get_uuid on *every* type to normalise them to the long form
-# Eventually aiohomekit will use the long form exclusively amd this can be removed.
-for k, v in list(CHARACTERISTIC_PLATFORMS.items()):
-    value = CHARACTERISTIC_PLATFORMS.pop(k)
-    CHARACTERISTIC_PLATFORMS[CharacteristicsTypes.get_uuid(k)] = value
 
 
 # Device classes

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -47,7 +47,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if not (entity_class := ENTITY_TYPES.get(service.short_type)):
+        if not (entity_class := ENTITY_TYPES.get(service.type)):
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -197,7 +197,7 @@ async def async_setup_triggers_for_entry(hass: HomeAssistant, config_entry):
     @callback
     def async_add_service(service):
         aid = service.accessory.aid
-        service_type = service.short_type
+        service_type = service.type
 
         # If not a known service type then we can't handle any stateless events for it
         if service_type not in TRIGGER_FINDERS:

--- a/homeassistant/components/homekit_controller/diagnostics.py
+++ b/homeassistant/components/homekit_controller/diagnostics.py
@@ -15,7 +15,7 @@ from .connection import HKDevice
 from .const import KNOWN_DEVICES
 
 REDACTED_CHARACTERISTICS = [
-    CharacteristicsTypes.get_uuid(CharacteristicsTypes.SERIAL_NUMBER),
+    CharacteristicsTypes.SERIAL_NUMBER,
 ]
 
 REDACTED_CONFIG_ENTRY_KEYS = [
@@ -112,12 +112,7 @@ def _async_get_diagnostics(
     for accessory in accessories:
         for service in accessory.get("services", []):
             for char in service.get("characteristics", []):
-                try:
-                    normalized = CharacteristicsTypes.get_uuid(char["type"])
-                except KeyError:
-                    normalized = char["type"]
-
-                if normalized in REDACTED_CHARACTERISTICS:
+                if char["type"] in REDACTED_CHARACTERISTICS:
                     char["value"] = REDACTED
 
     if device:

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -160,7 +160,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if not (entity_class := ENTITY_TYPES.get(service.short_type)):
+        if not (entity_class := ENTITY_TYPES.get(service.type)):
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)

--- a/homeassistant/components/homekit_controller/humidifier.py
+++ b/homeassistant/components/homekit_controller/humidifier.py
@@ -252,7 +252,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if service.short_type != ServicesTypes.HUMIDIFIER_DEHUMIDIFIER:
+        if service.type != ServicesTypes.HUMIDIFIER_DEHUMIDIFIER:
             return False
 
         info = {"aid": service.accessory.aid, "iid": service.iid}

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if service.short_type != ServicesTypes.LIGHTBULB:
+        if service.type != ServicesTypes.LIGHTBULB:
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitLight(conn, info)], True)

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if service.short_type != ServicesTypes.LOCK_MECHANISM:
+        if service.type != ServicesTypes.LOCK_MECHANISM:
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitLock(conn, info)], True)

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==0.6.11"],
+  "requirements": ["aiohomekit==0.7.0"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],

--- a/homeassistant/components/homekit_controller/media_player.py
+++ b/homeassistant/components/homekit_controller/media_player.py
@@ -54,7 +54,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if service.short_type != ServicesTypes.TELEVISION:
+        if service.type != ServicesTypes.TELEVISION:
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([HomeKitTelevision(conn, info)], True)

--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -17,62 +17,62 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import KNOWN_DEVICES, CharacteristicEntity
 
 NUMBER_ENTITIES: dict[str, NumberEntityDescription] = {
-    CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL,
+    CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL,
         name="Spray Quantity",
         icon="mdi:water",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.EVE_DEGREE_ELEVATION: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.EVE_DEGREE_ELEVATION,
+    CharacteristicsTypes.VENDOR_EVE_DEGREE_ELEVATION: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_EVE_DEGREE_ELEVATION,
         name="Elevation",
         icon="mdi:elevation-rise",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.AQARA_GATEWAY_VOLUME: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.AQARA_GATEWAY_VOLUME,
+    CharacteristicsTypes.VENDOR_AQARA_GATEWAY_VOLUME: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_AQARA_GATEWAY_VOLUME,
         name="Volume",
         icon="mdi:volume-high",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.AQARA_E1_GATEWAY_VOLUME: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.AQARA_E1_GATEWAY_VOLUME,
+    CharacteristicsTypes.VENDOR_AQARA_E1_GATEWAY_VOLUME: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_AQARA_E1_GATEWAY_VOLUME,
         name="Volume",
         icon="mdi:volume-high",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.ECOBEE_HOME_TARGET_COOL: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.ECOBEE_HOME_TARGET_COOL,
+    CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_COOL: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_COOL,
         name="Home Cool Target",
         icon="mdi:thermometer-minus",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.ECOBEE_HOME_TARGET_HEAT: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.ECOBEE_HOME_TARGET_HEAT,
+    CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_HEAT: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_HEAT,
         name="Home Heat Target",
         icon="mdi:thermometer-plus",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.ECOBEE_SLEEP_TARGET_COOL: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.ECOBEE_SLEEP_TARGET_COOL,
+    CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_COOL: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_COOL,
         name="Sleep Cool Target",
         icon="mdi:thermometer-minus",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.ECOBEE_SLEEP_TARGET_HEAT: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.ECOBEE_SLEEP_TARGET_HEAT,
+    CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_HEAT: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_HEAT,
         name="Sleep Heat Target",
         icon="mdi:thermometer-plus",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.ECOBEE_AWAY_TARGET_COOL: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.ECOBEE_AWAY_TARGET_COOL,
+    CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_COOL: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_COOL,
         name="Away Cool Target",
         icon="mdi:thermometer-minus",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.ECOBEE_AWAY_TARGET_HEAT: NumberEntityDescription(
-        key=CharacteristicsTypes.Vendor.ECOBEE_AWAY_TARGET_HEAT,
+    CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_HEAT: NumberEntityDescription(
+        key=CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_HEAT,
         name="Away Heat Target",
         icon="mdi:thermometer-plus",
         entity_category=EntityCategory.CONFIG,
@@ -226,5 +226,5 @@ class HomeKitEcobeeFanModeNumber(CharacteristicEntity, NumberEntity):
 
 
 NUMBER_ENTITY_CLASSES: dict[str, type] = {
-    CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: HomeKitEcobeeFanModeNumber,
+    CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: HomeKitEcobeeFanModeNumber,
 }

--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -35,7 +35,7 @@ class EcobeeModeSelect(CharacteristicEntity, SelectEntity):
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
         return [
-            CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE,
+            CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE,
         ]
 
     @property
@@ -47,7 +47,7 @@ class EcobeeModeSelect(CharacteristicEntity, SelectEntity):
         """Set the current mode."""
         option_int = _ECOBEE_MODE_TO_NUMBERS[option]
         await self.async_put_characteristics(
-            {CharacteristicsTypes.Vendor.ECOBEE_SET_HOLD_SCHEDULE: option_int}
+            {CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: option_int}
         )
 
 
@@ -62,7 +62,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_characteristic(char: Characteristic):
-        if char.type == CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE:
+        if char.type == CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE:
             info = {"aid": char.service.accessory.aid, "iid": char.service.iid}
             async_add_entities([EcobeeModeSelect(conn, info, char)])
             return True

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -42,85 +42,85 @@ class HomeKitSensorEntityDescription(SensorEntityDescription):
 
 
 SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_WATT: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_WATT,
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_WATT: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_WATT,
         name="Power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=POWER_WATT,
     ),
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_AMPS: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_AMPS,
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_AMPS: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_AMPS,
         name="Current",
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
     ),
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_AMPS_20: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_AMPS_20,
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_AMPS_20: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_AMPS_20,
         name="Current",
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
     ),
-    CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_KW_HOUR: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.CONNECTSENSE_ENERGY_KW_HOUR,
+    CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_KW_HOUR: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_CONNECTSENSE_ENERGY_KW_HOUR,
         name="Energy kWh",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
     ),
-    CharacteristicsTypes.Vendor.EVE_ENERGY_WATT: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.EVE_ENERGY_WATT,
+    CharacteristicsTypes.VENDOR_EVE_ENERGY_WATT: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_EVE_ENERGY_WATT,
         name="Power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=POWER_WATT,
     ),
-    CharacteristicsTypes.Vendor.EVE_ENERGY_KW_HOUR: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.EVE_ENERGY_KW_HOUR,
+    CharacteristicsTypes.VENDOR_EVE_ENERGY_KW_HOUR: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_EVE_ENERGY_KW_HOUR,
         name="Energy kWh",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
     ),
-    CharacteristicsTypes.Vendor.EVE_ENERGY_VOLTAGE: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.EVE_ENERGY_VOLTAGE,
+    CharacteristicsTypes.VENDOR_EVE_ENERGY_VOLTAGE: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_EVE_ENERGY_VOLTAGE,
         name="Volts",
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
     ),
-    CharacteristicsTypes.Vendor.EVE_ENERGY_AMPERE: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.EVE_ENERGY_AMPERE,
+    CharacteristicsTypes.VENDOR_EVE_ENERGY_AMPERE: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_EVE_ENERGY_AMPERE,
         name="Amps",
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
     ),
-    CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY,
+    CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY,
         name="Power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=POWER_WATT,
     ),
-    CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2,
+    CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY_2: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY_2,
         name="Power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=POWER_WATT,
     ),
-    CharacteristicsTypes.Vendor.EVE_DEGREE_AIR_PRESSURE: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.EVE_DEGREE_AIR_PRESSURE,
+    CharacteristicsTypes.VENDOR_EVE_DEGREE_AIR_PRESSURE: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_EVE_DEGREE_AIR_PRESSURE,
         name="Air Pressure",
         device_class=SensorDeviceClass.PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PRESSURE_HPA,
     ),
-    CharacteristicsTypes.Vendor.VOCOLINC_OUTLET_ENERGY: HomeKitSensorEntityDescription(
-        key=CharacteristicsTypes.Vendor.VOCOLINC_OUTLET_ENERGY,
+    CharacteristicsTypes.VENDOR_VOCOLINC_OUTLET_ENERGY: HomeKitSensorEntityDescription(
+        key=CharacteristicsTypes.VENDOR_VOCOLINC_OUTLET_ENERGY,
         name="Power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -134,10 +134,7 @@ SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
         native_unit_of_measurement=TEMP_CELSIUS,
         # This sensor is only for temperature characteristics that are not part
         # of a temperature sensor service.
-        probe=(
-            lambda char: char.service.type
-            != ServicesTypes.get_uuid(ServicesTypes.TEMPERATURE_SENSOR)
-        ),
+        probe=(lambda char: char.service.type != ServicesTypes.TEMPERATURE_SENSOR),
     ),
     CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT: HomeKitSensorEntityDescription(
         key=CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT,
@@ -147,10 +144,7 @@ SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
         native_unit_of_measurement=PERCENTAGE,
         # This sensor is only for humidity characteristics that are not part
         # of a humidity sensor service.
-        probe=(
-            lambda char: char.service.type
-            != ServicesTypes.get_uuid(ServicesTypes.HUMIDITY_SENSOR)
-        ),
+        probe=(lambda char: char.service.type != ServicesTypes.HUMIDITY_SENSOR),
     ),
     CharacteristicsTypes.AIR_QUALITY: HomeKitSensorEntityDescription(
         key=CharacteristicsTypes.AIR_QUALITY,
@@ -201,15 +195,6 @@ SIMPLE_SENSOR: dict[str, HomeKitSensorEntityDescription] = {
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     ),
 }
-
-# For legacy reasons, "built-in" characteristic types are in their short form
-# And vendor types don't have a short form
-# This means long and short forms get mixed up in this dict, and comparisons
-# don't work!
-# We call get_uuid on *every* type to normalise them to the long form
-# Eventually aiohomekit will use the long form exclusively amd this can be removed.
-for k, v in list(SIMPLE_SENSOR.items()):
-    SIMPLE_SENSOR[CharacteristicsTypes.get_uuid(k)] = SIMPLE_SENSOR.pop(k)
 
 
 class HomeKitHumiditySensor(HomeKitEntity, SensorEntity):
@@ -415,7 +400,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if not (entity_class := ENTITY_TYPES.get(service.short_type)):
+        if not (entity_class := ENTITY_TYPES.get(service.type)):
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -35,14 +35,14 @@ class DeclarativeSwitchEntityDescription(SwitchEntityDescription):
 
 
 SWITCH_ENTITIES: dict[str, DeclarativeSwitchEntityDescription] = {
-    CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE: DeclarativeSwitchEntityDescription(
-        key=CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE,
+    CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE: DeclarativeSwitchEntityDescription(
+        key=CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE,
         name="Pairing Mode",
         icon="mdi:lock-open",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.Vendor.AQARA_E1_PAIRING_MODE: DeclarativeSwitchEntityDescription(
-        key=CharacteristicsTypes.Vendor.AQARA_E1_PAIRING_MODE,
+    CharacteristicsTypes.VENDOR_AQARA_E1_PAIRING_MODE: DeclarativeSwitchEntityDescription(
+        key=CharacteristicsTypes.VENDOR_AQARA_E1_PAIRING_MODE,
         name="Pairing Mode",
         icon="mdi:lock-open",
         entity_category=EntityCategory.CONFIG,
@@ -189,7 +189,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_service(service):
-        if not (entity_class := ENTITY_TYPES.get(service.short_type)):
+        if not (entity_class := ENTITY_TYPES.get(service.type)):
             return False
         info = {"aid": service.accessory.aid, "iid": service.iid}
         async_add_entities([entity_class(conn, info)], True)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -184,7 +184,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.6.11
+aiohomekit==0.7.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.6.11
+aiohomekit==0.7.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -10,7 +10,6 @@ from typing import Any, Final
 from unittest import mock
 
 from aiohomekit.model import Accessories, Accessory
-from aiohomekit.model.services import ServicesTypes
 from aiohomekit.testing import FakeController, FakePairing
 
 from homeassistant.components import zeroconf
@@ -261,7 +260,7 @@ async def setup_test_component(hass, setup_accessory, capitalize=False, suffix=N
 
     domain = None
     for service in accessory.services:
-        service_name = ServicesTypes.get_short_uuid(service.type)
+        service_name = service.type
         if service_name in HOMEKIT_ACCESSORY_DISPATCH:
             domain = HOMEKIT_ACCESSORY_DISPATCH[service_name]
             break

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -9,7 +9,7 @@ def create_switch_with_setup_button(accessory):
     """Define setup button characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 
-    setup = service.add_char(CharacteristicsTypes.Vendor.HAA_SETUP)
+    setup = service.add_char(CharacteristicsTypes.VENDOR_HAA_SETUP)
 
     setup.value = ""
     setup.format = "string"
@@ -24,7 +24,7 @@ def create_switch_with_ecobee_clear_hold_button(accessory):
     """Define setup button characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 
-    setup = service.add_char(CharacteristicsTypes.Vendor.ECOBEE_CLEAR_HOLD)
+    setup = service.add_char(CharacteristicsTypes.VENDOR_ECOBEE_CLEAR_HOLD)
 
     setup.value = ""
     setup.format = "string"
@@ -57,7 +57,7 @@ async def test_press_button(hass):
     button.async_assert_service_values(
         ServicesTypes.OUTLET,
         {
-            CharacteristicsTypes.Vendor.HAA_SETUP: "#HAA@trcmd",
+            CharacteristicsTypes.VENDOR_HAA_SETUP: "#HAA@trcmd",
         },
     )
 
@@ -86,6 +86,6 @@ async def test_ecobee_clear_hold_press_button(hass):
     clear_hold.async_assert_service_values(
         ServicesTypes.OUTLET,
         {
-            CharacteristicsTypes.Vendor.ECOBEE_CLEAR_HOLD: True,
+            CharacteristicsTypes.VENDOR_ECOBEE_CLEAR_HOLD: True,
         },
     )

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -151,7 +151,7 @@ async def test_config_entry(hass: HomeAssistant, hass_client: ClientSession, utc
                     },
                     {
                         "iid": 13,
-                        "type": "4aaaf940-0dec-11e5-b939-0800200c9a66",
+                        "type": "4AAAF940-0DEC-11E5-B939-0800200C9A66",
                         "characteristics": [
                             {
                                 "type": "4AAAF942-0DEC-11E5-B939-0800200C9A66",
@@ -422,7 +422,7 @@ async def test_device(hass: HomeAssistant, hass_client: ClientSession, utcnow):
                     },
                     {
                         "iid": 13,
-                        "type": "4aaaf940-0dec-11e5-b939-0800200c9a66",
+                        "type": "4AAAF940-0DEC-11E5-B939-0800200C9A66",
                         "characteristics": [
                             {
                                 "type": "4AAAF942-0DEC-11E5-B939-0800200C9A66",

--- a/tests/components/homekit_controller/test_number.py
+++ b/tests/components/homekit_controller/test_number.py
@@ -10,7 +10,7 @@ def create_switch_with_spray_level(accessory):
     service = accessory.add_service(ServicesTypes.OUTLET)
 
     spray_level = service.add_char(
-        CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL
+        CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL
     )
 
     spray_level.perms.append("ev")
@@ -31,7 +31,7 @@ def create_switch_with_ecobee_fan_mode(accessory):
     service = accessory.add_service(ServicesTypes.OUTLET)
 
     ecobee_fan_mode = service.add_char(
-        CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED
+        CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED
     )
 
     ecobee_fan_mode.value = 0
@@ -67,7 +67,7 @@ async def test_read_number(hass, utcnow):
 
     state = await spray_level.async_update(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: 5},
+        {CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: 5},
     )
     assert state.state == "5"
 
@@ -93,7 +93,7 @@ async def test_write_number(hass, utcnow):
     )
     spray_level.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: 5},
+        {CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: 5},
     )
 
     await hass.services.async_call(
@@ -104,7 +104,7 @@ async def test_write_number(hass, utcnow):
     )
     spray_level.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: 3},
+        {CharacteristicsTypes.VENDOR_VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: 3},
     )
 
 
@@ -129,7 +129,7 @@ async def test_write_ecobee_fan_mode_number(hass, utcnow):
     )
     fan_mode.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: 1},
+        {CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: 1},
     )
 
     await hass.services.async_call(
@@ -140,7 +140,7 @@ async def test_write_ecobee_fan_mode_number(hass, utcnow):
     )
     fan_mode.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: 2},
+        {CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: 2},
     )
 
     await hass.services.async_call(
@@ -151,7 +151,7 @@ async def test_write_ecobee_fan_mode_number(hass, utcnow):
     )
     fan_mode.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: 99},
+        {CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: 99},
     )
 
     await hass.services.async_call(
@@ -162,7 +162,7 @@ async def test_write_ecobee_fan_mode_number(hass, utcnow):
     )
     fan_mode.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: 100},
+        {CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: 100},
     )
 
     await hass.services.async_call(
@@ -173,5 +173,5 @@ async def test_write_ecobee_fan_mode_number(hass, utcnow):
     )
     fan_mode.async_assert_service_values(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.ECOBEE_FAN_WRITE_SPEED: 0},
+        {CharacteristicsTypes.VENDOR_ECOBEE_FAN_WRITE_SPEED: 0},
     )

--- a/tests/components/homekit_controller/test_select.py
+++ b/tests/components/homekit_controller/test_select.py
@@ -10,11 +10,11 @@ def create_service_with_ecobee_mode(accessory: Accessory):
     """Define a thermostat with ecobee mode characteristics."""
     service = accessory.add_service(ServicesTypes.THERMOSTAT, add_required=True)
 
-    current_mode = service.add_char(CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE)
+    current_mode = service.add_char(CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE)
     current_mode.value = 0
     current_mode.perms.append("ev")
 
-    service.add_char(CharacteristicsTypes.Vendor.ECOBEE_SET_HOLD_SCHEDULE)
+    service.add_char(CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE)
 
     return service
 
@@ -35,7 +35,7 @@ async def test_read_current_mode(hass, utcnow):
     state = await ecobee_mode.async_update(
         ServicesTypes.THERMOSTAT,
         {
-            CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE: 0,
+            CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE: 0,
         },
     )
     assert state.state == "home"
@@ -43,7 +43,7 @@ async def test_read_current_mode(hass, utcnow):
     state = await ecobee_mode.async_update(
         ServicesTypes.THERMOSTAT,
         {
-            CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE: 1,
+            CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE: 1,
         },
     )
     assert state.state == "sleep"
@@ -51,7 +51,7 @@ async def test_read_current_mode(hass, utcnow):
     state = await ecobee_mode.async_update(
         ServicesTypes.THERMOSTAT,
         {
-            CharacteristicsTypes.Vendor.ECOBEE_CURRENT_MODE: 2,
+            CharacteristicsTypes.VENDOR_ECOBEE_CURRENT_MODE: 2,
         },
     )
     assert state.state == "away"
@@ -79,7 +79,7 @@ async def test_write_current_mode(hass, utcnow):
     )
     current_mode.async_assert_service_values(
         ServicesTypes.THERMOSTAT,
-        {CharacteristicsTypes.Vendor.ECOBEE_SET_HOLD_SCHEDULE: 0},
+        {CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: 0},
     )
 
     await hass.services.async_call(
@@ -90,7 +90,7 @@ async def test_write_current_mode(hass, utcnow):
     )
     current_mode.async_assert_service_values(
         ServicesTypes.THERMOSTAT,
-        {CharacteristicsTypes.Vendor.ECOBEE_SET_HOLD_SCHEDULE: 1},
+        {CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: 1},
     )
 
     await hass.services.async_call(
@@ -101,5 +101,5 @@ async def test_write_current_mode(hass, utcnow):
     )
     current_mode.async_assert_service_values(
         ServicesTypes.THERMOSTAT,
-        {CharacteristicsTypes.Vendor.ECOBEE_SET_HOLD_SCHEDULE: 2},
+        {CharacteristicsTypes.VENDOR_ECOBEE_SET_HOLD_SCHEDULE: 2},
     )

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -247,7 +247,7 @@ def create_switch_with_sensor(accessory):
     service = accessory.add_service(ServicesTypes.OUTLET)
 
     realtime_energy = service.add_char(
-        CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY
+        CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY
     )
     realtime_energy.value = 0
     realtime_energy.format = "float"
@@ -275,7 +275,7 @@ async def test_switch_with_sensor(hass, utcnow):
     state = await energy_helper.async_update(
         ServicesTypes.OUTLET,
         {
-            CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY: 1,
+            CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY: 1,
         },
     )
     assert state.state == "1"
@@ -283,7 +283,7 @@ async def test_switch_with_sensor(hass, utcnow):
     state = await energy_helper.async_update(
         ServicesTypes.OUTLET,
         {
-            CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY: 50,
+            CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY: 50,
         },
     )
     assert state.state == "50"
@@ -295,7 +295,7 @@ async def test_sensor_unavailable(hass, utcnow):
 
     # Find the energy sensor and mark it as offline
     outlet = helper.accessory.services.first(service_type=ServicesTypes.OUTLET)
-    realtime_energy = outlet[CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY]
+    realtime_energy = outlet[CharacteristicsTypes.VENDOR_KOOGEEK_REALTIME_ENERGY]
     realtime_energy.status = HapStatusCode.UNABLE_TO_COMMUNICATE
 
     # Helper will be for the primary entity, which is the outlet. Make a helper for the sensor.

--- a/tests/components/homekit_controller/test_switch.py
+++ b/tests/components/homekit_controller/test_switch.py
@@ -42,7 +42,7 @@ def create_char_switch_service(accessory):
     """Define swtch characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 
-    on_char = service.add_char(CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE)
+    on_char = service.add_char(CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE)
     on_char.perms.append("ev")
     on_char.value = False
 
@@ -178,7 +178,7 @@ async def test_char_switch_change_state(hass, utcnow):
     helper.async_assert_service_values(
         ServicesTypes.OUTLET,
         {
-            CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE: True,
+            CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE: True,
         },
     )
 
@@ -191,7 +191,7 @@ async def test_char_switch_change_state(hass, utcnow):
     helper.async_assert_service_values(
         ServicesTypes.OUTLET,
         {
-            CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE: False,
+            CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE: False,
         },
     )
 
@@ -205,13 +205,13 @@ async def test_char_switch_read_state(hass, utcnow):
     # Simulate that someone switched on the device in the real world not via HA
     switch_1 = await helper.async_update(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE: True},
+        {CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE: True},
     )
     assert switch_1.state == "on"
 
     # Simulate that device switched off in the real world not via HA
     switch_1 = await helper.async_update(
         ServicesTypes.OUTLET,
-        {CharacteristicsTypes.Vendor.AQARA_PAIRING_MODE: False},
+        {CharacteristicsTypes.VENDOR_AQARA_PAIRING_MODE: False},
     )
     assert switch_1.state == "off"


### PR DESCRIPTION
## Proposed change

I want to make some enum-like classes in aiohomekit actually enums (so we can using them in typing). To do that I need to remove some old aiohomekit cruft.

This PR takes us most of the way there on the home assistant side. In terms of how we use them on this side, `CharacteristicsTypes` and `ServicesTypes` are now as close as I can get them to enums without making them enums. I'll need to do some more work in aiohomekit before that though.

`aiohomekit` for the most part now only presents us with normalized UUIDs. So we now only work with the normalized full UUID on this side of the API. This means using `.type` instead of `.short_type`. It means that `CharacteristicsType.ON` now returns the normalized UUID. This means no `CharacteristicsType.get_uuid` etc. There is one call to `normalize_uuid` and I can get rid of that soon too.

To prepare for `CharacteristicsType` to be a enum, `CharacteristicsType.Vendor.ABC` got flattened down to `CharacteristicsType.VENDOR_ABC`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
