### PR TITLE
Support songpal wireless-only soundbar identifiers

### DIFF
--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -212,13 +212,18 @@ class SongpalEntity(MediaPlayerEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._sysinfo.macAddr
+        return self._sysinfo.macAddr or self._sysinfo.wirelessMacAddr
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        connections = set()
+        if self._sysinfo.macAddr:
+            connections.add((dr.CONNECTION_NETWORK_MAC, self._sysinfo.macAddr))
+        if self._sysinfo.wirelessMacAddr:
+            connections.add((dr.CONNECTION_NETWORK_MAC, self._sysinfo.wirelessMacAddr))
         return DeviceInfo(
-            connections={(dr.CONNECTION_NETWORK_MAC, self._sysinfo.macAddr)},
+            connections=connections,
             identifiers={(DOMAIN, self.unique_id)},
             manufacturer="Sony Corporation",
             model=self._model,

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from songpal import SongpalException
+from songpal.containers import Sysinfo
 
 from homeassistant.components.songpal.const import CONF_ENDPOINT
 from homeassistant.const import CONF_NAME
@@ -12,6 +13,7 @@ HOST = "0.0.0.0"
 ENDPOINT = f"http://{HOST}:10000/sony"
 MODEL = "model"
 MAC = "mac"
+WIRELESS_MAC = "wmac"
 SW_VERSION = "sw_ver"
 
 CONF_DATA = {
@@ -20,7 +22,7 @@ CONF_DATA = {
 }
 
 
-def _create_mocked_device(throw_exception=False):
+def _create_mocked_device(throw_exception=False, wired_mac=MAC, wireless_mac=None):
     mocked_device = MagicMock()
 
     type(mocked_device).get_supported_methods = AsyncMock(
@@ -35,9 +37,15 @@ def _create_mocked_device(throw_exception=False):
         return_value=interface_info
     )
 
-    sys_info = MagicMock()
-    sys_info.macAddr = MAC
-    sys_info.version = SW_VERSION
+    sys_info = Sysinfo(
+        bdAddr=None,
+        macAddr=wired_mac,
+        wirelessMacAddr=wireless_mac,
+        bssid=None,
+        ssid=None,
+        bleID=None,
+        version=SW_VERSION,
+    )
     type(mocked_device).get_system_info = AsyncMock(return_value=sys_info)
 
     volume1 = MagicMock()

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -29,6 +29,7 @@ from . import (
     MAC,
     MODEL,
     SW_VERSION,
+    WIRELESS_MAC,
     _create_mocked_device,
     _patch_media_player_device,
 )
@@ -126,6 +127,78 @@ async def test_state(hass):
     assert entity.unique_id == MAC
 
 
+async def test_state_wireless(hass):
+    """Test state of the entity with only Wireless MAC."""
+    mocked_device = _create_mocked_device(wired_mac=None, wireless_mac=WIRELESS_MAC)
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.name == FRIENDLY_NAME
+    assert state.state == STATE_ON
+    attributes = state.as_dict()["attributes"]
+    assert attributes["volume_level"] == 0.5
+    assert attributes["is_volume_muted"] is False
+    assert attributes["source_list"] == ["title1", "title2"]
+    assert attributes["source"] == "title2"
+    assert attributes["supported_features"] == SUPPORT_SONGPAL
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(
+        identifiers={(songpal.DOMAIN, WIRELESS_MAC)}
+    )
+    assert device.connections == {(dr.CONNECTION_NETWORK_MAC, WIRELESS_MAC)}
+    assert device.manufacturer == "Sony Corporation"
+    assert device.name == FRIENDLY_NAME
+    assert device.sw_version == SW_VERSION
+    assert device.model == MODEL
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get(ENTITY_ID)
+    assert entity.unique_id == WIRELESS_MAC
+
+
+async def test_state_both(hass):
+    """Test state of the entity with both Wired and Wireless MAC."""
+    mocked_device = _create_mocked_device(wired_mac=MAC, wireless_mac=WIRELESS_MAC)
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.name == FRIENDLY_NAME
+    assert state.state == STATE_ON
+    attributes = state.as_dict()["attributes"]
+    assert attributes["volume_level"] == 0.5
+    assert attributes["is_volume_muted"] is False
+    assert attributes["source_list"] == ["title1", "title2"]
+    assert attributes["source"] == "title2"
+    assert attributes["supported_features"] == SUPPORT_SONGPAL
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
+    assert device.connections == {
+        (dr.CONNECTION_NETWORK_MAC, MAC),
+        (dr.CONNECTION_NETWORK_MAC, WIRELESS_MAC),
+    }
+    assert device.manufacturer == "Sony Corporation"
+    assert device.name == FRIENDLY_NAME
+    assert device.sw_version == SW_VERSION
+    assert device.model == MODEL
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get(ENTITY_ID)
+    # We prefer the wired mac if present.
+    assert entity.unique_id == MAC
+
+
 async def test_services(hass):
     """Test services."""
     mocked_device = _create_mocked_device()
@@ -173,11 +246,7 @@ async def test_services(hass):
     mocked_device.set_sound_settings.assert_called_once_with("name", "value")
     mocked_device.set_sound_settings.reset_mock()
 
-    mocked_device2 = _create_mocked_device()
-    sys_info = MagicMock()
-    sys_info.macAddr = "mac2"
-    sys_info.version = SW_VERSION
-    type(mocked_device2).get_system_info = AsyncMock(return_value=sys_info)
+    mocked_device2 = _create_mocked_device(wired_mac="mac2")
     entry2 = MockConfigEntry(
         domain=songpal.DOMAIN, data={CONF_NAME: "d2", CONF_ENDPOINT: ENDPOINT}
     )
@@ -194,6 +263,27 @@ async def test_services(hass):
     )
     mocked_device.set_sound_settings.assert_called_once_with("name", "value")
     mocked_device2.set_sound_settings.assert_called_once_with("name", "value")
+    mocked_device.set_sound_settings.reset_mock()
+    mocked_device2.set_sound_settings.reset_mock()
+
+    mocked_device3 = _create_mocked_device(wired_mac=None, wireless_mac=WIRELESS_MAC)
+    entry3 = MockConfigEntry(
+        domain=songpal.DOMAIN, data={CONF_NAME: "d2", CONF_ENDPOINT: ENDPOINT}
+    )
+    entry3.add_to_hass(hass)
+    with _patch_media_player_device(mocked_device3):
+        await hass.config_entries.async_setup(entry3.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        songpal.DOMAIN,
+        SET_SOUND_SETTING,
+        {"entity_id": "all", "name": "name", "value": "value"},
+        blocking=True,
+    )
+    mocked_device.set_sound_settings.assert_called_once_with("name", "value")
+    mocked_device2.set_sound_settings.assert_called_once_with("name", "value")
+    mocked_device3.set_sound_settings.assert_called_once_with("name", "value")
 
 
 async def test_websocket_events(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As shown in #64868, a number of newer models don't come wiht a macAddr
attributes, so for those fall back to the wireless address.

This could be hidden by the python-songpal library but for now this will
make it possible to have multiple modern songpal devices on the same
network.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64868
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
