### PR TITLE
Enable mypy checks for homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -48,7 +48,7 @@ class HomeKitEntity(Entity):
         self._features = 0
         self.setup()
 
-        self._signals = []
+        self._signals: list[Any] = []
 
         super().__init__()
 
@@ -145,7 +145,7 @@ class HomeKitEntity(Entity):
         return f"homekit-{self._accessory.unique_id}-{self._aid}-{self._iid}"
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the device if any."""
         return self.accessory_info.value(CharacteristicsTypes.NAME)
 

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -48,8 +48,6 @@ class HomeKitEntity(Entity):
         self._features = 0
         self.setup()
 
-        self._signals: list[Any] = []
-
         super().__init__()
 
     @property
@@ -71,7 +69,7 @@ class HomeKitEntity(Entity):
 
     async def async_added_to_hass(self):
         """Entity added to hass."""
-        self._signals.append(
+        self.async_on_remove(
             self.hass.helpers.dispatcher.async_dispatcher_connect(
                 self._accessory.signal_state_updated, self.async_write_ha_state
             )
@@ -84,10 +82,6 @@ class HomeKitEntity(Entity):
         """Prepare to be removed from hass."""
         self._accessory.remove_pollable_characteristics(self._aid)
         self._accessory.remove_watchable_characteristics(self._aid)
-
-        for signal_remove in self._signals:
-            signal_remove()
-        self._signals.clear()
 
     async def async_put_characteristics(self, characteristics: dict[str, Any]):
         """

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -280,9 +280,13 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if self.controller is None:
                 await self._async_setup_controller()
 
+            # mypy can't see that self._async_setup_controller() always sets self.controller or throws
+            assert self.controller
+
             pairing = self.controller.load_pairing(
                 existing.data["AccessoryPairingID"], dict(existing.data)
             )
+
             try:
                 await pairing.list_accessories_and_characteristics()
             except AuthenticationError:

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -76,7 +76,7 @@ class TriggerSource:
 
     async def async_attach_trigger(
         self,
-        config: TRIGGER_SCHEMA,
+        config: ConfigType,
         action: AutomationActionType,
         automation_info: AutomationTriggerInfo,
     ) -> CALLBACK_TYPE:

--- a/homeassistant/components/homekit_controller/diagnostics.py
+++ b/homeassistant/components/homekit_controller/diagnostics.py
@@ -44,7 +44,7 @@ async def async_get_device_diagnostics(
 def _async_get_diagnostics_for_device(
     hass: HomeAssistant, device: DeviceEntry
 ) -> dict[str, Any]:
-    data = {}
+    data: dict[str, Any] = {}
 
     data["name"] = device.name
     data["model"] = device.model
@@ -60,7 +60,7 @@ def _async_get_diagnostics_for_device(
         include_disabled_entities=True,
     )
 
-    hass_entities.sort(key=lambda entry: entry.original_name)
+    hass_entities.sort(key=lambda entry: entry.original_name or "")
 
     for entity_entry in hass_entities:
         state = hass.states.get(entity_entry.entity_id)
@@ -95,7 +95,7 @@ def _async_get_diagnostics(
     hkid = entry.data["AccessoryPairingID"]
     connection: HKDevice = hass.data[KNOWN_DEVICES][hkid]
 
-    data = {
+    data: dict[str, Any] = {
         "config-entry": {
             "title": entry.title,
             "version": entry.version,
@@ -123,6 +123,8 @@ def _async_get_diagnostics(
         devices = data["devices"] = []
         for device_id in connection.devices.values():
             device = device_registry.async_get(device_id)
+            if not device:
+                continue
             devices.append(_async_get_diagnostics_for_device(hass, device))
 
     return data

--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -122,7 +122,7 @@ class HomeKitNumber(CharacteristicEntity, NumberEntity):
         super().__init__(conn, info, char)
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the device if any."""
         if prefix := super().name:
             return f"{prefix} {self.entity_description.name}"

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -143,7 +143,7 @@ class DeclarativeCharacteristicSwitch(CharacteristicEntity, SwitchEntity):
         super().__init__(conn, info, char)
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the device if any."""
         if prefix := super().name:
             return f"{prefix} {self.entity_description.name}"

--- a/mypy.ini
+++ b/mypy.ini
@@ -2088,9 +2088,6 @@ ignore_errors = true
 [mypy-homeassistant.components.homekit.*]
 ignore_errors = true
 
-[mypy-homeassistant.components.homekit_controller.*]
-ignore_errors = true
-
 [mypy-homeassistant.components.honeywell.*]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -35,7 +35,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.here_travel_time.*",
     "homeassistant.components.home_plus_control.*",
     "homeassistant.components.homekit.*",
-    "homeassistant.components.homekit_controller.*",
     "homeassistant.components.honeywell.*",
     "homeassistant.components.icloud.*",
     "homeassistant.components.influxdb.*",


### PR DESCRIPTION
## Proposed change

Enables mypy checks on homekit_controller.

Future PR's will add more types to make this more useful, this is just enough to get the check turned on in CI and passing.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
