### PR TITLE
Fix MQTT expire_after effects after reloading

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -127,7 +127,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
             and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
         ):
             expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
-            if expiration_at < (dt_util.utcnow() + timedelta(seconds=5)):
+            if expiration_at < (time_now := dt_util.utcnow() + timedelta(seconds=5)):
                 # Skip reactivating the binary_sensor
                 _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
                 return
@@ -137,7 +137,11 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
             self._expiration_trigger = async_track_point_in_utc_time(
                 self.hass, self._value_is_expired, expiration_at
             )
-            _LOGGER.debug("State recovered after reload for %s", self.entity_id)
+            _LOGGER.debug(
+                "State recovered after reload for %s, remaining time before expiring %s",
+                self.entity_id,
+                expiration_at - time_now,
+            )
             self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -142,7 +142,6 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
                 self.entity_id,
                 expiration_at - time_now,
             )
-            self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove exprire triggers."""

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -114,6 +114,14 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove exprire triggers."""
+        # Clean up expire triggers
+        if self._expiration_trigger:
+            _LOGGER.debug("Clean up expire after trigger for %s", self.entity_id)
+            self._expiration_trigger()
+            self._expiration_trigger = None
+
     @staticmethod
     def config_schema():
         """Return the config schema."""

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -125,12 +125,12 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
             and expire_after > 0
             and (last_state := await self.async_get_last_state()) is not None
             and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
+            and (
+                expiration_at := last_state.last_changed
+                + timedelta(seconds=expire_after)
+            )
+            > (time_now := dt_util.utcnow())
         ):
-            expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
-            if expiration_at < (time_now := dt_util.utcnow() + timedelta(seconds=5)):
-                # Skip reactivating the binary_sensor
-                _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
-                return
             self._expired = False
             self._state = last_state.state
 

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -125,12 +125,12 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
             and expire_after > 0
             and (last_state := await self.async_get_last_state()) is not None
             and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-            and (
-                expiration_at := last_state.last_changed
-                + timedelta(seconds=expire_after)
-            )
-            > (time_now := dt_util.utcnow())
         ):
+            expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
+            if expiration_at < (time_now := dt_util.utcnow()):
+                # Skip reactivating the binary_sensor
+                _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
+                return
             self._expired = False
             self._state = last_state.state
 

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -121,6 +121,8 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
             _LOGGER.debug("Clean up expire after trigger for %s", self.entity_id)
             self._expiration_trigger()
             self._expiration_trigger = None
+            self._expired = False
+        await MqttEntity.async_will_remove_from_hass(self)
 
     @staticmethod
     def config_schema():

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_PAYLOAD_ON,
     CONF_VALUE_TEMPLATE,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
@@ -123,11 +124,16 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
             (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None
             and expire_after > 0
             and (last_state := await self.async_get_last_state()) is not None
-            and last_state != STATE_UNAVAILABLE
+            and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
         ):
+            expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
+            if expiration_at < (dt_util.utcnow() + timedelta(seconds=5)):
+                # Skip reactivating the binary_sensor
+                _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
+                return
             self._expired = False
             self._state = last_state.state
-            expiration_at = dt_util.utcnow() + timedelta(seconds=expire_after)
+
             self._expiration_trigger = async_track_point_in_utc_time(
                 self.hass, self._value_is_expired, expiration_at
             )

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -118,7 +118,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity, RestoreEntity):
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     async def async_added_to_hass(self) -> None:
-        """Recover active entities with exire trigger."""
+        """Restore state for entities with expire_after set."""
         await super().async_added_to_hass()
         if (
             (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -87,10 +87,8 @@ def add_entity_discovery_data(hass, discovery_data, entity_id):
 
 def update_entity_discovery_data(hass, discovery_payload, entity_id):
     """Update discovery data."""
-    entity_info = hass.data[DATA_MQTT_DEBUG_INFO]["entities"].get(entity_id)
-    if entity_info is not None:
-        entity_info["discovery_data"][ATTR_DISCOVERY_PAYLOAD] = discovery_payload
-    return entity_info
+    entity_info = hass.data[DATA_MQTT_DEBUG_INFO]["entities"][entity_id]
+    entity_info["discovery_data"][ATTR_DISCOVERY_PAYLOAD] = discovery_payload
 
 
 def remove_entity_data(hass, entity_id):

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -87,8 +87,10 @@ def add_entity_discovery_data(hass, discovery_data, entity_id):
 
 def update_entity_discovery_data(hass, discovery_payload, entity_id):
     """Update discovery data."""
-    entity_info = hass.data[DATA_MQTT_DEBUG_INFO]["entities"][entity_id]
-    entity_info["discovery_data"][ATTR_DISCOVERY_PAYLOAD] = discovery_payload
+    entity_info = hass.data[DATA_MQTT_DEBUG_INFO]["entities"].get(entity_id)
+    if entity_info is not None:
+        entity_info["discovery_data"][ATTR_DISCOVERY_PAYLOAD] = discovery_payload
+    return entity_info
 
 
 def remove_entity_data(hass, entity_id):

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -487,8 +487,10 @@ class MqttDiscoveryUpdate(Entity):
                 payload,
             )
             old_payload = self._discovery_data[ATTR_DISCOVERY_PAYLOAD]
-            debug_info.update_entity_discovery_data(self.hass, payload, self.entity_id)
-            if not payload:
+            entity_info = debug_info.update_entity_discovery_data(
+                self.hass, payload, self.entity_id
+            )
+            if not payload and entity_info is not None:
                 # Empty payload: Remove component
                 _LOGGER.info("Removing component: %s", self.entity_id)
                 self._cleanup_discovery_on_remove()

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -188,7 +188,6 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
                 self.entity_id,
                 expiration_at - time_now,
             )
-            self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove exprire triggers."""

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -160,6 +160,14 @@ class MqttSensor(MqttEntity, SensorEntity):
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove exprire triggers."""
+        # Clean up expire triggers
+        if self._expiration_trigger:
+            _LOGGER.debug("Clean up expire after trigger for %s", self.entity_id)
+            self._expiration_trigger()
+            self._expiration_trigger = None
+
     @staticmethod
     def config_schema():
         """Return the config schema."""

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -171,12 +171,12 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
             and expire_after > 0
             and (last_state := await self.async_get_last_state()) is not None
             and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
-            and (
-                expiration_at := last_state.last_changed
-                + timedelta(seconds=expire_after)
-            )
-            > (time_now := dt_util.utcnow())
         ):
+            expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
+            if expiration_at < (time_now := dt_util.utcnow()):
+                # Skip reactivating the sensor
+                _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
+                return
             self._expired = False
             self._state = last_state.state
 

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -167,6 +167,8 @@ class MqttSensor(MqttEntity, SensorEntity):
             _LOGGER.debug("Clean up expire after trigger for %s", self.entity_id)
             self._expiration_trigger()
             self._expiration_trigger = None
+            self._expired = False
+        await MqttEntity.async_will_remove_from_hass(self)
 
     @staticmethod
     def config_schema():

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -171,12 +171,12 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
             and expire_after > 0
             and (last_state := await self.async_get_last_state()) is not None
             and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
+            and (
+                expiration_at := last_state.last_changed
+                + timedelta(seconds=expire_after)
+            )
+            > (time_now := dt_util.utcnow())
         ):
-            expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
-            if expiration_at < (time_now := dt_util.utcnow() + timedelta(seconds=5)):
-                # Skip reactivating the sensor
-                _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
-                return
             self._expired = False
             self._state = last_state.state
 

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -23,12 +23,14 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
@@ -140,7 +142,7 @@ async def _async_setup_entity(
     async_add_entities([MqttSensor(hass, config, config_entry, discovery_data)])
 
 
-class MqttSensor(MqttEntity, SensorEntity):
+class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
     """Representation of a sensor that can be updated using MQTT."""
 
     _entity_id_format = ENTITY_ID_FORMAT
@@ -278,6 +280,20 @@ class MqttSensor(MqttEntity, SensorEntity):
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+        if (
+            (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None
+            and expire_after > 0
+            and (last_state := await self.async_get_last_state()) is not None
+            and last_state != STATE_UNAVAILABLE
+        ):
+            self._expired = False
+            self._state = last_state.state
+            expiration_at = dt_util.utcnow() + timedelta(seconds=expire_after)
+            self._expiration_trigger = async_track_point_in_utc_time(
+                self.hass, self._value_is_expired, expiration_at
+            )
+            _LOGGER.debug("State recovered after reload for %s", self.entity_id)
+            self.async_write_ha_state()
 
     @callback
     def _value_is_expired(self, *_):

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -162,6 +162,24 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
+    async def async_added_to_hass(self) -> None:
+        """Recover active entities with exire trigger."""
+        await super().async_added_to_hass()
+        if (
+            (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None
+            and expire_after > 0
+            and (last_state := await self.async_get_last_state()) is not None
+            and last_state != STATE_UNAVAILABLE
+        ):
+            self._expired = False
+            self._state = last_state.state
+            expiration_at = dt_util.utcnow() + timedelta(seconds=expire_after)
+            self._expiration_trigger = async_track_point_in_utc_time(
+                self.hass, self._value_is_expired, expiration_at
+            )
+            _LOGGER.debug("State recovered after reload for %s", self.entity_id)
+            self.async_write_ha_state()
+
     async def async_will_remove_from_hass(self) -> None:
         """Remove exprire triggers."""
         # Clean up expire triggers
@@ -280,20 +298,6 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state, topics
         )
-        if (
-            (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None
-            and expire_after > 0
-            and (last_state := await self.async_get_last_state()) is not None
-            and last_state != STATE_UNAVAILABLE
-        ):
-            self._expired = False
-            self._state = last_state.state
-            expiration_at = dt_util.utcnow() + timedelta(seconds=expire_after)
-            self._expiration_trigger = async_track_point_in_utc_time(
-                self.hass, self._value_is_expired, expiration_at
-            )
-            _LOGGER.debug("State recovered after reload for %s", self.entity_id)
-            self.async_write_ha_state()
 
     @callback
     def _value_is_expired(self, *_):

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -164,7 +164,7 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     async def async_added_to_hass(self) -> None:
-        """Recover active entities with exire trigger."""
+        """Restore state for entities with expire_after set."""
         await super().async_added_to_hass()
         if (
             (expire_after := self._config.get(CONF_EXPIRE_AFTER)) is not None
@@ -173,7 +173,7 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
             and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
         ):
             expiration_at = last_state.last_changed + timedelta(seconds=expire_after)
-            if expiration_at < (dt_util.utcnow() + timedelta(seconds=5)):
+            if expiration_at < (time_now := dt_util.utcnow() + timedelta(seconds=5)):
                 # Skip reactivating the sensor
                 _LOGGER.debug("Skip state recovery after reload for %s", self.entity_id)
                 return
@@ -183,7 +183,11 @@ class MqttSensor(MqttEntity, SensorEntity, RestoreEntity):
             self._expiration_trigger = async_track_point_in_utc_time(
                 self.hass, self._value_is_expired, expiration_at
             )
-            _LOGGER.debug("State recovered after reload for %s", self.entity_id)
+            _LOGGER.debug(
+                "State recovered after reload for %s, remaining time before expiring %s",
+                self.entity_id,
+                expiration_at - time_now,
+            )
             self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self) -> None:

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -875,8 +875,8 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
     await help_test_reloadable(hass, mqtt_mock, caplog, tmp_path, domain, config)
 
 
-async def test_cleanup_triggers(hass, mqtt_mock, caplog, tmp_path):
-    """Test cleanup old triggers at reloading."""
+async def test_cleanup_triggers_and_restoring_state(hass, mqtt_mock, caplog, tmp_path):
+    """Test cleanup old triggers at reloading and restoring the state."""
     domain = binary_sensor.DOMAIN
     config = copy.deepcopy(DEFAULT_CONFIG[domain])
     config["expire_after"] = 10
@@ -892,9 +892,10 @@ async def test_cleanup_triggers(hass, mqtt_mock, caplog, tmp_path):
 
     await help_test_reload_with_config(hass, caplog, tmp_path, domain, config)
     assert "Clean up expire after trigger for binary_sensor.test" in caplog.text
+    assert "State recovered after reload for binary_sensor.test" in caplog.text
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == "on"
 
     async_fire_mqtt_message(hass, "test-topic", "OFF")
     state = hass.states.get("binary_sensor.test")

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -893,9 +893,9 @@ async def test_cleanup_triggers(hass, mqtt_mock, caplog, tmp_path):
     await help_test_reload_with_config(hass, caplog, tmp_path, domain, config)
     assert "Clean up expire after trigger for binary_sensor.test" in caplog.text
 
-    state = hass.states.get("sensor.test")
+    state = hass.states.get("binary_sensor.test")
     assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, "test-topic", "OFF")
-    state = hass.states.get("sensor.test")
+    state = hass.states.get("binary_sensor.test")
     assert state.state == "off"

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -953,9 +953,10 @@ async def test_cleanup_triggers(hass, mqtt_mock, caplog, tmp_path):
 
     await help_test_reload_with_config(hass, caplog, tmp_path, domain, config)
     assert "Clean up expire after trigger for sensor.test" in caplog.text
+    assert "State recovered after reload for sensor.test" in caplog.text
 
     state = hass.states.get("sensor.test")
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == "100"
 
     async_fire_mqtt_message(hass, "test-topic", "101")
     state = hass.states.get("sensor.test")

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -939,28 +939,49 @@ async def test_reloadable(hass, mqtt_mock, caplog, tmp_path):
 async def test_cleanup_triggers(hass, mqtt_mock, caplog, tmp_path):
     """Test cleanup old triggers at reloading."""
     domain = sensor.DOMAIN
-    config = copy.deepcopy(DEFAULT_CONFIG[domain])
-    config["expire_after"] = 10
+    config1 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config1["name"] = "test1"
+    config1["expire_after"] = 30
+    config1["state_topic"] = "test-topic1"
+    config2 = copy.deepcopy(DEFAULT_CONFIG[domain])
+    config2["name"] = "test2"
+    config2["expire_after"] = 3
+    config2["state_topic"] = "test-topic2"
     assert await async_setup_component(
         hass,
         sensor.DOMAIN,
-        {sensor.DOMAIN: config},
+        {sensor.DOMAIN: [config1, config2]},
     )
     await hass.async_block_till_done()
-    async_fire_mqtt_message(hass, "test-topic", "100")
-    state = hass.states.get("sensor.test")
+    async_fire_mqtt_message(hass, "test-topic1", "100")
+    state = hass.states.get("sensor.test1")
     assert state.state == "100"
 
-    await help_test_reload_with_config(hass, caplog, tmp_path, domain, config)
-    assert "Clean up expire after trigger for sensor.test" in caplog.text
-    assert "State recovered after reload for sensor.test" in caplog.text
+    async_fire_mqtt_message(hass, "test-topic2", "200")
+    state = hass.states.get("sensor.test2")
+    assert state.state == "200"
 
-    state = hass.states.get("sensor.test")
+    await help_test_reload_with_config(
+        hass, caplog, tmp_path, domain, [config1, config2]
+    )
+    assert "Clean up expire after trigger for sensor.test1" in caplog.text
+    assert "Clean up expire after trigger for sensor.test2" in caplog.text
+    assert "State recovered after reload for sensor.test1" in caplog.text
+    assert "Skip state recovery after reload for sensor.test2" in caplog.text
+
+    state = hass.states.get("sensor.test1")
     assert state.state == "100"
 
-    async_fire_mqtt_message(hass, "test-topic", "101")
-    state = hass.states.get("sensor.test")
+    state = hass.states.get("sensor.test2")
+    assert state.state == STATE_UNAVAILABLE
+
+    async_fire_mqtt_message(hass, "test-topic1", "101")
+    state = hass.states.get("sensor.test1")
     assert state.state == "101"
+
+    async_fire_mqtt_message(hass, "test-topic2", "201")
+    state = hass.states.get("sensor.test2")
+    assert state.state == "201"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the MQTT sensor or binary_sensor platform are used with the `expire_after` option, a timer used to auto expire the sensor value. When reloading the MQTT integration these sensors are not clean up and influence the availability the new loaded entity.

The PR cleans up the old `sensor` and `binary_sensor` timers at reload.

After reloading the sensor's state will be restored. A new timer will be started. When a new update is received the timer will be in sync again.

This PR also fixed an error where entities that use `RestoreEntity` were tried to remove twice.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63546
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
