### PR TITLE
Add Thermostat platform to Z-Wave.Me integration #65331

### DIFF
--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -1,0 +1,108 @@
+"""Representation of a thermostat."""
+from __future__ import annotations
+
+from zwave_me_ws import ZWaveMeData
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import ZWaveMeEntity
+from .const import DOMAIN, ZWaveMePlatform
+
+TEMPERATURE_DEFAULT_STEP = 0.5
+
+DEVICE_NAME = ZWaveMePlatform.CLIMATE
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the climate platform."""
+
+    @callback
+    def add_new_device(new_device: ZWaveMeData) -> None:
+        """Add a new device."""
+        controller = hass.data[DOMAIN][config_entry.entry_id]
+        climate = ZWaveMeClimate(controller, new_device)
+
+        async_add_entities(
+            [
+                climate,
+            ]
+        )
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, f"ZWAVE_ME_NEW_{DEVICE_NAME.upper()}", add_new_device
+        )
+    )
+
+
+class ZWaveMeClimate(ZWaveMeEntity, ClimateEntity):
+    """Representation of a ZWaveMe sensor."""
+
+    def set_temperature(self, **kwargs) -> None:
+        """Set new target temperature."""
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+
+        self.hass.data[DOMAIN].zwave_api.send_command(
+            self.device.id, "exact?level=" + str(temperature)
+        )
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the temperature_unit."""
+        return self.device.scaleTitle
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the state of the sensor."""
+        return self.device.level
+
+    @property
+    def max_temp(self) -> float:
+        """Return min temperature for the device."""
+        return self.device.max
+
+    @property
+    def min_temp(self) -> float:
+        """Return max temperature for the device."""
+        return self.device.min
+
+    @property
+    def hvac_modes(self) -> list[str]:
+        """Return the list of available operation modes."""
+        return [HVAC_MODE_COOL, HVAC_MODE_HEAT]
+
+    @property
+    def hvac_action(self) -> str:
+        """Return the current action."""
+        return CURRENT_HVAC_HEAT
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return the current mode."""
+        return HVAC_MODE_HEAT
+
+    @property
+    def supported_features(self) -> int:
+        """Return the supported features."""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def target_temperature_step(self) -> float:
+        """Return the supported step of target temperature."""
+        return TEMPERATURE_DEFAULT_STEP

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -13,6 +13,7 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
 from . import ZWaveMeEntity
 from .const import DOMAIN, ZWaveMePlatform
 

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -58,8 +58,8 @@ class ZWaveMeClimate(ZWaveMeEntity, ClimateEntity):
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
 
-        self.hass.data[DOMAIN].zwave_api.send_command(
-            self.device.id, "exact?level=" + str(temperature)
+        self.controller.zwave_api.send_command(
+            self.device.id, f"exact?level={temperature}"
         )
 
     @property

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -85,12 +85,7 @@ class ZWaveMeClimate(ZWaveMeEntity, ClimateEntity):
     @property
     def hvac_modes(self) -> list[str]:
         """Return the list of available operation modes."""
-        return [HVAC_MODE_COOL, HVAC_MODE_HEAT]
-
-    @property
-    def hvac_action(self) -> str:
-        """Return the current action."""
-        return CURRENT_HVAC_HEAT
+        return [HVAC_MODE_HEAT, ]
 
     @property
     def hvac_mode(self) -> str:

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -5,8 +5,6 @@ from zwave_me_ws import ZWaveMeData
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    CURRENT_HVAC_HEAT,
-    HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -15,7 +13,6 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
 from . import ZWaveMeEntity
 from .const import DOMAIN, ZWaveMePlatform
 

--- a/homeassistant/components/zwave_me/climate.py
+++ b/homeassistant/components/zwave_me/climate.py
@@ -85,7 +85,7 @@ class ZWaveMeClimate(ZWaveMeEntity, ClimateEntity):
     @property
     def hvac_modes(self) -> list[str]:
         """Return the list of available operation modes."""
-        return [HVAC_MODE_HEAT, ]
+        return [HVAC_MODE_HEAT]
 
     @property
     def hvac_mode(self) -> str:

--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -17,7 +17,7 @@ class ZWaveMePlatform(StrEnum):
     SWITCH = "binarySwitch"
     SENSOR = "sensorMultilevel"
     RGBW_LIGHT = "switchRGBW"
-    RGB_LIGHT = ("switchRGB",)
+    RGB_LIGHT = "switchRGB"
 
 
 PLATFORMS = [

--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -9,19 +9,21 @@ DOMAIN = "zwave_me"
 class ZWaveMePlatform(StrEnum):
     """Included ZWaveMe platforms."""
 
+    BINARY_SENSOR = "sensorBinary"
+    BUTTON = "toggleButton"
+    CLIMATE = "thermostat"
+    LOCK = "doorlock"
     NUMBER = "switchMultilevel"
     SWITCH = "binarySwitch"
-    BUTTON = "toggleButton"
-    LOCK = "doorlock"
     SENSOR = "sensorMultilevel"
-    BINARY_SENSOR = "sensorBinary"
     RGBW_LIGHT = "switchRGBW"
-    RGB_LIGHT = "switchRGB"
+    RGB_LIGHT = ("switchRGB",)
 
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.CLIMATE,
     Platform.LIGHT,
     Platform.LOCK,
     Platform.NUMBER,

--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -14,7 +14,7 @@ class ZWaveMePlatform(StrEnum):
     CLIMATE = "thermostat"
     LOCK = "doorlock"
     NUMBER = "switchMultilevel"
-    SWITCH = "binarySwitch"
+    SWITCH = "switchBinary"
     SENSOR = "sensorMultilevel"
     RGBW_LIGHT = "switchRGBW"
     RGB_LIGHT = "switchRGB"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20684

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
