### PR TITLE
Allow removing keys from automation

### DIFF
--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -1,5 +1,4 @@
 """Provide configuration end points for Automations."""
-from collections import OrderedDict
 import uuid
 
 from homeassistant.components.automation.config import (
@@ -52,7 +51,15 @@ class EditAutomationConfigView(EditIdBasedConfigView):
 
     def _write_value(self, hass, data, config_key, new_value):
         """Set value."""
-        index = None
+        updated_value = {CONF_ID: config_key}
+
+        for key in ("id", "alias", "description", "trigger", "condition", "action"):
+            if key in new_value:
+                updated_value[key] = new_value[key]
+
+        updated_value.update(new_value)
+
+        updated = False
         for index, cur_value in enumerate(data):
             # When people copy paste their automations to the config file,
             # they sometimes forget to add IDs. Fix it here.
@@ -60,23 +67,8 @@ class EditAutomationConfigView(EditIdBasedConfigView):
                 cur_value[CONF_ID] = uuid.uuid4().hex
 
             elif cur_value[CONF_ID] == config_key:
-                break
-        else:
-            cur_value = OrderedDict()
-            cur_value[CONF_ID] = config_key
-            index = len(data)
-            data.append(cur_value)
+                data[index] = updated_value
+                updated = True
 
-        # Iterate through some keys that we want to have ordered in the output
-        updated_value = OrderedDict()
-        for key in ("id", "alias", "description", "trigger", "condition", "action"):
-            if key in cur_value:
-                updated_value[key] = cur_value[key]
-            if key in new_value:
-                updated_value[key] = new_value[key]
-
-        # We cover all current fields above, but just in case we start
-        # supporting more fields in the future.
-        updated_value.update(cur_value)
-        updated_value.update(new_value)
-        data[index] = updated_value
+        if not updated:
+            data.append(updated_value)

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -53,10 +53,13 @@ class EditAutomationConfigView(EditIdBasedConfigView):
         """Set value."""
         updated_value = {CONF_ID: config_key}
 
-        for key in ("id", "alias", "description", "trigger", "condition", "action"):
+        # Iterate through some keys that we want to have ordered in the output
+        for key in ("alias", "description", "trigger", "condition", "action"):
             if key in new_value:
                 updated_value[key] = new_value[key]
 
+        # We cover all current fields above, but just in case we start
+        # supporting more fields in the future.
         updated_value.update(new_value)
 
         updated = False

--- a/homeassistant/components/config/scene.py
+++ b/homeassistant/components/config/scene.py
@@ -47,8 +47,8 @@ class EditSceneConfigView(EditIdBasedConfigView):
 
     def _write_value(self, hass, data, config_key, new_value):
         """Set value."""
-        # Iterate through some keys that we want to have ordered in the output
         updated_value = {CONF_ID: config_key}
+        # Iterate through some keys that we want to have ordered in the output
         for key in ("name", "entities"):
             if key in new_value:
                 updated_value[key] = new_value[key]


### PR DESCRIPTION


## Proposed change
We would add the new config to the current config, thus not allowing removal of keys.

Since we always send the full config we don't need to do that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
