### PR TITLE
Detect battery-operated Sonos devices going offline

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -160,6 +160,7 @@ SONOS_SPEAKER_ACTIVITY = "sonos_speaker_activity"
 SONOS_SPEAKER_ADDED = "sonos_speaker_added"
 SONOS_STATE_UPDATED = "sonos_state_updated"
 SONOS_REBOOTED = "sonos_rebooted"
+SONOS_VANISHED = "sonos_vanished"
 
 SOURCE_LINEIN = "Line-in"
 SOURCE_TV = "TV"

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -582,7 +582,7 @@ class SonosSpeaker:
         if not self.available:
             return
         _LOGGER.debug(
-            "%s has gone away (%s), marking unavailable", self.zone_name, reason
+            "%s has vanished (%s), marking unavailable", self.zone_name, reason
         )
         await self.async_offline()
 
@@ -702,7 +702,13 @@ class SonosSpeaker:
         if xml := event.variables.get("zone_group_state"):
             zgs = ET.fromstring(xml)
             for vanished_device in zgs.find("VanishedDevices"):
-                if (reason := vanished_device.get("Reason")) == "UNKNOWN":
+                if (reason := vanished_device.get("Reason")) != "sleeping":
+                    _LOGGER.debug(
+                        "Ignoring %s marked %s as vanished with reason: %s",
+                        self.zone_name,
+                        vanished_device.get("ZoneName"),
+                        reason,
+                    )
                     continue
                 uid = vanished_device.get("UUID")
                 async_dispatcher_send(

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -702,11 +702,13 @@ class SonosSpeaker:
         if xml := event.variables.get("zone_group_state"):
             zgs = ET.fromstring(xml)
             for vanished_device in zgs.find("VanishedDevices"):
+                if (reason := vanished_device.get("Reason")) == "UNKNOWN":
+                    continue
                 uid = vanished_device.get("UUID")
                 async_dispatcher_send(
                     self.hass,
                     f"{SONOS_VANISHED}-{uid}",
-                    vanished_device.get("Reason"),
+                    reason,
                 )
 
         if "zone_player_uui_ds_in_group" not in event.variables:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -12,6 +12,7 @@ from typing import Any
 import urllib.parse
 
 import async_timeout
+import defusedxml.ElementTree as ET
 from soco.core import MUSIC_SRC_LINE_IN, MUSIC_SRC_RADIO, MUSIC_SRC_TV, SoCo
 from soco.data_structures import DidlAudioBroadcast, DidlPlaylistContainer
 from soco.events_base import Event as SonosEvent, SubscriptionBase
@@ -56,6 +57,7 @@ from .const import (
     SONOS_STATE_PLAYING,
     SONOS_STATE_TRANSITIONING,
     SONOS_STATE_UPDATED,
+    SONOS_VANISHED,
     SOURCE_LINEIN,
     SOURCE_TV,
     SUBSCRIPTION_TIMEOUT,
@@ -225,6 +227,7 @@ class SonosSpeaker:
             (SONOS_SPEAKER_ADDED, self.update_group_for_uid),
             (f"{SONOS_REBOOTED}-{self.soco.uid}", self.async_rebooted),
             (f"{SONOS_SPEAKER_ACTIVITY}-{self.soco.uid}", self.speaker_activity),
+            (f"{SONOS_VANISHED}-{self.soco.uid}", self.async_vanished),
         )
 
         for (signal, target) in dispatch_pairs:
@@ -388,6 +391,8 @@ class SonosSpeaker:
 
     async def async_unsubscribe(self) -> None:
         """Cancel all subscriptions."""
+        if not self._subscriptions:
+            return
         _LOGGER.debug("Unsubscribing from events for %s", self.zone_name)
         results = await asyncio.gather(
             *(subscription.unsubscribe() for subscription in self._subscriptions),
@@ -572,6 +577,15 @@ class SonosSpeaker:
         self.hass.data[DATA_SONOS].discovery_known.discard(self.soco.uid)
         self.async_write_entity_states()
 
+    async def async_vanished(self, reason: str) -> None:
+        """Handle removal of speaker when marked as vanished."""
+        if not self.available:
+            return
+        _LOGGER.debug(
+            "%s has gone away (%s), marking unavailable", self.zone_name, reason
+        )
+        await self.async_offline()
+
     async def async_rebooted(self, soco: SoCo) -> None:
         """Handle a detected speaker reboot."""
         _LOGGER.warning(
@@ -685,7 +699,17 @@ class SonosSpeaker:
     @callback
     def async_update_groups(self, event: SonosEvent) -> None:
         """Handle callback for topology change event."""
-        if not hasattr(event, "zone_player_uui_ds_in_group"):
+        if xml := event.variables.get("zone_group_state"):
+            zgs = ET.fromstring(xml)
+            for vanished_device in zgs.find("VanishedDevices"):
+                uid = vanished_device.get("UUID")
+                async_dispatcher_send(
+                    self.hass,
+                    f"{SONOS_VANISHED}-{uid}",
+                    vanished_device.get("Reason"),
+                )
+
+        if "zone_player_uui_ds_in_group" not in event.variables:
             return
         self.event_stats.process(event)
         self.hass.async_create_task(self.create_update_groups_coro(event))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
One of the Sonos subscription event payloads contains information regarding other speakers in the system which have "vanished" along with a reason. This is fairly common with battery-operated speakers which are powered off or go to sleep. This change detects the event and marks the appropriate device(s) as offline immediately.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
