### PR TITLE
Add switch platform to UptimeRobot

### DIFF
--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -59,6 +59,7 @@ class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator):
     """Data update coordinator for UptimeRobot."""
 
     data: list[UptimeRobotMonitor]
+    config_entry: ConfigEntry
 
     def __init__(
         self,

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -28,7 +28,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     key: str = entry.data[CONF_API_KEY]
     if key.startswith("ur") or key.startswith("m"):
-        raise ConfigEntryAuthFailed("The provided API key is 'read-only' or 'monitor'")
+        raise ConfigEntryAuthFailed(
+            "Wrong API key type detected, use the 'main' API key"
+        )
     uptime_robot_api = UptimeRobot(key, async_get_clientsession(hass))
     dev_reg = await async_get_registry(hass)
 

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -27,8 +27,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up UptimeRobot from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     key: str = entry.data[CONF_API_KEY]
-    if key.startswith("ur"):
-        raise ConfigEntryAuthFailed("Read-only API key")
+    if key.startswith("ur") or key.startswith("m"):
+        raise ConfigEntryAuthFailed("The provided API key is 'read-only' or 'monitor'")
     uptime_robot_api = UptimeRobot(key, async_get_clientsession(hass))
     dev_reg = await async_get_registry(hass)
 

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -26,9 +26,10 @@ from .const import API_ATTR_OK, COORDINATOR_UPDATE_INTERVAL, DOMAIN, LOGGER, PLA
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up UptimeRobot from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    uptime_robot_api = UptimeRobot(
-        entry.data[CONF_API_KEY], async_get_clientsession(hass)
-    )
+    key: str = entry.data[CONF_API_KEY]
+    if key.startswith("ur"):
+        raise ConfigEntryAuthFailed("Read-only API key")
+    uptime_robot_api = UptimeRobot(key, async_get_clientsession(hass))
     dev_reg = await async_get_registry(hass)
 
     hass.data[DOMAIN][entry.entry_id] = coordinator = UptimeRobotDataUpdateCoordinator(

--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -23,18 +23,16 @@ async def async_setup_entry(
     """Set up the UptimeRobot binary_sensors."""
     coordinator: UptimeRobotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            UptimeRobotBinarySensor(
-                coordinator,
-                BinarySensorEntityDescription(
-                    key=str(monitor.id),
-                    name=monitor.friendly_name,
-                    device_class=BinarySensorDeviceClass.CONNECTIVITY,
-                ),
-                monitor=monitor,
-            )
-            for monitor in coordinator.data
-        ],
+        UptimeRobotBinarySensor(
+            coordinator,
+            BinarySensorEntityDescription(
+                key=str(monitor.id),
+                name=monitor.friendly_name,
+                device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            ),
+            monitor=monitor,
+        )
+        for monitor in coordinator.data
     )
 
 

--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -32,7 +32,6 @@ async def async_setup_entry(
                     device_class=BinarySensorDeviceClass.CONNECTIVITY,
                 ),
                 monitor=monitor,
-                config_entry=entry,
             )
             for monitor in coordinator.data
         ],

--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -32,6 +32,7 @@ async def async_setup_entry(
                     device_class=BinarySensorDeviceClass.CONNECTIVITY,
                 ),
                 monitor=monitor,
+                config_entry=entry,
             )
             for monitor in coordinator.data
         ],

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -36,7 +36,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         response: UptimeRobotApiResponse | UptimeRobotApiError | None = None
         key: str = data[CONF_API_KEY]
         if key.startswith("ur") or key.startswith("m"):
-            LOGGER.error("The provided API key is 'read-only' or 'monitor'")
+            LOGGER.error("Wrong API key type detected, use the 'main' API key")
             errors["base"] = "not_main_key"
             return errors, None
         uptime_robot_api = UptimeRobot(key, async_get_clientsession(self.hass))

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -34,9 +34,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Validate the user input allows us to connect."""
         errors: dict[str, str] = {}
         response: UptimeRobotApiResponse | UptimeRobotApiError | None = None
-        uptime_robot_api = UptimeRobot(
-            data[CONF_API_KEY], async_get_clientsession(self.hass)
-        )
+        key: str = data[CONF_API_KEY]
+        if key.startswith("ur"):
+            LOGGER.error("The provided API key is 'read-only'")
+            errors["base"] = "read_only_key"
+            return errors, None
+        uptime_robot_api = UptimeRobot(key, async_get_clientsession(self.hass))
 
         try:
             response = await uptime_robot_api.async_get_account_details()

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -35,9 +35,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         response: UptimeRobotApiResponse | UptimeRobotApiError | None = None
         key: str = data[CONF_API_KEY]
-        if key.startswith("ur"):
-            LOGGER.error("The provided API key is 'read-only'")
-            errors["base"] = "read_only_key"
+        if key.startswith("ur") or key.startswith("m"):
+            LOGGER.error("The provided API key is 'read-only' or 'monitor'")
+            errors["base"] = "not_main_key"
             return errors, None
         uptime_robot_api = UptimeRobot(key, async_get_clientsession(self.hass))
 

--- a/homeassistant/components/uptimerobot/const.py
+++ b/homeassistant/components/uptimerobot/const.py
@@ -13,7 +13,7 @@ LOGGER: Logger = getLogger(__package__)
 COORDINATOR_UPDATE_INTERVAL: timedelta = timedelta(seconds=10)
 
 DOMAIN: Final = "uptimerobot"
-PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 ATTRIBUTION: Final = "Data provided by UptimeRobot"
 

--- a/homeassistant/components/uptimerobot/entity.py
+++ b/homeassistant/components/uptimerobot/entity.py
@@ -15,6 +15,7 @@ class UptimeRobotEntity(CoordinatorEntity):
     """Base UptimeRobot entity."""
 
     _attr_attribution = ATTRIBUTION
+    coordinator: UptimeRobotDataUpdateCoordinator
 
     def __init__(
         self,

--- a/homeassistant/components/uptimerobot/entity.py
+++ b/homeassistant/components/uptimerobot/entity.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pyuptimerobot import UptimeRobotMonitor
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -22,13 +21,11 @@ class UptimeRobotEntity(CoordinatorEntity):
         coordinator: UptimeRobotDataUpdateCoordinator,
         description: EntityDescription,
         monitor: UptimeRobotMonitor,
-        config_entry: ConfigEntry,
     ) -> None:
         """Initialize UptimeRobot entities."""
         super().__init__(coordinator)
         self.entity_description = description
         self._monitor = monitor
-        self._config_entry = config_entry
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(self.monitor.id))},
             name=self.monitor.friendly_name,

--- a/homeassistant/components/uptimerobot/entity.py
+++ b/homeassistant/components/uptimerobot/entity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pyuptimerobot import UptimeRobotMonitor
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -21,11 +22,13 @@ class UptimeRobotEntity(CoordinatorEntity):
         coordinator: UptimeRobotDataUpdateCoordinator,
         description: EntityDescription,
         monitor: UptimeRobotMonitor,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize UptimeRobot entities."""
         super().__init__(coordinator)
         self.entity_description = description
         self._monitor = monitor
+        self._config_entry = config_entry
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(self.monitor.id))},
             name=self.monitor.friendly_name,

--- a/homeassistant/components/uptimerobot/entity.py
+++ b/homeassistant/components/uptimerobot/entity.py
@@ -5,11 +5,9 @@ from pyuptimerobot import UptimeRobotMonitor
 
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import UptimeRobotDataUpdateCoordinator
 from .const import ATTR_TARGET, ATTRIBUTION, DOMAIN
 
 
@@ -20,7 +18,7 @@ class UptimeRobotEntity(CoordinatorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: UptimeRobotDataUpdateCoordinator,
         description: EntityDescription,
         monitor: UptimeRobotMonitor,
     ) -> None:
@@ -40,6 +38,7 @@ class UptimeRobotEntity(CoordinatorEntity):
             ATTR_TARGET: self.monitor.url,
         }
         self._attr_unique_id = str(self.monitor.id)
+        self.api = coordinator.api
 
     @property
     def _monitors(self) -> list[UptimeRobotMonitor]:

--- a/homeassistant/components/uptimerobot/sensor.py
+++ b/homeassistant/components/uptimerobot/sensor.py
@@ -38,19 +38,17 @@ async def async_setup_entry(
     """Set up the UptimeRobot sensors."""
     coordinator: UptimeRobotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            UptimeRobotSensor(
-                coordinator,
-                SensorEntityDescription(
-                    key=str(monitor.id),
-                    name=monitor.friendly_name,
-                    entity_category=EntityCategory.DIAGNOSTIC,
-                    device_class="uptimerobot__monitor_status",
-                ),
-                monitor=monitor,
-            )
-            for monitor in coordinator.data
-        ],
+        UptimeRobotSensor(
+            coordinator,
+            SensorEntityDescription(
+                key=str(monitor.id),
+                name=monitor.friendly_name,
+                entity_category=EntityCategory.DIAGNOSTIC,
+                device_class="uptimerobot__monitor_status",
+            ),
+            monitor=monitor,
+        )
+        for monitor in coordinator.data
     )
 
 

--- a/homeassistant/components/uptimerobot/sensor.py
+++ b/homeassistant/components/uptimerobot/sensor.py
@@ -48,7 +48,6 @@ async def async_setup_entry(
                     device_class="uptimerobot__monitor_status",
                 ),
                 monitor=monitor,
-                config_entry=entry,
             )
             for monitor in coordinator.data
         ],

--- a/homeassistant/components/uptimerobot/sensor.py
+++ b/homeassistant/components/uptimerobot/sensor.py
@@ -48,6 +48,7 @@ async def async_setup_entry(
                     device_class="uptimerobot__monitor_status",
                 ),
                 monitor=monitor,
+                config_entry=entry,
             )
             for monitor in coordinator.data
         ],

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -2,14 +2,14 @@
     "config": {
         "step": {
             "user": {
-                "description": "You need to supply a 'main' API key from UptimeRobot",
+                "description": "You need to supply the 'main' API key from UptimeRobot",
                 "data": {
                     "api_key": "[%key:common::config_flow::data::api_key%]"
                 }
             },
             "reauth_confirm": {
                 "title": "[%key:common::config_flow::title::reauth%]",
-                "description": "You need to supply a new 'main'' API key from UptimeRobot",
+                "description": "You need to supply a new 'main' API key from UptimeRobot",
                 "data": {
                     "api_key": "[%key:common::config_flow::data::api_key%]"
                 }
@@ -19,7 +19,7 @@
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
             "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
             "unknown": "[%key:common::config_flow::error::unknown%]",
-            "read_only_key": "The API key you provided is a 'read-only' key, please provide a 'main' key",
+            "read_only_key": "The API key you provided is a 'read-only' key, please provide the 'main' key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration."
         },
         "abort": {

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -19,7 +19,7 @@
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
             "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
             "unknown": "[%key:common::config_flow::error::unknown%]",
-            "not_main_key": "The API key you provided is a 'read-only' or 'monitor' key, please provide the 'main' key",
+            "not_main_key": "Wrong API key type detected, use the 'main' API key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration."
         },
         "abort": {

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -2,14 +2,14 @@
     "config": {
         "step": {
             "user": {
-                "description": "You need to supply a read-only API key from UptimeRobot",
+                "description": "You need to supply a 'main' API key from UptimeRobot",
                 "data": {
                     "api_key": "[%key:common::config_flow::data::api_key%]"
                 }
             },
             "reauth_confirm": {
                 "title": "[%key:common::config_flow::title::reauth%]",
-                "description": "You need to supply a new read-only API key from UptimeRobot",
+                "description": "You need to supply a new 'main'' API key from UptimeRobot",
                 "data": {
                     "api_key": "[%key:common::config_flow::data::api_key%]"
                 }
@@ -19,6 +19,7 @@
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
             "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
             "unknown": "[%key:common::config_flow::error::unknown%]",
+            "read_only_key": "The API key you provided is a 'read-only' key, please provide a 'main' key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration."
         },
         "abort": {

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -19,7 +19,7 @@
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
             "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
             "unknown": "[%key:common::config_flow::error::unknown%]",
-            "read_only_key": "The API key you provided is a 'read-only' key, please provide the 'main' key",
+            "not_main_key": "The API key you provided is a 'read-only' or 'monitor' key, please provide the 'main' key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration."
         },
         "abort": {

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -53,9 +53,8 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
         try:
             response = await self.api.async_edit_monitor(**kwargs)
         except UptimeRobotAuthenticationException:
-            if self.coordinator.config_entry:
-                self.coordinator.config_entry.async_start_reauth(self.hass)
-            LOGGER.error("API exception: Authentication error with empty config entry")
+            LOGGER.debug("API authentication error, calling reauth")
+            self.coordinator.config_entry.async_start_reauth(self.hass)
             return
         except UptimeRobotException as exception:
             LOGGER.error("API exception: %s", exception)

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -46,12 +46,7 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return True if the entity is on."""
-        return bool(self.monitor.status == 2)
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.monitor.status not in (8, 9)
+        return bool(self.monitor.status != 0)
 
     async def _async_edit_monitor(self, **kwargs: Any) -> None:
         """Edit monitor status."""

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -25,18 +25,16 @@ async def async_setup_entry(
     """Set up the UptimeRobot switches."""
     coordinator: UptimeRobotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            UptimeRobotSwitch(
-                coordinator,
-                SwitchEntityDescription(
-                    key=str(monitor.id),
-                    name=f"{monitor.friendly_name} Active",
-                    device_class=SwitchDeviceClass.SWITCH,
-                ),
-                monitor=monitor,
-            )
-            for monitor in coordinator.data
-        ],
+        UptimeRobotSwitch(
+            coordinator,
+            SwitchEntityDescription(
+                key=str(monitor.id),
+                name=f"{monitor.friendly_name} Active",
+                device_class=SwitchDeviceClass.SWITCH,
+            ),
+            monitor=monitor,
+        )
+        for monitor in coordinator.data
     )
 
 

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
                 coordinator,
                 SwitchEntityDescription(
                     key=str(monitor.id),
-                    name=f"{monitor.friendly_name} Pause",
+                    name=f"{monitor.friendly_name} Active",
                     device_class=SwitchDeviceClass.SWITCH,
                 ),
                 monitor=monitor,
@@ -49,7 +49,7 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return True if the entity is on."""
-        return bool(self.monitor.status == 0)
+        return bool(self.monitor.status == 2)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -12,6 +12,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import UptimeRobotDataUpdateCoordinator
@@ -60,10 +61,8 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
         try:
             response = await self.api.async_edit_monitor(**kwargs)
             self.async_write_ha_state()
-        except UptimeRobotAuthenticationException:
-            LOGGER.error(
-                "Authentication Error: Please check the provided credentials and verify that you can log into the web interface"
-            )
+        except UptimeRobotAuthenticationException as exception:
+            raise ConfigEntryAuthFailed(exception) from exception
         else:
             if response.status != API_ATTR_OK:
                 LOGGER.error("API exception: %s", response.error.message, exc_info=True)

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -1,0 +1,80 @@
+"""UptimeRobot switch platform."""
+from __future__ import annotations
+
+from typing import Any
+
+from pyuptimerobot import UptimeRobotAuthenticationException
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import UptimeRobotDataUpdateCoordinator
+from .const import API_ATTR_OK, DOMAIN, LOGGER
+from .entity import UptimeRobotEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the UptimeRobot switches."""
+    coordinator: UptimeRobotDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            UptimeRobotSwitch(
+                coordinator,
+                SwitchEntityDescription(
+                    key=str(monitor.id),
+                    name=f"{monitor.friendly_name} Pause",
+                    device_class=SwitchDeviceClass.SWITCH,
+                ),
+                monitor=monitor,
+            )
+            for monitor in coordinator.data
+        ],
+    )
+
+
+class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
+    """Representation of a UptimeRobot switch."""
+
+    _attr_icon = "mdi:cog"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the entity is on."""
+        return bool(self.monitor.status == 0)
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.monitor.status not in (8, 9)
+
+    async def _async_edit_monitor(self, **kwargs: Any) -> None:
+        """Edit monitor status."""
+        try:
+            response = await self.api.async_edit_monitor(**kwargs)
+            self.async_write_ha_state()
+        except UptimeRobotAuthenticationException:
+            LOGGER.error(
+                "Authentication Error: Please check the provided credentials and verify that you can log into the web interface",
+                exc_info=True,
+            )
+        else:
+            if response.status != API_ATTR_OK:
+                LOGGER.error(
+                    "Switch API exception: %s", response.error.message, exc_info=True
+                )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn on switch."""
+        await self._async_edit_monitor(id=self.monitor.id, status=1)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn off switch."""
+        await self._async_edit_monitor(id=self.monitor.id, status=0)

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -34,7 +34,6 @@ async def async_setup_entry(
                     device_class=SwitchDeviceClass.SWITCH,
                 ),
                 monitor=monitor,
-                config_entry=entry,
             )
             for monitor in coordinator.data
         ],
@@ -62,7 +61,9 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
             response = await self.api.async_edit_monitor(**kwargs)
             self.async_write_ha_state()
         except UptimeRobotAuthenticationException:
-            self._config_entry.async_start_reauth(self.hass)
+            if self.coordinator.config_entry:
+                self.coordinator.config_entry.async_start_reauth(self.hass)
+            LOGGER.error("API exception: Authentiocation error with empty config entry")
         else:
             if response.status != API_ATTR_OK:
                 LOGGER.error("API exception: %s", response.error.message, exc_info=True)

--- a/homeassistant/components/uptimerobot/switch.py
+++ b/homeassistant/components/uptimerobot/switch.py
@@ -62,14 +62,11 @@ class UptimeRobotSwitch(UptimeRobotEntity, SwitchEntity):
             self.async_write_ha_state()
         except UptimeRobotAuthenticationException:
             LOGGER.error(
-                "Authentication Error: Please check the provided credentials and verify that you can log into the web interface",
-                exc_info=True,
+                "Authentication Error: Please check the provided credentials and verify that you can log into the web interface"
             )
         else:
             if response.status != API_ATTR_OK:
-                LOGGER.error(
-                    "Switch API exception: %s", response.error.message, exc_info=True
-                )
+                LOGGER.error("API exception: %s", response.error.message, exc_info=True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn on switch."""

--- a/homeassistant/components/uptimerobot/translations/en.json
+++ b/homeassistant/components/uptimerobot/translations/en.json
@@ -9,7 +9,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_api_key": "Invalid API key",
-            "read_only_key": "The API key you provided is a 'read-only' key, please provide a 'main' key",
+            "read_only_key": "The API key you provided is a 'read-only' key, please provide the 'main' key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration.",
             "unknown": "Unexpected error"
         },
@@ -18,14 +18,14 @@
                 "data": {
                     "api_key": "API Key"
                 },
-                "description": "You need to supply a new 'main'' API key from UptimeRobot",
+                "description": "You need to supply a new 'main' API key from UptimeRobot",
                 "title": "Reauthenticate Integration"
             },
             "user": {
                 "data": {
                     "api_key": "API Key"
                 },
-                "description": "You need to supply a 'main' API key from UptimeRobot"
+                "description": "You need to supply the 'main' API key from UptimeRobot"
             }
         }
     }

--- a/homeassistant/components/uptimerobot/translations/en.json
+++ b/homeassistant/components/uptimerobot/translations/en.json
@@ -9,6 +9,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_api_key": "Invalid API key",
+            "read_only_key": "The API key you provided is a 'read-only' key, please provide a 'main' key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration.",
             "unknown": "Unexpected error"
         },
@@ -17,14 +18,14 @@
                 "data": {
                     "api_key": "API Key"
                 },
-                "description": "You need to supply a new read-only API key from UptimeRobot",
+                "description": "You need to supply a new 'main'' API key from UptimeRobot",
                 "title": "Reauthenticate Integration"
             },
             "user": {
                 "data": {
                     "api_key": "API Key"
                 },
-                "description": "You need to supply a read-only API key from UptimeRobot"
+                "description": "You need to supply a 'main' API key from UptimeRobot"
             }
         }
     }

--- a/homeassistant/components/uptimerobot/translations/en.json
+++ b/homeassistant/components/uptimerobot/translations/en.json
@@ -9,7 +9,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_api_key": "Invalid API key",
-            "read_only_key": "The API key you provided is a 'read-only' key, please provide the 'main' key",
+            "not_main_key": "The API key you provided is a 'read-only' or 'monitor' key, please provide the 'main' key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration.",
             "unknown": "Unexpected error"
         },

--- a/homeassistant/components/uptimerobot/translations/en.json
+++ b/homeassistant/components/uptimerobot/translations/en.json
@@ -9,7 +9,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_api_key": "Invalid API key",
-            "not_main_key": "The API key you provided is a 'read-only' or 'monitor' key, please provide the 'main' key",
+            "not_main_key": "Wrong API key type detected, use the 'main' API key",
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration.",
             "unknown": "Unexpected error"
         },

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -20,7 +20,8 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-MOCK_UPTIMEROBOT_API_KEY = "0242ac120003"
+MOCK_UPTIMEROBOT_API_KEY = "u0242ac120003"
+MOCK_UPTIMEROBOT_API_KEY_READ_ONLY = "ur0242ac120003"
 MOCK_UPTIMEROBOT_EMAIL = "test@test.test"
 MOCK_UPTIMEROBOT_UNIQUE_ID = "1234567890"
 
@@ -50,6 +51,13 @@ MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA = {
     "domain": DOMAIN,
     "title": MOCK_UPTIMEROBOT_EMAIL,
     "data": {"platform": DOMAIN, "api_key": MOCK_UPTIMEROBOT_API_KEY},
+    "unique_id": MOCK_UPTIMEROBOT_UNIQUE_ID,
+    "source": config_entries.SOURCE_USER,
+}
+MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA_KEY_READ_ONLY = {
+    "domain": DOMAIN,
+    "title": MOCK_UPTIMEROBOT_EMAIL,
+    "data": {"platform": DOMAIN, "api_key": MOCK_UPTIMEROBOT_API_KEY_READ_ONLY},
     "unique_id": MOCK_UPTIMEROBOT_UNIQUE_ID,
     "source": config_entries.SOURCE_USER,
 }

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -37,6 +37,14 @@ MOCK_UPTIMEROBOT_MONITOR = {
     "type": 1,
     "url": "http://example.com",
 }
+MOCK_UPTIMEROBOT_MONITOR_PAUSED = {
+    "id": 1234,
+    "friendly_name": "Test monitor",
+    "status": 0,
+    "type": 1,
+    "url": "http://example.com",
+}
+
 
 MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA = {
     "domain": DOMAIN,
@@ -50,6 +58,7 @@ STATE_UP = "up"
 
 UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY = "binary_sensor.test_monitor"
 UPTIMEROBOT_SENSOR_TEST_ENTITY = "sensor.test_monitor"
+UPTIMEROBOT_SWITCH_TEST_ENTITY = "switch.test_monitor_pause"
 
 
 class MockApiResponseKey(str, Enum):

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -58,7 +58,7 @@ STATE_UP = "up"
 
 UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY = "binary_sensor.test_monitor"
 UPTIMEROBOT_SENSOR_TEST_ENTITY = "sensor.test_monitor"
-UPTIMEROBOT_SWITCH_TEST_ENTITY = "switch.test_monitor_pause"
+UPTIMEROBOT_SWITCH_TEST_ENTITY = "switch.test_monitor_active"
 
 
 class MockApiResponseKey(str, Enum):

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -77,7 +77,7 @@ async def test_form_read_only(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"]["base"] == "read_only_key"
+    assert result2["errors"]["base"] == "not_main_key"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.data_entry_flow import (
 from .common import (
     MOCK_UPTIMEROBOT_ACCOUNT,
     MOCK_UPTIMEROBOT_API_KEY,
+    MOCK_UPTIMEROBOT_API_KEY_READ_ONLY,
     MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA,
     MOCK_UPTIMEROBOT_UNIQUE_ID,
     MockApiResponseKey,
@@ -54,6 +55,29 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result2["title"] == MOCK_UPTIMEROBOT_ACCOUNT["email"]
     assert result2["data"] == {CONF_API_KEY: MOCK_UPTIMEROBOT_API_KEY}
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_read_only(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        return_value=mock_uptimerobot_api_response(key=MockApiResponseKey.ACCOUNT),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_API_KEY: MOCK_UPTIMEROBOT_API_KEY_READ_ONLY},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"]["base"] == "read_only_key"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -79,7 +79,8 @@ async def test_reauthentication_trigger_key_read_only(
 
     assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
     assert (
-        mock_config_entry.reason == "The provided API key is 'read-only' or 'monitor'"
+        mock_config_entry.reason
+        == "Wrong API key type detected, use the 'main' API key"
     )
 
     assert len(flows) == 1

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -78,7 +78,9 @@ async def test_reauthentication_trigger_key_read_only(
     flows = hass.config_entries.flow.async_progress()
 
     assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
-    assert mock_config_entry.reason == "Read-only API key"
+    assert (
+        mock_config_entry.reason == "The provided API key is 'read-only' or 'monitor'"
+    )
 
     assert len(flows) == 1
     flow = flows[0]

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from pyuptimerobot import UptimeRobotAuthenticationException
+from pyuptimerobot import UptimeRobotAuthenticationException, UptimeRobotException
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -143,7 +143,7 @@ async def test_general_exception(hass: HomeAssistant, caplog) -> None:
 
     with patch(
         "pyuptimerobot.UptimeRobot.async_edit_monitor",
-        side_effect=OSError,
+        side_effect=UptimeRobotException,
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -1,4 +1,4 @@
-"""Test UptimeRobot sensor."""
+"""Test UptimeRobot switch."""
 
 from unittest.mock import patch
 
@@ -25,8 +25,6 @@ from .common import (
 
 from tests.common import MockConfigEntry
 
-SWITCH_ICON = "mdi:cog"
-
 
 async def test_presentation(hass: HomeAssistant) -> None:
     """Test the presenstation of UptimeRobot sensors."""
@@ -35,7 +33,7 @@ async def test_presentation(hass: HomeAssistant) -> None:
     entity = hass.states.get(UPTIMEROBOT_SWITCH_TEST_ENTITY)
 
     assert entity.state == STATE_OFF
-    assert entity.attributes["icon"] == SWITCH_ICON
+    assert entity.attributes["icon"] == "mdi:cog"
     assert entity.attributes["target"] == MOCK_UPTIMEROBOT_MONITOR["url"]
 
 

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -1,0 +1,103 @@
+"""Test UptimeRobot sensor."""
+
+from unittest.mock import patch
+
+from pyuptimerobot import UptimeRobotAuthenticationException
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from .common import (
+    MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA,
+    MOCK_UPTIMEROBOT_MONITOR,
+    MOCK_UPTIMEROBOT_MONITOR_PAUSED,
+    UPTIMEROBOT_SWITCH_TEST_ENTITY,
+    mock_uptimerobot_api_response,
+    setup_uptimerobot_integration,
+)
+
+from tests.common import MockConfigEntry
+
+SWITCH_ICON = "mdi:cog"
+
+
+async def test_presentation(hass: HomeAssistant) -> None:
+    """Test the presenstation of UptimeRobot sensors."""
+    await setup_uptimerobot_integration(hass)
+
+    entity = hass.states.get(UPTIMEROBOT_SWITCH_TEST_ENTITY)
+
+    assert entity.state == STATE_OFF
+    assert entity.attributes["icon"] == SWITCH_ICON
+    assert entity.attributes["target"] == MOCK_UPTIMEROBOT_MONITOR["url"]
+
+
+async def test_switch_off(hass: HomeAssistant) -> None:
+    """Test entity unaviable on update failure."""
+    await setup_uptimerobot_integration(hass)
+
+    with patch("pyuptimerobot.UptimeRobot.async_edit_monitor"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: UPTIMEROBOT_SWITCH_TEST_ENTITY},
+            blocking=True,
+        )
+
+    entity = hass.states.get(UPTIMEROBOT_SWITCH_TEST_ENTITY)
+    assert entity.state == STATE_OFF
+
+
+async def test_switch_on(hass: HomeAssistant) -> None:
+    """Test entity unaviable on update failure."""
+
+    mock_entry = MockConfigEntry(**MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA)
+    mock_entry.add_to_hass(hass)
+
+    with patch(
+        "pyuptimerobot.UptimeRobot.async_get_monitors",
+        return_value=mock_uptimerobot_api_response(
+            data=[MOCK_UPTIMEROBOT_MONITOR_PAUSED]
+        ),
+    ):
+
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patch("pyuptimerobot.UptimeRobot.async_edit_monitor"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: UPTIMEROBOT_SWITCH_TEST_ENTITY},
+            blocking=True,
+        )
+
+        entity = hass.states.get(UPTIMEROBOT_SWITCH_TEST_ENTITY)
+        assert entity.state == STATE_ON
+
+
+async def test_authentication_error(hass: HomeAssistant, caplog) -> None:
+    """Test authentication error turning switch on/off."""
+    await setup_uptimerobot_integration(hass)
+
+    entity = hass.states.get(UPTIMEROBOT_SWITCH_TEST_ENTITY)
+    assert entity.state == STATE_OFF
+
+    with patch(
+        "pyuptimerobot.UptimeRobot.async_edit_monitor",
+        side_effect=UptimeRobotAuthenticationException,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: UPTIMEROBOT_SWITCH_TEST_ENTITY},
+            blocking=True,
+        )
+        assert "Authentication Error" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This integration now provides a switch entity that will let you pause/resume monitoring of a monitor. Because of that, you need to use the 'main' UptimeRobot API key, if you previously used that, you will not have to do anything, but if you used the read-only API or a monitor-specific API key, the integration will ask you to reauthorize on the first startup.

To get your API key, go to [My Settings](https://uptimerobot.com/dashboard#mySettings) on the UptimeRobot website, at the bottom you will find your key.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add switch platform to UptimeRobot

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21747

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
