### PR TITLE
Fix race when handling updated MQTT discovery data

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -173,7 +173,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
             self._config[CONF_COMMAND_TEMPLATE], entity=self
         ).async_render
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -198,7 +198,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
             self._state = payload
             self.async_write_ha_state()
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,
             self._sub_state,
             {
@@ -210,6 +210,10 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
                 }
             },
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def state(self):

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -125,7 +125,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
             entity=self,
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -202,7 +202,7 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
 
             self.async_write_ha_state()
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,
             self._sub_state,
             {
@@ -214,6 +214,10 @@ class MqttBinarySensor(MqttEntity, BinarySensorEntity):
                 }
             },
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @callback
     def _value_is_expired(self, *_):

--- a/homeassistant/components/mqtt/button.py
+++ b/homeassistant/components/mqtt/button.py
@@ -95,6 +95,9 @@ class MqttButton(MqttEntity, ButtonEntity):
             config.get(CONF_COMMAND_TEMPLATE), entity=self
         ).async_render
 
+    def _prepare_subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
 

--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -90,7 +90,7 @@ class MqttCamera(MqttEntity, Camera):
         """Return the config schema."""
         return DISCOVERY_SCHEMA
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -99,7 +99,7 @@ class MqttCamera(MqttEntity, Camera):
             """Handle new MQTT messages."""
             self._last_image = msg.payload
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,
             self._sub_state,
             {
@@ -111,6 +111,10 @@ class MqttCamera(MqttEntity, Camera):
                 }
             },
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -358,11 +358,6 @@ class MqttClimate(MqttEntity, ClimateEntity):
         """Return the config schema."""
         return DISCOVERY_SCHEMA
 
-    async def async_added_to_hass(self):
-        """Handle being added to Home Assistant."""
-        await super().async_added_to_hass()
-        await self._subscribe_topics()
-
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
         self._topic = {key: config.get(key) for key in TOPIC_KEYS}
@@ -417,7 +412,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         self._command_templates = command_templates
 
-    async def _subscribe_topics(self):  # noqa: C901
+    def _prepare_subscribe_topics(self):  # noqa: C901
         """(Re)Subscribe to topics."""
         topics = {}
         qos = self._config[CONF_QOS]
@@ -615,9 +610,13 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         add_subscription(topics, CONF_HOLD_STATE_TOPIC, handle_hold_mode_received)
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -335,7 +335,7 @@ class MqttCover(MqttEntity, CoverEntity):
             config_attributes=template_config_attributes,
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -460,9 +460,13 @@ class MqttCover(MqttEntity, CoverEntity):
                 "encoding": self._config[CONF_ENCODING] or None,
             }
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def assumed_state(self):

--- a/homeassistant/components/mqtt/device_tracker/schema_discovery.py
+++ b/homeassistant/components/mqtt/device_tracker/schema_discovery.py
@@ -77,7 +77,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
             self._config.get(CONF_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -94,7 +94,7 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
 
             self.async_write_ha_state()
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,
             self._sub_state,
             {
@@ -105,6 +105,10 @@ class MqttDeviceTracker(MqttEntity, TrackerEntity):
                 }
             },
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def latitude(self):

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -351,7 +351,7 @@ class MqttFan(MqttEntity, FanEntity):
                 entity=self,
             ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -479,9 +479,13 @@ class MqttFan(MqttEntity, FanEntity):
             }
             self._oscillation = False
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def assumed_state(self):

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -267,7 +267,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
                 entity=self,
             ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -373,9 +373,13 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
             }
             self._mode = None
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def assumed_state(self):

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -304,9 +304,8 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             except (KeyError, ValueError):
                 _LOGGER.warning("Invalid or incomplete color value received")
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
-        last_state = await self.async_get_last_state()
 
         @callback
         @log_messages(self.hass, self.entity_id)
@@ -370,7 +369,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             self.async_write_ha_state()
 
         if self._topic[CONF_STATE_TOPIC] is not None:
-            self._sub_state = await subscription.async_subscribe_topics(
+            self._sub_state = subscription.async_prepare_subscribe_topics(
                 self.hass,
                 self._sub_state,
                 {
@@ -383,6 +382,11 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                 },
             )
 
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
+
+        last_state = await self.async_get_last_state()
         if self._optimistic and last_state:
             self._state = last_state.state == STATE_ON
             last_attributes = last_state.attributes

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -123,7 +123,7 @@ class MqttLock(MqttEntity, LockEntity):
             entity=self,
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -142,7 +142,7 @@ class MqttLock(MqttEntity, LockEntity):
             # Force into optimistic mode.
             self._optimistic = True
         else:
-            self._sub_state = await subscription.async_subscribe_topics(
+            self._sub_state = subscription.async_prepare_subscribe_topics(
                 self.hass,
                 self._sub_state,
                 {
@@ -154,6 +154,10 @@ class MqttLock(MqttEntity, LockEntity):
                     }
                 },
             )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def is_locked(self):

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -66,7 +66,11 @@ from .discovery import (
     set_discovery_hash,
 )
 from .models import ReceiveMessage
-from .subscription import async_subscribe_topics, async_unsubscribe_topics
+from .subscription import (
+    async_prepare_subscribe_topics,
+    async_subscribe_topics,
+    async_unsubscribe_topics,
+)
 from .util import valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
@@ -249,14 +253,19 @@ class MqttAttributes(Entity):
     async def async_added_to_hass(self) -> None:
         """Subscribe MQTT events."""
         await super().async_added_to_hass()
+        self._attributes_prepare_subscribe_topics()
         await self._attributes_subscribe_topics()
+
+    def attributes_prepare_discovery_update(self, config: dict):
+        """Handle updated discovery message."""
+        self._attributes_config = config
+        self._attributes_prepare_subscribe_topics()
 
     async def attributes_discovery_update(self, config: dict):
         """Handle updated discovery message."""
-        self._attributes_config = config
         await self._attributes_subscribe_topics()
 
-    async def _attributes_subscribe_topics(self):
+    def _attributes_prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         attr_tpl = MqttValueTemplate(
             self._attributes_config.get(CONF_JSON_ATTRS_TEMPLATE), entity=self
@@ -284,7 +293,7 @@ class MqttAttributes(Entity):
                 _LOGGER.warning("Erroneous JSON: %s", payload)
                 self._attributes = None
 
-        self._attributes_sub_state = await async_subscribe_topics(
+        self._attributes_sub_state = async_prepare_subscribe_topics(
             self.hass,
             self._attributes_sub_state,
             {
@@ -297,9 +306,13 @@ class MqttAttributes(Entity):
             },
         )
 
+    async def _attributes_subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await async_subscribe_topics(self.hass, self._attributes_sub_state)
+
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""
-        self._attributes_sub_state = await async_unsubscribe_topics(
+        self._attributes_sub_state = async_unsubscribe_topics(
             self.hass, self._attributes_sub_state
         )
 
@@ -322,6 +335,7 @@ class MqttAvailability(Entity):
     async def async_added_to_hass(self) -> None:
         """Subscribe MQTT events."""
         await super().async_added_to_hass()
+        self._availability_prepare_subscribe_topics()
         await self._availability_subscribe_topics()
         self.async_on_remove(
             async_dispatcher_connect(self.hass, MQTT_CONNECTED, self.async_mqtt_connect)
@@ -332,9 +346,13 @@ class MqttAvailability(Entity):
             )
         )
 
-    async def availability_discovery_update(self, config: dict):
+    def availability_prepare_discovery_update(self, config: dict):
         """Handle updated discovery message."""
         self._availability_setup_from_config(config)
+        self._availability_prepare_subscribe_topics()
+
+    async def availability_discovery_update(self, config: dict):
+        """Handle updated discovery message."""
         await self._availability_subscribe_topics()
 
     def _availability_setup_from_config(self, config):
@@ -366,7 +384,7 @@ class MqttAvailability(Entity):
 
         self._avail_config = config
 
-    async def _availability_subscribe_topics(self):
+    def _availability_prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -398,11 +416,15 @@ class MqttAvailability(Entity):
             for topic in self._avail_topics
         }
 
-        self._availability_sub_state = await async_subscribe_topics(
+        self._availability_sub_state = async_prepare_subscribe_topics(
             self.hass,
             self._availability_sub_state,
             topics,
         )
+
+    async def _availability_subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await async_subscribe_topics(self.hass, self._availability_sub_state)
 
     @callback
     def async_mqtt_connect(self):
@@ -412,7 +434,7 @@ class MqttAvailability(Entity):
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""
-        self._availability_sub_state = await async_unsubscribe_topics(
+        self._availability_sub_state = async_unsubscribe_topics(
             self.hass, self._availability_sub_state
         )
 
@@ -524,6 +546,11 @@ class MqttDiscoveryUpdate(Entity):
     async def async_removed_from_registry(self) -> None:
         """Clear retained discovery topic in broker."""
         if not self._removed_from_hass:
+            # Stop subscribing to discovery updates to not trigger when we clear the
+            # discovery topic
+            self._cleanup_discovery_on_remove()
+
+            # Clear the discovery topic so the entity is not rediscovered after a restart
             discovery_topic = self._discovery_data[ATTR_DISCOVERY_TOPIC]
             publish(self.hass, discovery_topic, "", retain=True)
 
@@ -596,7 +623,7 @@ class MqttEntityDeviceInfo(Entity):
         self._device_config = device_config
         self._config_entry = config_entry
 
-    async def device_info_discovery_update(self, config: dict):
+    def device_info_discovery_update(self, config: dict):
         """Handle updated discovery message."""
         self._device_config = config.get(CONF_DEVICE)
         device_registry = dr.async_get(self.hass)
@@ -652,6 +679,7 @@ class MqttEntity(
     async def async_added_to_hass(self):
         """Subscribe mqtt events."""
         await super().async_added_to_hass()
+        self._prepare_subscribe_topics()
         await self._subscribe_topics()
 
     async def discovery_update(self, discovery_payload):
@@ -659,15 +687,22 @@ class MqttEntity(
         config = self.config_schema()(discovery_payload)
         self._config = config
         self._setup_from_config(self._config)
+
+        # Prepare MQTT subscriptions
+        self.attributes_prepare_discovery_update(config)
+        self.availability_prepare_discovery_update(config)
+        self.device_info_discovery_update(config)
+        self._prepare_subscribe_topics()
+
+        # Finalize MQTT subscriptions
         await self.attributes_discovery_update(config)
         await self.availability_discovery_update(config)
-        await self.device_info_discovery_update(config)
         await self._subscribe_topics()
         self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""
-        self._sub_state = await subscription.async_unsubscribe_topics(
+        self._sub_state = subscription.async_unsubscribe_topics(
             self.hass, self._sub_state
         )
         await MqttAttributes.async_will_remove_from_hass(self)
@@ -681,6 +716,10 @@ class MqttEntity(
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
+
+    @abstractmethod
+    def _prepare_subscribe_topics(self):
+        """(Re)Subscribe to topics."""
 
     @abstractmethod
     async def _subscribe_topics(self):

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -546,11 +546,6 @@ class MqttDiscoveryUpdate(Entity):
     async def async_removed_from_registry(self) -> None:
         """Clear retained discovery topic in broker."""
         if not self._removed_from_hass:
-            # Stop subscribing to discovery updates to not trigger when we clear the
-            # discovery topic
-            self._cleanup_discovery_on_remove()
-
-            # Clear the discovery topic so the entity is not rediscovered after a restart
             discovery_topic = self._discovery_data[ATTR_DISCOVERY_TOPIC]
             publish(self.hass, discovery_topic, "", retain=True)
 

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -162,7 +162,7 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
             ).async_render_with_possible_json_value,
         }
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -200,7 +200,7 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
             # Force into optimistic mode.
             self._optimistic = True
         else:
-            self._sub_state = await subscription.async_subscribe_topics(
+            self._sub_state = subscription.async_prepare_subscribe_topics(
                 self.hass,
                 self._sub_state,
                 {
@@ -212,6 +212,10 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
                     }
                 },
             )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
         if self._optimistic and (last_state := await self.async_get_last_state()):
             self._current_number = last_state.state

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -128,7 +128,7 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
             ).async_render_with_possible_json_value,
         }
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -156,7 +156,7 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
             # Force into optimistic mode.
             self._optimistic = True
         else:
-            self._sub_state = await subscription.async_subscribe_topics(
+            self._sub_state = subscription.async_prepare_subscribe_topics(
                 self.hass,
                 self._sub_state,
                 {
@@ -168,6 +168,10 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
                     }
                 },
             )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
         if self._optimistic and (last_state := await self.async_get_last_state()):
             self._attr_current_option = last_state.state

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -174,7 +174,7 @@ class MqttSensor(MqttEntity, SensorEntity):
             self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -265,9 +265,13 @@ class MqttSensor(MqttEntity, SensorEntity):
                 "encoding": self._config[CONF_ENCODING] or None,
             }
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @callback
     def _value_is_expired(self, *_):

--- a/homeassistant/components/mqtt/siren.py
+++ b/homeassistant/components/mqtt/siren.py
@@ -214,7 +214,7 @@ class MqttSiren(MqttEntity, SirenEntity):
             entity=self,
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -274,7 +274,7 @@ class MqttSiren(MqttEntity, SirenEntity):
             # Force into optimistic mode.
             self._optimistic = True
         else:
-            self._sub_state = await subscription.async_subscribe_topics(
+            self._sub_state = subscription.async_prepare_subscribe_topics(
                 self.hass,
                 self._sub_state,
                 {
@@ -286,6 +286,10 @@ class MqttSiren(MqttEntity, SirenEntity):
                     }
                 },
             )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def assumed_state(self):

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -1,13 +1,12 @@
 """Helper to handle a set of topics to subscribe to."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 import attr
 
 from homeassistant.core import HomeAssistant
-from homeassistant.loader import bind_hass
 
 from . import debug_info
 from .. import mqtt
@@ -22,11 +21,12 @@ class EntitySubscription:
     hass: HomeAssistant = attr.ib()
     topic: str = attr.ib()
     message_callback: MessageCallbackType = attr.ib()
+    subscribe_task: Coroutine | None = attr.ib()
     unsubscribe_callback: Callable[[], None] | None = attr.ib()
     qos: int = attr.ib(default=0)
     encoding: str = attr.ib(default="utf-8")
 
-    async def resubscribe_if_necessary(self, hass, other):
+    def resubscribe_if_necessary(self, hass, other):
         """Re-subscribe to the new topic if necessary."""
         if not self._should_resubscribe(other):
             self.unsubscribe_callback = other.unsubscribe_callback
@@ -46,32 +46,40 @@ class EntitySubscription:
         # Prepare debug data
         debug_info.add_subscription(self.hass, self.message_callback, self.topic)
 
-        self.unsubscribe_callback = await mqtt.async_subscribe(
+        self.subscribe_task = mqtt.async_subscribe(
             hass, self.topic, self.message_callback, self.qos, self.encoding
         )
+
+    async def subscribe(self):
+        """Subscribe to a topic."""
+        if not self.subscribe_task:
+            return
+        self.unsubscribe_callback = await self.subscribe_task
 
     def _should_resubscribe(self, other):
         """Check if we should re-subscribe to the topic using the old state."""
         if other is None:
             return True
 
-        return (self.topic, self.qos, self.encoding) != (
+        return (self.topic, self.qos, self.encoding,) != (
             other.topic,
             other.qos,
             other.encoding,
         )
 
 
-@bind_hass
-async def async_subscribe_topics(
+def async_prepare_subscribe_topics(
     hass: HomeAssistant,
     new_state: dict[str, EntitySubscription] | None,
     topics: dict[str, Any],
 ) -> dict[str, EntitySubscription]:
-    """(Re)Subscribe to a set of MQTT topics.
+    """Prepare (re)subscribe to a set of MQTT topics.
 
     State is kept in sub_state and a dictionary mapping from the subscription
     key to the subscription state.
+
+    After this function has been called, async_subscribe_topics must be called to
+    finalize any new subscriptions.
 
     Please note that the sub state must not be shared between multiple
     sets of topics. Every call to async_subscribe_topics must always
@@ -88,10 +96,11 @@ async def async_subscribe_topics(
             qos=value.get("qos", DEFAULT_QOS),
             encoding=value.get("encoding", "utf-8"),
             hass=hass,
+            subscribe_task=None,
         )
         # Get the current subscription state
         current = current_subscriptions.pop(key, None)
-        await requested.resubscribe_if_necessary(hass, current)
+        requested.resubscribe_if_necessary(hass, current)
         new_state[key] = requested
 
     # Go through all remaining subscriptions and unsubscribe them
@@ -106,9 +115,19 @@ async def async_subscribe_topics(
     return new_state
 
 
-@bind_hass
-async def async_unsubscribe_topics(
+async def async_subscribe_topics(
+    hass: HomeAssistant,
+    sub_state: dict[str, EntitySubscription] | None,
+) -> None:
+    """(Re)Subscribe to a set of MQTT topics."""
+    if sub_state is None:
+        return
+    for sub in sub_state.values():
+        await sub.subscribe()
+
+
+def async_unsubscribe_topics(
     hass: HomeAssistant, sub_state: dict[str, EntitySubscription] | None
 ) -> dict[str, EntitySubscription]:
     """Unsubscribe from all MQTT topics managed by async_subscribe_topics."""
-    return await async_subscribe_topics(hass, sub_state, {})
+    return async_prepare_subscribe_topics(hass, sub_state, {})

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -132,7 +132,7 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
             self._config.get(CONF_VALUE_TEMPLATE), entity=self
         ).async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
 
         @callback
@@ -151,7 +151,7 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
             # Force into optimistic mode.
             self._optimistic = True
         else:
-            self._sub_state = await subscription.async_subscribe_topics(
+            self._sub_state = subscription.async_prepare_subscribe_topics(
                 self.hass,
                 self._sub_state,
                 {
@@ -163,6 +163,10 @@ class MqttSwitch(MqttEntity, SwitchEntity, RestoreEntity):
                     }
                 },
             )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
         if self._optimistic and (last_state := await self.async_get_last_state()):
             self._state = last_state.state == STATE_ON

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -175,7 +175,7 @@ class MQTTTagScanner:
 
             await self.hass.components.tag.async_scan_tag(tag_id, self.device_id)
 
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,
             self._sub_state,
             {
@@ -186,6 +186,7 @@ class MQTTTagScanner:
                 }
             },
         )
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     async def device_removed(self, event):
         """Handle the removal of a device."""
@@ -207,7 +208,7 @@ class MQTTTagScanner:
         self._remove_discovery()
 
         mqtt.publish(self.hass, discovery_topic, "", retain=True)
-        self._sub_state = await subscription.async_unsubscribe_topics(
+        self._sub_state = subscription.async_unsubscribe_topics(
             self.hass, self._sub_state
         )
         if self.device_id:

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -240,7 +240,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             )
         }
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         for tpl in self._templates.values():
             if tpl is not None:
@@ -325,7 +325,7 @@ class MqttVacuum(MqttEntity, VacuumEntity):
             self.async_write_ha_state()
 
         topics_list = {topic for topic in self._state_topics.values() if topic}
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass,
             self._sub_state,
             {
@@ -338,6 +338,10 @@ class MqttVacuum(MqttEntity, VacuumEntity):
                 for i, topic in enumerate(topics_list)
             },
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def is_on(self):

--- a/homeassistant/components/mqtt/vacuum/schema_state.py
+++ b/homeassistant/components/mqtt/vacuum/schema_state.py
@@ -197,7 +197,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             )
         }
 
-    async def _subscribe_topics(self):
+    def _prepare_subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -219,9 +219,13 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                 "qos": self._config[CONF_QOS],
                 "encoding": self._config[CONF_ENCODING] or None,
             }
-        self._sub_state = await subscription.async_subscribe_topics(
+        self._sub_state = subscription.async_prepare_subscribe_topics(
             self.hass, self._sub_state, topics
         )
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
     @property
     def state(self):

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -19,6 +19,7 @@ import voluptuous as vol
 
 from homeassistant.components import mqtt, websocket_api
 from homeassistant.components.mqtt.subscription import (
+    async_prepare_subscribe_topics,
     async_subscribe_topics,
     async_unsubscribe_topics,
 )
@@ -62,10 +63,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for topic in topics.values():
             if "msg_callback" in topic and "event_loop_safe" in topic:
                 topic["msg_callback"] = callback(topic["msg_callback"])
-        return await async_subscribe_topics(hass, sub_state, topics)
+        sub_state = async_prepare_subscribe_topics(hass, sub_state, topics)
+        await async_subscribe_topics(hass, sub_state)
+        return sub_state
 
     async def _unsubscribe_topics(sub_state: dict | None) -> dict:
-        return await async_unsubscribe_topics(hass, sub_state)
+        return async_unsubscribe_topics(hass, sub_state)
 
     tasmota_mqtt = TasmotaMQTTClient(_publish, _subscribe_topics, _unsubscribe_topics)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix race when handling updated MQTT discovery data

The problem fixed was that `MqttEntity.discovery_update` would yield before the entity was completely setup.

For example, the MQTT availability mixin would do this:
```py
    async def availability_discovery_update(self, config: dict):
        """Handle updated discovery message."""
        self._availability_setup_from_config(config)
        await self._availability_subscribe_topics()
```

If MQTT messages are received after calling `self._availability_setup_from_config(config)` but before `await self._availability_subscribe_topics()` has returned, the availability mixin is configured for the new configuration, but still subscribing to the old topics.

There were several variations of this, but the problem was always that we could end up handling MQTT messages before the entity was fully setup according to the new config.

This is solved in this PR by splitting the discovery update in two stages:
- Stage 1 - not allowed to yield: Prepare the entity, and unsubscribe from any MQTT topics that are no longer needed
- Stage 2 - allowed to yield: Subscribe to any new MQTT topics

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
