### PR TITLE
Revert "Update frontend to 20220202.0"

### DIFF
--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20220202.0"
+    "home-assistant-frontend==20220201.0"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ ciso8601==2.2.0
 cryptography==35.0.0
 emoji==1.6.3
 hass-nabucasa==0.52.0
-home-assistant-frontend==20220202.0
+home-assistant-frontend==20220201.0
 httpx==0.21.3
 ifaddr==0.1.7
 jinja2==3.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -842,7 +842,7 @@ hole==0.7.0
 holidays==0.12
 
 # homeassistant.components.frontend
-home-assistant-frontend==20220202.0
+home-assistant-frontend==20220201.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -543,7 +543,7 @@ hole==0.7.0
 holidays==0.12
 
 # homeassistant.components.frontend
-home-assistant-frontend==20220202.0
+home-assistant-frontend==20220201.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10


### PR DESCRIPTION
Reverts home-assistant/core#65432

Release was not published.

Or wait on: https://github.com/home-assistant/frontend/actions/runs/1784193073