### PR TITLE
Fix script / automation repeat with count 0 fails

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -741,8 +741,10 @@ class _ScriptRun:
 
         if saved_repeat_vars:
             self._variables["repeat"] = saved_repeat_vars
-        else:
+        elif "repeat" in self._variables:
             del self._variables["repeat"]
+        else:
+            _LOGGER.warning("Variables key repeat does not exist")
 
     async def _async_choose_step(self) -> None:
         """Choose a sequence."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -741,10 +741,8 @@ class _ScriptRun:
 
         if saved_repeat_vars:
             self._variables["repeat"] = saved_repeat_vars
-        elif "repeat" in self._variables:
-            del self._variables["repeat"]
         else:
-            _LOGGER.warning("Variables key repeat does not exist")
+            self._variables.pop("repeat", None)  # Not set if count = 0
 
     async def _async_choose_step(self) -> None:
         """Choose a sequence."""

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1742,6 +1742,50 @@ async def test_repeat_count(hass, caplog, count):
     )
 
 
+async def test_repeat_count_0(hass, caplog):
+    """Test repeat action w/ count option."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    count = 0
+
+    alias = "condition step"
+    sequence = cv.SCRIPT_SCHEMA(
+        {
+            "alias": alias,
+            "repeat": {
+                "count": count,
+                "sequence": {
+                    "event": event,
+                    "event_data_template": {
+                        "first": "{{ repeat.first }}",
+                        "index": "{{ repeat.index }}",
+                        "last": "{{ repeat.last }}",
+                    },
+                },
+            },
+        }
+    )
+
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+
+    await script_obj.async_run(context=Context())
+    await hass.async_block_till_done()
+
+    assert len(events) == count
+    for index, event in enumerate(events):
+        assert event.data.get("first") == (index == 0)
+        assert event.data.get("index") == index + 1
+        assert event.data.get("last") == (index == count - 1)
+    assert caplog.text.count(f"Repeating {alias}") == count
+    first_index = max(1, count - script.ACTION_TRACE_NODE_MAX_LEN + 1)
+    last_index = count + 1
+    assert_action_trace(
+        {
+            "0": [{}],
+        }
+    )
+
+
 @pytest.mark.parametrize("condition", ["while", "until"])
 async def test_repeat_condition_warning(hass, caplog, condition):
     """Test warning on repeat conditions."""

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1772,13 +1772,7 @@ async def test_repeat_count_0(hass, caplog):
     await hass.async_block_till_done()
 
     assert len(events) == count
-    for index, event in enumerate(events):
-        assert event.data.get("first") == (index == 0)
-        assert event.data.get("index") == index + 1
-        assert event.data.get("last") == (index == count - 1)
     assert caplog.text.count(f"Repeating {alias}") == count
-    first_index = max(1, count - script.ACTION_TRACE_NODE_MAX_LEN + 1)
-    last_index = count + 1
     assert_action_trace(
         {
             "0": [{}],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Issue https://github.com/home-assistant/core/issues/63977.
'repeat' key within self._variables does not exist for repeat configuration with loop count of 0. 
Based on this the key cannot be deleted and causes an error.
Checking if self._variable['repeat'] exists previously to deleting - if it does not exist write only a warning into logs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63977
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
