### PR TITLE
Add an option to configure the TX count in the UPB integration

### DIFF
--- a/homeassistant/components/upb/__init__.py
+++ b/homeassistant/components/upb/__init__.py
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         "UPStartExportFile": file,
     }
 
-    if tx_count := config_entry.options.get(CONF_TX_COUNT, None):
+    if tx_count := config_entry.options.get(CONF_TX_COUNT):
         pim_config["tx_count"] = tx_count
 
     upb = upb_lib.UpbPim(pim_config)
@@ -85,8 +85,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 async def _async_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
     """Handle options update."""
     upb = hass.data[DOMAIN][config_entry.entry_id]["upb"]
-    tx_count = config_entry.options.get(CONF_TX_COUNT, None)
-    if tx_count:
+    if tx_count := config_entry.options.get(CONF_TX_COUNT):
         _LOGGER.debug("Setting tx_count = %d", tx_count)
         upb.encoder.tx_count = tx_count
 

--- a/homeassistant/components/upb/const.py
+++ b/homeassistant/components/upb/const.py
@@ -12,6 +12,7 @@ ATTR_BRIGHTNESS = "brightness"
 ATTR_BRIGHTNESS_PCT = "brightness_pct"
 ATTR_RATE = "rate"
 CONF_NETWORK = "network"
+CONF_TX_COUNT = "tx_count"
 EVENT_UPB_SCENE_CHANGED = "upb.scene_changed"
 
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))

--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -2,7 +2,7 @@
   "domain": "upb",
   "name": "Universal Powerline Bus (UPB)",
   "documentation": "https://www.home-assistant.io/integrations/upb",
-  "requirements": ["upb_lib==0.4.12"],
+  "requirements": ["upb_lib==0.5.1"],
   "codeowners": ["@gwww"],
   "config_flow": true,
   "iot_class": "local_push",

--- a/homeassistant/components/upb/strings.json
+++ b/homeassistant/components/upb/strings.json
@@ -19,5 +19,16 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "UPB Options",
+        "description": "Setting the Transmission Count to 2 may be required for networks with a repeater.",
+        "data": {
+          "tx_count": "Transmission Count"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/upb/strings.json
+++ b/homeassistant/components/upb/strings.json
@@ -24,7 +24,7 @@
     "step": {
       "init": {
         "title": "UPB Options",
-        "description": "Setting the Transmission Count to 2 may be required for networks with a repeater.",
+        "description": "Setting the Transmission Count to 2 may be required for networks with a Three-Phase repeater.",
         "data": {
           "tx_count": "Transmission Count"
         }

--- a/homeassistant/components/upb/translations/en.json
+++ b/homeassistant/components/upb/translations/en.json
@@ -19,5 +19,16 @@
                 "title": "Connect to UPB PIM"
             }
         }
+    },
+    "options": {
+	"step": {
+	    "init": {
+		"title": "UPB Options",
+		"description": "Setting the Transmission Count to 2 may be required for networks with a Three-Phase repeater.",
+		"data": {
+		    "tx_count": "Transmission Count"
+		}
+	    }
+	}
     }
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2401,7 +2401,7 @@ unifi-discovery==1.1.2
 unifiled==0.11
 
 # homeassistant.components.upb
-upb_lib==0.4.12
+upb_lib==0.5.1
 
 # homeassistant.components.upcloud
 upcloud-api==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1465,7 +1465,7 @@ uEagle==0.0.2
 unifi-discovery==1.1.2
 
 # homeassistant.components.upb
-upb_lib==0.4.12
+upb_lib==0.5.1
 
 # homeassistant.components.upcloud
 upcloud-api==2.0.0


### PR DESCRIPTION
## Proposed change
Adds an option to configure the transmit count in UPB integration. Setting tx_count=2 is required for the integration to function on networks with a repeater. Support for configuring this value has been added to upb-lib in gwww/upb-lib#6 and gwww/upb-lib#7. Bumping dependency to 0.5.1 to pick them up.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] Silver
- [ ] Gold
- [ ] Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io