### PR TITLE
Move Freebox reboot service to a button entity

### DIFF
--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -1,5 +1,6 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 from datetime import timedelta
+import logging
 
 from freebox_api.exceptions import HttpRequestError
 import voluptuous as vol
@@ -28,6 +29,8 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 SCAN_INTERVAL = timedelta(seconds=30)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -67,6 +70,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Services
     async def async_reboot(call: ServiceCall) -> None:
         """Handle reboot service call."""
+        # The Freebox reboot service has been replaced by a
+        # dedicated button entity and marked as deprecated
+        _LOGGER.warning(
+            "The 'freebox.reboot' service is deprecated and "
+            "replaced by a dedicated reboot button entity; please "
+            "use that entity to reboot the freebox instead"
+        )
         await router.reboot()
 
     hass.services.async_register(DOMAIN, SERVICE_REBOOT, async_reboot)

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -1,0 +1,76 @@
+"""Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .router import FreeboxRouter
+
+
+@dataclass
+class FreeboxButtonRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    async_press: Callable[[FreeboxRouter], Awaitable]
+
+
+@dataclass
+class FreeboxButtonEntityDescription(
+    ButtonEntityDescription, FreeboxButtonRequiredKeysMixin
+):
+    """Class describing Freebox button entities."""
+
+
+BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
+    FreeboxButtonEntityDescription(
+        key="restart",
+        name="Restart Freebox",
+        device_class=ButtonDeviceClass.RESTART,
+        async_press=lambda router: router.reboot(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the buttons."""
+    router: FreeboxRouter = hass.data[DOMAIN][entry.unique_id]
+    entities = [
+        FreeboxButton(router, description) for description in BUTTON_DESCRIPTIONS
+    ]
+    async_add_entities(entities, True)
+
+
+class FreeboxButton(ButtonEntity):
+    """Representation of a Freebox button."""
+
+    entity_description: FreeboxButtonEntityDescription
+
+    def __init__(
+        self, router: FreeboxRouter, description: FreeboxButtonEntityDescription
+    ) -> None:
+        """Initialize a Freebox button."""
+        self.entity_description = description
+        self._router = router
+        self._attr_unique_id = f"{router.mac} {description.name}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return self._router.device_info
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.entity_description.async_press(self._router)

--- a/homeassistant/components/freebox/button.py
+++ b/homeassistant/components/freebox/button.py
@@ -34,8 +34,8 @@ class FreeboxButtonEntityDescription(
 
 BUTTON_DESCRIPTIONS: tuple[FreeboxButtonEntityDescription, ...] = (
     FreeboxButtonEntityDescription(
-        key="restart",
-        name="Restart Freebox",
+        key="reboot",
+        name="Reboot Freebox",
         device_class=ButtonDeviceClass.RESTART,
         async_press=lambda router: router.reboot(),
     ),

--- a/homeassistant/components/freebox/const.py
+++ b/homeassistant/components/freebox/const.py
@@ -17,7 +17,7 @@ APP_DESC = {
 }
 API_VERSION = "v6"
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH]
 
 DEFAULT_DEVICE_NAME = "Unknown device"
 

--- a/tests/components/freebox/test_button.py
+++ b/tests/components/freebox/test_button.py
@@ -1,0 +1,43 @@
+"""Tests for the Freebox config flow."""
+from unittest.mock import Mock, patch
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.components.freebox.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .const import MOCK_HOST, MOCK_PORT
+
+from tests.common import MockConfigEntry
+
+
+async def test_reboot_button(hass: HomeAssistant, router: Mock):
+    """Test reboot button."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT},
+        unique_id=MOCK_HOST,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert hass.config_entries.async_entries() == [entry]
+
+    assert router.call_count == 1
+    assert router().open.call_count == 1
+
+    with patch(
+        "homeassistant.components.freebox.router.FreeboxRouter.reboot"
+    ) as mock_service:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            service_data={
+                ATTR_ENTITY_ID: "button.reboot_freebox",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_service.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The 'freebox.reboot' service is deprecated and replaced by a dedicated reboot button entity; please use that entity to reboot the freebox instead

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move Freebox reboot service to a button entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
