### PR TITLE
Use Domain not Platform on test service calls

### DIFF
--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -6,6 +6,7 @@ from homeassistant.components.climate import (
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
     HVAC_MODE_HEAT,
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_PRESET_MODE,
@@ -49,7 +50,7 @@ async def test_setting_climate(
     await init_integration(hass, aioclient_mock)
     with patch("pyatag.entities.Climate.set_temp") as mock_set_temp:
         await hass.services.async_call(
-            Platform.CLIMATE,
+            CLIMATE_DOMAIN,
             SERVICE_SET_TEMPERATURE,
             {ATTR_ENTITY_ID: CLIMATE_ID, ATTR_TEMPERATURE: 15},
             blocking=True,
@@ -59,7 +60,7 @@ async def test_setting_climate(
 
     with patch("pyatag.entities.Climate.set_preset_mode") as mock_set_preset:
         await hass.services.async_call(
-            Platform.CLIMATE,
+            CLIMATE_DOMAIN,
             SERVICE_SET_PRESET_MODE,
             {ATTR_ENTITY_ID: CLIMATE_ID, ATTR_PRESET_MODE: PRESET_AWAY},
             blocking=True,
@@ -69,7 +70,7 @@ async def test_setting_climate(
 
     with patch("pyatag.entities.Climate.set_hvac_mode") as mock_set_hvac:
         await hass.services.async_call(
-            Platform.CLIMATE,
+            CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
             {ATTR_ENTITY_ID: CLIMATE_ID, ATTR_HVAC_MODE: HVAC_MODE_HEAT},
             blocking=True,

--- a/tests/components/atag/test_water_heater.py
+++ b/tests/components/atag/test_water_heater.py
@@ -2,7 +2,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.atag import DOMAIN
-from homeassistant.components.water_heater import SERVICE_SET_TEMPERATURE
+from homeassistant.components.water_heater import (
+    DOMAIN as WATER_HEATER_DOMAIN,
+    SERVICE_SET_TEMPERATURE,
+)
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -33,7 +36,7 @@ async def test_setting_target_temperature(
     await init_integration(hass, aioclient_mock)
     with patch("pyatag.entities.DHW.set_temp") as mock_set_temp:
         await hass.services.async_call(
-            Platform.WATER_HEATER,
+            WATER_HEATER_DOMAIN,
             SERVICE_SET_TEMPERATURE,
             {ATTR_ENTITY_ID: WATER_HEATER_ID, ATTR_TEMPERATURE: 50},
             blocking=True,

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -4,6 +4,7 @@ from unittest.mock import call
 
 from homeassistant.components.broadlink.const import DOMAIN
 from homeassistant.components.remote import (
+    DOMAIN as REMOTE_DOMAIN,
     SERVICE_SEND_COMMAND,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
@@ -59,7 +60,7 @@ async def test_remote_send_command(hass):
 
         remote = remotes[0]
         await hass.services.async_call(
-            Platform.REMOTE,
+            REMOTE_DOMAIN,
             SERVICE_SEND_COMMAND,
             {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
             blocking=True,
@@ -86,7 +87,7 @@ async def test_remote_turn_off_turn_on(hass):
 
         remote = remotes[0]
         await hass.services.async_call(
-            Platform.REMOTE,
+            REMOTE_DOMAIN,
             SERVICE_TURN_OFF,
             {"entity_id": remote.entity_id},
             blocking=True,
@@ -94,7 +95,7 @@ async def test_remote_turn_off_turn_on(hass):
         assert hass.states.get(remote.entity_id).state == STATE_OFF
 
         await hass.services.async_call(
-            Platform.REMOTE,
+            REMOTE_DOMAIN,
             SERVICE_SEND_COMMAND,
             {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
             blocking=True,
@@ -102,7 +103,7 @@ async def test_remote_turn_off_turn_on(hass):
         assert mock_setup.api.send_data.call_count == 0
 
         await hass.services.async_call(
-            Platform.REMOTE,
+            REMOTE_DOMAIN,
             SERVICE_TURN_ON,
             {"entity_id": remote.entity_id},
             blocking=True,
@@ -110,7 +111,7 @@ async def test_remote_turn_off_turn_on(hass):
         assert hass.states.get(remote.entity_id).state == STATE_ON
 
         await hass.services.async_call(
-            Platform.REMOTE,
+            REMOTE_DOMAIN,
             SERVICE_SEND_COMMAND,
             {"entity_id": remote.entity_id, "command": "b64:" + IR_PACKET},
             blocking=True,

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -83,7 +84,7 @@ async def test_owserver_switch(
             expected_entity[ATTR_STATE] = STATE_ON
 
         await hass.services.async_call(
-            Platform.SWITCH,
+            SWITCH_DOMAIN,
             SERVICE_TOGGLE,
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,

--- a/tests/components/plex/test_media_search.py
+++ b/tests/components/plex/test_media_search.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
     MEDIA_TYPE_EPISODE,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
@@ -15,7 +16,7 @@ from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
 )
 from homeassistant.components.plex.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import HomeAssistantError
 
 
@@ -29,7 +30,7 @@ async def test_media_lookups(
     requests_mock.get("/player/playback/playMedia", status_code=200)
 
     assert await hass.services.async_call(
-        Platform.MEDIA_PLAYER,
+        MEDIA_PLAYER_DOMAIN,
         SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: media_player_id,
@@ -41,7 +42,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         with patch("plexapi.server.PlexServer.fetchItem", side_effect=NotFound):
             assert await hass.services.async_call(
-                Platform.MEDIA_PLAYER,
+                MEDIA_PLAYER_DOMAIN,
                 SERVICE_PLAY_MEDIA,
                 {
                     ATTR_ENTITY_ID: media_player_id,
@@ -56,7 +57,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         payload = '{"library_name": "Not a Library", "show_name": "TV Show"}'
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -69,7 +70,7 @@ async def test_media_lookups(
 
     with patch("plexapi.library.LibrarySection.search") as search:
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -81,7 +82,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"show.title": "TV Show", "libtype": "show"})
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -95,7 +96,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -109,7 +110,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -128,7 +129,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -140,7 +141,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"artist.title": "Artist", "libtype": "artist"})
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -152,7 +153,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"album.title": "Album", "libtype": "album"})
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -166,7 +167,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -180,7 +181,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -199,7 +200,7 @@ async def test_media_lookups(
         )
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -219,7 +220,7 @@ async def test_media_lookups(
 
         # Movie searches
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -231,7 +232,7 @@ async def test_media_lookups(
         search.assert_called_with(**{"movie.title": "Movie 1", "libtype": None})
 
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -247,7 +248,7 @@ async def test_media_lookups(
         payload = '{"library_name": "Movies", "title": "Not a Movie"}'
         with patch("plexapi.library.LibrarySection.search", side_effect=BadRequest):
             assert await hass.services.async_call(
-                Platform.MEDIA_PLAYER,
+                MEDIA_PLAYER_DOMAIN,
                 SERVICE_PLAY_MEDIA,
                 {
                     ATTR_ENTITY_ID: media_player_id,
@@ -261,7 +262,7 @@ async def test_media_lookups(
 
     # Playlist searches
     assert await hass.services.async_call(
-        Platform.MEDIA_PLAYER,
+        MEDIA_PLAYER_DOMAIN,
         SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: media_player_id,
@@ -274,7 +275,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         payload = '{"playlist_name": "Not a Playlist"}'
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,
@@ -289,7 +290,7 @@ async def test_media_lookups(
     with pytest.raises(HomeAssistantError) as excinfo:
         payload = "{}"
         assert await hass.services.async_call(
-            Platform.MEDIA_PLAYER,
+            MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: media_player_id,

--- a/tests/components/renault/test_button.py
+++ b/tests/components/renault/test_button.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from renault_api.kamereon import schemas
 
-from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.components.button.const import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
@@ -150,7 +150,7 @@ async def test_button_start_charge(hass: HomeAssistant, config_entry: ConfigEntr
         ),
     ) as mock_action:
         await hass.services.async_call(
-            Platform.BUTTON, SERVICE_PRESS, service_data=data, blocking=True
+            BUTTON_DOMAIN, SERVICE_PRESS, service_data=data, blocking=True
         )
     assert len(mock_action.mock_calls) == 1
     assert mock_action.mock_calls[0][1] == ()
@@ -178,7 +178,7 @@ async def test_button_start_air_conditioner(
         ),
     ) as mock_action:
         await hass.services.async_call(
-            Platform.BUTTON, SERVICE_PRESS, service_data=data, blocking=True
+            BUTTON_DOMAIN, SERVICE_PRESS, service_data=data, blocking=True
         )
     assert len(mock_action.mock_calls) == 1
     assert mock_action.mock_calls[0][1] == (21, None)

--- a/tests/components/renault/test_select.py
+++ b/tests/components/renault/test_select.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 import pytest
 from renault_api.kamereon import schemas
 
-from homeassistant.components.select.const import ATTR_OPTION, SERVICE_SELECT_OPTION
+from homeassistant.components.select.const import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
@@ -145,7 +149,7 @@ async def test_select_charge_mode(hass: HomeAssistant, config_entry: ConfigEntry
         ),
     ) as mock_action:
         await hass.services.async_call(
-            Platform.SELECT, SERVICE_SELECT_OPTION, service_data=data, blocking=True
+            SELECT_DOMAIN, SERVICE_SELECT_OPTION, service_data=data, blocking=True
         )
     assert len(mock_action.mock_calls) == 1
     assert mock_action.mock_calls[0][1] == ("always",)

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -392,7 +392,7 @@ async def test_controlling_state_via_mqtt_inverted(hass, mqtt_mock, setup_tasmot
 async def call_service(hass, entity_id, service, **kwargs):
     """Call a fan service."""
     await hass.services.async_call(
-        Platform.COVER,
+        cover.DOMAIN,
         service,
         {"entity_id": entity_id, **kwargs},
         blocking=True,

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -6,6 +6,7 @@ import zigpy.profiles.zha as zha
 import zigpy.zcl.clusters.security as security
 import zigpy.zcl.foundation as zcl_f
 
+from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_ALARM_ARMED_AWAY,
@@ -62,7 +63,7 @@ async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_devic
     # arm_away from HA
     cluster.client_command.reset_mock()
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_arm_away",
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
@@ -85,7 +86,7 @@ async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_devic
     # trip alarm from faulty code entry
     cluster.client_command.reset_mock()
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_arm_away",
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
@@ -94,13 +95,13 @@ async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_devic
     assert hass.states.get(entity_id).state == STATE_ALARM_ARMED_AWAY
     cluster.client_command.reset_mock()
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_disarm",
         {ATTR_ENTITY_ID: entity_id, "code": "1111"},
         blocking=True,
     )
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_disarm",
         {ATTR_ENTITY_ID: entity_id, "code": "1111"},
         blocking=True,
@@ -123,7 +124,7 @@ async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_devic
     # arm_home from HA
     cluster.client_command.reset_mock()
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_arm_home",
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
@@ -143,7 +144,7 @@ async def test_alarm_control_panel(hass, zha_device_joined_restored, zigpy_devic
     # arm_night from HA
     cluster.client_command.reset_mock()
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_arm_night",
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
@@ -240,7 +241,7 @@ async def reset_alarm_panel(hass, cluster, entity_id):
     """Reset the state of the alarm panel."""
     cluster.client_command.reset_mock()
     await hass.services.async_call(
-        Platform.ALARM_CONTROL_PANEL,
+        ALARM_DOMAIN,
         "alarm_disarm",
         {ATTR_ENTITY_ID: entity_id, "code": "4321"},
         blocking=True,

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -25,6 +25,7 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
     CURRENT_HVAC_OFF,
+    DOMAIN as CLIMATE_DOMAIN,
     FAN_AUTO,
     FAN_LOW,
     FAN_ON,
@@ -525,7 +526,7 @@ async def test_target_temperature(
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate, hass)
     if preset:
         await hass.services.async_call(
-            Platform.CLIMATE,
+            CLIMATE_DOMAIN,
             SERVICE_SET_PRESET_MODE,
             {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: preset},
             blocking=True,
@@ -561,7 +562,7 @@ async def test_target_temperature_high(
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate, hass)
     if preset:
         await hass.services.async_call(
-            Platform.CLIMATE,
+            CLIMATE_DOMAIN,
             SERVICE_SET_PRESET_MODE,
             {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: preset},
             blocking=True,
@@ -597,7 +598,7 @@ async def test_target_temperature_low(
     entity_id = await find_entity_id(Platform.CLIMATE, device_climate, hass)
     if preset:
         await hass.services.async_call(
-            Platform.CLIMATE,
+            CLIMATE_DOMAIN,
             SERVICE_SET_PRESET_MODE,
             {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: preset},
             blocking=True,
@@ -628,7 +629,7 @@ async def test_set_hvac_mode(hass, device_climate, hvac_mode, sys_mode):
     assert state.state == HVAC_MODE_OFF
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: hvac_mode},
         blocking=True,
@@ -647,7 +648,7 @@ async def test_set_hvac_mode(hass, device_climate, hvac_mode, sys_mode):
     # turn off
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVAC_MODE_OFF},
         blocking=True,
@@ -675,7 +676,7 @@ async def test_preset_setting(hass, device_climate_sinope):
     ]
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -692,7 +693,7 @@ async def test_preset_setting(hass, device_climate_sinope):
         zcl_f.WriteAttributesResponse.deserialize(b"\x00")[0]
     ]
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -709,7 +710,7 @@ async def test_preset_setting(hass, device_climate_sinope):
         zcl_f.WriteAttributesResponse.deserialize(b"\x01\x01\x01")[0]
     ]
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_NONE},
         blocking=True,
@@ -726,7 +727,7 @@ async def test_preset_setting(hass, device_climate_sinope):
         zcl_f.WriteAttributesResponse.deserialize(b"\x00")[0]
     ]
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_NONE},
         blocking=True,
@@ -748,7 +749,7 @@ async def test_preset_setting_invalid(hass, device_climate_sinope):
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: "invalid_preset"},
         blocking=True,
@@ -769,7 +770,7 @@ async def test_set_temperature_hvac_mode(hass, device_climate):
     assert state.state == HVAC_MODE_OFF
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
             ATTR_ENTITY_ID: entity_id,
@@ -809,7 +810,7 @@ async def test_set_temperature_heat_cool(hass, device_climate_mock):
     assert state.state == HVAC_MODE_HEAT_COOL
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 21},
         blocking=True,
@@ -821,7 +822,7 @@ async def test_set_temperature_heat_cool(hass, device_climate_mock):
     assert thrm_cluster.write_attributes.await_count == 0
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
             ATTR_ENTITY_ID: entity_id,
@@ -843,7 +844,7 @@ async def test_set_temperature_heat_cool(hass, device_climate_mock):
     }
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -851,7 +852,7 @@ async def test_set_temperature_heat_cool(hass, device_climate_mock):
     thrm_cluster.write_attributes.reset_mock()
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
             ATTR_ENTITY_ID: entity_id,
@@ -895,7 +896,7 @@ async def test_set_temperature_heat(hass, device_climate_mock):
     assert state.state == HVAC_MODE_HEAT
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
             ATTR_ENTITY_ID: entity_id,
@@ -912,7 +913,7 @@ async def test_set_temperature_heat(hass, device_climate_mock):
     assert thrm_cluster.write_attributes.await_count == 0
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 21},
         blocking=True,
@@ -928,7 +929,7 @@ async def test_set_temperature_heat(hass, device_climate_mock):
     }
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -936,7 +937,7 @@ async def test_set_temperature_heat(hass, device_climate_mock):
     thrm_cluster.write_attributes.reset_mock()
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 22},
         blocking=True,
@@ -974,7 +975,7 @@ async def test_set_temperature_cool(hass, device_climate_mock):
     assert state.state == HVAC_MODE_COOL
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
             ATTR_ENTITY_ID: entity_id,
@@ -991,7 +992,7 @@ async def test_set_temperature_cool(hass, device_climate_mock):
     assert thrm_cluster.write_attributes.await_count == 0
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 21},
         blocking=True,
@@ -1007,7 +1008,7 @@ async def test_set_temperature_cool(hass, device_climate_mock):
     }
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -1015,7 +1016,7 @@ async def test_set_temperature_cool(hass, device_climate_mock):
     thrm_cluster.write_attributes.reset_mock()
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 22},
         blocking=True,
@@ -1057,7 +1058,7 @@ async def test_set_temperature_wrong_mode(hass, device_climate_mock):
     assert state.state == HVAC_MODE_DRY
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 24},
         blocking=True,
@@ -1080,7 +1081,7 @@ async def test_occupancy_reset(hass, device_climate_sinope):
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -1133,7 +1134,7 @@ async def test_set_fan_mode_not_supported(hass, device_climate_fan):
     fan_cluster = device_climate_fan.device.endpoints[1].fan
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_LOW},
         blocking=True,
@@ -1151,7 +1152,7 @@ async def test_set_fan_mode(hass, device_climate_fan):
     assert state.attributes[ATTR_FAN_MODE] == FAN_AUTO
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_ON},
         blocking=True,
@@ -1161,7 +1162,7 @@ async def test_set_fan_mode(hass, device_climate_fan):
 
     fan_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_AUTO},
         blocking=True,
@@ -1180,7 +1181,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
 
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_AWAY},
         blocking=True,
@@ -1193,7 +1194,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
 
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_SCHEDULE},
         blocking=True,
@@ -1209,7 +1210,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
 
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_COMFORT},
         blocking=True,
@@ -1225,7 +1226,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
 
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_ECO},
         blocking=True,
@@ -1241,7 +1242,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
 
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_BOOST},
         blocking=True,
@@ -1257,7 +1258,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
 
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_COMPLEX},
         blocking=True,
@@ -1273,7 +1274,7 @@ async def test_set_moes_preset(hass, device_climate_moes):
 
     thrm_cluster.write_attributes.reset_mock()
     await hass.services.async_call(
-        Platform.CLIMATE,
+        CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_NONE},
         blocking=True,

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -11,6 +11,7 @@ import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
+    DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
@@ -140,7 +141,7 @@ async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
         "zigpy.zcl.Cluster.request", return_value=mock_coro([0x1, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
@@ -153,7 +154,7 @@ async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
         "zigpy.zcl.Cluster.request", return_value=mock_coro([0x0, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
@@ -166,7 +167,7 @@ async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
         "zigpy.zcl.Cluster.request", return_value=mock_coro([0x5, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER,
+            COVER_DOMAIN,
             SERVICE_SET_COVER_POSITION,
             {"entity_id": entity_id, "position": 47},
             blocking=True,
@@ -183,7 +184,7 @@ async def test_cover(m1, hass, zha_device_joined_restored, zigpy_cover_device):
         "zigpy.zcl.Cluster.request", return_value=mock_coro([0x2, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_STOP_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_STOP_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
@@ -226,7 +227,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
     # close from UI command fails
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
@@ -237,7 +238,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
         "zigpy.zcl.Cluster.request", AsyncMock(return_value=[0x1, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
@@ -249,7 +250,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
     await send_attributes_report(hass, cluster_level, {0: 0})
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
@@ -261,7 +262,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
         "zigpy.zcl.Cluster.request", AsyncMock(return_value=[0x0, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
@@ -271,7 +272,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
     # set position UI command fails
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
         await hass.services.async_call(
-            Platform.COVER,
+            COVER_DOMAIN,
             SERVICE_SET_COVER_POSITION,
             {"entity_id": entity_id, "position": 47},
             blocking=True,
@@ -287,7 +288,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
         "zigpy.zcl.Cluster.request", AsyncMock(return_value=[0x5, zcl_f.Status.SUCCESS])
     ):
         await hass.services.async_call(
-            Platform.COVER,
+            COVER_DOMAIN,
             SERVICE_SET_COVER_POSITION,
             {"entity_id": entity_id, "position": 47},
             blocking=True,
@@ -313,7 +314,7 @@ async def test_shade(hass, zha_device_joined_restored, zigpy_shade_device):
     # test cover stop
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
         await hass.services.async_call(
-            Platform.COVER,
+            COVER_DOMAIN,
             SERVICE_STOP_COVER,
             {"entity_id": entity_id},
             blocking=True,
@@ -377,7 +378,7 @@ async def test_keen_vent(hass, zha_device_joined_restored, zigpy_keen_vent):
 
     with p1, p2:
         await hass.services.async_call(
-            Platform.COVER, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
         )
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
@@ -391,7 +392,7 @@ async def test_keen_vent(hass, zha_device_joined_restored, zigpy_keen_vent):
 
     with p1, p2:
         await hass.services.async_call(
-            Platform.COVER, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
+            COVER_DOMAIN, SERVICE_OPEN_COVER, {"entity_id": entity_id}, blocking=True
         )
         await asyncio.sleep(0)
         assert cluster_on_off.request.call_count == 1

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -14,6 +14,7 @@ from homeassistant.components.fan import (
     ATTR_PERCENTAGE_STEP,
     ATTR_PRESET_MODE,
     ATTR_SPEED,
+    DOMAIN as FAN_DOMAIN,
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_SPEED,
     SPEED_HIGH,
@@ -246,7 +247,7 @@ async def async_set_preset_mode(hass, entity_id, preset_mode=None):
     }
 
     await hass.services.async_call(
-        Platform.FAN, SERVICE_SET_PRESET_MODE, data, blocking=True
+        FAN_DOMAIN, SERVICE_SET_PRESET_MODE, data, blocking=True
     )
 
 

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -9,7 +9,11 @@ import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.lighting as lighting
 import zigpy.zcl.foundation as zcl_f
 
-from homeassistant.components.light import FLASH_LONG, FLASH_SHORT
+from homeassistant.components.light import (
+    DOMAIN as LIGHT_DOMAIN,
+    FLASH_LONG,
+    FLASH_SHORT,
+)
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.components.zha.light import FLASH_EFFECTS
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
@@ -327,7 +331,7 @@ async def async_test_on_off_from_hass(hass, cluster, entity_id):
     # turn on via UI
     cluster.request.reset_mock()
     await hass.services.async_call(
-        Platform.LIGHT, "turn_on", {"entity_id": entity_id}, blocking=True
+        LIGHT_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
     )
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
@@ -344,7 +348,7 @@ async def async_test_off_from_hass(hass, cluster, entity_id):
     # turn off via UI
     cluster.request.reset_mock()
     await hass.services.async_call(
-        Platform.LIGHT, "turn_off", {"entity_id": entity_id}, blocking=True
+        LIGHT_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
     )
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
@@ -362,7 +366,7 @@ async def async_test_level_on_off_from_hass(
     level_cluster.request.reset_mock()
     # turn on via UI
     await hass.services.async_call(
-        Platform.LIGHT, "turn_on", {"entity_id": entity_id}, blocking=True
+        LIGHT_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
     )
     assert on_off_cluster.request.call_count == 1
     assert on_off_cluster.request.await_count == 1
@@ -375,7 +379,7 @@ async def async_test_level_on_off_from_hass(
     level_cluster.request.reset_mock()
 
     await hass.services.async_call(
-        Platform.LIGHT,
+        LIGHT_DOMAIN,
         "turn_on",
         {"entity_id": entity_id, "transition": 10},
         blocking=True,
@@ -402,7 +406,7 @@ async def async_test_level_on_off_from_hass(
     level_cluster.request.reset_mock()
 
     await hass.services.async_call(
-        Platform.LIGHT,
+        LIGHT_DOMAIN,
         "turn_on",
         {"entity_id": entity_id, "brightness": 10},
         blocking=True,
@@ -448,7 +452,7 @@ async def async_test_flash_from_hass(hass, cluster, entity_id, flash):
     # turn on via UI
     cluster.request.reset_mock()
     await hass.services.async_call(
-        Platform.LIGHT,
+        LIGHT_DOMAIN,
         "turn_on",
         {"entity_id": entity_id, "flash": flash},
         blocking=True,

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -7,6 +7,7 @@ import zigpy.zcl.clusters.closures as closures
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.foundation as zcl_f
 
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     STATE_LOCKED,
     STATE_UNAVAILABLE,
@@ -96,7 +97,7 @@ async def async_lock(hass, cluster, entity_id):
     ):
         # lock via UI
         await hass.services.async_call(
-            Platform.LOCK, "lock", {"entity_id": entity_id}, blocking=True
+            LOCK_DOMAIN, "lock", {"entity_id": entity_id}, blocking=True
         )
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
@@ -110,7 +111,7 @@ async def async_unlock(hass, cluster, entity_id):
     ):
         # lock via UI
         await hass.services.async_call(
-            Platform.LOCK, "unlock", {"entity_id": entity_id}, blocking=True
+            LOCK_DOMAIN, "unlock", {"entity_id": entity_id}, blocking=True
         )
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -7,6 +7,7 @@ import zigpy.types
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.foundation as zcl_f
 
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.setup import async_setup_component
 
@@ -109,7 +110,7 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
     ):
         # set value via UI
         await hass.services.async_call(
-            Platform.NUMBER,
+            NUMBER_DOMAIN,
             "set_value",
             {"entity_id": entity_id, "value": 30.0},
             blocking=True,

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -13,6 +13,7 @@ from homeassistant.components.siren.const import (
     ATTR_DURATION,
     ATTR_TONE,
     ATTR_VOLUME_LEVEL,
+    DOMAIN as SIREN_DOMAIN,
 )
 from homeassistant.components.zha.core.const import (
     WARNING_DEVICE_MODE_EMERGENCY_PANIC,
@@ -72,7 +73,7 @@ async def test_siren(hass, siren):
     ):
         # turn on via UI
         await hass.services.async_call(
-            Platform.SIREN, "turn_on", {"entity_id": entity_id}, blocking=True
+            SIREN_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
         )
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args[0][0] is False
@@ -92,7 +93,7 @@ async def test_siren(hass, siren):
     ):
         # turn off via UI
         await hass.services.async_call(
-            Platform.SIREN, "turn_off", {"entity_id": entity_id}, blocking=True
+            SIREN_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
         )
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args[0][0] is False
@@ -112,7 +113,7 @@ async def test_siren(hass, siren):
     ):
         # turn on via UI
         await hass.services.async_call(
-            Platform.SIREN,
+            SIREN_DOMAIN,
             "turn_on",
             {
                 "entity_id": entity_id,

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -6,6 +6,7 @@ import zigpy.profiles.zha as zha
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.foundation as zcl_f
 
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 
@@ -136,7 +137,7 @@ async def test_switch(hass, zha_device_joined_restored, zigpy_device):
     ):
         # turn on via UI
         await hass.services.async_call(
-            Platform.SWITCH, "turn_on", {"entity_id": entity_id}, blocking=True
+            SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
         )
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
@@ -150,7 +151,7 @@ async def test_switch(hass, zha_device_joined_restored, zigpy_device):
     ):
         # turn off via UI
         await hass.services.async_call(
-            Platform.SWITCH, "turn_off", {"entity_id": entity_id}, blocking=True
+            SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
         )
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
@@ -219,7 +220,7 @@ async def test_zha_group_switch_entity(
     ):
         # turn on via UI
         await hass.services.async_call(
-            Platform.SWITCH, "turn_on", {"entity_id": entity_id}, blocking=True
+            SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
         )
         assert len(group_cluster_on_off.request.mock_calls) == 1
         assert group_cluster_on_off.request.call_args == call(
@@ -234,7 +235,7 @@ async def test_zha_group_switch_entity(
     ):
         # turn off via UI
         await hass.services.async_call(
-            Platform.SWITCH, "turn_off", {"entity_id": entity_id}, blocking=True
+            SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
         )
         assert len(group_cluster_on_off.request.mock_calls) == 1
         assert group_cluster_on_off.request.call_args == call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Platform enum should not be used against `hass.services.async_call`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
