### PR TITLE
Fix derivative integration showing unexpected spikes

### DIFF
--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -178,7 +178,6 @@ class DerivativeSensor(RestoreEntity, SensorEntity):
                     * Decimal(self._unit_time)
                 )
 
-                assert isinstance(new_derivative, Decimal)
             except ValueError as err:
                 _LOGGER.warning("While calculating derivative: %s", err)
             except DecimalException as err:

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -1,6 +1,7 @@
 """Numeric derivative of data coming from a source sensor over time."""
 from __future__ import annotations
 
+from datetime import timedelta
 from decimal import Decimal, DecimalException
 import logging
 
@@ -112,7 +113,9 @@ class DerivativeSensor(RestoreEntity, SensorEntity):
         self._sensor_source_id = source_entity
         self._round_digits = round_digits
         self._state = 0
-        self._state_list = []  # List of tuples with (timestamp, sensor_value)
+        self._state_list = (
+            []
+        )  # List of tuples with (timestamp_start, timestamp_end, derivative)
 
         self._name = name if name is not None else f"{source_entity} derivative"
 
@@ -155,6 +158,14 @@ class DerivativeSensor(RestoreEntity, SensorEntity):
                     "" if unit is None else unit
                 )
 
+            # filter out all derivatives older than `time_window` from our window list
+            self._state_list = [
+                (time_start, time_end, state)
+                for time_start, time_end, state in self._state_list
+                if (new_state.last_updated - time_end).total_seconds()
+                < self._time_window
+            ]
+
             try:
                 elapsed_time = (
                     new_state.last_updated - old_state.last_updated
@@ -167,15 +178,6 @@ class DerivativeSensor(RestoreEntity, SensorEntity):
                     * Decimal(self._unit_time)
                 )
 
-                # If outside of time window just report derivative (is the same as modeling it in the window),
-                # otherwise take the weighted average with the previous derivative
-                if elapsed_time < self._time_window:
-                    time_left = self._time_window - elapsed_time
-                    new_derivative = (
-                        new_derivative * Decimal(elapsed_time)
-                        + Decimal(self._state) * Decimal(time_left)
-                    ) / Decimal(self._time_window)
-
                 assert isinstance(new_derivative, Decimal)
             except ValueError as err:
                 _LOGGER.warning("While calculating derivative: %s", err)
@@ -185,9 +187,32 @@ class DerivativeSensor(RestoreEntity, SensorEntity):
                 )
             except AssertionError as err:
                 _LOGGER.error("Could not calculate derivative: %s", err)
+
+            # add latest derivative to the window list
+            self._state_list.append(
+                (old_state.last_updated, new_state.last_updated, new_derivative)
+            )
+
+            def calculate_weight(start, end, now):
+                window_start = now - timedelta(seconds=self._time_window)
+                if start < window_start:
+                    weight = (end - window_start).total_seconds() / self._time_window
+                else:
+                    weight = (end - start).total_seconds() / self._time_window
+                return weight
+
+            # If outside of time window just report derivative (is the same as modeling it in the window),
+            # otherwise take the weighted average with the previous derivatives
+            if elapsed_time > self._time_window:
+                derivative = new_derivative
             else:
-                self._state = new_derivative
-                self.async_write_ha_state()
+                derivative = 0
+                for (start, end, value) in self._state_list:
+                    weight = calculate_weight(start, end, new_state.last_updated)
+                    derivative = derivative + (value * Decimal(weight))
+
+            self._state = derivative
+            self.async_write_ha_state()
 
         async_track_state_change_event(
             self.hass, [self._sensor_source_id], calc_derivative

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -1,5 +1,7 @@
 """The tests for the derivative sensor platform."""
 from datetime import timedelta
+from math import sin
+import random
 from unittest.mock import patch
 
 from homeassistant.const import POWER_WATT, TIME_HOURS, TIME_MINUTES, TIME_SECONDS
@@ -178,6 +180,90 @@ async def test_data_moving_average_for_discrete_sensor(hass):
             # Test that the error is never more than
             # (time_window_in_minutes / true_derivative * 100) = 10% + ε
             assert abs(1 - derivative) <= 0.1 + 1e-6
+
+
+async def test_data_moving_average_for_irregular_times(hass):
+    """Test derivative sensor state."""
+    # We simulate the following situation:
+    # The temperature rises 1 °C per minute for 30 minutes long.
+    # There is 60 random datapoints (and the start and end) and the signal is normally distributed
+    # around the expected value with ±0.1°C
+    # We use a time window of 1 minute and expect an error of less than the standard deviation. (0.01)
+
+    time_window = 60
+    random.seed(0)
+    times = sorted(random.sample(range(1800), 60))
+
+    def temp_function(time):
+        random.seed(0)
+        temp = time / (600)
+        return random.gauss(temp, 0.1)
+
+    temperature_values = list(map(temp_function, times))
+
+    config, entity_id = await _setup_sensor(
+        hass,
+        {
+            "time_window": {"seconds": time_window},
+            "unit_time": TIME_MINUTES,
+            "round": 3,
+        },
+    )
+
+    base = dt_util.utcnow()
+    for time, value in zip(times, temperature_values):
+        now = base + timedelta(seconds=time)
+        with patch("homeassistant.util.dt.utcnow", return_value=now):
+            hass.states.async_set(entity_id, value, {}, force_update=True)
+            await hass.async_block_till_done()
+
+        if time_window < time and time > times[3]:
+            state = hass.states.get("sensor.power")
+            derivative = round(float(state.state), config["sensor"]["round"])
+            # Test that the error is never more than
+            # (time_window_in_minutes / true_derivative * 100) = 10% + ε
+            assert abs(0.1 - derivative) <= 0.01 + 1e-6
+
+
+async def test_double_signal_after_delay(hass):
+    """Test derivative sensor state."""
+    # The old algorithm would produce extreme values if, after a delay longer than the time window
+    # there would be two signals, a large spike would be produced. Check explicitly for this situation
+    time_window = 60
+    times = [*range(time_window * 10)]
+    times = times + [
+        time_window * 20,
+        time_window * 20 + 0.01,
+    ]
+
+    # just apply sine as some sort of temperature change and make sure the change after the delay is very small
+    temperature_values = [sin(x) for x in times]
+    temperature_values[-2] = temperature_values[-3] + 0.01
+    temperature_values[-1] = temperature_values[-2] + 0.01
+
+    config, entity_id = await _setup_sensor(
+        hass,
+        {
+            "time_window": {"seconds": time_window},
+            "unit_time": TIME_MINUTES,
+            "round": 3,
+        },
+    )
+
+    base = dt_util.utcnow()
+    previous = 0
+    for time, value in zip(times, temperature_values):
+        now = base + timedelta(seconds=time)
+        with patch("homeassistant.util.dt.utcnow", return_value=now):
+            hass.states.async_set(entity_id, value, {}, force_update=True)
+            await hass.async_block_till_done()
+        state = hass.states.get("sensor.power")
+        derivative = round(float(state.state), config["sensor"]["round"])
+        if time == times[-1]:
+            # Test that the error is never more than
+            # (time_window_in_minutes / true_derivative * 100) = 10% + ε
+            assert abs(previous - derivative) <= 0.01 + 1e-6
+        previous = derivative
 
 
 async def test_prefix(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the bug as described in https://github.com/home-assistant/core/issues/31579 (and others) for the derivative integration by implementing a more robust algorithm with respect to unevenly spaced updates. In essence applies a simple moving average weighted by time as described in http://www.eckner.com/papers/Algorithms%20for%20Unevenly%20Spaced%20Time%20Series.pdf in the SMAlast section. For more info, see the issue and my posts there. My code has changed a little from what I've described there, but the principle hasn't really changed. 

I have added a test for the issue (that fails for the old algorithm) and added a few more tests for unevenly spaced derivatives. Existing tests also show a higher accuracy than before. In addition I've run this code on my own installation for the past two weeks and it has solved the issue without impacting the signal.

Note that the old code essentially had an unpredictable smoothing window (it only had a maximum size), which means that the parameter has sort of changed in effectiveness (is that a word?). What I mean is, I expect that some people will want to reduce their window size with this new code, but the change is not strictly breaking. If this PR is accepted I'll happily update the documentation too (because my PRs have been denied in the past for surprising reasons I'd like to wait with that).

NOTE: I wasn't sure if I should add myself as a codeowner, so I did not, is that ok?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #31579
- This PR is related to issue: #31579
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
