### PR TITLE
Add back resolvers config flow dnsip

### DIFF
--- a/homeassistant/components/dnsip/config_flow.py
+++ b/homeassistant/components/dnsip/config_flow.py
@@ -31,6 +31,8 @@ from .const import (
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOSTNAME, default=DEFAULT_HOSTNAME): cv.string,
+        vol.Optional(CONF_RESOLVER, default=DEFAULT_RESOLVER): cv.string,
+        vol.Optional(CONF_RESOLVER_IPV6, default=DEFAULT_RESOLVER_IPV6): cv.string,
     }
 )
 
@@ -94,8 +96,8 @@ class DnsIPConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             hostname = user_input[CONF_HOSTNAME]
             name = DEFAULT_NAME if hostname == DEFAULT_HOSTNAME else hostname
-            resolver = DEFAULT_RESOLVER
-            resolver_ipv6 = DEFAULT_RESOLVER_IPV6
+            resolver = user_input.get(CONF_RESOLVER, DEFAULT_RESOLVER)
+            resolver_ipv6 = user_input.get(CONF_RESOLVER_IPV6, DEFAULT_RESOLVER_IPV6)
 
             validate = await async_validate_hostname(hostname, resolver, resolver_ipv6)
 

--- a/homeassistant/components/dnsip/config_flow.py
+++ b/homeassistant/components/dnsip/config_flow.py
@@ -31,6 +31,11 @@ from .const import (
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOSTNAME, default=DEFAULT_HOSTNAME): cv.string,
+    }
+)
+DATA_SCHEMA_ADV = vol.Schema(
+    {
+        vol.Required(CONF_HOSTNAME, default=DEFAULT_HOSTNAME): cv.string,
         vol.Optional(CONF_RESOLVER, default=DEFAULT_RESOLVER): cv.string,
         vol.Optional(CONF_RESOLVER_IPV6, default=DEFAULT_RESOLVER_IPV6): cv.string,
     }
@@ -121,6 +126,12 @@ class DnsIPConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+        if self.show_advanced_options is True:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=DATA_SCHEMA_ADV,
+                errors=errors,
+            )
         return self.async_show_form(
             step_id="user",
             data_schema=DATA_SCHEMA,

--- a/homeassistant/components/dnsip/strings.json
+++ b/homeassistant/components/dnsip/strings.json
@@ -3,7 +3,9 @@
         "step": {
             "user": {
                 "data": {
-                    "hostname": "The hostname for which to perform the DNS query"
+                    "hostname": "The hostname for which to perform the DNS query",
+                    "resolver": "Resolver for IPV4 lookup",
+                    "resolver_ipv6": "Resolver for IPV6 lookup"
                 }
             }
         },

--- a/homeassistant/components/dnsip/translations/en.json
+++ b/homeassistant/components/dnsip/translations/en.json
@@ -6,7 +6,9 @@
         "step": {
             "user": {
                 "data": {
-                    "hostname": "The hostname for which to perform the DNS query"
+                    "hostname": "The hostname for which to perform the DNS query",
+                    "resolver": "Resolver for IPV4 lookup",
+                    "resolver_ipv6": "Resolver for IPV6 lookup"
                 }
             }
         }

--- a/tests/components/dnsip/test_config_flow.py
+++ b/tests/components/dnsip/test_config_flow.py
@@ -7,6 +7,7 @@ from aiodns.error import DNSError
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.dnsip.config_flow import DATA_SCHEMA, DATA_SCHEMA_ADV
 from homeassistant.components.dnsip.const import (
     CONF_HOSTNAME,
     CONF_IPV4,
@@ -47,6 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == "form"
+    assert result["data_schema"] == DATA_SCHEMA
     assert result["errors"] == {}
 
     with patch(
@@ -74,6 +76,48 @@ async def test_form(hass: HomeAssistant) -> None:
     }
     assert result2["options"] == {
         "resolver": "208.67.222.222",
+        "resolver_ipv6": "2620:0:ccc::2",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_adv(hass: HomeAssistant) -> None:
+    """Test we get the form with advanced options on."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
+    )
+
+    assert result["data_schema"] == DATA_SCHEMA_ADV
+
+    with patch(
+        "homeassistant.components.dnsip.config_flow.aiodns.DNSResolver",
+        return_value=RetrieveDNS(),
+    ), patch(
+        "homeassistant.components.dnsip.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOSTNAME: "home-assistant.io",
+                CONF_RESOLVER: "8.8.8.8",
+                CONF_RESOLVER_IPV6: "2620:0:ccc::2",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "home-assistant.io"
+    assert result2["data"] == {
+        "hostname": "home-assistant.io",
+        "name": "home-assistant.io",
+        "ipv4": True,
+        "ipv6": True,
+    }
+    assert result2["options"] == {
+        "resolver": "8.8.8.8",
         "resolver_ipv6": "2620:0:ccc::2",
     }
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Put back config of resolvers at config flow entry to also support internal resolvers.
They were removed and made options only as part of migrating to config flow as off 2022.2
All other options seems more complex than just adding back this option directly at entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65471 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
