### PR TITLE
Update frontend to 20220203.0

### DIFF
--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20220202.0"
+    "home-assistant-frontend==20220203.0"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ ciso8601==2.2.0
 cryptography==35.0.0
 emoji==1.6.3
 hass-nabucasa==0.52.0
-home-assistant-frontend==20220202.0
+home-assistant-frontend==20220203.0
 httpx==0.21.3
 ifaddr==0.1.7
 jinja2==3.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -842,7 +842,7 @@ hole==0.7.0
 holidays==0.12
 
 # homeassistant.components.frontend
-home-assistant-frontend==20220202.0
+home-assistant-frontend==20220203.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -543,7 +543,7 @@ hole==0.7.0
 holidays==0.12
 
 # homeassistant.components.frontend
-home-assistant-frontend==20220202.0
+home-assistant-frontend==20220203.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10


### PR DESCRIPTION
## Breaking change

2022.2.0 had a fix for users of screen readers that were not able to click on some elements.
Unfortunately we had to revert this fix as it has some unwanted side effects. We are working to get the fix back in for the next release. You can ofcourse keep using 2022.2.0 in the meantime.

notes: https://github.com/home-assistant/frontend/releases/tag/20220203.0

needs: https://github.com/home-assistant/frontend/actions/runs/1791476041