### PR TITLE
Extend diagnostics data in Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -566,6 +566,13 @@ class AvmWrapper(FritzBoxTools):
             partial(self.get_wan_dsl_interface_config)
         )
 
+    async def async_get_wan_link_properties(self) -> dict[str, Any]:
+        """Call WANCommonInterfaceConfig service."""
+
+        return await self.hass.async_add_executor_job(
+            partial(self.get_wan_link_properties)
+        )
+
     async def async_get_port_mapping(self, con_type: str, index: int) -> dict[str, Any]:
         """Call GetGenericPortMappingEntry action."""
 
@@ -667,6 +674,13 @@ class AvmWrapper(FritzBoxTools):
         """Call WANDSLInterfaceConfig service."""
 
         return self._service_call_action("WANDSLInterfaceConfig", "1", "GetInfo")
+
+    def get_wan_link_properties(self) -> dict[str, Any]:
+        """Call WANCommonInterfaceConfig service."""
+
+        return self._service_call_action(
+            "WANCommonInterfaceConfig", "1", "GetCommonLinkProperties"
+        )
 
     def set_wlan_configuration(self, index: int, turn_on: bool) -> dict[str, Any]:
         """Call SetEnable action from WLANConfiguration service."""

--- a/homeassistant/components/fritz/diagnostics.py
+++ b/homeassistant/components/fritz/diagnostics.py
@@ -29,6 +29,19 @@ async def async_get_config_entry_diagnostics(
             "mesh_role": avm_wrapper.mesh_role,
             "last_update success": avm_wrapper.last_update_success,
             "last_exception": avm_wrapper.last_exception,
+            "discovered_services": list(avm_wrapper.connection.services),
+            "client_devices": [
+                {
+                    "connected_to": device.connected_to,
+                    "connection_type": device.connection_type,
+                    "hostname": device.hostname,
+                    "is_connected": device.is_connected,
+                    "last_activity": device.last_activity,
+                    "wan_access": device.wan_access,
+                }
+                for _, device in avm_wrapper.devices.items()
+            ],
+            "wan_link_properties": await avm_wrapper.async_get_wan_link_properties(),
         },
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add the `discovered_services` , `client_devices` and `wan_link_properties`

example data

```json
{
  {...},
  "data": {
    "entry": {
      "entry_id": "35b5195b73e7bf2295de44d5fdc8e47a",
      "version": 1,
      "domain": "fritz",
      "title": "FRITZ!Box 7530 AX",
      "data": {
        "host": "192.168.1.1",
        "password": "**REDACTED**",
        "port": 49000,
        "username": "**REDACTED**"
      },
      "options": {
        "consider_home": 5
      },
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": null,
      "disabled_by": null
    },
    "device_info": {
      "model": "FRITZ!Box 7530 AX",
      "current_firmware": "256.07.29",
      "latest_firmware": "",
      "update_available": false,
      "is_router": true,
      "mesh_role": "master",
      "last_update success": true,
      "last_exception": null,
      "discovered_services": [
        "any1",
        "WANCommonIFC1",
        "WANDSLLinkC1",
        "WANIPConn1",
        "WANIPv6Firewall1",
        "DeviceInfo1",
        "DeviceConfig1",
        "Layer3Forwarding1",
        "LANConfigSecurity1",
        "ManagementServer1",
        "Time1",
        "UserInterface1",
        "X_AVM-DE_Storage1",
        "X_AVM-DE_WebDAVClient1",
        "X_AVM-DE_UPnP1",
        "X_AVM-DE_Speedtest1",
        "X_AVM-DE_RemoteAccess1",
        "X_AVM-DE_MyFritz1",
        "X_VoIP1",
        "X_AVM-DE_OnTel1",
        "X_AVM-DE_Dect1",
        "X_AVM-DE_TAM1",
        "X_AVM-DE_AppSetup1",
        "X_AVM-DE_Homeauto1",
        "X_AVM-DE_Homeplug1",
        "X_AVM-DE_Filelinks1",
        "X_AVM-DE_Auth1",
        "X_AVM-DE_HostFilter1",
        "WLANConfiguration1",
        "WLANConfiguration2",
        "WLANConfiguration3",
        "Hosts1",
        "LANEthernetInterfaceConfig1",
        "LANHostConfigManagement1",
        "WANCommonInterfaceConfig1",
        "WANDSLInterfaceConfig1",
        "WANDSLLinkConfig1",
        "WANEthernetLinkConfig1",
        "WANPPPConnection1",
        "WANIPConnection1"
      ],
      "client_devices": [
        {
          "connected_to": "fritz.box",
          "connection_type": "LAN",
          "hostname": "printer",
          "is_connected": true,
          "last_activity": "2022-02-03T19:59:08.287643+00:00",
          "wan_access": true
        },
        {
          "connected_to": "fritz.box",
          "connection_type": "WLAN",
          "hostname": "shelly-misc-01",
          "is_connected": true,
          "last_activity": "2022-02-03T19:59:08.333617+00:00",
          "wan_access": true
        },
        {
          "connected_to": "fritz.box",
          "connection_type": "WLAN",
          "hostname": "iPhone",
          "is_connected": true,
          "last_activity": "2022-02-03T19:59:08.517604+00:00",
          "wan_access": true
        },
        {
          "connected_to": "fritz.box",
          "connection_type": "WLAN",
          "hostname": "HUAWEI-MediaPad-M5-d315b8",
          "is_connected": true,
          "last_activity": "2022-02-03T19:59:08.785716+00:00",
          "wan_access": true
        },
        {
          "connected_to": "",
          "connection_type": "",
          "hostname": "PC-192-168-1-127",
          "is_connected": false,
          "last_activity": null,
          "wan_access": true
        }
      ],
      "wan_link_properties": {
        "NewWANAccessType": "DSL",
        "NewLayer1UpstreamMaxBitRate": 51219000,
        "NewLayer1DownstreamMaxBitRate": 314792000,
        "NewPhysicalLinkStatus": "Up"
      }
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
