### PR TITLE
Add migration to migrate 'homewizard_energy' to 'homewizard'

### DIFF
--- a/homeassistant/components/homewizard/__init__.py
+++ b/homeassistant/components/homewizard/__init__.py
@@ -3,10 +3,11 @@ import logging
 
 from aiohwenergy import DisabledError
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import DOMAIN, PLATFORMS
@@ -19,6 +20,51 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Homewizard from a config entry."""
 
     _LOGGER.debug("__init__ async_setup_entry")
+
+    # Migrate `homewizard_energy` (custom_component) to `homewizard`
+    if entry.source == SOURCE_IMPORT and "old_config_entry_id" in entry.data:
+        # Remove the old config entry ID from the entry data so we don't try this again
+        # on the next setup
+        data = entry.data.copy()
+        old_config_entry_id = data.pop("old_config_entry_id")
+
+        hass.config_entries.async_update_entry(entry, data=data)
+        _LOGGER.debug(
+            (
+                "Setting up imported homewizard_energy entry %s for the first time as "
+                "homewizard entry %s"
+            ),
+            old_config_entry_id,
+            entry.entry_id,
+        )
+
+        ent_reg = er.async_get(hass)
+        for entity in er.async_entries_for_config_entry(ent_reg, old_config_entry_id):
+            _LOGGER.debug("Removing %s", entity.entity_id)
+            ent_reg.async_remove(entity.entity_id)
+
+            _LOGGER.debug("Re-creating %s for the new config entry", entity.entity_id)
+            # We will precreate the entity so that any customizations can be preserved
+            new_entity = ent_reg.async_get_or_create(
+                entity.domain,
+                DOMAIN,
+                entity.unique_id,
+                suggested_object_id=entity.entity_id.split(".")[1],
+                disabled_by=entity.disabled_by,
+                config_entry=entry,
+                original_name=entity.original_name,
+                original_icon=entity.original_icon,
+            )
+            _LOGGER.debug("Re-created %s", new_entity.entity_id)
+
+            # If there are customizations on the old entity, apply them to the new one
+            if entity.name or entity.icon:
+                ent_reg.async_update_entity(
+                    new_entity.entity_id, name=entity.name, icon=entity.icon
+                )
+
+        # Remove the old config entry and now the entry is fully migrated
+        hass.async_create_task(hass.config_entries.async_remove(old_config_entry_id))
 
     # Create coordinator
     coordinator = Coordinator(hass, entry.data[CONF_IP_ADDRESS])

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -12,6 +12,8 @@ from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_CREATE_
 
 from .generator import get_mock_device
 
+from tests.common import MockConfigEntry
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -86,6 +88,37 @@ async def test_discovery_flow_works(hass, aioclient_mock):
 
     assert result["result"]
     assert result["result"].unique_id == "HWE-P1_aabbccddeeff"
+
+
+async def test_config_flow_imports_entry(aioclient_mock, hass):
+    """Test config flow accepts imported configuration."""
+
+    device = get_mock_device()
+
+    mock_entry = MockConfigEntry(domain="homewizard_energy", data={"host": "1.2.3.4"})
+    mock_entry.add_to_hass(hass)
+
+    with patch("aiohwenergy.HomeWizardEnergy", return_value=device,), patch(
+        "homeassistant.components.homewizard.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_IMPORT,
+                "old_config_entry_id": mock_entry.entry_id,
+            },
+            data=mock_entry.data,
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == f"{device.device.product_name} (aabbccddeeff)"
+    assert result["data"][CONF_IP_ADDRESS] == "1.2.3.4"
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert len(device.initialize.mock_calls) == 1
+    assert len(device.close.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_discovery_disabled_api(hass, aioclient_mock):

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -4,9 +4,11 @@ from unittest.mock import patch
 
 from aiohwenergy import AiohwenergyException, DisabledError
 
+from homeassistant import config_entries
 from homeassistant.components.homewizard.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.helpers import entity_registry as er
 
 from .generator import get_mock_device
 
@@ -66,6 +68,94 @@ async def test_load_failed_host_unavailable(aioclient_mock, hass):
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_init_accepts_and_migrates_old_entry(aioclient_mock, hass):
+    """Test config flow accepts imported configuration."""
+
+    device = get_mock_device()
+
+    # Add original entry
+    original_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4"},
+        entry_id="old_id",
+    )
+    original_entry.add_to_hass(hass)
+
+    # Give it some entities to see of they migrate properly
+    ent_reg = er.async_get(hass)
+    old_entity_active_power = ent_reg.async_get_or_create(
+        "sensor",
+        "homewizard_energy",
+        "p1_active_power_unique_id",
+        config_entry=original_entry,
+        original_name="Active Power",
+        suggested_object_id="p1_active_power",
+    )
+    old_entity_switch = ent_reg.async_get_or_create(
+        "switch",
+        "homewizard_energy",
+        "socket_switch_unique_id",
+        config_entry=original_entry,
+        original_name="Switch",
+        suggested_object_id="socket_switch",
+    )
+    old_entity_disabled_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        "homewizard_energy",
+        "socket_disabled_unique_id",
+        config_entry=original_entry,
+        original_name="Switch Disabled",
+        suggested_object_id="socket_disabled",
+        disabled_by=er.DISABLED_USER,
+    )
+    # Update some user-customs
+    ent_reg.async_update_entity(old_entity_active_power.entity_id, name="new_name")
+    ent_reg.async_update_entity(old_entity_switch.entity_id, icon="new_icon")
+
+    imported_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IP_ADDRESS: "1.2.3.4", "old_config_entry_id": "old_id"},
+        source=config_entries.SOURCE_IMPORT,
+        entry_id="new_id",
+    )
+    imported_entry.add_to_hass(hass)
+
+    # Add the entry_id to trigger migration
+    with patch(
+        "aiohwenergy.HomeWizardEnergy",
+        return_value=device,
+    ):
+        await hass.config_entries.async_setup(imported_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert original_entry.state is ConfigEntryState.NOT_LOADED
+    assert imported_entry.state is ConfigEntryState.LOADED
+
+    # Check if new entities are migrated
+    new_entity_active_power = ent_reg.async_get(old_entity_active_power.entity_id)
+    assert new_entity_active_power.platform == DOMAIN
+    assert new_entity_active_power.name == "new_name"
+    assert new_entity_active_power.icon is None
+    assert new_entity_active_power.original_name == "Active Power"
+    assert new_entity_active_power.unique_id == "p1_active_power_unique_id"
+    assert new_entity_active_power.disabled_by is None
+
+    new_entity_switch = ent_reg.async_get(old_entity_switch.entity_id)
+    assert new_entity_switch.platform == DOMAIN
+    assert new_entity_switch.name is None
+    assert new_entity_switch.icon == "new_icon"
+    assert new_entity_switch.original_name == "Switch"
+    assert new_entity_switch.unique_id == "socket_switch_unique_id"
+    assert new_entity_switch.disabled_by is None
+
+    new_entity_disabled_sensor = ent_reg.async_get(old_entity_disabled_sensor.entity_id)
+    assert new_entity_disabled_sensor.platform == DOMAIN
+    assert new_entity_disabled_sensor.name is None
+    assert new_entity_disabled_sensor.original_name == "Switch Disabled"
+    assert new_entity_disabled_sensor.unique_id == "socket_disabled_unique_id"
+    assert new_entity_disabled_sensor.disabled_by == er.DISABLED_USER
 
 
 async def test_load_detect_api_disabled(aioclient_mock, hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Users that used the custom integration ([link](https://github.com/DCSBL/ha-homewizard-energy)) have to migrate the component because the domain is changes from `homewizard_energy` to `homewizard`. They have to reconfigure the integration and match the entity ID's to preserve history and all configurations.

This adds the possibility for the custom component to trigger a migration. This migration is based on https://github.com/home-assistant/core/pull/59698

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 
- This PR is related to issue: https://github.com/DCSBL/ha-homewizard-energy/issues/74
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
