### PR TITLE
Add diagnostics support for Asuswrt

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -80,6 +80,7 @@ omit =
     homeassistant/components/asterisk_cdr/mailbox.py
     homeassistant/components/asterisk_mbox/*
     homeassistant/components/asuswrt/__init__.py
+    homeassistant/components/asuswrt/diagnostics.py
     homeassistant/components/asuswrt/router.py
     homeassistant/components/aten_pe/*
     homeassistant/components/atome/*

--- a/homeassistant/components/asuswrt/diagnostics.py
+++ b/homeassistant/components/asuswrt/diagnostics.py
@@ -1,6 +1,8 @@
 """Diagnostics support for Asuswrt."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -15,7 +17,7 @@ TO_REDACT = {CONF_PASSWORD, CONF_USERNAME}
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> dict:
+) -> dict[str, dict[str, Any]]:
     """Return diagnostics for a config entry."""
     data = {"entry": async_redact_data(entry.as_dict(), TO_REDACT)}
 
@@ -27,52 +29,54 @@ async def async_get_config_entry_diagnostics(
     hass_device = device_registry.async_get_device(
         identifiers=router.device_info["identifiers"]
     )
-    if hass_device:
-        data["device"] = {
-            "name": hass_device.name,
-            "name_by_user": hass_device.name_by_user,
-            "disabled": hass_device.disabled,
-            "disabled_by": hass_device.disabled_by,
-            "device_info": async_redact_data(dict(router.device_info), {"identifiers"}),
-            "entities": [],
-            "tracked_devices": [],
-        }
+    if not hass_device:
+        return data
 
-        hass_entities = er.async_entries_for_device(
-            entity_registry,
-            device_id=hass_device.id,
-            include_disabled_entities=True,
+    data["device"] = {
+        "name": hass_device.name,
+        "name_by_user": hass_device.name_by_user,
+        "disabled": hass_device.disabled,
+        "disabled_by": hass_device.disabled_by,
+        "device_info": async_redact_data(dict(router.device_info), {"identifiers"}),
+        "entities": [],
+        "tracked_devices": [],
+    }
+
+    hass_entities = er.async_entries_for_device(
+        entity_registry,
+        device_id=hass_device.id,
+        include_disabled_entities=True,
+    )
+
+    for entity_entry in hass_entities:
+        state = hass.states.get(entity_entry.entity_id)
+        state_dict = None
+        if state:
+            state_dict = state.as_dict()
+            # The context doesn't provide useful information in this case.
+            state_dict.pop("context", None)
+
+        data["device"]["entities"].append(
+            {
+                "disabled": entity_entry.disabled,
+                "disabled_by": entity_entry.disabled_by,
+                "entity_category": entity_entry.entity_category,
+                "device_class": entity_entry.device_class,
+                "original_device_class": entity_entry.original_device_class,
+                "icon": entity_entry.icon,
+                "original_icon": entity_entry.original_icon,
+                "unit_of_measurement": entity_entry.unit_of_measurement,
+                "state": state_dict,
+            }
         )
 
-        for entity_entry in hass_entities:
-            state = hass.states.get(entity_entry.entity_id)
-            state_dict = None
-            if state:
-                state_dict = state.as_dict()
-                # The context doesn't provide useful information in this case.
-                state_dict.pop("context", None)
-
-            data["device"]["entities"].append(
-                {
-                    "disabled": entity_entry.disabled,
-                    "disabled_by": entity_entry.disabled_by,
-                    "entity_category": entity_entry.entity_category,
-                    "device_class": entity_entry.device_class,
-                    "original_device_class": entity_entry.original_device_class,
-                    "icon": entity_entry.icon,
-                    "original_icon": entity_entry.original_icon,
-                    "unit_of_measurement": entity_entry.unit_of_measurement,
-                    "state": state_dict,
-                }
-            )
-
-        for device in router.devices.values():
-            data["device"]["tracked_devices"].append(
-                {
-                    "name": device.name or "Unknown device",
-                    "ip_address": device.ip_address,
-                    "last_activity": device.last_activity,
-                }
-            )
+    for device in router.devices.values():
+        data["device"]["tracked_devices"].append(
+            {
+                "name": device.name or "Unknown device",
+                "ip_address": device.ip_address,
+                "last_activity": device.last_activity,
+            }
+        )
 
     return data

--- a/homeassistant/components/asuswrt/diagnostics.py
+++ b/homeassistant/components/asuswrt/diagnostics.py
@@ -52,7 +52,7 @@ async def async_get_config_entry_diagnostics(
         state = hass.states.get(entity_entry.entity_id)
         state_dict = None
         if state:
-            state_dict = state.as_dict()
+            state_dict = dict(state.as_dict())
             # The context doesn't provide useful information in this case.
             state_dict.pop("context", None)
 

--- a/homeassistant/components/asuswrt/diagnostics.py
+++ b/homeassistant/components/asuswrt/diagnostics.py
@@ -38,7 +38,7 @@ async def async_get_config_entry_diagnostics(
         "disabled": hass_device.disabled,
         "disabled_by": hass_device.disabled_by,
         "device_info": async_redact_data(dict(router.device_info), {"identifiers"}),
-        "entities": [],
+        "entities": {},
         "tracked_devices": [],
     }
 
@@ -53,22 +53,24 @@ async def async_get_config_entry_diagnostics(
         state_dict = None
         if state:
             state_dict = dict(state.as_dict())
+            # The entity_id is already provided at root level.
+            state_dict.pop("entity_id", None)
             # The context doesn't provide useful information in this case.
             state_dict.pop("context", None)
 
-        data["device"]["entities"].append(
-            {
-                "disabled": entity_entry.disabled,
-                "disabled_by": entity_entry.disabled_by,
-                "entity_category": entity_entry.entity_category,
-                "device_class": entity_entry.device_class,
-                "original_device_class": entity_entry.original_device_class,
-                "icon": entity_entry.icon,
-                "original_icon": entity_entry.original_icon,
-                "unit_of_measurement": entity_entry.unit_of_measurement,
-                "state": state_dict,
-            }
-        )
+        data["device"]["entities"][entity_entry.entity_id] = {
+            "name": entity_entry.name,
+            "original_name": entity_entry.original_name,
+            "disabled": entity_entry.disabled,
+            "disabled_by": entity_entry.disabled_by,
+            "entity_category": entity_entry.entity_category,
+            "device_class": entity_entry.device_class,
+            "original_device_class": entity_entry.original_device_class,
+            "icon": entity_entry.icon,
+            "original_icon": entity_entry.original_icon,
+            "unit_of_measurement": entity_entry.unit_of_measurement,
+            "state": state_dict,
+        }
 
     for device in router.devices.values():
         data["device"]["tracked_devices"].append(

--- a/homeassistant/components/asuswrt/diagnostics.py
+++ b/homeassistant/components/asuswrt/diagnostics.py
@@ -1,0 +1,78 @@
+"""Diagnostics support for Asuswrt."""
+from __future__ import annotations
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .const import DATA_ASUSWRT, DOMAIN
+from .router import AsusWrtRouter
+
+TO_REDACT = {CONF_PASSWORD, CONF_USERNAME}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    data = {"entry": async_redact_data(entry.as_dict(), TO_REDACT)}
+
+    router: AsusWrtRouter = hass.data[DOMAIN][entry.entry_id][DATA_ASUSWRT]
+
+    # Gather information how this AsusWrt device is represented in Home Assistant
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+    hass_device = device_registry.async_get_device(
+        identifiers=router.device_info["identifiers"]
+    )
+    if hass_device:
+        data["device"] = {
+            "name": hass_device.name,
+            "name_by_user": hass_device.name_by_user,
+            "disabled": hass_device.disabled,
+            "disabled_by": hass_device.disabled_by,
+            "device_info": async_redact_data(dict(router.device_info), {"identifiers"}),
+            "entities": [],
+            "tracked_devices": [],
+        }
+
+        hass_entities = er.async_entries_for_device(
+            entity_registry,
+            device_id=hass_device.id,
+            include_disabled_entities=True,
+        )
+
+        for entity_entry in hass_entities:
+            state = hass.states.get(entity_entry.entity_id)
+            state_dict = None
+            if state:
+                state_dict = state.as_dict()
+                # The context doesn't provide useful information in this case.
+                state_dict.pop("context", None)
+
+            data["device"]["entities"].append(
+                {
+                    "disabled": entity_entry.disabled,
+                    "disabled_by": entity_entry.disabled_by,
+                    "entity_category": entity_entry.entity_category,
+                    "device_class": entity_entry.device_class,
+                    "original_device_class": entity_entry.original_device_class,
+                    "icon": entity_entry.icon,
+                    "original_icon": entity_entry.original_icon,
+                    "unit_of_measurement": entity_entry.unit_of_measurement,
+                    "state": state_dict,
+                }
+            )
+
+        for device in router.devices.values():
+            data["device"]["tracked_devices"].append(
+                {
+                    "name": device.name or "Unknown device",
+                    "ip_address": device.ip_address,
+                    "last_activity": device.last_activity,
+                }
+            )
+
+    return data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to the AsusWrt integration.

Example dump:

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2022.3.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.7",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Rome",
    "os_name": "Linux",
    "os_version": "5.13.0-28-generic",
    "run_as_root": true
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "asuswrt",
    "name": "ASUSWRT",
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/asuswrt",
    "requirements": [
      "aioasuswrt==1.4.0"
    ],
    "codeowners": [
      "@kennedyshead",
      "@ollo69"
    ],
    "iot_class": "local_polling",
    "loggers": [
      "aioasuswrt",
      "asyncssh"
    ],
    "is_built_in": true
  },
  "data": {
    "entry": {
      "entry_id": "66ef2585e3dfc980dc09d77d6900ef37",
      "version": 1,
      "domain": "asuswrt",
      "title": "192.168.10.1",
      "data": {
        "host": "192.168.10.1",
        "username": "**REDACTED**",
        "protocol": "ssh",
        "port": 22,
        "mode": "router",
        "password": "**REDACTED**"
      },
      "options": {},
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": null,
      "disabled_by": null
    },
    "device": {
      "name": "192.168.10.1",
      "name_by_user": null,
      "disabled": false,
      "disabled_by": null,
      "device_info": {
        "identifiers": "**REDACTED**",
        "name": "192.168.10.1",
        "model": "RT-AX86U_EPA",
        "manufacturer": "Asus",
        "sw_version": "3.0.0.4 (build 386.4)",
        "configuration_url": "http://192.168.10.1"
      },
      "entities": [
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:upload",
          "unit_of_measurement": "GB",
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:cpu-32-bit",
          "unit_of_measurement": null,
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:cpu-32-bit",
          "unit_of_measurement": null,
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:upload-network",
          "unit_of_measurement": "Mbit/s",
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "temperature",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "\u00b0C",
          "state": null
        },
        {
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:router-network",
          "unit_of_measurement": "Devices",
          "state": {
            "entity_id": "sensor.asuswrt_devices_connected",
            "state": "37",
            "attributes": {
              "state_class": "measurement",
              "hostname": "192.168.10.1",
              "unit_of_measurement": "Devices",
              "icon": "mdi:router-network",
              "friendly_name": "Asuswrt Devices Connected"
            },
            "last_changed": "2022-02-04T00:04:34.861208+00:00",
            "last_updated": "2022-02-04T00:04:34.861208+00:00"
          }
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:cpu-32-bit",
          "unit_of_measurement": null,
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:download",
          "unit_of_measurement": "GB",
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:download-network",
          "unit_of_measurement": "Mbit/s",
          "state": null
        },
        {
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "temperature",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "\u00b0C",
          "state": null
        }
      ],
      "tracked_devices": [
        {
          "name": "Frigorifero-LG",
          "ip_address": "192.168.10.28",
          "last_activity": "2022-02-04T00:04:34.484797+00:00"
        },
        {
          "name": "MTClima-Letto",
          "ip_address": "192.168.10.26",
          "last_activity": "2022-02-04T00:04:34.484805+00:00"
        },
        {
          "name": "Ingresso",
          "ip_address": "192.168.10.191",
          "last_activity": "2022-02-04T00:04:34.484807+00:00"
        }
      ]
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
