### PR TITLE
2022.2.1 part 2

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -227,7 +227,7 @@ def _async_subscribe_pico_remote_events(
             action = ACTION_RELEASE
 
         type_ = device["type"]
-        name = device["name"]
+        area, name = device["name"].split("_", 1)
         button_number = device["button_number"]
         # The original implementation used LIP instead of LEAP
         # so we need to convert the button number to maintain compat
@@ -252,7 +252,7 @@ def _async_subscribe_pico_remote_events(
                 ATTR_BUTTON_NUMBER: lip_button_number,
                 ATTR_LEAP_BUTTON_NUMBER: button_number,
                 ATTR_DEVICE_NAME: name,
-                ATTR_AREA_NAME: name.split("_")[0],
+                ATTR_AREA_NAME: area,
                 ATTR_ACTION: action,
             },
         )

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -264,7 +264,8 @@ def get_model_name(info: dict[str, Any]) -> str:
 
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     """Get name based on device and channel name."""
-    key = key.replace("input", "switch")
+    if device.config.get("switch:0"):
+        key = key.replace("input", "switch")
     device_name = get_rpc_device_name(device)
     entity_name: str | None = device.config[key].get("name", device_name)
 


### PR DESCRIPTION
- Fix lutron_caseta button events including area name in device name ([@bdraco] - [#65601]) ([lutron_caseta docs])
- Fix Shelly Plus i4 KeyError ([@thecode] - [#65604]) ([shelly docs])

[#65601]: https://github.com/home-assistant/core/pull/65601
[#65604]: https://github.com/home-assistant/core/pull/65604
[@bdraco]: https://github.com/bdraco
[@thecode]: https://github.com/thecode
[lutron_caseta docs]: https://www.home-assistant.io/integrations/lutron_caseta/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/