### PR TITLE
Raise when zwave_js device automation fails validation

### DIFF
--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -99,7 +99,16 @@ async def async_validate_condition_config(
 
     # We return early if the config entry for this device is not ready because we can't
     # validate the value without knowing the state of the device
-    if async_is_device_config_entry_not_loaded(hass, config[CONF_DEVICE_ID]):
+    try:
+        device_config_entry_not_loaded = async_is_device_config_entry_not_loaded(
+            hass, config[CONF_DEVICE_ID]
+        )
+    except ValueError as err:
+        raise InvalidDeviceAutomationConfig(
+            f"Device {config[CONF_DEVICE_ID]} not found"
+        ) from err
+
+    if device_config_entry_not_loaded:
         return config
 
     if config[CONF_TYPE] == VALUE_TYPE:

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -217,7 +217,16 @@ async def async_validate_trigger_config(
 
     # We return early if the config entry for this device is not ready because we can't
     # validate the value without knowing the state of the device
-    if async_is_device_config_entry_not_loaded(hass, config[CONF_DEVICE_ID]):
+    try:
+        device_config_entry_not_loaded = async_is_device_config_entry_not_loaded(
+            hass, config[CONF_DEVICE_ID]
+        )
+    except ValueError as err:
+        raise InvalidDeviceAutomationConfig(
+            f"Device {config[CONF_DEVICE_ID]} not found"
+        ) from err
+
+    if device_config_entry_not_loaded:
         return config
 
     trigger_type = config[CONF_TYPE]

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -298,7 +298,8 @@ def async_is_device_config_entry_not_loaded(
     """Return whether device's config entries are not loaded."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get(device_id)
-    assert device
+    if device is None:
+        raise ValueError(f"Device {device_id} not found")
     return any(
         (entry := hass.config_entries.async_get_entry(entry_id))
         and entry.state != ConfigEntryState.LOADED

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -596,6 +596,7 @@ async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
         == INVALID_CONFIG
     )
 
+    # Test invalid device ID fails validation
     with pytest.raises(InvalidDeviceAutomationConfig):
         await device_condition.async_validate_condition_config(
             hass,

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -596,6 +596,22 @@ async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
         == INVALID_CONFIG
     )
 
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_condition.async_validate_condition_config(
+            hass,
+            {
+                "condition": "device",
+                "domain": DOMAIN,
+                "type": "value",
+                "device_id": "invalid_device_id",
+                "command_class": CommandClass.DOOR_LOCK.value,
+                "property": 9999,
+                "property_key": 9999,
+                "endpoint": 9999,
+                "value": 9999,
+            },
+        )
+
 
 async def test_get_value_from_config_failure(
     hass, client, hank_binary_switch, integration

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -1370,3 +1370,19 @@ async def test_failure_scenarios(hass, client, hank_binary_switch, integration):
         await device_trigger.async_validate_trigger_config(hass, INVALID_CONFIG)
         == INVALID_CONFIG
     )
+
+    # Test invalid device ID fails validation
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_validate_trigger_config(
+            hass,
+            {
+                "platform": "device",
+                "domain": DOMAIN,
+                "device_id": "invalid_device_id",
+                "type": "zwave_js.value_updated.value",
+                "command_class": CommandClass.DOOR_LOCK.value,
+                "property": 9999,
+                "property_key": 9999,
+                "endpoint": 9999,
+            },
+        )


### PR DESCRIPTION
## Proposed change
Fixes https://github.com/home-assistant/core/issues/65488


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/65488
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
