### PR TITLE
Fix Z-Wave lights

### DIFF
--- a/homeassistant/components/zwave/light.py
+++ b/homeassistant/components/zwave/light.py
@@ -123,7 +123,7 @@ class ZwaveDimmer(ZWaveDeviceEntity, LightEntity):
         self._state = None
         self._color_mode = None
         self._supported_color_modes = set()
-        self._supported_features = None
+        self._supported_features = 0
         self._delay = delay
         self._refresh_value = refresh
         self._zw098 = None

--- a/tests/components/zwave/test_light.py
+++ b/tests/components/zwave/test_light.py
@@ -39,7 +39,7 @@ def test_get_device_detects_dimmer(mock_openzwave):
     device = light.get_device(node=node, values=values, node_config={})
     assert isinstance(device, light.ZwaveDimmer)
     assert device.color_mode == COLOR_MODE_BRIGHTNESS
-    assert device.supported_features is None
+    assert device.supported_features == 0
     assert device.supported_color_modes == {COLOR_MODE_BRIGHTNESS}
 
 
@@ -52,7 +52,7 @@ def test_get_device_detects_colorlight(mock_openzwave):
     device = light.get_device(node=node, values=values, node_config={})
     assert isinstance(device, light.ZwaveColorLight)
     assert device.color_mode == COLOR_MODE_RGB
-    assert device.supported_features is None
+    assert device.supported_features == 0
     assert device.supported_color_modes == {COLOR_MODE_RGB}
 
 
@@ -68,7 +68,7 @@ def test_get_device_detects_zw098(mock_openzwave):
     device = light.get_device(node=node, values=values, node_config={})
     assert isinstance(device, light.ZwaveColorLight)
     assert device.color_mode == COLOR_MODE_RGB
-    assert device.supported_features is None
+    assert device.supported_features == 0
     assert device.supported_color_modes == {COLOR_MODE_COLOR_TEMP, COLOR_MODE_RGB}
 
 
@@ -84,7 +84,7 @@ def test_get_device_detects_rgbw_light(mock_openzwave):
     device.value_added()
     assert isinstance(device, light.ZwaveColorLight)
     assert device.color_mode == COLOR_MODE_RGBW
-    assert device.supported_features is None
+    assert device.supported_features == 0
     assert device.supported_color_modes == {COLOR_MODE_RGBW}
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With 2022.2 Z-Wave lights (using the deprecated integration) are failing with the below errors:
```
2022-02-04 00:09:13 ERROR (MainThread) [homeassistant.components.light] Error adding entities for domain light with platform zwave
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 514, in _async_add_entity
    capabilities=entity.capability_attributes,
  File "/usr/src/homeassistant/homeassistant/components/light/__init__.py", line 834, in capability_attributes
    if supported_features & SUPPORT_EFFECT:
TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'
2022-02-04 00:09:13 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 514, in _async_add_entity
    capabilities=entity.capability_attributes,
  File "/usr/src/homeassistant/homeassistant/components/light/__init__.py", line 834, in capability_attributes
    if supported_features & SUPPORT_EFFECT:
TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'
```
It's unclear why it's started failing all of a sudden (some Python setting changed to not ignore the error like previously?) but this change fixes it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
