### PR TITLE
Netgear add reboot button, allow/block device and traffic sensors

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -53,12 +53,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         name=router.device_name,
         model=router.model,
         sw_version=router.firmware_version,
+        hw_version=router.hardware_version,
         configuration_url=f"http://{entry.data[CONF_HOST]}/",
     )
 
     async def async_update_data() -> bool:
         """Fetch data from the router."""
         data = await router.async_update_device_trackers()
+        await router.async_get_traffic_meter()
         return data
 
     # Create update coordinator

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -1,0 +1,64 @@
+"""Support for Netgear Button."""
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
+from .router import NetgearRouter, NetgearRouterEntity
+
+BUTTONS = [
+    ButtonEntityDescription(
+        key="reboot",
+        name="Reboot",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+    )
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up button for Netgear component."""
+    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
+    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    entities = []
+
+    for entity_description in BUTTONS:
+        entities.append(
+            NetgearRebootButtonEntity(coordinator, router, entity_description)
+        )
+
+    async_add_entities(entities)
+
+
+class NetgearRebootButtonEntity(NetgearRouterEntity, ButtonEntity):
+    """Netgear reboot button."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        router: NetgearRouter,
+        entity_description: ButtonEntityDescription,
+    ) -> None:
+        """Initialize a Netgear device."""
+        super().__init__(coordinator, router)
+        self.entity_description = entity_description
+        self._name = f"{router.device_name} {self.entity_description.name}"
+        self._unique_id = f"{router.serial_number}-{self.entity_description.key}"
+
+    async def async_press(self) -> None:
+        """Triggers the button press service."""
+        await self.hass.async_add_executor_job(self._router.api.reboot)
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the Netgear device."""

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -5,12 +5,12 @@ from homeassistant.const import Platform
 
 DOMAIN = "netgear"
 
+PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH, Platform.BUTTON]
+
 CONF_CONSIDER_HOME = "consider_home"
 
 KEY_ROUTER = "router"
 KEY_COORDINATOR = "coordinator"
-
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -12,11 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
-from .router import (
-    NetgearDeviceEntity,
-    NetgearRouter,
-    NetgearRouterEntity,
-)
+from .router import NetgearDeviceEntity, NetgearRouter, NetgearRouterEntity
 
 SENSOR_TYPES = {
     "type": SensorEntityDescription(
@@ -133,12 +129,14 @@ async def async_setup_entry(
     """Set up device tracker for Netgear component."""
     router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
     coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
-    
+
     # Router entities
     router_entities = []
 
     for attribute in SENSOR_TRAFFIC_TYPES:
-        router_entities.append(NetgearRouterTrafficEntity(coordinator, router, attribute))
+        router_entities.append(
+            NetgearRouterTrafficEntity(coordinator, router, attribute)
+        )
 
     async_add_entities(router_entities)
 

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -5,26 +5,32 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import DATA_MEGABYTES, PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
-from .router import NetgearDeviceEntity, NetgearRouter
+from .router import (
+    NetgearDeviceEntity,
+    NetgearRouter,
+    NetgearRouterEntity,
+)
 
 SENSOR_TYPES = {
     "type": SensorEntityDescription(
         key="type",
         name="link type",
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:lan",
     ),
     "link_rate": SensorEntityDescription(
         key="link_rate",
         name="link rate",
         native_unit_of_measurement="Mbps",
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:speedometer",
     ),
     "signal": SensorEntityDescription(
         key="signal",
@@ -37,11 +43,86 @@ SENSOR_TYPES = {
         key="ssid",
         name="ssid",
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:wifi-marker",
     ),
     "conn_ap_mac": SensorEntityDescription(
         key="conn_ap_mac",
         name="access point mac",
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:router-network",
+    ),
+}
+
+SENSOR_TRAFFIC_TYPES = {
+    "NewTodayUpload": SensorEntityDescription(
+        key="NewTodayUpload",
+        name="Upload today",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:upload",
+    ),
+    "NewTodayDownload": SensorEntityDescription(
+        key="NewTodayDownload",
+        name="Download today",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:download",
+    ),
+    "NewYesterdayUpload": SensorEntityDescription(
+        key="NewYesterdayUpload",
+        name="Upload yesterday",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:upload",
+    ),
+    "NewYesterdayDownload": SensorEntityDescription(
+        key="NewYesterdayDownload",
+        name="Download yesterday",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:download",
+    ),
+    "NewWeekUpload": SensorEntityDescription(
+        key="NewWeekUpload",
+        name="Upload week",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:upload",
+    ),
+    "NewWeekDownload": SensorEntityDescription(
+        key="NewWeekDownload",
+        name="Download week",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:download",
+    ),
+    "NewMonthUpload": SensorEntityDescription(
+        key="NewMonthUpload",
+        name="Upload month",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:upload",
+    ),
+    "NewMonthDownload": SensorEntityDescription(
+        key="NewMonthDownload",
+        name="Download month",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:download",
+    ),
+    "NewLastMonthUpload": SensorEntityDescription(
+        key="NewLastMonthUpload",
+        name="Upload last month",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:upload",
+    ),
+    "NewLastMonthDownload": SensorEntityDescription(
+        key="NewLastMonthDownload",
+        name="Download last month",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=DATA_MEGABYTES,
+        icon="mdi:download",
     ),
 }
 
@@ -52,8 +133,17 @@ async def async_setup_entry(
     """Set up device tracker for Netgear component."""
     router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
     coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
-    tracked = set()
+    
+    # Router entities
+    router_entities = []
 
+    for attribute in SENSOR_TRAFFIC_TYPES:
+        router_entities.append(NetgearRouterTrafficEntity(coordinator, router, attribute))
+
+    async_add_entities(router_entities)
+
+    # Entities per network device
+    tracked = set()
     sensors = ["type", "link_rate", "signal"]
     if router.method_version == 2:
         sensors.extend(["ssid", "conn_ap_mac"])
@@ -119,3 +209,60 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
         self._active = self._device["active"]
         if self._device.get(self._attribute) is not None:
             self._state = self._device[self._attribute]
+
+
+class NetgearRouterTrafficEntity(NetgearRouterEntity, SensorEntity):
+    """Representation of a device connected to a Netgear router."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        router: NetgearRouter,
+        attribute: str,
+    ) -> None:
+        """Initialize a Netgear device."""
+        super().__init__(coordinator, router)
+        self._attribute = attribute
+        self.entity_description = SENSOR_TRAFFIC_TYPES[self._attribute]
+        self._name = f"{router.device_name} {self.entity_description.name}"
+        self._unique_id = f"{router.serial_number}-{self._attribute}"
+        self._traffic = None
+        self._traffic_avg = None
+        self._traffic_avg_attr = f"{self.entity_description.name} average"
+        self.async_update_device()
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self._traffic
+
+    @property
+    def extra_state_attributes(self):
+        """Return device specific state attributes."""
+        extra_attr = {}
+        if self._traffic_avg is not None:
+            extra_attr[self._traffic_avg_attr] = self._traffic_avg
+        return extra_attr
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the Netgear device."""
+        if self._router.traffic_data is not None:
+            data = self._router.traffic_data.get(self._attribute)
+            if isinstance(data, float):
+                self._traffic = data
+            elif isinstance(data, tuple):
+                self._traffic = data[0]
+                self._traffic_avg = data[1]
+
+    async def async_added_to_hass(self):
+        """Entity added to hass."""
+        self._router.traffic_meter_entities = self._router.traffic_meter_entities + 1
+        await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self):
+        """Entity removed from hass."""
+        self._router.traffic_meter_entities = self._router.traffic_meter_entities - 1
+        await super().async_will_remove_from_hass()

--- a/homeassistant/components/netgear/switch.py
+++ b/homeassistant/components/netgear/switch.py
@@ -1,0 +1,107 @@
+"""Support for Netgear switches."""
+import logging
+
+from pynetgear import ALLOW, BLOCK
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
+from .router import NetgearDeviceEntity, NetgearRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+SWITCH_TYPES = [
+    SwitchEntityDescription(
+        key="allow_or_block",
+        name="Allowed on network",
+        icon="mdi:block-helper",
+        entity_category=EntityCategory.CONFIG,
+    )
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up switches for Netgear component."""
+    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
+    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    tracked = set()
+
+    @callback
+    def new_device_callback() -> None:
+        """Add new devices if needed."""
+        new_entities = []
+        if not coordinator.data:
+            return
+
+        for mac, device in router.devices.items():
+            if mac in tracked:
+                continue
+
+            new_entities.extend(
+                [
+                    NetgearAllowBlock(coordinator, router, device, entity_description)
+                    for entity_description in SWITCH_TYPES
+                ]
+            )
+            tracked.add(mac)
+
+        if new_entities:
+            async_add_entities(new_entities)
+
+    entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
+
+    coordinator.data = True
+    new_device_callback()
+
+
+class NetgearAllowBlock(NetgearDeviceEntity, SwitchEntity):
+    """Allow or Block a device from the network."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        router: NetgearRouter,
+        device: dict,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize a Netgear device."""
+        super().__init__(coordinator, router, device)
+        self.entity_description = entity_description
+        self._name = f"{self.get_device_name()} {self.entity_description.name}"
+        self._unique_id = f"{self._mac}-{self.entity_description.key}"
+        self._state = True
+        self.async_update_device()
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self.hass.async_add_executor_job(
+            self._router.api.allow_block_device, self._mac, ALLOW
+        )
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self.hass.async_add_executor_job(
+            self._router.api.allow_block_device, self._mac, BLOCK
+        )
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the Netgear device."""
+        self._device = self._router.devices[self._mac]
+        self._active = self._device["active"]
+        self._state = self._device[self.entity_description.key] == "Allow"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new features to the netgear integration:
- Reboot button for the router
- Allow/Block switch for each device connected to the router (Allowed on the network)
- Traffic data sensors for the router

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
