### PR TITLE
Netgear add reboot button

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -730,6 +730,7 @@ omit =
     homeassistant/components/nest/legacy/*
     homeassistant/components/netdata/sensor.py
     homeassistant/components/netgear/__init__.py
+    homeassistant/components/netgear/button.py
     homeassistant/components/netgear/device_tracker.py
     homeassistant/components/netgear/router.py
     homeassistant/components/netgear/sensor.py

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -1,0 +1,65 @@
+"""Support for Netgear Button."""
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
+from .router import NetgearRouter, NetgearRouterEntity
+
+BUTTONS = [
+    ButtonEntityDescription(
+        key="reboot",
+        name="Reboot",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+    )
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up button for Netgear component."""
+    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
+    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    entities = []
+
+    for entity_description in BUTTONS:
+        entities.append(
+            NetgearRebootButtonEntity(coordinator, router, entity_description)
+        )
+
+    async_add_entities(entities)
+
+
+class NetgearRebootButtonEntity(NetgearRouterEntity, ButtonEntity):
+    """Netgear reboot button."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        router: NetgearRouter,
+        entity_description: ButtonEntityDescription,
+    ) -> None:
+        """Initialize a Netgear device."""
+        super().__init__(coordinator, router)
+        self.entity_description = entity_description
+        self._name = f"{router.device_name} {self.entity_description.name}"
+        self._unique_id = f"{router.serial_number}-{self.entity_description.key}"
+
+    async def async_press(self) -> None:
+        """Triggers the button press service."""
+        async with self._router.api_lock:
+            await self.hass.async_add_executor_job(self._router.api.reboot)
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the Netgear device."""

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -2,6 +2,8 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 
+from typing import Any
+
 from homeassistant.components.button import (
     ButtonDeviceClass,
     ButtonEntity,

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
 from .router import NetgearRouter, NetgearRouterEntity
 
+
 @dataclass
 class NetgearButtonEntityDescriptionRequired:
     """Required attributes of NetgearButtonEntityDescription."""

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -1,5 +1,5 @@
 """Support for Netgear Button."""
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 
 from homeassistant.components.button import (

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -17,15 +17,16 @@ from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
 from .router import NetgearRouter, NetgearRouterEntity
 
 @dataclass
-class NetgearButtonEntityDescriptionRequired():
-    """required properties of NetgearButtonEntityDescription."""
+class NetgearButtonEntityDescriptionRequired:
+    """Required attributes of NetgearButtonEntityDescription."""
 
     action: Callable
 
 @dataclass
-class NetgearButtonEntityDescription(NetgearButtonEntityDescriptionRequired, ButtonEntityDescription):
+class NetgearButtonEntityDescription(
+    ButtonEntityDescription, NetgearButtonEntityDescriptionRequired
+):
     """Class describing Netgear button entities."""
-    pass
 
 
 BUTTONS = [

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -22,6 +22,7 @@ class NetgearButtonEntityDescriptionRequired:
 
     action: Callable
 
+
 @dataclass
 class NetgearButtonEntityDescription(
     ButtonEntityDescription, NetgearButtonEntityDescriptionRequired

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -29,7 +29,7 @@ BUTTONS = [
         name="Reboot",
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
-        action=lambda router: router.async_reboot
+        action=lambda router: router.async_reboot,
     )
 ]
 

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -72,8 +72,8 @@ class NetgearRouterButtonEntity(NetgearRouterEntity, ButtonEntity):
         """Initialize a Netgear device."""
         super().__init__(coordinator, router)
         self.entity_description = entity_description
-        self._name = f"{router.device_name} {self.entity_description.name}"
-        self._unique_id = f"{router.serial_number}-{self.entity_description.key}"
+        self._name = f"{router.device_name} {entity_description.name}"
+        self._unique_id = f"{router.serial_number}-{entity_description.key}"
 
     async def async_press(self) -> None:
         """Triggers the button press service."""

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -21,7 +21,7 @@ from .router import NetgearRouter, NetgearRouterEntity
 class NetgearButtonEntityDescriptionRequired:
     """Required attributes of NetgearButtonEntityDescription."""
 
-    action: Callable[[NetgearRouter], None]
+    action: Callable[[NetgearRouter], Callable[[], Coroutine[Any, Any, None]]]
 
 
 @dataclass

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -57,8 +57,7 @@ class NetgearRebootButtonEntity(NetgearRouterEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Triggers the button press service."""
-        async with self._router.api_lock:
-            await self.hass.async_add_executor_job(self._router.api.reboot)
+        await self._router.async_reboot()
 
     @callback
     def async_update_device(self) -> None:

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -1,7 +1,6 @@
 """Support for Netgear Button."""
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-
 from typing import Any
 
 from homeassistant.components.button import (

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -48,14 +48,10 @@ async def async_setup_entry(
     """Set up button for Netgear component."""
     router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
     coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
-    entities = []
-
-    for entity_description in BUTTONS:
-        entities.append(
-            NetgearRouterButtonEntity(coordinator, router, entity_description)
-        )
-
-    async_add_entities(entities)
+    async_add_entities(
+        NetgearRouterButtonEntity(coordinator, router, entity_description)
+        for entity_description in BUTTONS
+    )
 
 
 class NetgearRouterButtonEntity(NetgearRouterEntity, ButtonEntity):

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
 from .router import NetgearRouter, NetgearRouterEntity
 
+
 @dataclass
 class NetgearButtonEntityDescription(ButtonEntityDescription):
     """Class describing Netgear button entities."""

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -54,11 +54,13 @@ async def async_setup_entry(
 class NetgearRouterButtonEntity(NetgearRouterEntity, ButtonEntity):
     """Netgear Router button entity."""
 
+    entity_description: NetgearButtonEntityDescription
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
         router: NetgearRouter,
-        entity_description: ButtonEntityDescription,
+        entity_description: NetgearButtonEntityDescription,
     ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator, router)

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -16,12 +16,16 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
 from .router import NetgearRouter, NetgearRouterEntity
 
-
 @dataclass
-class NetgearButtonEntityDescription(ButtonEntityDescription):
-    """Class describing Netgear button entities."""
+class NetgearButtonEntityDescriptionRequired():
+    """required properties of NetgearButtonEntityDescription."""
 
     action: Callable
+
+@dataclass
+class NetgearButtonEntityDescription(NetgearButtonEntityDescriptionRequired, ButtonEntityDescription):
+    """Class describing Netgear button entities."""
+    pass
 
 
 BUTTONS = [

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -21,7 +21,7 @@ from .router import NetgearRouter, NetgearRouterEntity
 class NetgearButtonEntityDescription(ButtonEntityDescription):
     """Class describing Netgear button entities."""
 
-    action: Callable = lambda router: router
+    action: Callable
 
 
 BUTTONS = [

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -21,7 +21,7 @@ from .router import NetgearRouter, NetgearRouterEntity
 class NetgearButtonEntityDescriptionRequired:
     """Required attributes of NetgearButtonEntityDescription."""
 
-    action: Callable
+    action: Callable[[NetgearRouter], None]
 
 
 @dataclass

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -29,7 +29,7 @@ BUTTONS = [
         name="Reboot",
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
-        action: Callable = lambda router: router.async_reboot
+        action=lambda router: router.async_reboot
     )
 ]
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "netgear"
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH, Platform.BUTTON]
+PLATFORMS = [Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH]
 
 CONF_CONSIDER_HOME = "consider_home"
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "netgear"
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH], Platform.BUTTON
+PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH, Platform.BUTTON]
 
 CONF_CONSIDER_HOME = "consider_home"
 

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "netgear"
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH], Platform.BUTTON
 
 CONF_CONSIDER_HOME = "consider_home"
 

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -82,14 +82,14 @@ class NetgearRouter:
         )
         self._consider_home = timedelta(seconds=consider_home_int)
 
-        self._api: Netgear = None
-        self._api_lock = asyncio.Lock()
+        self.api: Netgear = None
+        self.api_lock = asyncio.Lock()
 
         self.devices = {}
 
     def _setup(self) -> None:
         """Set up a Netgear router sync portion."""
-        self._api = get_api(
+        self.api = get_api(
             self._password,
             self._host,
             self._username,
@@ -97,7 +97,7 @@ class NetgearRouter:
             self._ssl,
         )
 
-        self._info = self._api.get_info()
+        self._info = self.api.get_info()
         if self._info is None:
             return False
 
@@ -112,7 +112,7 @@ class NetgearRouter:
                 self.method_version = 2
 
         if self.method_version == 2:
-            if not self._api.get_attached_devices_2():
+            if not self.api.get_attached_devices_2():
                 _LOGGER.error(
                     "Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2",
                     self.model,
@@ -155,14 +155,14 @@ class NetgearRouter:
     async def async_get_attached_devices(self) -> list:
         """Get the devices connected to the router."""
         if self.method_version == 1:
-            async with self._api_lock:
+            async with self.api_lock:
                 return await self.hass.async_add_executor_job(
-                    self._api.get_attached_devices
+                    self.api.get_attached_devices
                 )
 
-        async with self._api_lock:
+        async with self.api_lock:
             return await self.hass.async_add_executor_job(
-                self._api.get_attached_devices_2
+                self.api.get_attached_devices_2
             )
 
     async def async_update_device_trackers(self, now=None) -> None:
@@ -198,8 +198,8 @@ class NetgearRouter:
 
     async def async_get_traffic_meter(self) -> None:
         """Get the traffic meter data of the router."""
-        async with self._api_lock:
-            return await self.hass.async_add_executor_job(self._api.get_traffic_meter)
+        async with self.api_lock:
+            return await self.hass.async_add_executor_job(self.api.get_traffic_meter)
 
     async def async_allow_block_device(self, mac: str, allow_block: str) -> None:
         """Allow or block a device connected to the router."""
@@ -211,12 +211,12 @@ class NetgearRouter:
     @property
     def port(self) -> int:
         """Port used by the API."""
-        return self._api.port
+        return self.api.port
 
     @property
     def ssl(self) -> bool:
         """SSL used by the API."""
-        return self._api.ssl
+        return self.api.ssl
 
 
 class NetgearBaseEntity(CoordinatorEntity):

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -208,6 +208,11 @@ class NetgearRouter:
                 self._api.allow_block_device, mac, allow_block
             )
 
+    async def async_reboot(self) -> None:
+        """Reboot the router."""
+        async with self._api_lock:
+            await self.hass.async_add_executor_job(self._api.reboot)
+
     @property
     def port(self) -> int:
         """Port used by the API."""

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -82,14 +82,14 @@ class NetgearRouter:
         )
         self._consider_home = timedelta(seconds=consider_home_int)
 
-        self.api: Netgear = None
-        self.api_lock = asyncio.Lock()
+        self._api: Netgear = None
+        self._api_lock = asyncio.Lock()
 
         self.devices = {}
 
     def _setup(self) -> None:
         """Set up a Netgear router sync portion."""
-        self.api = get_api(
+        self._api = get_api(
             self._password,
             self._host,
             self._username,
@@ -97,7 +97,7 @@ class NetgearRouter:
             self._ssl,
         )
 
-        self._info = self.api.get_info()
+        self._info = self._api.get_info()
         if self._info is None:
             return False
 
@@ -112,7 +112,7 @@ class NetgearRouter:
                 self.method_version = 2
 
         if self.method_version == 2:
-            if not self.api.get_attached_devices_2():
+            if not self._api.get_attached_devices_2():
                 _LOGGER.error(
                     "Netgear Model '%s' in MODELS_V2 list, but failed to get attached devices using V2",
                     self.model,
@@ -155,14 +155,14 @@ class NetgearRouter:
     async def async_get_attached_devices(self) -> list:
         """Get the devices connected to the router."""
         if self.method_version == 1:
-            async with self.api_lock:
+            async with self._api_lock:
                 return await self.hass.async_add_executor_job(
-                    self.api.get_attached_devices
+                    self._api.get_attached_devices
                 )
 
-        async with self.api_lock:
+        async with self._api_lock:
             return await self.hass.async_add_executor_job(
-                self.api.get_attached_devices_2
+                self._api.get_attached_devices_2
             )
 
     async def async_update_device_trackers(self, now=None) -> None:
@@ -198,8 +198,8 @@ class NetgearRouter:
 
     async def async_get_traffic_meter(self) -> None:
         """Get the traffic meter data of the router."""
-        async with self.api_lock:
-            return await self.hass.async_add_executor_job(self.api.get_traffic_meter)
+        async with self._api_lock:
+            return await self.hass.async_add_executor_job(self._api.get_traffic_meter)
 
     async def async_allow_block_device(self, mac: str, allow_block: str) -> None:
         """Allow or block a device connected to the router."""
@@ -211,12 +211,12 @@ class NetgearRouter:
     @property
     def port(self) -> int:
         """Port used by the API."""
-        return self.api.port
+        return self._api.port
 
     @property
     def ssl(self) -> bool:
         """SSL used by the API."""
-        return self.api.ssl
+        return self._api.ssl
 
 
 class NetgearBaseEntity(CoordinatorEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add button entity to Netgear to reboot the router

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21528

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
