### PR TITLE
Restore states for RFLink binary_sensors

### DIFF
--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -13,11 +13,13 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_FORCE_UPDATE,
     CONF_NAME,
+    STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.helpers.event as evt
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import CONF_ALIASES, RflinkDevice
@@ -67,7 +69,7 @@ async def async_setup_platform(
     async_add_entities(devices_from_config(config))
 
 
-class RflinkBinarySensor(RflinkDevice, BinarySensorEntity):
+class RflinkBinarySensor(RflinkDevice, BinarySensorEntity, RestoreEntity):
     """Representation of an Rflink binary sensor."""
 
     def __init__(
@@ -80,6 +82,12 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorEntity):
         self._off_delay = off_delay
         self._delay_listener = None
         super().__init__(device_id, **kwargs)
+
+    async def async_added_to_hass(self):
+        """Restore RFLink BinarySensor state."""
+        await super().async_added_to_hass()
+        if (old_state := await self.async_get_last_state()) is not None:
+            self._state = old_state.state == STATE_ON
 
     def _handle_event(self, event):
         """Domain specific event handler."""

--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -87,7 +87,10 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorEntity, RestoreEntity):
         """Restore RFLink BinarySensor state."""
         await super().async_added_to_hass()
         if (old_state := await self.async_get_last_state()) is not None:
-            self._state = old_state.state == STATE_ON
+            if self._off_delay is None:
+                self._state = old_state.state == STATE_ON
+            else:
+                self._state = False
 
     def _handle_event(self, event):
         """Domain specific event handler."""

--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -15,10 +15,10 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-import homeassistant.core as ha
+from homeassistant.core import CoreState, State, callback
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_time_changed, mock_restore_cache
 from tests.components.rflink.test_init import mock_rflink
 
 DOMAIN = "binary_sensor"
@@ -91,12 +91,18 @@ async def test_entity_availability(hass, monkeypatch):
     config[CONF_RECONNECT_INTERVAL] = 60
 
     # Create platform and entities
-    _, _, _, disconnect_callback = await mock_rflink(
+    event_callback, _, _, disconnect_callback = await mock_rflink(
         hass, config, DOMAIN, monkeypatch, failures=failures
     )
 
-    # Entities are available by default
+    # Entities are unknown by default
     assert hass.states.get("binary_sensor.test").state == STATE_UNKNOWN
+
+    # test binary_sensor status change
+    event_callback({"id": "test", "command": "on"})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.test").state == STATE_ON
 
     # Mock a disconnect of the Rflink device
     disconnect_callback()
@@ -113,8 +119,8 @@ async def test_entity_availability(hass, monkeypatch):
     # Wait for dispatch events to propagate
     await hass.async_block_till_done()
 
-    # Entities should be available again
-    assert hass.states.get("binary_sensor.test").state == STATE_UNKNOWN
+    # Entities should restore its status
+    assert hass.states.get("binary_sensor.test").state == STATE_ON
 
 
 async def test_off_delay(hass, legacy_patchable_time, monkeypatch):
@@ -129,12 +135,12 @@ async def test_off_delay(hass, legacy_patchable_time, monkeypatch):
 
     on_event = {"id": "test2", "command": "on"}
 
-    @ha.callback
-    def callback(event):
+    @callback
+    def listener(event):
         """Verify event got called."""
         events.append(event)
 
-    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, listener)
 
     now = dt_util.utcnow()
     # fake time and turn on sensor
@@ -178,3 +184,23 @@ async def test_off_delay(hass, legacy_patchable_time, monkeypatch):
     state = hass.states.get("binary_sensor.test2")
     assert state.state == STATE_OFF
     assert len(events) == 3
+
+
+async def test_restore_state(hass, monkeypatch):
+    """Ensure states are restored on startup."""
+    mock_restore_cache(
+        hass, (State(f"{DOMAIN}.test", STATE_ON), State(f"{DOMAIN}.test2", STATE_OFF))
+    )
+
+    hass.state = CoreState.starting
+
+    # setup mocking rflink module
+    _, _, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
+
+    state = hass.states.get(f"{DOMAIN}.test")
+    assert state
+    assert state.state == STATE_ON
+
+    state = hass.states.get(f"{DOMAIN}.test2")
+    assert state
+    assert state.state == STATE_OFF

--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -189,7 +189,7 @@ async def test_off_delay(hass, legacy_patchable_time, monkeypatch):
 async def test_restore_state(hass, monkeypatch):
     """Ensure states are restored on startup."""
     mock_restore_cache(
-        hass, (State(f"{DOMAIN}.test", STATE_ON), State(f"{DOMAIN}.test2", STATE_OFF))
+        hass, (State(f"{DOMAIN}.test", STATE_ON), State(f"{DOMAIN}.test2", STATE_ON))
     )
 
     hass.state = CoreState.starting
@@ -201,6 +201,7 @@ async def test_restore_state(hass, monkeypatch):
     assert state
     assert state.state == STATE_ON
 
+    # off_delay config must restore to off
     state = hass.states.get(f"{DOMAIN}.test2")
     assert state
     assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since HA 2022.02 `binary_sensor` entities have a new `unknown` state.
This has been identified as a breaking change.

Some RFLink users have reported that this new state breaks their automations after restarting HA.
A possible solution to this problem is for the RFLink binary sensors to restore their previous state (as other RFLink entities already do).

I am aware of the requirement to refactor the RFLink integration, but since it is a breaking change, I hope that the PR could be accepted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65559
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
