### PR TITLE
Remove deprecated format for date(time) sensors

### DIFF
--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -165,71 +165,28 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
 
 
 @pytest.mark.parametrize(
-    "device_class,native_value,state_value",
+    "device_class,state_value,provides",
     [
-        (SensorDeviceClass.DATE, "2021-11-09", "2021-11-09"),
-        (
-            SensorDeviceClass.DATE,
-            "2021-01-09T12:00:00+00:00",
-            "2021-01-09",
-        ),
-        (
-            SensorDeviceClass.DATE,
-            "2021-01-09T00:00:00+01:00",
-            "2021-01-08",
-        ),
-        (
-            SensorDeviceClass.TIMESTAMP,
-            "2021-01-09T12:00:00+00:00",
-            "2021-01-09T12:00:00+00:00",
-        ),
-        (
-            SensorDeviceClass.TIMESTAMP,
-            "2021-01-09 12:00:00+00:00",
-            "2021-01-09T12:00:00+00:00",
-        ),
-        (
-            SensorDeviceClass.TIMESTAMP,
-            "2021-01-09T12:00:00+04:00",
-            "2021-01-09T08:00:00+00:00",
-        ),
-        (
-            SensorDeviceClass.TIMESTAMP,
-            "2021-01-09 12:00:00+01:00",
-            "2021-01-09T11:00:00+00:00",
-        ),
-        (
-            SensorDeviceClass.TIMESTAMP,
-            "2021-01-09 12:00:00",
-            "2021-01-09T12:00:00",
-        ),
-        (
-            SensorDeviceClass.TIMESTAMP,
-            "2021-01-09T12:00:00",
-            "2021-01-09T12:00:00",
-        ),
+        (SensorDeviceClass.DATE, "2021-01-09", "date"),
+        (SensorDeviceClass.TIMESTAMP, "2021-01-09T12:00:00+00:00", "datetime"),
     ],
 )
 async def test_deprecated_datetime_str(
-    hass, caplog, enable_custom_integrations, device_class, native_value, state_value
+    hass, caplog, enable_custom_integrations, device_class, state_value, provides
 ):
     """Test warning on deprecated str for a date(time) value."""
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
     platform.ENTITIES["0"] = platform.MockSensor(
-        name="Test", native_value=native_value, device_class=device_class
+        name="Test", native_value=state_value, device_class=device_class
     )
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
-    state = hass.states.get(entity0.entity_id)
-    assert state.state == state_value
     assert (
-        "is providing a string for its state, while the device class is "
-        f"'{device_class}', this is not valid and will be unsupported "
-        "from Home Assistant 2022.2."
+        f"Invalid {provides}: sensor.test has a {device_class} device class "
+        f"but does not provide a {provides} state but {type(state_value)}"
     ) in caplog.text
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

When using datetime and date device classes in sensors, the returned native value must (respectively) be a datetime or date Python object.

Returning an iso formatted date(time) string in these cases was previously deprecated and the fallback/backward compatibility has been removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Cleans up backwards compatible layer introduced in #52671

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
