### PR TITLE
Improve androidtv mac address handling and test coverage

### DIFF
--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import ConfigType
@@ -33,14 +34,30 @@ from .const import (
     DEVICE_ANDROIDTV,
     DEVICE_FIRETV,
     DOMAIN,
+    PROP_ETHMAC,
     PROP_SERIALNO,
+    PROP_WIFIMAC,
     SIGNAL_CONFIG_ENTITY,
 )
 
+INVALID_MACS = ["ff:ff:ff:ff:ff:ff"]
 PLATFORMS = [Platform.MEDIA_PLAYER]
 RELOAD_OPTIONS = [CONF_STATE_DETECTION_RULES]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_androidtv_mac(dev_props):
+    """Return formatted mac from device properties."""
+    if eth_mac := dev_props.get(PROP_ETHMAC):
+        mac = format_mac(eth_mac)
+        if mac not in INVALID_MACS:
+            return mac
+    if wifi_mac := dev_props.get(PROP_WIFIMAC):
+        mac = format_mac(wifi_mac)
+        if mac not in INVALID_MACS:
+            return mac
+    return None
 
 
 def _setup_androidtv(hass, config):

--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -40,9 +40,10 @@ from .const import (
     SIGNAL_CONFIG_ENTITY,
 )
 
-INVALID_MACS = ["ff:ff:ff:ff:ff:ff"]
 PLATFORMS = [Platform.MEDIA_PLAYER]
 RELOAD_OPTIONS = [CONF_STATE_DETECTION_RULES]
+
+_INVALID_MACS = {"ff:ff:ff:ff:ff:ff"}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,11 +52,11 @@ def get_androidtv_mac(dev_props):
     """Return formatted mac from device properties."""
     if eth_mac := dev_props.get(PROP_ETHMAC):
         mac = format_mac(eth_mac)
-        if mac not in INVALID_MACS:
+        if mac not in _INVALID_MACS:
             return mac
     if wifi_mac := dev_props.get(PROP_WIFIMAC):
         mac = format_mac(wifi_mac)
-        if mac not in INVALID_MACS:
+        if mac not in _INVALID_MACS:
             return mac
     return None
 

--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -50,14 +50,11 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_androidtv_mac(dev_props):
     """Return formatted mac from device properties."""
-    if eth_mac := dev_props.get(PROP_ETHMAC):
-        mac = format_mac(eth_mac)
-        if mac not in _INVALID_MACS:
-            return mac
-    if wifi_mac := dev_props.get(PROP_WIFIMAC):
-        mac = format_mac(wifi_mac)
-        if mac not in _INVALID_MACS:
-            return mac
+    for prop_mac in (PROP_ETHMAC, PROP_WIFIMAC):
+        if if_mac := dev_props.get(prop_mac):
+            mac = format_mac(if_mac)
+            if mac not in _INVALID_MACS:
+                return mac
     return None
 
 

--- a/homeassistant/components/androidtv/config_flow.py
+++ b/homeassistant/components/androidtv/config_flow.py
@@ -11,9 +11,8 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.device_registry import format_mac
 
-from . import async_connect_androidtv
+from . import async_connect_androidtv, get_androidtv_mac
 from .const import (
     CONF_ADB_SERVER_IP,
     CONF_ADB_SERVER_PORT,
@@ -132,9 +131,7 @@ class AndroidTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             PROP_WIFIMAC,
             dev_prop.get(PROP_WIFIMAC),
         )
-        unique_id = format_mac(
-            dev_prop.get(PROP_ETHMAC) or dev_prop.get(PROP_WIFIMAC, "")
-        )
+        unique_id = get_androidtv_mac(dev_prop)
         await aftv.adb_close()
         return None, unique_id
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -51,12 +51,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import get_androidtv_mac
 from .const import (
     ANDROID_DEV,
     ANDROID_DEV_OPT,
@@ -80,8 +81,6 @@ from .const import (
     DEVICE_ANDROIDTV,
     DEVICE_CLASSES,
     DOMAIN,
-    PROP_ETHMAC,
-    PROP_WIFIMAC,
     SIGNAL_CONFIG_ENTITY,
 )
 
@@ -343,7 +342,7 @@ class ADBDevice(MediaPlayerEntity):
             self._attr_device_info[ATTR_MANUFACTURER] = manufacturer
         if sw_version := info.get(ATTR_SW_VERSION):
             self._attr_device_info[ATTR_SW_VERSION] = sw_version
-        if mac := format_mac(info.get(PROP_ETHMAC) or info.get(PROP_WIFIMAC, "")):
+        if mac := get_androidtv_mac(info):
             self._attr_device_info[ATTR_CONNECTIONS] = {(CONNECTION_NETWORK_MAC, mac)}
 
         self._app_id_to_name = {}

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -1,12 +1,16 @@
 """Define patches used for androidtv tests."""
-
 from unittest.mock import mock_open, patch
+
+from androidtv.constants import CMD_DEVICE_PROPERTIES, CMD_MAC_ETH0, CMD_MAC_WLAN0
 
 KEY_PYTHON = "python"
 KEY_SERVER = "server"
 
 ADB_DEVICE_TCP_ASYNC_FAKE = "AdbDeviceTcpAsyncFake"
 DEVICE_ASYNC_FAKE = "DeviceAsyncFake"
+
+PROPS_DEV_INFO = "fake\nfake\n0123456\nfake"
+PROPS_DEV_MAC = "ether ab:cd:ef:gh:ij:kl brd"
 
 
 class AdbDeviceTcpAsyncFake:
@@ -100,12 +104,18 @@ def patch_connect(success):
     }
 
 
-def patch_shell(response=None, error=False):
+def patch_shell(response=None, error=False, mac_eth=False):
     """Mock the `AdbDeviceTcpAsyncFake.shell` and `DeviceAsyncFake.shell` methods."""
 
     async def shell_success(self, cmd, *args, **kwargs):
         """Mock the `AdbDeviceTcpAsyncFake.shell` and `DeviceAsyncFake.shell` methods when they are successful."""
         self.shell_cmd = cmd
+        if cmd == CMD_DEVICE_PROPERTIES:
+            return PROPS_DEV_INFO
+        if cmd == CMD_MAC_WLAN0:
+            return PROPS_DEV_MAC
+        if cmd == CMD_MAC_ETH0:
+            return PROPS_DEV_MAC if mac_eth else None
         return response
 
     async def shell_fail_python(self, cmd, *args, **kwargs):
@@ -184,16 +194,4 @@ PATCH_STOP_APP = patch("androidtv.basetv.basetv_async.BaseTVAsync.stop_app")
 PATCH_ANDROIDTV_UPDATE_EXCEPTION = patch(
     "androidtv.androidtv.androidtv_async.AndroidTVAsync.update",
     side_effect=ZeroDivisionError,
-)
-
-PATCH_DEVICE_PROPERTIES = patch(
-    "androidtv.basetv.basetv_async.BaseTVAsync.get_device_properties",
-    return_value={
-        "manufacturer": "a",
-        "model": "b",
-        "serialno": "c",
-        "sw_version": "d",
-        "wifimac": "ab:cd:ef:gh:ij:kl",
-        "ethmac": None,
-    },
 )

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -142,29 +142,6 @@ def _setup(config):
     return patch_key, entity_id, config_entry
 
 
-async def test_setup_with_properties(hass):
-    """Test that setup succeeds with device properties.
-
-    the response must be a string with the following info separated with line break:
-    "manufacturer, model, serialno, version, mac_wlan0_output, mac_eth0_output"
-
-    """
-
-    patch_key, entity_id, config_entry = _setup(CONFIG_ANDROIDTV_ADB_SERVER)
-    config_entry.add_to_hass(hass)
-    response = "fake\nfake\n0123456\nfake\nether a1:b1:c1:d1:e1:f1 brd\nnone"
-
-    with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell(response)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
-
-        state = hass.states.get(entity_id)
-        assert state is not None
-
-
 @pytest.mark.parametrize(
     "config",
     [
@@ -190,9 +167,8 @@ async def test_reconnect(hass, caplog, config):
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -259,9 +235,8 @@ async def test_adb_shell_returns_none(hass, config):
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -289,9 +264,8 @@ async def test_setup_with_adbkey(hass):
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
         patch_key
     ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER, PATCH_ISFILE, PATCH_ACCESS:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -324,9 +298,8 @@ async def test_sources(hass, config0):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -404,9 +377,8 @@ async def _test_exclude_sources(hass, config0, expected_sources):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -486,9 +458,8 @@ async def _test_select_source(hass, config0, source, expected_arg, method_patch)
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -714,9 +685,8 @@ async def test_setup_fail(hass, config):
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id) is False
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -733,9 +703,8 @@ async def test_adb_command(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         with patch(
             "androidtv.basetv.basetv_async.BaseTVAsync.adb_shell", return_value=response
@@ -763,9 +732,8 @@ async def test_adb_command_unicode_decode_error(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         with patch(
             "androidtv.basetv.basetv_async.BaseTVAsync.adb_shell",
@@ -793,9 +761,8 @@ async def test_adb_command_key(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         with patch(
             "androidtv.basetv.basetv_async.BaseTVAsync.adb_shell", return_value=response
@@ -823,9 +790,8 @@ async def test_adb_command_get_properties(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         with patch(
             "androidtv.androidtv.androidtv_async.AndroidTVAsync.get_properties_dict",
@@ -853,9 +819,8 @@ async def test_learn_sendevent(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         with patch(
             "androidtv.basetv.basetv_async.BaseTVAsync.learn_sendevent",
@@ -882,9 +847,8 @@ async def test_update_lock_not_acquired(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
         await hass.helpers.entity_component.async_update_entity(entity_id)
@@ -918,9 +882,8 @@ async def test_download(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         # Failed download because path is not whitelisted
         with patch("androidtv.basetv.basetv_async.BaseTVAsync.adb_pull") as patch_pull:
@@ -965,9 +928,8 @@ async def test_upload(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         # Failed upload because path is not whitelisted
         with patch("androidtv.basetv.basetv_async.BaseTVAsync.adb_push") as patch_push:
@@ -1010,9 +972,8 @@ async def test_androidtv_volume_set(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     with patch(
         "androidtv.basetv.basetv_async.BaseTVAsync.set_volume_level", return_value=0.5
@@ -1038,9 +999,8 @@ async def test_get_image(hass, hass_ws_client):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     with patchers.patch_shell("11")[patch_key]:
         await hass.helpers.entity_component.async_update_entity(entity_id)
@@ -1115,9 +1075,8 @@ async def test_services_androidtv(hass):
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
         with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-            with patchers.PATCH_DEVICE_PROPERTIES:
-                assert await hass.config_entries.async_setup(config_entry.entry_id)
-                await hass.async_block_till_done()
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
 
         with patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key]:
             await _test_service(
@@ -1162,9 +1121,8 @@ async def test_services_firetv(hass):
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
         with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-            with patchers.PATCH_DEVICE_PROPERTIES:
-                assert await hass.config_entries.async_setup(config_entry.entry_id)
-                await hass.async_block_till_done()
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
 
         with patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key]:
             await _test_service(hass, entity_id, SERVICE_MEDIA_STOP, "back")
@@ -1179,9 +1137,8 @@ async def test_volume_mute(hass):
 
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[patch_key]:
         with patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-            with patchers.PATCH_DEVICE_PROPERTIES:
-                assert await hass.config_entries.async_setup(config_entry.entry_id)
-                await hass.async_block_till_done()
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
 
         with patchers.patch_shell(SHELL_RESPONSE_STANDBY)[patch_key]:
             service_data = {ATTR_ENTITY_ID: entity_id, ATTR_MEDIA_VOLUME_MUTED: True}
@@ -1224,9 +1181,8 @@ async def test_connection_closed_on_ha_stop(hass):
     with patchers.PATCH_ADB_DEVICE_TCP, patchers.patch_connect(True)[
         patch_key
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key]:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         with patch(
             "androidtv.androidtv.androidtv_async.AndroidTVAsync.adb_close"
@@ -1249,9 +1205,8 @@ async def test_exception(hass):
     ], patchers.patch_shell(SHELL_RESPONSE_OFF)[
         patch_key
     ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
-        with patchers.PATCH_DEVICE_PROPERTIES:
-            assert await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is related to PR #65615
I review the code to retrieve the mac address from device properties and added some config-flow test to cover more conditions. I also review the media-player tests to restore coverage of some line missing related to device info.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
