### PR TITLE
Remove unnecessary `TYPE_CHECKING` declarations in SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Iterable
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from simplipy import API
 from simplipy.device import Device, DeviceTypes
@@ -235,8 +235,7 @@ def _async_get_system_for_service_call(
     ) is None:
         raise vol.Invalid("Invalid device ID specified")
 
-    if TYPE_CHECKING:
-        assert alarm_control_panel_device_entry.via_device_id
+    assert alarm_control_panel_device_entry.via_device_id
 
     if (
         base_station_device_entry := device_registry.async_get(
@@ -493,8 +492,7 @@ class SimpliSafe:
 
     async def _async_start_websocket_loop(self) -> None:
         """Start a websocket reconnection loop."""
-        if TYPE_CHECKING:
-            assert self._api.websocket
+        assert self._api.websocket
 
         should_reconnect = True
 
@@ -526,8 +524,7 @@ class SimpliSafe:
                 LOGGER.debug("Websocket reconnection task successfully canceled")
                 self._websocket_reconnect_task = None
 
-            if TYPE_CHECKING:
-                assert self._api.websocket
+            assert self._api.websocket
             await self._api.websocket.async_disconnect()
 
     @callback
@@ -564,9 +561,8 @@ class SimpliSafe:
 
     async def async_init(self) -> None:
         """Initialize the SimpliSafe "manager" class."""
-        if TYPE_CHECKING:
-            assert self._api.refresh_token
-            assert self._api.websocket
+        assert self._api.refresh_token
+        assert self._api.websocket
 
         self._api.websocket.add_event_callback(self._async_websocket_on_event)
         self._websocket_reconnect_task = asyncio.create_task(
@@ -575,9 +571,7 @@ class SimpliSafe:
 
         async def async_websocket_disconnect_listener(_: Event) -> None:
             """Define an event handler to disconnect from the websocket."""
-            if TYPE_CHECKING:
-                assert self._api.websocket
-
+            assert self._api.websocket
             await self._async_cancel_websocket_loop()
 
         self.entry.async_on_unload(
@@ -624,10 +618,8 @@ class SimpliSafe:
             """Handle a new refresh token."""
             async_save_refresh_token(token)
 
-            if TYPE_CHECKING:
-                assert self._api.websocket
-
             # Open a new websocket connection with the fresh token:
+            assert self._api.websocket
             await self._async_cancel_websocket_loop()
             self._websocket_reconnect_task = self._hass.async_create_task(
                 self._async_start_websocket_loop()

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -1,8 +1,6 @@
 """Support for SimpliSafe alarm control panels."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from simplipy.errors import SimplipyError
 from simplipy.system import SystemStates
 from simplipy.system.v3 import SystemV3
@@ -240,8 +238,9 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
     def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
         """Update the entity when new data comes from the websocket."""
         self._attr_changed_by = event.changed_by
-        if TYPE_CHECKING:
-            assert event.event_type
+
+        assert event.event_type
+
         if state := STATE_MAP_FROM_WEBSOCKET_EVENT.get(event.event_type):
             self._attr_state = state
             self.async_reset_error_count()

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the SimpliSafe component."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, NamedTuple
 
 from simplipy import API
 from simplipy.errors import InvalidCredentialsError, SimplipyError
@@ -97,8 +97,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self._async_show_form()
 
-        if TYPE_CHECKING:
-            assert self._oauth_values
+        assert self._oauth_values
 
         errors = {}
         session = aiohttp_client.async_get_clientsession(self.hass)

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -1,7 +1,7 @@
 """Support for SimpliSafe locks."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from simplipy.device.lock import Lock, LockStates
 from simplipy.errors import SimplipyError
@@ -100,8 +100,8 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
     @callback
     def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
         """Update the entity when new data comes from the websocket."""
-        if TYPE_CHECKING:
-            assert event.event_type
+        assert event.event_type
+
         if state := STATE_MAP_FROM_WEBSOCKET_EVENT.get(event.event_type) is not None:
             self._attr_is_locked = state
             self.async_reset_error_count()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SimpliSafe is full of `TYPE_CHECKING` declarations that don't need to be there (since they're not protecting circularly-imported resources). This PR cleans things up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
