### PR TITLE
Reduce System Bridge load on server

### DIFF
--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -63,16 +63,20 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
             await self.bridge.async_send_event(
                 "get-data",
                 [
-                    "battery",
-                    "cpu",
-                    "display",
-                    "filesystem",
-                    "graphics",
-                    "memory",
-                    "network",
-                    "os",
-                    "processes",
-                    "system",
+                    {"service": "battery", "method": "findAll", "observe": True},
+                    {"service": "cpu", "method": "findAll", "observe": True},
+                    {"service": "display", "method": "findAll", "observe": True},
+                    {"service": "filesystem", "method": "findSizes", "observe": True},
+                    {"service": "graphics", "method": "findAll", "observe": True},
+                    {"service": "memory", "method": "findAll", "observe": True},
+                    {"service": "network", "method": "findAll", "observe": True},
+                    {"service": "os", "method": "findAll", "observe": False},
+                    {
+                        "service": "processes",
+                        "method": "findCurrentLoad",
+                        "observe": True,
+                    },
+                    {"service": "system", "method": "findAll", "observe": False},
                 ],
             )
             await self.bridge.listen_for_events(callback=self.async_handle_event)

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.2.3"],
+  "requirements": ["systembridge==2.3.1"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2311,7 +2311,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.2.3
+systembridge==2.3.1
 
 # homeassistant.components.tailscale
 tailscale==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1420,7 +1420,7 @@ sunwatcher==0.2.1
 surepy==0.7.2
 
 # homeassistant.components.system_bridge
-systembridge==2.2.3
+systembridge==2.3.1
 
 # homeassistant.components.tailscale
 tailscale==0.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates to new schema and calls specific methods/endpoints from controller to reduce load on server. Package handles these changes in data.

Package changes:
https://github.com/timmo001/system-bridge-connector-py/compare/v2.2.3...v2.3.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade

<!--
## Additional information
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] 🥈 Silver

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
