### PR TITLE
Add Rfxtrx command_on/command_off support for PT-2262 switch entities

### DIFF
--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -7,7 +7,7 @@ import RFXtrx as rfxtrxmod
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ON
+from homeassistant.const import CONF_COMMAND_OFF, CONF_COMMAND_ON, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -17,8 +17,15 @@ from . import (
     DeviceTuple,
     RfxtrxCommandEntity,
     async_setup_platform_entry,
+    get_pt2262_cmd,
 )
-from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST, CONF_SIGNAL_REPETITIONS
+from .const import (
+    COMMAND_OFF_LIST,
+    COMMAND_ON_LIST,
+    CONF_DATA_BITS,
+    CONF_SIGNAL_REPETITIONS,
+    DEVICE_PACKET_TYPE_LIGHTING4,
+)
 
 DATA_SWITCH = f"{DOMAIN}_switch"
 
@@ -53,6 +60,9 @@ async def async_setup_entry(
                 event.device,
                 device_id,
                 entity_info.get(CONF_SIGNAL_REPETITIONS, DEFAULT_SIGNAL_REPETITIONS),
+                entity_info.get(CONF_DATA_BITS),
+                entity_info.get(CONF_COMMAND_ON),
+                entity_info.get(CONF_COMMAND_OFF),
                 event=event if auto else None,
             )
         ]
@@ -65,6 +75,22 @@ async def async_setup_entry(
 class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
     """Representation of a RFXtrx switch."""
 
+    def __init__(
+        self,
+        device: rfxtrxmod.RFXtrxDevice,
+        device_id: DeviceTuple,
+        signal_repetitions: int = 1,
+        data_bits: int | None = None,
+        cmd_on: int | None = None,
+        cmd_off: int | None = None,
+        event: rfxtrxmod.RFXtrxEvent | None = None,
+    ) -> None:
+        """Initialize the RFXtrx switch."""
+        super().__init__(device, device_id, signal_repetitions, event=event)
+        self._data_bits = data_bits
+        self._cmd_on = cmd_on
+        self._cmd_off = cmd_off
+
     async def async_added_to_hass(self):
         """Restore device state."""
         await super().async_added_to_hass()
@@ -74,14 +100,33 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
             if old_state is not None:
                 self._state = old_state.state == STATE_ON
 
-    def _apply_event(self, event: rfxtrxmod.RFXtrxEvent) -> None:
-        """Apply command from rfxtrx."""
+    def _apply_event_lighting4(self, event: rfxtrxmod.RFXtrxEvent):
+        """Apply event for a lighting 4 device."""
+        if self._data_bits is not None:
+            cmdstr = get_pt2262_cmd(event.device.id_string, self._data_bits)
+            assert cmdstr
+            cmd = int(cmdstr, 16)
+            if cmd == self._cmd_on:
+                self._state = True
+            elif cmd == self._cmd_off:
+                self._state = False
+        else:
+            self._state = True
+
+    def _apply_event_standard(self, event: rfxtrxmod.RFXtrxEvent) -> None:
         assert isinstance(event, rfxtrxmod.ControlEvent)
-        super()._apply_event(event)
         if event.values["Command"] in COMMAND_ON_LIST:
             self._state = True
         elif event.values["Command"] in COMMAND_OFF_LIST:
             self._state = False
+
+    def _apply_event(self, event: rfxtrxmod.RFXtrxEvent) -> None:
+        """Apply command from rfxtrx."""
+        super()._apply_event(event)
+        if event.device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
+            self._apply_event_lighting4(event)
+        else:
+            self._apply_event_standard(event)
 
     @callback
     def _handle_event(
@@ -100,12 +145,18 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        await self._async_send(self._device.send_on)
+        if self._cmd_on is not None:
+            await self._async_send(self._device.send_command, self._cmd_on)
+        else:
+            await self._async_send(self._device.send_on)
         self._state = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        await self._async_send(self._device.send_off)
+        if self._cmd_off is not None:
+            await self._async_send(self._device.send_command, self._cmd_off)
+        else:
+            await self._async_send(self._device.send_off)
         self._state = False
         self.async_write_ha_state()

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -38,7 +38,7 @@ async def test_one(hass, rfxtrx):
 
 
 async def test_one_pt2262(hass, rfxtrx):
-    """Test with 1 sensor."""
+    """Test with 1 PT2262 sensor."""
     entry_data = create_rfx_test_cfg(
         devices={
             "0913000022670e013970": {

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -52,6 +52,50 @@ async def test_one_switch(hass, rfxtrx):
     ]
 
 
+async def test_one_pt2262_switch(hass, rfxtrx):
+    """Test with 1 PT2262 switch."""
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013970": {
+                "signal_repetitions": 1,
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            }
+        }
+    )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.pt2262_22670e")
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": "switch.pt2262_22670e"}, blocking=True
+    )
+
+    state = hass.states.get("switch.pt2262_22670e")
+    assert state.state == "on"
+
+    await hass.services.async_call(
+        "switch", "turn_off", {"entity_id": "switch.pt2262_22670e"}, blocking=True
+    )
+
+    state = hass.states.get("switch.pt2262_22670e")
+    assert state.state == "off"
+
+    assert rfxtrx.transport.send.mock_calls == [
+        call(bytearray(b"\x09\x13\x00\x00\x22\x67\x0e\x01\x39\x00")),
+        call(bytearray(b"\x09\x13\x00\x00\x22\x67\x0f\x01\x39\x00")),
+    ]
+
+
 @pytest.mark.parametrize("state", ["on", "off"])
 async def test_state_restore(hass, rfxtrx, state):
     """State restoration."""
@@ -180,6 +224,47 @@ async def test_switch_events(hass, rfxtrx):
     await rfxtrx.signal("0b1100100213c7f210030f70")
     assert hass.states.get("switch.ac_213c7f2_5").state == "off"
     assert hass.states.get("switch.ac_213c7f2_16").state == "off"
+
+
+async def test_pt2262_switch_events(hass, rfxtrx):
+    """Test with 1 PT2262 switch."""
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0913000022670e013970": {
+                "signal_repetitions": 1,
+                "data_bits": 4,
+                "command_on": 0xE,
+                "command_off": 0x7,
+            }
+        }
+    )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.pt2262_22670e")
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+
+    # "Command: 0xE"
+    await rfxtrx.signal("0913000022670e013970")
+    assert hass.states.get("switch.pt2262_22670e").state == "on"
+
+    # "Command: 0x0"
+    await rfxtrx.signal("09130000226700013970")
+    assert hass.states.get("switch.pt2262_22670e").state == "on"
+
+    # "Command: 0x7"
+    await rfxtrx.signal("09130000226707013d70")
+    assert hass.states.get("switch.pt2262_22670e").state == "off"
+
+    # "Command: 0x1"
+    await rfxtrx.signal("09130000226701013d70")
+    assert hass.states.get("switch.pt2262_22670e").state == "off"
 
 
 async def test_discover_switch(hass, rfxtrx_automatic):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The RFXtrx integration has extra options for PT-2262 sensors under the Lighting4 protocol to interpret data packets properly (data_bits, command_on, command_off). This works fine for the binary_sensor entities, but not for the corresponding switch entities. State is not updated properly and turning the switch on/off will transmit the wrong command.

This pull request adds support for the data_bits, command_on, command_off options for switch entities, such that state is updated properly and it is also possible to send proper on/off commands for PT-2262 switches.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
