### PR TITLE
Remove options flow from Plugwise

### DIFF
--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -15,17 +15,14 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     API,
     DEFAULT_PORT,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_USERNAME,
     DOMAIN,
     FLOW_NET,
@@ -185,37 +182,6 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=CONNECTION_SCHEMA,
             errors=errors,
         )
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return PlugwiseOptionsFlowHandler(config_entry)
-
-
-class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
-    """Plugwise option flow."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Manage the Plugwise options."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        api = self.hass.data[DOMAIN][self.config_entry.entry_id][API]
-        interval = DEFAULT_SCAN_INTERVAL[api.smile_type]
-
-        data = {
-            vol.Optional(
-                CONF_SCAN_INTERVAL,
-                default=self.config_entry.options.get(CONF_SCAN_INTERVAL, interval),
-            ): int
-        }
-
-        return self.async_show_form(step_id="init", data_schema=vol.Schema(data))
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -1,4 +1,6 @@
 """Constants for Plugwise component."""
+from datetime import timedelta
+
 from homeassistant.const import Platform
 
 API = "api"
@@ -18,7 +20,6 @@ SCHEDULE_ON = "true"
 SMILE = "smile"
 STRETCH = "stretch"
 STRETCH_USERNAME = "stretch"
-UNDO_UPDATE_LISTENER = "undo_update_listener"
 UNIT_LUMEN = "lm"
 
 PLATFORMS_GATEWAY = [
@@ -47,9 +48,9 @@ DEFAULT_MIN_TEMP = 4
 DEFAULT_NAME = "Smile"
 DEFAULT_PORT = 80
 DEFAULT_SCAN_INTERVAL = {
-    "power": 10,
-    "stretch": 60,
-    "thermostat": 60,
+    "power": timedelta(seconds=10),
+    "stretch": timedelta(seconds=60),
+    "thermostat": timedelta(seconds=60),
 }
 DEFAULT_TIMEOUT = 60
 DEFAULT_USERNAME = "smile"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Plugwise config flow."""
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from plugwise.exceptions import (
     ConnectionFailedError,
@@ -12,7 +12,6 @@ from homeassistant.components import zeroconf
 from homeassistant.components.plugwise.const import (
     API,
     DEFAULT_PORT,
-    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FLOW_NET,
     FLOW_TYPE,
@@ -24,7 +23,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_SCAN_INTERVAL,
     CONF_SOURCE,
     CONF_USERNAME,
 )
@@ -375,68 +373,3 @@ async def test_form_other_problem(hass, mock_smile):
 
     assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "unknown"}
-
-
-async def test_options_flow_power(hass, mock_smile) -> None:
-    """Test config flow options DSMR environments."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title=CONF_NAME,
-        data={CONF_HOST: TEST_HOST, CONF_PASSWORD: TEST_PASSWORD},
-        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
-    )
-
-    hass.data[DOMAIN] = {entry.entry_id: {"api": MagicMock(smile_type="power")}}
-    entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.plugwise.async_setup_entry", return_value=True
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        result = await hass.config_entries.options.async_init(entry.entry_id)
-
-        assert result["type"] == RESULT_TYPE_FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_SCAN_INTERVAL: 10}
-        )
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["data"] == {
-            CONF_SCAN_INTERVAL: 10,
-        }
-
-
-async def test_options_flow_thermo(hass, mock_smile) -> None:
-    """Test config flow options for thermostatic environments."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title=CONF_NAME,
-        data={CONF_HOST: TEST_HOST, CONF_PASSWORD: TEST_PASSWORD},
-        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
-    )
-
-    hass.data[DOMAIN] = {entry.entry_id: {"api": MagicMock(smile_type="thermostat")}}
-    entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.plugwise.async_setup_entry", return_value=True
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        result = await hass.config_entries.options.async_init(entry.entry_id)
-
-        assert result["type"] == RESULT_TYPE_FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_SCAN_INTERVAL: 60}
-        )
-
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["data"] == {
-            CONF_SCAN_INTERVAL: 60,
-        }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Changing the scan interval options of Plugwise devices in the integration configuration, has been removed. Home Assistant will, by default, use a sane and safe interval.

If you, however, still need to customize the interval, you can do so by disabling automatic updates for the integration and using an automation to trigger `homeassistant.update_entity` service on your preferred interval.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See breaking changes above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
