### PR TITLE
Add support for picking discovered devices to WiZ

### DIFF
--- a/homeassistant/components/wiz/config_flow.py
+++ b/homeassistant/components/wiz/config_flow.py
@@ -14,10 +14,13 @@ from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DOMAIN, WIZ_EXCEPTIONS
-from .utils import name_from_bulb_type_and_mac
+from .const import DEFAULT_NAME, DISCOVER_SCAN_TIMEOUT, DOMAIN, WIZ_EXCEPTIONS
+from .discovery import async_discover_devices
+from .utils import _short_mac, name_from_bulb_type_and_mac
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_DEVICE = "device"
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -28,6 +31,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._discovered_device: DiscoveredBulb | None = None
+        self._discovered_devices: dict[str, DiscoveredBulb] = {}
         self._name: str | None = None
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
@@ -85,13 +89,59 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({}),
         )
 
+    async def async_step_pick_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the step to pick discovered device."""
+        errors = {}
+        if user_input is not None:
+            device = self._discovered_devices[user_input[CONF_DEVICE]]
+            await self.async_set_unique_id(device.mac_address, raise_on_progress=False)
+            bulb = wizlight(device.ip_address)
+            try:
+                bulbtype = await bulb.get_bulbtype()
+            except WIZ_EXCEPTIONS:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=name_from_bulb_type_and_mac(bulbtype, device.mac_address),
+                    data={CONF_HOST: device.ip_address},
+                )
+
+        current_unique_ids = self._async_current_ids()
+        current_hosts = {
+            entry.data[CONF_HOST]
+            for entry in self._async_current_entries(include_ignore=False)
+        }
+        discovered_devices = await async_discover_devices(
+            self.hass, DISCOVER_SCAN_TIMEOUT
+        )
+        self._discovered_devices = {
+            device.mac_address: device for device in discovered_devices
+        }
+        devices_name = {
+            mac: f"{DEFAULT_NAME} {_short_mac(mac)} ({device.ip_address})"
+            for mac, device in self._discovered_devices.items()
+            if mac not in current_unique_ids and device.ip_address not in current_hosts
+        }
+        # Check if there is at least one device
+        if not devices_name:
+            return self.async_abort(reason="no_devices_found")
+        return self.async_show_form(
+            step_id="pick_device",
+            errors=errors,
+            data_schema=vol.Schema({vol.Required(CONF_DEVICE): vol.In(devices_name)}),
+        )
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
-            bulb = wizlight(user_input[CONF_HOST])
+            if not (host := user_input[CONF_HOST]):
+                return await self.async_step_pick_device()
+            bulb = wizlight(host)
             try:
                 mac = await bulb.getMac()
                 bulbtype = await bulb.get_bulbtype()
@@ -117,6 +167,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            data_schema=vol.Schema({vol.Optional(CONF_HOST, default=""): str}),
             errors=errors,
         )

--- a/homeassistant/components/wiz/config_flow.py
+++ b/homeassistant/components/wiz/config_flow.py
@@ -93,7 +93,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the step to pick discovered device."""
-        errors = {}
         if user_input is not None:
             device = self._discovered_devices[user_input[CONF_DEVICE]]
             await self.async_set_unique_id(device.mac_address, raise_on_progress=False)
@@ -101,7 +100,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 bulbtype = await bulb.get_bulbtype()
             except WIZ_EXCEPTIONS:
-                errors["base"] = "cannot_connect"
+                return self.async_abort(reason="cannot_connect")
             else:
                 return self.async_create_entry(
                     title=name_from_bulb_type_and_mac(bulbtype, device.mac_address),
@@ -129,7 +128,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_devices_found")
         return self.async_show_form(
             step_id="pick_device",
-            errors=errors,
             data_schema=vol.Schema({vol.Required(CONF_DEVICE): vol.In(devices_name)}),
         )
 

--- a/homeassistant/components/wiz/entity.py
+++ b/homeassistant/components/wiz/entity.py
@@ -29,12 +29,18 @@ class WizToggleEntity(CoordinatorEntity, ToggleEntity):
             manufacturer="WiZ",
             model=bulb_type.name,
         )
+        self._async_update_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_is_on = self._device.status
+        self._async_update_state()
         super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_state(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = self._device.status
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the device to turn off."""

--- a/homeassistant/components/wiz/entity.py
+++ b/homeassistant/components/wiz/entity.py
@@ -29,17 +29,16 @@ class WizToggleEntity(CoordinatorEntity, ToggleEntity):
             manufacturer="WiZ",
             model=bulb_type.name,
         )
-        self._async_update_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._async_update_state()
+        self._async_update_attrs()
         super()._handle_coordinator_update()
 
     @callback
-    def _async_update_state(self) -> None:
-        """Handle updated data from the coordinator."""
+    def _async_update_attrs(self) -> None:
+        """Handle updating _attr values."""
         self._attr_is_on = self._device.status
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -72,11 +72,11 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
             )
         if bulb_type.features.effect:
             self._attr_supported_features = SUPPORT_EFFECT
-        self._async_update_state()
+        self._async_update_attrs()
 
     @callback
-    def _async_update_state(self) -> None:
-        """Handle updated data from the coordinator."""
+    def _async_update_attrs(self) -> None:
+        """Handle updating _attr values."""
         state = self._device.state
         color_modes = self.supported_color_modes
         assert color_modes is not None
@@ -97,7 +97,7 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         else:
             self._attr_color_mode = COLOR_MODE_BRIGHTNESS
         self._attr_effect = state.get_scene()
-        super()._async_update_state()
+        super()._async_update_attrs()
 
     @callback
     def _async_pilot_builder(self, **kwargs: Any) -> PilotBuilder:

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -83,7 +83,8 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         bulb_type: BulbType = self._device.bulbtype
         self._attr_effect_list = wiz_data.scenes
         self._attr_min_mireds, self._attr_max_mireds = get_min_max_mireds(bulb_type)
-        self._attr_supported_color_modes = get_supported_color_modes(bulb_type)
+        self._supported_color_modes = get_supported_color_modes(bulb_type)
+        self._attr_supported_color_modes = self._supported_color_modes
         if bulb_type.features.effect:
             self._attr_supported_features = SUPPORT_EFFECT
 
@@ -93,14 +94,15 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         state = self._device.state
         if (brightness := state.get_brightness()) is not None:
             self._attr_brightness = max(0, min(255, brightness))
-        color_modes = self.supported_color_modes
-        assert color_modes is not None
-        if COLOR_MODE_COLOR_TEMP in color_modes and state.get_colortemp() is not None:
+        if (
+            COLOR_MODE_COLOR_TEMP in self._supported_color_modes
+            and state.get_colortemp() is not None
+        ):
             self._attr_color_mode = COLOR_MODE_COLOR_TEMP
             if color_temp := state.get_colortemp():
                 self._attr_color_temp = color_temperature_kelvin_to_mired(color_temp)
         elif (
-            COLOR_MODE_HS in color_modes
+            COLOR_MODE_HS in self._supported_color_modes
             and (rgb := state.get_rgb()) is not None
             and rgb[0] is not None
         ):

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -88,7 +88,7 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
             self._attr_supported_features = SUPPORT_EFFECT
 
     @callback
-    def _handle_coordinator_update(self) -> None:
+    def _async_update_state(self) -> None:
         """Handle updated data from the coordinator."""
         state = self._device.state
         if (brightness := state.get_brightness()) is not None:
@@ -110,7 +110,7 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         else:
             self._attr_color_mode = COLOR_MODE_BRIGHTNESS
         self._attr_effect = state.get_scene()
-        super()._handle_coordinator_update()
+        super()._async_update_state()
 
     @callback
     def _async_pilot_builder(self, **kwargs: Any) -> PilotBuilder:

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from pywizlight import PilotBuilder
-from pywizlight.bulblibrary import BulbClass, BulbType
+from pywizlight.bulblibrary import BulbClass, BulbType, Features
 from pywizlight.rgbcw import convertHSfromRGBCW
 from pywizlight.scenes import get_id_from_scene_name
 
@@ -53,8 +53,8 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         """Initialize an WiZLight."""
         super().__init__(wiz_data, name)
         bulb_type: BulbType = self._device.bulbtype
+        features: Features = bulb_type.features
         color_modes = set()
-        features = bulb_type.features
         if features.color:
             color_modes.add(COLOR_MODE_HS)
         if features.color_tmp:

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -79,7 +79,6 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
 
     def __init__(self, wiz_data: WizData, name: str) -> None:
         """Initialize an WiZLight."""
-        super().__init__(wiz_data, name)
         bulb_type: BulbType = self._device.bulbtype
         self._supported_color_modes = get_supported_color_modes(bulb_type)
         self._attr_effect_list = wiz_data.scenes
@@ -87,6 +86,7 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         self._attr_supported_color_modes = self._supported_color_modes
         if bulb_type.features.effect:
             self._attr_supported_features = SUPPORT_EFFECT
+        super().__init__(wiz_data, name)
 
     @callback
     def _async_update_state(self) -> None:

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -34,34 +34,6 @@ from .models import WizData
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_COLOR_MODES = {COLOR_MODE_HS, COLOR_MODE_COLOR_TEMP}
-DEFAULT_MIN_MIREDS = 153
-DEFAULT_MAX_MIREDS = 454
-
-
-def get_supported_color_modes(bulb_type: BulbType) -> set[str]:
-    """Flag supported features."""
-    color_modes = set()
-    features = bulb_type.features
-    if features.color:
-        color_modes.add(COLOR_MODE_HS)
-    if features.color_tmp:
-        color_modes.add(COLOR_MODE_COLOR_TEMP)
-    if not color_modes and features.brightness:
-        color_modes.add(COLOR_MODE_BRIGHTNESS)
-    return color_modes
-
-
-def get_min_max_mireds(bulb_type: BulbType) -> tuple[int, int]:
-    """Return the coldest and warmest color_temp that this light supports."""
-    # DW bulbs have no kelvin
-    if bulb_type.bulb_type == BulbClass.DW:
-        return 0, 0
-    # If bulbtype is TW or RGB then return the kelvin value
-    return color_temperature_kelvin_to_mired(
-        bulb_type.kelvin_range.max
-    ), color_temperature_kelvin_to_mired(bulb_type.kelvin_range.min)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -81,9 +53,23 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         """Initialize an WiZLight."""
         super().__init__(wiz_data, name)
         bulb_type: BulbType = self._device.bulbtype
+        color_modes = set()
+        features = bulb_type.features
+        if features.color:
+            color_modes.add(COLOR_MODE_HS)
+        if features.color_tmp:
+            color_modes.add(COLOR_MODE_COLOR_TEMP)
+        if not color_modes and features.brightness:
+            color_modes.add(COLOR_MODE_BRIGHTNESS)
+        self._attr_supported_color_modes = color_modes
         self._attr_effect_list = wiz_data.scenes
-        self._attr_min_mireds, self._attr_max_mireds = get_min_max_mireds(bulb_type)
-        self._attr_supported_color_modes = get_supported_color_modes(bulb_type)
+        if bulb_type.bulb_type != BulbClass.DW:
+            self._attr_min_mireds = color_temperature_kelvin_to_mired(
+                bulb_type.kelvin_range.max
+            )
+            self._attr_max_mireds = color_temperature_kelvin_to_mired(
+                bulb_type.kelvin_range.min
+            )
         if bulb_type.features.effect:
             self._attr_supported_features = SUPPORT_EFFECT
         self._async_update_state()

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -79,30 +79,29 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
 
     def __init__(self, wiz_data: WizData, name: str) -> None:
         """Initialize an WiZLight."""
+        super().__init__(wiz_data, name)
         bulb_type: BulbType = self._device.bulbtype
-        self._supported_color_modes = get_supported_color_modes(bulb_type)
         self._attr_effect_list = wiz_data.scenes
         self._attr_min_mireds, self._attr_max_mireds = get_min_max_mireds(bulb_type)
-        self._attr_supported_color_modes = self._supported_color_modes
+        self._attr_supported_color_modes = get_supported_color_modes(bulb_type)
         if bulb_type.features.effect:
             self._attr_supported_features = SUPPORT_EFFECT
-        super().__init__(wiz_data, name)
+        self._async_update_state()
 
     @callback
     def _async_update_state(self) -> None:
         """Handle updated data from the coordinator."""
         state = self._device.state
+        color_modes = self.supported_color_modes
+        assert color_modes is not None
         if (brightness := state.get_brightness()) is not None:
             self._attr_brightness = max(0, min(255, brightness))
-        if (
-            COLOR_MODE_COLOR_TEMP in self._supported_color_modes
-            and state.get_colortemp() is not None
-        ):
+        if COLOR_MODE_COLOR_TEMP in color_modes and state.get_colortemp() is not None:
             self._attr_color_mode = COLOR_MODE_COLOR_TEMP
             if color_temp := state.get_colortemp():
                 self._attr_color_temp = color_temperature_kelvin_to_mired(color_temp)
         elif (
-            COLOR_MODE_HS in self._supported_color_modes
+            COLOR_MODE_HS in color_modes
             and (rgb := state.get_rgb()) is not None
             and rgb[0] is not None
         ):

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -81,9 +81,9 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
         """Initialize an WiZLight."""
         super().__init__(wiz_data, name)
         bulb_type: BulbType = self._device.bulbtype
+        self._supported_color_modes = get_supported_color_modes(bulb_type)
         self._attr_effect_list = wiz_data.scenes
         self._attr_min_mireds, self._attr_max_mireds = get_min_max_mireds(bulb_type)
-        self._supported_color_modes = get_supported_color_modes(bulb_type)
         self._attr_supported_color_modes = self._supported_color_modes
         if bulb_type.features.effect:
             self._attr_supported_features = SUPPORT_EFFECT

--- a/homeassistant/components/wiz/strings.json
+++ b/homeassistant/components/wiz/strings.json
@@ -6,10 +6,15 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         },
-        "description": "Enter the IP address of the device."
+        "description": "If you leave the host empty, discovery will be used to find devices."
       },
       "discovery_confirm": {
         "description": "Do you want to setup {name} ({host})?"
+      },
+      "pick_device": {
+        "data": {
+          "device": "Device"
+        }
       }
     },
     "error": {

--- a/homeassistant/components/wiz/switch.py
+++ b/homeassistant/components/wiz/switch.py
@@ -29,6 +29,11 @@ async def async_setup_entry(
 class WizSocketEntity(WizToggleEntity, SwitchEntity):
     """Representation of a WiZ socket."""
 
+    def __init__(self, wiz_data: WizData, name: str) -> None:
+        """Initialize a WiZ socket."""
+        super().__init__(wiz_data, name)
+        self._async_update_state()
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the socket to turn on."""
         await self._device.turn_on(PilotBuilder())

--- a/homeassistant/components/wiz/switch.py
+++ b/homeassistant/components/wiz/switch.py
@@ -32,7 +32,7 @@ class WizSocketEntity(WizToggleEntity, SwitchEntity):
     def __init__(self, wiz_data: WizData, name: str) -> None:
         """Initialize a WiZ socket."""
         super().__init__(wiz_data, name)
-        self._async_update_state()
+        self._async_update_attrs()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the socket to turn on."""

--- a/homeassistant/components/wiz/translations/en.json
+++ b/homeassistant/components/wiz/translations/en.json
@@ -14,11 +14,16 @@
             "discovery_confirm": {
                 "description": "Do you want to setup {name} ({host})?"
             },
+            "pick_device": {
+                "data": {
+                    "device": "Device"
+                }
+            },
             "user": {
                 "data": {
                     "host": "Host"
                 },
-                "description": "Enter the IP address of the device."
+                "description": "If you leave the host empty, discovery will be used to find devices."
             }
         }
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for picking discovered devices to WiZ

In case dhcp discovery is not available.

Few things remaining:

Current status of the cleanup:
- Var names and General code cleanups - https://github.com/home-assistant/core/pull/65819
- Cleanup `async_turn_on` (https://github.com/home-assistant/core/pull/44779#discussion_r771738838)
- Fix smart plugs (they show up as bulbs) - https://github.com/home-assistant/core/pull/65819
- Add dhcp discovery https://github.com/home-assistant/core/pull/65752
- Add pick device in config flow - https://github.com/home-assistant/core/pull/65826
- Fix the library to keep the connection open and not create background tasks that cannot be trapped (log floods with `Error doing job: Task exception was never retrieved` when bulb is offline at startup - [upstream PR](https://github.com/sbidy/pywizlight/pull/99)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
