### PR TITLE
Add optional operating_state attribute to HumidifierEntity

### DIFF
--- a/homeassistant/components/demo/humidifier.py
+++ b/homeassistant/components/demo/humidifier.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from homeassistant.components.humidifier import HumidifierDeviceClass, HumidifierEntity
-from homeassistant.components.humidifier.const import SUPPORT_MODES
+from homeassistant.components.humidifier.const import (
+    SUPPORT_MODES,
+    SUPPORT_OPERATING_STATE,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -36,6 +39,7 @@ async def async_setup_platform(
                 name="Hygrostat",
                 mode="home",
                 available_modes=["home", "eco"],
+                operating_state="Idle",
                 target_humidity=50,
             ),
         ]
@@ -61,6 +65,7 @@ class DemoHumidifier(HumidifierEntity):
         name: str,
         mode: str | None,
         target_humidity: int,
+        operating_state: str | None = None,
         available_modes: list[str] | None = None,
         is_on: bool = True,
         device_class: HumidifierDeviceClass | None = None,
@@ -73,6 +78,9 @@ class DemoHumidifier(HumidifierEntity):
             self._attr_supported_features = (
                 self._attr_supported_features | SUPPORT_MODES
             )
+        if operating_state is not None:
+            self._attr_supported_features |= SUPPORT_OPERATING_STATE
+            self._attr_operating_state = operating_state
         self._attr_target_humidity = target_humidity
         self._attr_mode = mode
         self._attr_available_modes = available_modes

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -33,6 +33,7 @@ from .const import (  # noqa: F401
     ATTR_HUMIDITY,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
+    ATTR_OPERATING_STATE,
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MIN_HUMIDITY,
     DEVICE_CLASS_DEHUMIDIFIER,
@@ -41,6 +42,7 @@ from .const import (  # noqa: F401
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
     SUPPORT_MODES,
+    SUPPORT_OPERATING_STATE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -132,6 +134,7 @@ class HumidifierEntity(ToggleEntity):
     _attr_min_humidity: int = DEFAULT_MIN_HUMIDITY
     _attr_mode: str | None
     _attr_target_humidity: int | None = None
+    _attr_operating_state: str | None = None
 
     @property
     def capability_attributes(self) -> dict[str, Any]:
@@ -169,6 +172,9 @@ class HumidifierEntity(ToggleEntity):
         if supported_features & SUPPORT_MODES:
             data[ATTR_MODE] = self.mode
 
+        if supported_features & SUPPORT_OPERATING_STATE:
+            data[ATTR_OPERATING_STATE] = self.operating_state
+
         return data
 
     @property
@@ -191,6 +197,14 @@ class HumidifierEntity(ToggleEntity):
         Requires SUPPORT_MODES.
         """
         return self._attr_available_modes
+
+    @property
+    def operating_state(self) -> str | None:
+        """Return the operating state.
+
+        Requires ATTR_OPERATING_STATE.
+        """
+        return self._attr_operating_state
 
     def set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""

--- a/homeassistant/components/humidifier/const.py
+++ b/homeassistant/components/humidifier/const.py
@@ -10,6 +10,7 @@ MODE_AUTO = "auto"
 MODE_BABY = "baby"
 
 ATTR_AVAILABLE_MODES = "available_modes"
+ATTR_OPERATING_STATE = "operating_state"
 ATTR_HUMIDITY = "humidity"
 ATTR_MAX_HUMIDITY = "max_humidity"
 ATTR_MIN_HUMIDITY = "min_humidity"
@@ -28,3 +29,4 @@ SERVICE_SET_MODE = "set_mode"
 SERVICE_SET_HUMIDITY = "set_humidity"
 
 SUPPORT_MODES = 1
+SUPPORT_OPERATING_STATE = 1 << 1

--- a/tests/components/demo/test_humidifier.py
+++ b/tests/components/demo/test_humidifier.py
@@ -7,6 +7,7 @@ from homeassistant.components.humidifier.const import (
     ATTR_HUMIDITY,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
+    ATTR_OPERATING_STATE,
     DOMAIN,
     MODE_AWAY,
     MODE_ECO,
@@ -113,6 +114,14 @@ async def test_set_hold_mode_eco(hass):
 
     state = hass.states.get(ENTITY_HYGROSTAT)
     assert state.attributes.get(ATTR_MODE) == MODE_ECO
+
+
+async def test_operating_state(hass):
+    """Test operating state attribute."""
+    state = hass.states.get(ENTITY_HYGROSTAT)
+    assert state.attributes.get(ATTR_OPERATING_STATE) == "Idle"
+    state = hass.states.get(ENTITY_HUMIDIFIER)
+    assert state.attributes.get(ATTR_OPERATING_STATE) is None
 
 
 async def test_turn_on(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is extracted from https://github.com/home-assistant/core/pull/65847.

ZWave humidifiers expose the current operating state of the humidifier, which is different from the "mode" in which the humidifier is set. For instance, in "auto" mode, the operating state will go back and forth between Humidifying and Idle. I added this new attribute since I think this exposes useful information to users which had no good way of being exposed before. My intention is to follow up with UX changes to display this attribute in the Humidifier card when available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/65847#discussion_r800107870
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
