### PR TITLE
Add device class for combined humidifier and de-humidifier

### DIFF
--- a/homeassistant/components/demo/humidifier.py
+++ b/homeassistant/components/demo/humidifier.py
@@ -33,6 +33,12 @@ async def async_setup_platform(
                 device_class=HumidifierDeviceClass.DEHUMIDIFIER,
             ),
             DemoHumidifier(
+                name="Combined Humidifier/Dehumidifier",
+                mode=None,
+                target_humidity=41,
+                device_class=HumidifierDeviceClass.HUMIDIFIER_AND_DEHUMIDIFIER,
+            ),
+            DemoHumidifier(
                 name="Hygrostat",
                 mode="home",
                 available_modes=["home", "eco"],

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -56,6 +56,7 @@ class HumidifierDeviceClass(StrEnum):
 
     HUMIDIFIER = "humidifier"
     DEHUMIDIFIER = "dehumidifier"
+    HUMIDIFIER_AND_DEHUMIDIFIER = "humidifier_and_dehumidifier"
 
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.Coerce(HumidifierDeviceClass))

--- a/tests/components/demo/test_humidifier.py
+++ b/tests/components/demo/test_humidifier.py
@@ -3,6 +3,7 @@
 import pytest
 import voluptuous as vol
 
+from homeassistant.components.humidifier import HumidifierDeviceClass
 from homeassistant.components.humidifier.const import (
     ATTR_HUMIDITY,
     ATTR_MAX_HUMIDITY,
@@ -27,6 +28,7 @@ from homeassistant.setup import async_setup_component
 ENTITY_DEHUMIDIFIER = "humidifier.dehumidifier"
 ENTITY_HYGROSTAT = "humidifier.hygrostat"
 ENTITY_HUMIDIFIER = "humidifier.humidifier"
+ENTITY_COMBINED = "humidifier.combined_humidifier_dehumidifier"
 
 
 @pytest.fixture(autouse=True)
@@ -36,6 +38,18 @@ async def setup_demo_humidifier(hass):
         hass, DOMAIN, {"humidifier": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
+
+
+def test_device_class(hass):
+    """Test the initial parameters."""
+    state = hass.states.get(ENTITY_HUMIDIFIER)
+    assert state.device_class == HumidifierDeviceClass.HUMIDIFIER
+    state = hass.states.get(ENTITY_DEHUMIDIFIER)
+    assert state.device_class == HumidifierDeviceClass.DEHUMIDIFIER
+    state = hass.states.get(ENTITY_HYGROSTAT)
+    assert state.device_class == HumidifierDeviceClass.HUMIDIFIER
+    state = hass.states.get(ENTITY_COMBINED)
+    assert state.device_class == HumidifierDeviceClass.HUMIDIFIER_AND_DEHUMIDIFIER
 
 
 def test_setup_params(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements this suggestion: https://github.com/home-assistant/core/pull/65847#discussion_r800107930

Z-Wave devices can be both a humidifier and a de-humidifier. The Z-Wave spec exposes 4 modes: off, humidify, de-humidify, and auto. In `Auto` mode, the device has two setpoints, and will humidify or de-humidify as the humidity goes below or above the setpoints. I considered the alternative option of adding two entities for a single Z-Wave device, one for the humidifier and another for a de-humidifier, however I don't think this would make sense. Since there is a single physical appliance with a single "mode", it would create a weird user experience, such as no ability to change the "mode" or turn either entities on/off independently.

Given what the Z-Wave spec allows for, I think what makes the most sense is a single entity which controls both humidifier and de-humidifier setpoints. This PR adds a new device class, however I am unsure if this is actually necessary. I could simply set the device_class to `humidifier`, even though a device supports both. I don't know enough about the implications of setting a slightly inaccurate `device_class` to know if adding a new more accurate one is the correct approach. Interested to hear what you think @Shulyaka 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/65847#discussion_r800107930
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
