### PR TITLE
Add Z-Wave thermostat fan entity

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -7,8 +7,6 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_CURRENT_TEMP_PROPERTY,
-    THERMOSTAT_FAN_MODE_PROPERTY,
-    THERMOSTAT_FAN_STATE_PROPERTY,
     THERMOSTAT_HUMIDITY_PROPERTY,
     THERMOSTAT_MODE_PROPERTY,
     THERMOSTAT_MODE_SETPOINT_MAP,
@@ -183,13 +181,13 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             check_all_endpoints=True,
         )
         self._fan_mode = self.get_zwave_value(
-            THERMOSTAT_FAN_MODE_PROPERTY,
+            THERMOSTAT_MODE_PROPERTY,
             CommandClass.THERMOSTAT_FAN_MODE,
             add_to_watched_value_ids=True,
             check_all_endpoints=True,
         )
         self._fan_state = self.get_zwave_value(
-            THERMOSTAT_FAN_STATE_PROPERTY,
+            THERMOSTAT_OPERATING_STATE_PROPERTY,
             CommandClass.THERMOSTAT_FAN_STATE,
             add_to_watched_value_ids=True,
             check_all_endpoints=True,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -7,6 +7,8 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_CURRENT_TEMP_PROPERTY,
+    THERMOSTAT_FAN_MODE_PROPERTY,
+    THERMOSTAT_FAN_STATE_PROPERTY,
     THERMOSTAT_HUMIDITY_PROPERTY,
     THERMOSTAT_MODE_PROPERTY,
     THERMOSTAT_MODE_SETPOINT_MAP,
@@ -181,13 +183,13 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             check_all_endpoints=True,
         )
         self._fan_mode = self.get_zwave_value(
-            THERMOSTAT_MODE_PROPERTY,
+            THERMOSTAT_FAN_MODE_PROPERTY,
             CommandClass.THERMOSTAT_FAN_MODE,
             add_to_watched_value_ids=True,
             check_all_endpoints=True,
         )
         self._fan_state = self.get_zwave_value(
-            THERMOSTAT_OPERATING_STATE_PROPERTY,
+            THERMOSTAT_FAN_STATE_PROPERTY,
             CommandClass.THERMOSTAT_FAN_STATE,
             add_to_watched_value_ids=True,
             check_all_endpoints=True,

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -34,6 +34,7 @@ from zwave_js_server.const.command_class.sound_switch import (
 )
 from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_CURRENT_TEMP_PROPERTY,
+    THERMOSTAT_FAN_MODE_PROPERTY,
     THERMOSTAT_MODE_PROPERTY,
     THERMOSTAT_SETPOINT_PROPERTY,
 )
@@ -508,6 +509,16 @@ DISCOVERY_SCHEMAS = [
             },
             property={DOOR_STATUS_PROPERTY},
             type={"any"},
+        ),
+    ),
+    # thermostat fan
+    ZWaveDiscoverySchema(
+        platform="fan",
+        hint="thermostat_fan",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.THERMOSTAT_FAN_MODE},
+            property={THERMOSTAT_FAN_MODE_PROPERTY},
+            type={"number"},
         ),
     ),
     # humidifier

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -520,6 +520,7 @@ DISCOVERY_SCHEMAS = [
             property={THERMOSTAT_FAN_MODE_PROPERTY},
             type={"number"},
         ),
+        entity_registry_enabled_default=False,
     ),
     # humidifier
     # hygrostats supporting mode (and optional setpoint)

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -265,7 +265,6 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
 
     async def async_turn_on(
         self,
-        speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
         **kwargs: Any,

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -256,6 +256,10 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
             add_to_watched_value_ids=True,
             check_all_endpoints=True,
         )
+
+        if not self._fan_mode:
+            raise ValueError("Thermostat fan mode is required")
+
         self._fan_off = self.get_zwave_value(
             THERMOSTAT_FAN_OFF_PROPERTY,
             CommandClass.THERMOSTAT_FAN_MODE,
@@ -277,15 +281,13 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the device on."""
-        if self._fan_off is None:
-            return None
-        await self.info.node.async_set_value(self._fan_off, False)
+        if self._fan_off:
+            await self.info.node.async_set_value(self._fan_off, False)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        if self._fan_off is None:
-            return None
-        await self.info.node.async_set_value(self._fan_off, True)
+        if self._fan_off:
+            await self.info.node.async_set_value(self._fan_off, True)
 
     @property
     def is_on(self) -> bool:
@@ -298,8 +300,7 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
         if (
-            self._fan_mode
-            and self._fan_mode.value is not None
+            self._fan_mode.value is not None
             and str(self._fan_mode.value) in self._fan_mode.metadata.states
         ):
             return cast(str, self._fan_mode.metadata.states[str(self._fan_mode.value)])
@@ -324,7 +325,7 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
     @property
     def preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
-        if self._fan_mode and self._fan_mode.metadata.states:
+        if self._fan_mode.metadata.states:
             return list(self._fan_mode.metadata.states.values())
         return None
 
@@ -351,7 +352,7 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
         """Return the optional state attributes."""
         attrs = {}
 
-        if self.fan_state:
-            attrs[ATTR_FAN_STATE] = self.fan_state
+        if state := self.fan_state:
+            attrs[ATTR_FAN_STATE] = state
 
         return attrs

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -282,14 +282,14 @@ class ZwaveThermostatFan(ZWaveBaseEntity, FanEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if device is on."""
-        if value := get_value_of_zwave_value(self._fan_off) is None:
+        if (value := get_value_of_zwave_value(self._fan_off)) is None:
             return None
         return not cast(bool, value)
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
-        value = get_value_of_zwave_value(self._fan_off)
+        value = get_value_of_zwave_value(self._fan_mode)
         if value is None or str(value) not in self._fan_mode.metadata.states:
             return None
         return cast(str, self._fan_mode.metadata.states[str(value)])

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -676,6 +676,22 @@ def climate_adc_t3000_missing_mode_fixture(client, climate_adc_t3000_state):
     return node
 
 
+@pytest.fixture(name="climate_adc_t3000_missing_fan_mode_states")
+def climate_adc_t3000_missing_fan_mode_states_fixture(client, climate_adc_t3000_state):
+    """Mock a climate ADC-T3000 node with missing 'states' metadata on Thermostat Fan Mode."""
+    data = copy.deepcopy(climate_adc_t3000_state)
+    data["name"] = f"{data['name']} missing fan mode states"
+    for value in data["values"]:
+        if (
+            value["commandClassName"] == "Thermostat Fan Mode"
+            and value["property"] == "mode"
+        ):
+            del value["metadata"]["states"]
+    node = Node(client, data)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
 @pytest.fixture(name="climate_danfoss_lc_13")
 def climate_danfoss_lc_13_fixture(client, climate_danfoss_lc_13_state):
     """Mock a climate radio danfoss LC-13 node."""

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry
 
 
@@ -614,12 +615,13 @@ async def test_thermostat_fan_without_off(
     assert state.state == STATE_UNKNOWN
 
     # Test turning off
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
 
     assert len(client.async_send_command.call_args_list) == 0
     assert state.state == STATE_UNKNOWN
@@ -627,12 +629,13 @@ async def test_thermostat_fan_without_off(
     client.async_send_command.reset_mock()
 
     # Test turning on
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
 
     assert len(client.async_send_command.call_args_list) == 0
     assert state.state == STATE_UNKNOWN

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -3,7 +3,6 @@ import math
 
 import pytest
 from voluptuous.error import MultipleInvalid
-from zwave_js_server.event import Event
 from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
 
@@ -12,10 +11,8 @@ from homeassistant.components.fan import (
     ATTR_PERCENTAGE_STEP,
     ATTR_PRESET_MODE,
     ATTR_PRESET_MODES,
-    ATTR_SPEED,
     DOMAIN as FAN_DOMAIN,
     SERVICE_SET_PRESET_MODE,
-    SPEED_MEDIUM,
     SUPPORT_PRESET_MODE,
 )
 from homeassistant.components.zwave_js.fan import ATTR_FAN_STATE

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -811,7 +811,7 @@ async def test_removed_device(
     # Check how many entities there are
     ent_reg = er.async_get(hass)
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
-    assert len(entity_entries) == 28
+    assert len(entity_entries) == 29
 
     # Remove a node and reload the entry
     old_node = client.driver.controller.nodes.pop(13)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a new `ZwaveThermostatFan` class which implements proper `FanEntity` for the Thermostat Fan Mode and Thermostat Fan State CCs.

Currently the fan mode & state for a z-wave thermostat is only exposed via attributes on a `climate` entity. This is not the most useful for users, as we don't get history of state changes out of the box, and automations are trickier to implement.

I'm proposing adding a fan entity, which is useful on its own, since typically a fan connected to a HVAC unit can be turned on or off to perform useful work independently of the heating/cooling setting of the thermostat. For example the fan can be turned on to circulate the air, or to humidify/de-humidify while no cooling or heating is happening.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
