### PR TITLE
Fix TOD incorrectly determining the state between sunrise and sunset

### DIFF
--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -163,13 +163,14 @@ class TodSensor(BinarySensorEntity):
 
         # We are calculating the _time_after value assuming that it will happen today
         # But that is not always true, e.g. after 23:00, before 12:00 and now is 10:00
-        # If _time_before and _time_after are ahead of current_datetime:
+        # If _time_before and _time_after are ahead of nowutc:
         # _time_before is set to 12:00 next day
         # _time_after is set to 23:00 today
-        # current_datetime is set to 10:00 today
+        # nowutc is set to 10:00 today
         if (
-            self._time_after > self.current_datetime
-            and self._time_before > self.current_datetime + timedelta(days=1)
+            not is_sun_event(self._after)
+            and self._time_after > nowutc
+            and self._time_before > nowutc + timedelta(days=1)
         ):
             # remove one day from _time_before and _time_after
             self._time_after -= timedelta(days=1)

--- a/homeassistant/components/tod/binary_sensor.py
+++ b/homeassistant/components/tod/binary_sensor.py
@@ -161,6 +161,20 @@ class TodSensor(BinarySensorEntity):
 
         self._time_before = before_event_date
 
+        # We are calculating the _time_after value assuming that it will happen today
+        # But that is not always true, e.g. after 23:00, before 12:00 and now is 10:00
+        # If _time_before and _time_after are ahead of current_datetime:
+        # _time_before is set to 12:00 next day
+        # _time_after is set to 23:00 today
+        # current_datetime is set to 10:00 today
+        if (
+            self._time_after > self.current_datetime
+            and self._time_before > self.current_datetime + timedelta(days=1)
+        ):
+            # remove one day from _time_before and _time_after
+            self._time_after -= timedelta(days=1)
+            self._time_before -= timedelta(days=1)
+
         # Add offset to utc boundaries according to the configuration
         self._time_after += self._after_offset
         self._time_before += self._before_offset

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -163,6 +163,25 @@ async def test_midnight_turnover_before_midnight_outside_period(hass):
     assert state.state == STATE_OFF
 
 
+async def test_after_happens_tomorrow(hass):
+    """Test when both before and after are in the future, and after is later than before."""
+    test_time = datetime(2019, 1, 10, 10, 00, 0, tzinfo=dt_util.UTC)
+    config = {
+        "binary_sensor": [
+            {"platform": "tod", "name": "Night", "after": "23:00", "before": "12:00"}
+        ]
+    }
+    with patch(
+        "homeassistant.components.tod.binary_sensor.dt_util.utcnow",
+        return_value=test_time,
+    ):
+        await async_setup_component(hass, "binary_sensor", config)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.night")
+    assert state.state == STATE_ON
+
+
 async def test_midnight_turnover_after_midnight_outside_period(hass):
     """Test midnight turnover setting before midnight inside period ."""
     test_time = datetime(2019, 1, 10, 20, 0, 0, tzinfo=dt_util.UTC)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The changes made in PR #30199 which contains fixes for #24577 and #21974 were accidentally reverted in #48573 which has caused the time of day component to show an incorrect state after home assistant restarts in some situations, for example as per #50315

This PR is just a cherry-pick of the commit from #30199 to re-apply the same fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50315
- This PR is related to issue: #30199 #24577 #21974 #48573
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
