### PR TITLE
BinarySensorEntityDescriptions for Plugwise

### DIFF
--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -1,9 +1,13 @@
 """Plugwise Binary Sensor component for Home Assistant."""
 from plugwise.smile import Smile
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -20,11 +24,19 @@ from .const import (
 )
 from .entity import PlugwiseEntity
 
-BINARY_SENSOR_MAP = {
-    "dhw_state": ["Domestic Hot Water State", None],
-    "slave_boiler_state": ["Secondary Heater Device State", None],
-}
 SEVERITIES = ["other", "info", "warning", "error"]
+BINARY_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
+    BinarySensorEntityDescription(
+        key="dhw_state",
+        name="DHW State",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BinarySensorEntityDescription(
+        key="slave_boiler_state",
+        name="Slave Boiler Stat",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -46,8 +58,8 @@ async def async_setup_entry(
 
         if device_properties["class"] == "heater_central":
             data = api.get_device_data(dev_id)
-            for binary_sensor in BINARY_SENSOR_MAP:
-                if binary_sensor not in data:
+            for description in BINARY_SENSORS:
+                if description.key not in data:
                     continue
 
                 entities.append(
@@ -56,7 +68,7 @@ async def async_setup_entry(
                         coordinator,
                         device_properties["name"],
                         dev_id,
-                        binary_sensor,
+                        description,
                     )
                 )
 
@@ -67,7 +79,10 @@ async def async_setup_entry(
                     coordinator,
                     device_properties["name"],
                     dev_id,
-                    "plugwise_notification",
+                    BinarySensorEntityDescription(
+                        key="plugwise_notification",
+                        name="Plugwise Notification",
+                    ),
                 )
             )
 
@@ -83,19 +98,18 @@ class SmileBinarySensor(PlugwiseEntity, BinarySensorEntity):
         coordinator: DataUpdateCoordinator,
         name: str,
         dev_id: str,
-        binary_sensor: str,
+        description: BinarySensorEntityDescription,
     ) -> None:
         """Initialise the binary_sensor."""
         super().__init__(api, coordinator, name, dev_id)
-        self._binary_sensor = binary_sensor
+        self.entity_description = description
         self._attr_is_on = False
-        self._attr_unique_id = f"{dev_id}-{binary_sensor}"
+        self._attr_unique_id = f"{dev_id}-{description.key}"
 
         if dev_id == self._api.heater_id:
             self._entity_name = "Auxiliary"
 
-        sensorname = binary_sensor.replace("_", " ").title()
-        self._name = f"{self._entity_name} {sensorname}"
+        self._name = f"{self._entity_name} {description.name}"
 
         if dev_id == self._api.gateway_id:
             self._entity_name = f"Smile {self._entity_name}"
@@ -113,19 +127,19 @@ class PwBinarySensor(SmileBinarySensor):
     def _async_process_data(self) -> None:
         """Update the entity."""
         if not (data := self._api.get_device_data(self._dev_id)):
-            LOGGER.error("Received no data for device %s", self._binary_sensor)
+            LOGGER.error("Received no data for device %s", self._dev_id)
             self.async_write_ha_state()
             return
 
-        if self._binary_sensor not in data:
+        if self.entity_description.key not in data:
             self.async_write_ha_state()
             return
 
-        self._attr_is_on = data[self._binary_sensor]
+        self._attr_is_on = data[self.entity_description.key]
 
-        if self._binary_sensor == "dhw_state":
+        if self.entity_description.key == "dhw_state":
             self._attr_icon = FLOW_ON_ICON if self._attr_is_on else FLOW_OFF_ICON
-        if self._binary_sensor == "slave_boiler_state":
+        if self.entity_description.key == "slave_boiler_state":
             self._attr_icon = FLAME_ICON if self._attr_is_on else IDLE_ICON
 
         self.async_write_ha_state()
@@ -140,10 +154,10 @@ class PwNotifySensor(SmileBinarySensor):
         coordinator: DataUpdateCoordinator,
         name: str,
         dev_id: str,
-        binary_sensor: str,
+        description: BinarySensorEntityDescription,
     ) -> None:
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, dev_id, binary_sensor)
+        super().__init__(api, coordinator, name, dev_id, description)
 
         self._attr_extra_state_attributes = {}
 

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -33,7 +33,7 @@ BINARY_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
     ),
     BinarySensorEntityDescription(
         key="slave_boiler_state",
-        name="Slave Boiler State",
+        name="Secondary Boiler State",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -33,7 +33,7 @@ BINARY_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
     ),
     BinarySensorEntityDescription(
         key="slave_boiler_state",
-        name="Slave Boiler Stat",
+        name="Slave Boiler State",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -11,7 +11,7 @@ async def test_anna_climate_binary_sensor_entities(hass, mock_smile_anna):
     entry = await async_init_integration(hass, mock_smile_anna)
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("binary_sensor.auxiliary_slave_boiler_state")
+    state = hass.states.get("binary_sensor.auxiliary_secondary_boiler_state")
     assert str(state.state) == STATE_OFF
 
     state = hass.states.get("binary_sensor.auxiliary_dhw_state")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Initial step in introducing the use of `EntityDescription`s in the binary sensor platform of the  Plugwise integration. 

Note: This implementation starts introducing them, allowing to extend and refactor more using them in the future.

No changes in tests, as this doesn't functionally change anything at this point.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
