### PR TITLE
Add diagnostics support for Nut

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -759,6 +759,7 @@ omit =
     homeassistant/components/nuki/const.py
     homeassistant/components/nuki/binary_sensor.py
     homeassistant/components/nuki/lock.py
+    homeassistant/components/nut/diagnostics.py
     homeassistant/components/nx584/alarm_control_panel.py
     homeassistant/components/nzbget/coordinator.py
     homeassistant/components/obihai/*

--- a/homeassistant/components/nut/diagnostics.py
+++ b/homeassistant/components/nut/diagnostics.py
@@ -1,0 +1,79 @@
+"""Diagnostics support for Nut."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import PyNUTData
+from .const import DOMAIN, PYNUT_DATA, PYNUT_UNIQUE_ID
+
+TO_REDACT = {CONF_PASSWORD, CONF_USERNAME}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, dict[str, Any]]:
+    """Return diagnostics for a config entry."""
+    data = {"entry": async_redact_data(entry.as_dict(), TO_REDACT)}
+    hass_data = hass.data[DOMAIN][entry.entry_id]
+
+    # Get information from Nut library
+    nut_data: PyNUTData = hass_data[PYNUT_DATA]
+    data["nut_data"] = {"ups_list": nut_data.ups_list, "status": nut_data.status}
+
+    # Gather information how this Nut device is represented in Home Assistant
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+    hass_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, hass_data[PYNUT_UNIQUE_ID])}
+    )
+    if not hass_device:
+        return data
+
+    data["device"] = {
+        "name": hass_device.name,
+        "name_by_user": hass_device.name_by_user,
+        "disabled": hass_device.disabled,
+        "disabled_by": hass_device.disabled_by,
+        "manufacturer": hass_device.manufacturer,
+        "model": hass_device.model,
+        "sw_version": hass_device.sw_version,
+        "entities": {},
+    }
+
+    hass_entities = er.async_entries_for_device(
+        entity_registry,
+        device_id=hass_device.id,
+        include_disabled_entities=True,
+    )
+
+    for entity_entry in hass_entities:
+        state = hass.states.get(entity_entry.entity_id)
+        state_dict = None
+        if state:
+            state_dict = dict(state.as_dict())
+            # The entity_id is already provided at root level.
+            state_dict.pop("entity_id", None)
+            # The context doesn't provide useful information in this case.
+            state_dict.pop("context", None)
+
+        data["device"]["entities"][entity_entry.entity_id] = {
+            "name": entity_entry.name,
+            "original_name": entity_entry.original_name,
+            "disabled": entity_entry.disabled,
+            "disabled_by": entity_entry.disabled_by,
+            "entity_category": entity_entry.entity_category,
+            "device_class": entity_entry.device_class,
+            "original_device_class": entity_entry.original_device_class,
+            "icon": entity_entry.icon,
+            "original_icon": entity_entry.original_icon,
+            "unit_of_measurement": entity_entry.unit_of_measurement,
+            "state": state_dict,
+        }
+
+    return data

--- a/homeassistant/components/nut/diagnostics.py
+++ b/homeassistant/components/nut/diagnostics.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import attr
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -36,13 +38,7 @@ async def async_get_config_entry_diagnostics(
         return data
 
     data["device"] = {
-        "name": hass_device.name,
-        "name_by_user": hass_device.name_by_user,
-        "disabled": hass_device.disabled,
-        "disabled_by": hass_device.disabled_by,
-        "manufacturer": hass_device.manufacturer,
-        "model": hass_device.model,
-        "sw_version": hass_device.sw_version,
+        **attr.asdict(hass_device),
         "entities": {},
     }
 
@@ -63,16 +59,9 @@ async def async_get_config_entry_diagnostics(
             state_dict.pop("context", None)
 
         data["device"]["entities"][entity_entry.entity_id] = {
-            "name": entity_entry.name,
-            "original_name": entity_entry.original_name,
-            "disabled": entity_entry.disabled,
-            "disabled_by": entity_entry.disabled_by,
-            "entity_category": entity_entry.entity_category,
-            "device_class": entity_entry.device_class,
-            "original_device_class": entity_entry.original_device_class,
-            "icon": entity_entry.icon,
-            "original_icon": entity_entry.original_icon,
-            "unit_of_measurement": entity_entry.unit_of_measurement,
+            **attr.asdict(
+                entity_entry, filter=lambda attr, value: attr.name != "entity_id"
+            ),
             "state": state_dict,
         }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics support to the Nut integration.

Example dump:

```
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2022.3.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.9.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Rome",
    "os_name": "Linux",
    "os_version": "5.10.60.1-microsoft-standard-WSL2",
    "run_as_root": true
  },
  "custom_components": {
    "smartthinq_sensors": {
      "version": "0.12.9",
      "requirements": [
        "pycountry>=20.7.3"
      ]
    }
  },
  "integration_manifest": {
    "domain": "nut",
    "name": "Network UPS Tools (NUT)",
    "documentation": "https://www.home-assistant.io/integrations/nut",
    "requirements": [
      "pynut2==2.1.2"
    ],
    "codeowners": [
      "@bdraco",
      "@ollo69"
    ],
    "config_flow": true,
    "zeroconf": [
      "_nut._tcp.local."
    ],
    "iot_class": "local_polling",
    "loggers": [
      "pynut2"
    ],
    "is_built_in": true
  },
  "data": {
    "entry": {
      "entry_id": "cb01c1c1e5f25081b8d66c3879bc88f4",
      "version": 1,
      "domain": "nut",
      "title": "192.168.10.27:3493",
      "data": {
        "host": "192.168.10.27",
        "port": 3493,
        "username": "**REDACTED**",
        "password": "**REDACTED**"
      },
      "options": {},
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": null,
      "disabled_by": null
    },
    "nut_data": {
      "ups_list": {
        "eraplus800": "Technoware Era Plus 800"
      },
      "status": {
        "battery.charge": "100",
        "battery.voltage": "13.90",
        "battery.voltage.high": "13.00",
        "battery.voltage.low": "10.40",
        "battery.voltage.nominal": "12.0",
        "device.type": "ups",
        "driver.name": "blazer_usb",
        "driver.parameter.langid_fix": "0x409",
        "driver.parameter.pollinterval": "2",
        "driver.parameter.port": "auto",
        "driver.parameter.synchronous": "no",
        "driver.version": "2.7.4",
        "driver.version.internal": "0.12",
        "input.current.nominal": "5.0",
        "input.frequency": "49.8",
        "input.frequency.nominal": "50",
        "input.voltage": "244.0",
        "input.voltage.fault": "244.0",
        "input.voltage.nominal": "230",
        "output.voltage": "234.5",
        "ups.beeper.status": "enabled",
        "ups.delay.shutdown": "30",
        "ups.delay.start": "180",
        "ups.load": "16",
        "ups.productid": "5161",
        "ups.status": "OL",
        "ups.type": "offline / line interactive",
        "ups.vendorid": "0665"
      }
    },
    "device": {
      "name": "Eraplus800",
      "name_by_user": null,
      "disabled": false,
      "disabled_by": null,
      "manufacturer": "0665",
      "model": "5161",
      "sw_version": null,
      "entities": {
        "sensor.eraplus800_load": {
          "name": null,
          "original_name": "Eraplus800 Load",
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:gauge",
          "unit_of_measurement": "%",
          "state": {
            "state": "16",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "%",
              "icon": "mdi:gauge",
              "friendly_name": "Eraplus800 Load"
            },
            "last_changed": "2022-02-06T12:25:26.317373+00:00",
            "last_updated": "2022-02-06T12:25:26.317373+00:00"
          }
        },
        "sensor.eraplus800_load_restart_delay": {
          "name": null,
          "original_name": "Eraplus800 Load Restart Delay",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:timer-outline",
          "unit_of_measurement": "s",
          "state": null
        },
        "sensor.eraplus800_ups_shutdown_delay": {
          "name": null,
          "original_name": "Eraplus800 UPS Shutdown Delay",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:timer-outline",
          "unit_of_measurement": "s",
          "state": null
        },
        "sensor.eraplus800_beeper_status": {
          "name": null,
          "original_name": "Eraplus800 Beeper Status",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:information-outline",
          "unit_of_measurement": null,
          "state": null
        },
        "sensor.eraplus800_ups_type": {
          "name": null,
          "original_name": "Eraplus800 UPS Type",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:information-outline",
          "unit_of_measurement": null,
          "state": null
        },
        "sensor.eraplus800_battery_charge": {
          "name": null,
          "original_name": "Eraplus800 Battery Charge",
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": "battery",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "%",
          "state": {
            "state": "100",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "%",
              "device_class": "battery",
              "friendly_name": "Eraplus800 Battery Charge"
            },
            "last_changed": "2022-02-06T12:25:26.319097+00:00",
            "last_updated": "2022-02-06T12:25:26.319097+00:00"
          }
        },
        "sensor.eraplus800_battery_voltage": {
          "name": null,
          "original_name": "Eraplus800 Battery Voltage",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": null
        },
        "sensor.eraplus800_nominal_battery_voltage": {
          "name": null,
          "original_name": "Eraplus800 Nominal Battery Voltage",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": null
        },
        "sensor.eraplus800_low_battery_voltage": {
          "name": null,
          "original_name": "Eraplus800 Low Battery Voltage",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": null
        },
        "sensor.eraplus800_high_battery_voltage": {
          "name": null,
          "original_name": "Eraplus800 High Battery Voltage",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": null
        },
        "sensor.eraplus800_input_voltage": {
          "name": null,
          "original_name": "Eraplus800 Input Voltage",
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": {
            "state": "244.0",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "V",
              "device_class": "voltage",
              "friendly_name": "Eraplus800 Input Voltage"
            },
            "last_changed": "2022-02-06T12:25:26.320756+00:00",
            "last_updated": "2022-02-06T12:25:26.320756+00:00"
          }
        },
        "sensor.eraplus800_nominal_input_voltage": {
          "name": null,
          "original_name": "Eraplus800 Nominal Input Voltage",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": null
        },
        "sensor.eraplus800_input_line_frequency": {
          "name": null,
          "original_name": "Eraplus800 Input Line Frequency",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:flash",
          "unit_of_measurement": "Hz",
          "state": null
        },
        "sensor.eraplus800_nominal_input_line_frequency": {
          "name": null,
          "original_name": "Eraplus800 Nominal Input Line Frequency",
          "disabled": true,
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:flash",
          "unit_of_measurement": "Hz",
          "state": null
        },
        "sensor.eraplus800_output_voltage": {
          "name": null,
          "original_name": "Eraplus800 Output Voltage",
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": "voltage",
          "icon": null,
          "original_icon": null,
          "unit_of_measurement": "V",
          "state": {
            "state": "234.5",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "V",
              "device_class": "voltage",
              "friendly_name": "Eraplus800 Output Voltage"
            },
            "last_changed": "2022-02-06T12:25:26.322582+00:00",
            "last_updated": "2022-02-06T12:25:26.322582+00:00"
          }
        },
        "sensor.eraplus800_status": {
          "name": null,
          "original_name": "Eraplus800 Status",
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:information-outline",
          "unit_of_measurement": null,
          "state": {
            "state": "Online",
            "attributes": {
              "icon": "mdi:information-outline",
              "friendly_name": "Eraplus800 Status"
            },
            "last_changed": "2022-02-06T12:25:26.322972+00:00",
            "last_updated": "2022-02-06T12:25:26.322972+00:00"
          }
        },
        "sensor.eraplus800_status_data": {
          "name": null,
          "original_name": "Eraplus800 Status Data",
          "disabled": false,
          "disabled_by": null,
          "entity_category": null,
          "device_class": null,
          "original_device_class": null,
          "icon": null,
          "original_icon": "mdi:information-outline",
          "unit_of_measurement": null,
          "state": {
            "state": "OL",
            "attributes": {
              "icon": "mdi:information-outline",
              "friendly_name": "Eraplus800 Status Data"
            },
            "last_changed": "2022-02-06T12:25:26.569481+00:00",
            "last_updated": "2022-02-06T12:25:26.569481+00:00"
          }
        }
      }
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
