### PR TITLE
Update proxmox integration to support auto discovery

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -139,29 +139,31 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             node_name = node["node"]
             node_coordinators = coordinators[host_name][node_name] = {}
 
-        await get_node_vms(hass)
+            await get_node_vms(hass)
 
-        for node_vm in hass.data[PROXMOX_HOSTS][host_name]["vms"]:
-            coordinator = create_coordinator_container_vm(
-                hass, proxmox, host_name, node_name, node_vm["vmid"], TYPE_VM
-            )
+            for node_vm in hass.data[PROXMOX_HOSTS][host_name][node_name]["vms"]:
+                coordinator = create_coordinator_container_vm(
+                    hass, proxmox, host_name, node_name, node_vm["vmid"], TYPE_VM
+                )
 
-            # Fetch initial data
-            await coordinator.async_refresh()
+                # Fetch initial data
+                await coordinator.async_refresh()
 
-            node_coordinators[node_vm["vmid"]] = coordinator
+                node_coordinators[node_vm["vmid"]] = coordinator
 
-        await get_node_containers(hass)
+            await get_node_containers(hass)
 
-        for container_id in hass.data[PROXMOX_HOSTS][host_name]["containers"]:
-            coordinator = create_coordinator_container_vm(
-                hass, proxmox, host_name, node_name, container_id, TYPE_CONTAINER
-            )
+            for container_id in hass.data[PROXMOX_HOSTS][host_name][node_name][
+                "containers"
+            ]:
+                coordinator = create_coordinator_container_vm(
+                    hass, proxmox, host_name, node_name, container_id, TYPE_CONTAINER
+                )
 
-            # Fetch initial data
-            await coordinator.async_refresh()
+                # Fetch initial data
+                await coordinator.async_refresh()
 
-            node_coordinators[container_id] = coordinator
+                node_coordinators[container_id] = coordinator
 
     for component in PLATFORMS:
         await hass.async_create_task(
@@ -189,6 +191,9 @@ async def get_nodes(hass, config):
         nodes = await hass.async_add_executor_job(get_nodes_call)
         hass.data[PROXMOX_HOSTS][host]["nodes"] = nodes
 
+        for node in hass.data[PROXMOX_HOSTS][host]["nodes"]:
+            hass.data[PROXMOX_HOSTS][host][node["node"]] = {}
+
 
 async def get_node_vms(hass):
     """Get Proxmox node VMs."""
@@ -208,7 +213,7 @@ async def get_node_vms(hass):
             except (ResourceException, requests.exceptions.ConnectionError):
                 return None
 
-            hass.data[PROXMOX_HOSTS][host]["vms"] = vms
+            hass.data[PROXMOX_HOSTS][host][node["node"]]["vms"] = vms
 
 
 async def get_node_containers(hass):
@@ -229,7 +234,7 @@ async def get_node_containers(hass):
             except (ResourceException, requests.exceptions.ConnectionError):
                 return None
 
-            hass.data[PROXMOX_HOSTS][host]["containers"] = containers
+            hass.data[PROXMOX_HOSTS][host][node["node"]]["containers"] = containers
 
 
 def create_coordinator_container_vm(

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -188,7 +188,12 @@ async def get_nodes(hass, config):
         hass.data[PROXMOX_HOSTS][host] = {}
         proxmox_client = hass.data[PROXMOX_CLIENTS][host]
         proxmox = proxmox_client.get_api_client()
-        nodes = await hass.async_add_executor_job(get_nodes_call)
+
+        try:
+            nodes = await hass.async_add_executor_job(get_nodes_call)
+        except (ResourceException, requests.exceptions.ConnectionError):
+            return None
+
         hass.data[PROXMOX_HOSTS][host]["nodes"] = nodes
 
         for node in hass.data[PROXMOX_HOSTS][host]["nodes"]:

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import COORDINATORS, DOMAIN, PROXMOX_CLIENTS, ProxmoxEntity
+from . import COORDINATORS, DOMAIN, PROXMOX_CLIENTS, PROXMOX_HOSTS, ProxmoxEntity
 
 
 async def async_setup_platform(
@@ -29,10 +29,11 @@ async def async_setup_platform(
         if hass.data[PROXMOX_CLIENTS][host_name] is None:
             continue
 
-        for node_config in host_config["nodes"]:
-            node_name = node_config["node"]
+        for node in hass.data[PROXMOX_HOSTS][host_name]["nodes"]:
+            node_name = node["node"]
 
-            for vm_id in node_config["vms"]:
+            for node_vm in hass.data[PROXMOX_HOSTS][host_name]["vms"]:
+                vm_id = node_vm["vmid"]
                 coordinator = host_name_coordinators[node_name][vm_id]
 
                 # unfound vm case
@@ -45,7 +46,8 @@ async def async_setup_platform(
                 )
                 sensors.append(vm_sensor)
 
-            for container_id in node_config["containers"]:
+            for node_container in hass.data[PROXMOX_HOSTS][host_name]["containers"]:
+                container_id = node_container["vmid"]
                 coordinator = host_name_coordinators[node_name][container_id]
 
                 # unfound container case

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -32,7 +32,7 @@ async def async_setup_platform(
         for node in hass.data[PROXMOX_HOSTS][host_name]["nodes"]:
             node_name = node["node"]
 
-            for node_vm in hass.data[PROXMOX_HOSTS][host_name]["vms"]:
+            for node_vm in hass.data[PROXMOX_HOSTS][host_name][node_name]["vms"]:
                 vm_id = node_vm["vmid"]
                 coordinator = host_name_coordinators[node_name][vm_id]
 
@@ -46,7 +46,9 @@ async def async_setup_platform(
                 )
                 sensors.append(vm_sensor)
 
-            for node_container in hass.data[PROXMOX_HOSTS][host_name]["containers"]:
+            for node_container in hass.data[PROXMOX_HOSTS][host_name][node_name][
+                "containers"
+            ]:
                 container_id = node_container["vmid"]
                 coordinator = host_name_coordinators[node_name][container_id]
 


### PR DESCRIPTION
## Breaking change
Not really a breaking change as such, but the existing hardcoded list of nodes and VMs etc in the `configuration.yml` file would be ignored.


## Proposed change
Currently to use this integration, a hardcoded list of nodes and VM's / containers must be set in the `configuration.yml` file. This PR removes the need for need for that and instead auto discovers VMs and containers making the integration more intuitive and open for further enhancements.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21515

**Local testing:**
Proxmox:
![image](https://user-images.githubusercontent.com/14127638/152682988-c4f49e3e-0084-4113-a644-7c4d84c00b2c.png)

Home assistant Proxmox entities:
![image](https://user-images.githubusercontent.com/14127638/152683089-4c020399-9e30-4ac5-8667-5c8110eb10f3.png)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
