### PR TITLE
Remove deprecated yaml config from AsusWRT

### DIFF
--- a/homeassistant/components/asuswrt/__init__.py
+++ b/homeassistant/components/asuswrt/__init__.py
@@ -1,122 +1,17 @@
 """Support for ASUSWRT devices."""
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_MODE,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_PROTOCOL,
-    CONF_SENSORS,
-    CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP,
-    Platform,
-)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_DNSMASQ,
-    CONF_INTERFACE,
-    CONF_REQUIRE_IP,
-    CONF_SSH_KEY,
-    DATA_ASUSWRT,
-    DEFAULT_DNSMASQ,
-    DEFAULT_INTERFACE,
-    DEFAULT_SSH_PORT,
-    DOMAIN,
-    MODE_AP,
-    MODE_ROUTER,
-    PROTOCOL_SSH,
-    PROTOCOL_TELNET,
-)
+from .const import DATA_ASUSWRT, DOMAIN
 from .router import AsusWrtRouter
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 
-CONF_PUB_KEY = "pub_key"
-SECRET_GROUP = "Password or SSH Key"
-SENSOR_TYPES = ["devices", "upload_speed", "download_speed", "download", "upload"]
-
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_HOST): cv.string,
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Optional(CONF_PROTOCOL, default=PROTOCOL_SSH): vol.In(
-                        [PROTOCOL_SSH, PROTOCOL_TELNET]
-                    ),
-                    vol.Optional(CONF_MODE, default=MODE_ROUTER): vol.In(
-                        [MODE_ROUTER, MODE_AP]
-                    ),
-                    vol.Optional(CONF_PORT, default=DEFAULT_SSH_PORT): cv.port,
-                    vol.Optional(CONF_REQUIRE_IP, default=True): cv.boolean,
-                    vol.Exclusive(CONF_PASSWORD, SECRET_GROUP): cv.string,
-                    vol.Exclusive(CONF_SSH_KEY, SECRET_GROUP): cv.isfile,
-                    vol.Exclusive(CONF_PUB_KEY, SECRET_GROUP): cv.isfile,
-                    vol.Optional(CONF_SENSORS): vol.All(
-                        cv.ensure_list, [vol.In(SENSOR_TYPES)]
-                    ),
-                    vol.Optional(CONF_INTERFACE, default=DEFAULT_INTERFACE): cv.string,
-                    vol.Optional(CONF_DNSMASQ, default=DEFAULT_DNSMASQ): cv.string,
-                }
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the AsusWrt integration."""
-    if (conf := config.get(DOMAIN)) is None:
-        return True
-
-    # save the options from config yaml
-    options = {}
-    mode = conf.get(CONF_MODE, MODE_ROUTER)
-    for name, value in conf.items():
-        if name in [CONF_DNSMASQ, CONF_INTERFACE, CONF_REQUIRE_IP]:
-            if name == CONF_REQUIRE_IP and mode != MODE_AP:
-                continue
-            options[name] = value
-    hass.data[DOMAIN] = {"yaml_options": options}
-
-    # check if already configured
-    domains_list = hass.config_entries.async_domains()
-    if DOMAIN in domains_list:
-        return True
-
-    # remove not required config keys
-    if pub_key := conf.pop(CONF_PUB_KEY, ""):
-        conf[CONF_SSH_KEY] = pub_key
-
-    conf.pop(CONF_REQUIRE_IP, True)
-    conf.pop(CONF_SENSORS, {})
-    conf.pop(CONF_INTERFACE, "")
-    conf.pop(CONF_DNSMASQ, "")
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-        )
-    )
-
-    return True
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up AsusWrt platform."""
-
-    # import options from yaml if empty
-    yaml_options = hass.data.get(DOMAIN, {}).pop("yaml_options", {})
-    if not entry.options and yaml_options:
-        hass.config_entries.async_update_entry(entry, options=yaml_options)
 
     router = AsusWrtRouter(hass, entry)
     await router.setup()

--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -165,10 +165,6 @@ class AsusWrtFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data=user_input,
         )
 
-    async def async_step_import(self, user_input=None):
-        """Import a config entry."""
-        return await self.async_step_user(user_input)
-
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.components.asuswrt.const import (
     DOMAIN,
 )
 from homeassistant.components.device_tracker.const import CONF_CONSIDER_HOME
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
     CONF_MODE,
@@ -76,62 +76,6 @@ async def test_user(hass, connect):
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == HOST
         assert result["data"] == CONFIG_DATA
-
-        assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import(hass, connect):
-    """Test import step."""
-    with patch(
-        "homeassistant.components.asuswrt.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry, patch(
-        "homeassistant.components.asuswrt.config_flow.socket.gethostbyname",
-        return_value=IP_ADDRESS,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=CONFIG_DATA,
-        )
-        await hass.async_block_till_done()
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == HOST
-        assert result["data"] == CONFIG_DATA
-
-        assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_ssh(hass, connect):
-    """Test import step with ssh file."""
-    config_data = CONFIG_DATA.copy()
-    config_data.pop(CONF_PASSWORD)
-    config_data[CONF_SSH_KEY] = SSH_KEY
-
-    with patch(
-        "homeassistant.components.asuswrt.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry, patch(
-        "homeassistant.components.asuswrt.config_flow.socket.gethostbyname",
-        return_value=IP_ADDRESS,
-    ), patch(
-        "homeassistant.components.asuswrt.config_flow.os.path.isfile",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.asuswrt.config_flow.os.access",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config_data,
-        )
-        await hass.async_block_till_done()
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == HOST
-        assert result["data"] == config_data
 
         assert len(mock_setup_entry.mock_calls) == 1
 
@@ -210,15 +154,6 @@ async def test_abort_if_already_setup(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
-            data=CONFIG_DATA,
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "single_instance_allowed"
-
-        # Should fail, same HOST (import)
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
             data=CONFIG_DATA,
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration of the AsusWRT integration has been removed.

AsusWRT is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove deprecated yaml config from AsusWRT. Config Flow was introduced with PR #46468

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
