### PR TITLE
Initialize AlarmDecoder binary_sensor state as off instead of unknown

### DIFF
--- a/homeassistant/components/alarmdecoder/binary_sensor.py
+++ b/homeassistant/components/alarmdecoder/binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .const import (
     CONF_RELAY_ADDR,
@@ -32,6 +33,8 @@ ATTR_RF_LOOP3 = "rf_loop3"
 ATTR_RF_LOOP2 = "rf_loop2"
 ATTR_RF_LOOP4 = "rf_loop4"
 ATTR_RF_LOOP1 = "rf_loop1"
+
+DEFAULT_STATE_TIMEOUT = 30
 
 
 async def async_setup_entry(
@@ -77,6 +80,7 @@ class AlarmDecoderBinarySensor(BinarySensorEntity):
         self._zone_number = int(zone_number)
         self._zone_type = zone_type
         self._attr_name = zone_name
+        self._attr_is_on = None
         self._rfid = zone_rfid
         self._loop = zone_loop
         self._relay_addr = relay_addr
@@ -111,6 +115,13 @@ class AlarmDecoderBinarySensor(BinarySensorEntity):
                 SIGNAL_REL_MESSAGE, self._rel_message_callback
             )
         )
+
+        def set_default_state(_):
+            if self._attr_is_on is None:
+                self._attr_is_on = False
+                self.schedule_update_ha_state()
+
+        async_call_later(self.hass, DEFAULT_STATE_TIMEOUT, set_default_state)
 
     def _fault_callback(self, zone):
         """Update the zone's state, if needed."""

--- a/homeassistant/components/alarmdecoder/binary_sensor.py
+++ b/homeassistant/components/alarmdecoder/binary_sensor.py
@@ -5,7 +5,6 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
 
 from .const import (
     CONF_RELAY_ADDR,
@@ -33,8 +32,6 @@ ATTR_RF_LOOP3 = "rf_loop3"
 ATTR_RF_LOOP2 = "rf_loop2"
 ATTR_RF_LOOP4 = "rf_loop4"
 ATTR_RF_LOOP1 = "rf_loop1"
-
-DEFAULT_STATE_TIMEOUT = 30
 
 
 async def async_setup_entry(
@@ -80,7 +77,7 @@ class AlarmDecoderBinarySensor(BinarySensorEntity):
         self._zone_number = int(zone_number)
         self._zone_type = zone_type
         self._attr_name = zone_name
-        self._attr_is_on = None
+        self._attr_is_on = False
         self._rfid = zone_rfid
         self._loop = zone_loop
         self._relay_addr = relay_addr
@@ -115,13 +112,6 @@ class AlarmDecoderBinarySensor(BinarySensorEntity):
                 SIGNAL_REL_MESSAGE, self._rel_message_callback
             )
         )
-
-        def set_default_state(_):
-            if self._attr_is_on is None:
-                self._attr_is_on = False
-                self.schedule_update_ha_state()
-
-        async_call_later(self.hass, DEFAULT_STATE_TIMEOUT, set_default_state)
 
     def _fault_callback(self, zone):
         """Update the zone's state, if needed."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `binary_sensor` states are only explicitly set after receiving some activity on the zone. This was fine until #60193 allowed `None` as a valid state. In most cases the default state should be `False` as the zone is not faulted, but we don't know for sure until we wait for messages to possibly arrive.

~~This keeps the states in an `Unknown` state for 30 seconds after being added, and then falls back to the previous (effective) default of `False`.~~

This PR simply sets a default state of "off" for all `binary_sensor` entities to reinstate the previous behavior.

There may be better ways of doing this, but I'm not intimately familiar with the underlying library. For example, perhaps if the alarm panel shows no faults, set _all_ `binary_sensors` to `False` immediately.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65740 fixes #65521
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
