### PR TITLE
Disallow cross-origin requests for webhooks

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -167,6 +167,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ssl_key=ssl_key,
         trusted_proxies=trusted_proxies,
         ssl_profile=ssl_profile,
+        cors_origins=cors_origins,
     )
     await server.async_initialize(
         cors_origins=cors_origins,
@@ -218,6 +219,7 @@ class HomeAssistantHTTP:
         server_port: int,
         trusted_proxies: list[str],
         ssl_profile: str,
+        cors_origins: list[str],
     ) -> None:
         """Initialize the HTTP Home Assistant server."""
         self.app = web.Application(middlewares=[], client_max_size=MAX_CLIENT_SIZE)
@@ -229,6 +231,7 @@ class HomeAssistantHTTP:
         self.server_port = server_port
         self.trusted_proxies = trusted_proxies
         self.ssl_profile = ssl_profile
+        self.cors_origins = cors_origins
         self.runner: web.AppRunner | None = None
         self.site: HomeAssistantTCPSite | None = None
 

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -177,6 +177,26 @@ async def test_webhook_local_only(hass, mock_client):
     # No hook received
     assert len(hooks) == 1
 
+    # Request with Referer header set.
+    resp = await mock_client.post(
+        f"/api/webhook/{webhook_id}",
+        headers={"Referer": "https://home-assistant.io/"},
+        json={"data": True},
+    )
+    assert resp.status == HTTPStatus.OK
+    # No hook received
+    assert len(hooks) == 1
+
+    # Request with Origin header set.
+    resp = await mock_client.post(
+        f"/api/webhook/{webhook_id}",
+        headers={"Origin": "https://home-assistant.io/"},
+        json={"data": True},
+    )
+    assert resp.status == HTTPStatus.OK
+    # No hook received
+    assert len(hooks) == 1
+
 
 async def test_listing_webhook(
     hass, hass_ws_client, hass_access_token, enable_custom_integrations


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Webhooks have been adjusted to not allow access from web browsers by default. Trusted web pages can still be allowed by adjusting the [cors_allowed_origins](https://www.home-assistant.io/integrations/http/#cors_allowed_origins) configuration for the http integration. If you see a log message similar to `Received likely CSRF request from non-trusted origin for webhook`, then add the origin to the cors_allowed_origins configuration. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Webhooks can be triggered by devices and services outside of Home Assistant. But they can also be triggered by cross-origin requests in the browser. A web browser could accidentally allow a non-local website to activate a webhook.

```
(non-local website) <-> (local browser) -> (webhook)
```

This PR aims to make it harder for a non-local website to activate/trigger a webhook via a browser. It does so by disabling the `cors_allowed` setting, preventing a non-trusted website from sending non-simple requests. HEAD & POST methods are considered [simple requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and do not trigger a CORS preflight check. This PR adds a "Referer" header check to verify these requests come from a trusted site.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/56446
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
