### PR TITLE
Cache webostv supported_features state

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -144,7 +144,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         self._current_source = None
         self._source_list: dict = {}
 
-        self._supported_features = None
+        self._supported_features: int | None = None
 
     async def async_added_to_hass(self) -> None:
         """Connect and subscribe to dispatcher signals and state updates."""

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -34,6 +34,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
     STATE_OFF,
@@ -44,6 +45,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import WebOsClientWrapper
 from .const import (
@@ -121,7 +123,7 @@ def cmd(
     return cmd_wrapper
 
 
-class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
+class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
     """Representation of a LG webOS Smart TV."""
 
     def __init__(
@@ -148,6 +150,8 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Connect and subscribe to dispatcher signals and state updates."""
+        await super().async_added_to_hass()
+
         self.async_on_remove(
             async_dispatcher_connect(self.hass, DOMAIN, self.async_signal_handler)
         )
@@ -155,6 +159,12 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         await self._client.register_state_update_callback(
             self.async_handle_state_update
         )
+
+        if self._supported_features is not None:
+            return
+
+        if (state := await self.async_get_last_state()) is not None:
+            self._supported_features = state.attributes.get(ATTR_SUPPORTED_FEATURES)
 
     async def async_will_remove_from_hass(self) -> None:
         """Call disconnect on removal."""
@@ -328,7 +338,8 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         if self._wrapper.turn_on:
             supported |= SUPPORT_TURN_ON
 
-        self._supported_features = supported
+        if self.state != STATE_OFF:
+            self._supported_features = supported
 
         return supported
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -330,7 +330,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
         supported = SUPPORT_WEBOSTV
 
-        if self._client.sound_output in (None, "external_arc", "external_speaker"):
+        if self._client.sound_output in ("external_arc", "external_speaker"):
             supported = supported | SUPPORT_WEBOSTV_VOLUME
         elif self._client.sound_output != "lineout":
             supported = supported | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -144,6 +144,8 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         self._current_source = None
         self._source_list: dict = {}
 
+        self._supported_features = None
+
     async def async_added_to_hass(self) -> None:
         """Connect and subscribe to dispatcher signals and state updates."""
         self.async_on_remove(
@@ -313,15 +315,20 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @property
     def supported_features(self) -> int:
         """Flag media player features that are supported."""
+        if self.state == STATE_OFF and self._supported_features is not None:
+            return self._supported_features
+
         supported = SUPPORT_WEBOSTV
 
-        if self._client.sound_output in ("external_arc", "external_speaker"):
+        if self._client.sound_output in (None, "external_arc", "external_speaker"):
             supported = supported | SUPPORT_WEBOSTV_VOLUME
         elif self._client.sound_output != "lineout":
             supported = supported | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
 
         if self._wrapper.turn_on:
             supported |= SUPPORT_TURN_ON
+
+        self._supported_features = supported
 
         return supported
 

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -565,26 +565,7 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     await setup_webostv(hass)
     await client.mock_state_update()
 
-    # TV off start, support volume mute, step
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
-    attrs = hass.states.get(ENTITY_ID).attributes
-
-    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
-
-    # TV on, support volume mute, step, step
-    monkeypatch.setattr(client, "is_on", True)
-    monkeypatch.setattr(client, "sound_output", "speaker")
-    await client.mock_state_update()
-
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
-    attrs = hass.states.get(ENTITY_ID).attributes
-
-    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
-
-    # TV off, support volume mute, step, step
-    monkeypatch.setattr(client, "is_on", False)
-    await client.mock_state_update()
-
+    # TV off, support volume mute, step, set
     supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
     attrs = hass.states.get(ENTITY_ID).attributes
 
@@ -600,11 +581,32 @@ async def test_cached_supported_features(hass, client, monkeypatch):
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
-    # TV off, support volume mute, step, step
+    # TV off, support volume mute, step
     monkeypatch.setattr(client, "is_on", False)
+    monkeypatch.setattr(client, "sound_output", None)
     await client.mock_state_update()
 
     supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # TV on, support volume mute, step, set
+    monkeypatch.setattr(client, "is_on", True)
+    monkeypatch.setattr(client, "sound_output", "speaker")
+    await client.mock_state_update()
+
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # TV off, support volume mute, step, step, set
+    monkeypatch.setattr(client, "is_on", False)
+    monkeypatch.setattr(client, "sound_output", None)
+    await client.mock_state_update()
+
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -556,3 +556,55 @@ async def test_supported_features(hass, client, monkeypatch):
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+
+async def test_cached_supported_features(hass, client, monkeypatch):
+    """Test test supported features."""
+    monkeypatch.setattr(client, "is_on", False)
+    monkeypatch.setattr(client, "sound_output", None)
+    await setup_webostv(hass)
+    await client.mock_state_update()
+
+    # TV off start, support volume mute, step
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # TV on, support volume mute, step, step
+    monkeypatch.setattr(client, "is_on", True)
+    monkeypatch.setattr(client, "sound_output", "speaker")
+    await client.mock_state_update()
+
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # TV off, support volume mute, step, step
+    monkeypatch.setattr(client, "is_on", False)
+    await client.mock_state_update()
+
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # TV on, support volume mute, step
+    monkeypatch.setattr(client, "is_on", True)
+    monkeypatch.setattr(client, "sound_output", "external_speaker")
+    await client.mock_state_update()
+
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # TV off, support volume mute, step, step
+    monkeypatch.setattr(client, "is_on", False)
+    await client.mock_state_update()
+
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In order to mitigate the problem of the TV not being able to correctly report the supported features when it is off (as it can't correctly detect external audio devices), we will now cache the last reported value when it was on and return that value when it goes off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59718

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
