### PR TITLE
Add apparent and reactive power DeviceClass to Fronius SmartMeter

### DIFF
--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     FREQUENCY_HERTZ,
     PERCENTAGE,
     POWER_VOLT_AMPERE,
+    POWER_VOLT_AMPERE_REACTIVE,
     POWER_WATT,
     TEMP_CELSIUS,
 )
@@ -52,7 +53,6 @@ _LOGGER: Final = logging.getLogger(__name__)
 
 ELECTRIC_CHARGE_AMPERE_HOURS: Final = "Ah"
 ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"
-POWER_VOLT_AMPERE_REACTIVE: Final = "var"
 
 PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend(
@@ -338,6 +338,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_apparent_phase_1",
         name="Power apparent phase 1",
         native_unit_of_measurement=POWER_VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -346,6 +347,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_apparent_phase_2",
         name="Power apparent phase 2",
         native_unit_of_measurement=POWER_VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -354,6 +356,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_apparent_phase_3",
         name="Power apparent phase 3",
         native_unit_of_measurement=POWER_VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -362,6 +365,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_apparent",
         name="Power apparent",
         native_unit_of_measurement=POWER_VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -397,6 +401,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_reactive_phase_1",
         name="Power reactive phase 1",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
+        device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -405,6 +410,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_reactive_phase_2",
         name="Power reactive phase 2",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
+        device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -413,6 +419,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_reactive_phase_3",
         name="Power reactive phase 3",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
+        device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,
@@ -421,6 +428,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="power_reactive",
         name="Power reactive",
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
+        device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-outline",
         entity_registry_enabled_default=False,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add apparent and reactive power DeviceClass to Fronius SmartMeter

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #62010
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
