### PR TITLE
Alert: set status to "on" only after first notification sent

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -205,7 +205,7 @@ class Alert(ToggleEntity):
         self._firing = False
         self._ack = False
         self._cancel = None
-        self._send_done_message = False
+        self._notification_sent = False
         self.entity_id = f"{DOMAIN}.{entity_id}"
 
         event.async_track_state_change_event(
@@ -251,7 +251,7 @@ class Alert(ToggleEntity):
         self._cancel()
         self._ack = False
         self._firing = False
-        if self._send_done_message:
+        if self._notification_sent:
             await self._notify_done_message()
         self.async_write_ha_state()
 
@@ -271,7 +271,7 @@ class Alert(ToggleEntity):
 
         if not self._ack:
             _LOGGER.info("Alerting: %s", self._attr_name)
-            self._send_done_message = True
+            self._notification_sent = True
 
             if self._message_template is not None:
                 message = self._message_template.async_render(parse_result=False)
@@ -284,7 +284,7 @@ class Alert(ToggleEntity):
     async def _notify_done_message(self, *args):
         """Send notification of complete alert."""
         _LOGGER.info("Alerting: %s", self._done_message_template)
-        self._send_done_message = False
+        self._notification_sent = False
 
         if self._done_message_template is None:
             return

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -215,7 +215,7 @@ class Alert(ToggleEntity):
     @property
     def state(self):  # pylint: disable=overridden-final-method
         """Return the alert status."""
-        if self._firing:
+        if self._firing and self._notification_sent:
             if self._ack:
                 return STATE_OFF
             return STATE_ON
@@ -272,6 +272,7 @@ class Alert(ToggleEntity):
         if not self._ack:
             _LOGGER.info("Alerting: %s", self._attr_name)
             self._notification_sent = True
+            self.async_write_ha_state()
 
             if self._message_template is not None:
                 message = self._message_template.async_render(parse_result=False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
I don't think so but the change changes the behavior of the  [alert](https://www.home-assistant.io/integrations/alert/) integration  slightly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The [alert](https://www.home-assistant.io/integrations/alert/) integration has an option to [skip the first alert](https://www.home-assistant.io/integrations/alert/#skip_first). If this option is set, then the alert will not fire immediately but after some defined delay. In this case the integration currently reports the state of the alert until the first notification as `on`. 

This can be misleading for other integrations because the alert was not really active, yet. Therefore, let's change the behavior and only report the state `on` whenever an actual alert was sent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #37828
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
