### PR TITLE
Add tplink hardware version to device info

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -54,6 +54,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
             model=self.device.model,
             name=self.device.alias,
             sw_version=self.device.hw_info["sw_ver"],
+            hw_version=self.device.hw_info["hw_ver"],
         )
 
     @property

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -38,7 +38,7 @@ def _mocked_bulb() -> SmartBulb:
     bulb.device_id = MAC_ADDRESS
     bulb.valid_temperature_range.min = 4000
     bulb.valid_temperature_range.max = 9000
-    bulb.hw_info = {"sw_ver": "1.0.0"}
+    bulb.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     bulb.turn_off = AsyncMock()
     bulb.turn_on = AsyncMock()
     bulb.set_brightness = AsyncMock()
@@ -65,7 +65,7 @@ def _mocked_dimmer() -> SmartDimmer:
     dimmer.device_id = MAC_ADDRESS
     dimmer.valid_temperature_range.min = 4000
     dimmer.valid_temperature_range.max = 9000
-    dimmer.hw_info = {"sw_ver": "1.0.0"}
+    dimmer.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     dimmer.turn_off = AsyncMock()
     dimmer.turn_on = AsyncMock()
     dimmer.set_brightness = AsyncMock()
@@ -88,7 +88,7 @@ def _mocked_plug() -> SmartPlug:
     plug.is_strip = False
     plug.is_plug = True
     plug.device_id = MAC_ADDRESS
-    plug.hw_info = {"sw_ver": "1.0.0"}
+    plug.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     plug.turn_off = AsyncMock()
     plug.turn_on = AsyncMock()
     plug.set_led = AsyncMock()
@@ -109,7 +109,7 @@ def _mocked_strip() -> SmartStrip:
     strip.is_strip = True
     strip.is_plug = True
     strip.device_id = MAC_ADDRESS
-    strip.hw_info = {"sw_ver": "1.0.0"}
+    strip.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     strip.turn_off = AsyncMock()
     strip.turn_on = AsyncMock()
     strip.set_led = AsyncMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds hardware version to tplink device info.

![image](https://user-images.githubusercontent.com/3705853/152702815-f33b1c50-2da3-4667-b17d-3670ee0e25cb.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
