### PR TITLE
Small cleanup of sonarr sensor platform

### DIFF
--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -90,7 +90,7 @@ def sonarr_exception_handler(func: Callable) -> Callable:
     and handles the availability of the entity.
     """
 
-    async def handler(self, *args, **kwargs):  # type: ignore
+    async def handler(self, *args, **kwargs):
         try:
             await func(self, *args, **kwargs)
             self.last_update_success = True

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -6,9 +6,9 @@ from datetime import timedelta
 from functools import wraps
 import logging
 from typing import Any, TypeVar
-from typing_extensions import Concatenate, ParamSpec
 
 from sonarr import Sonarr, SonarrConnectionError, SonarrError
+from typing_extensions import Concatenate, ParamSpec
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -112,7 +112,7 @@ def sonarr_exception_handler(
                 _LOGGER.error("Invalid response from API: %s", error)
                 self.last_update_success = False
 
-    return handler
+    return wrapper
 
 
 class SonarrSensor(SonarrEntity, SensorEntity):

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -68,7 +68,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
 )
 
 _T = TypeVar("_T", bound="SonarrSensor")
-_R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -91,7 +91,7 @@ async def async_setup_entry(
 
 def sonarr_exception_handler(
     func: Callable[Concatenate[_T, _P], Awaitable[None]]  # type: ignore[misc]
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]:
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
     """Decorate Sonarr calls to handle Sonarr exceptions.
 
     A decorator that wraps the passed in function, catches Sonarr errors,
@@ -104,11 +104,11 @@ def sonarr_exception_handler(
             await func(self, *args, **kwargs)
             self.last_update_success = True
         except SonarrConnectionError as error:
-            if self.last_update_success:
+            if self.available:
                 _LOGGER.error("Error communicating with API: %s", error)
             self.last_update_success = False
         except SonarrError as error:
-            if self.last_update_success:
+            if self.available:
                 _LOGGER.error("Invalid response from API: %s", error)
                 self.last_update_success = False
 

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -94,11 +94,11 @@ def sonarr_exception_handler(func):
             await func(self, *args, **kwargs)
             self.last_update_success = True
         except SonarrConnectionError as error:
-            if self.available:
+            if self.last_update_success:
                 _LOGGER.error("Error communicating with API: %s", error)
             self.last_update_success = False
         except SonarrError as error:
-            if self.available:
+            if self.last_update_success:
                 _LOGGER.error("Invalid response from API: %s", error)
                 self.last_update_success = False
 
@@ -107,6 +107,11 @@ def sonarr_exception_handler(func):
 
 class SonarrSensor(SonarrEntity, SensorEntity):
     """Implementation of the Sonarr sensor."""
+
+    data: dict[str, Any]
+    last_update_success: bool
+    upcoming_days: int
+    wanted_max_items: int
 
     def __init__(
         self,
@@ -119,10 +124,10 @@ class SonarrSensor(SonarrEntity, SensorEntity):
         self.entity_description = description
         self._attr_unique_id = f"{entry_id}_{description.key}"
 
-        self.data: dict[str, Any] = {}
-        self.last_update_success: bool = False
-        self.upcoming_days: int = options[CONF_UPCOMING_DAYS]
-        self.wanted_max_items: int = options[CONF_WANTED_MAX_ITEMS]
+        self.data = {}
+        self.last_update_success = True
+        self.upcoming_days = options[CONF_UPCOMING_DAYS]
+        self.wanted_max_items = options[CONF_WANTED_MAX_ITEMS]
 
         super().__init__(
             sonarr=sonarr,

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -1,6 +1,7 @@
 """Support for Sonarr sensors."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import timedelta
 import logging
 from typing import Any
@@ -82,14 +83,14 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-def sonarr_exception_handler(func):
+def sonarr_exception_handler(func: Callable) -> Callable:
     """Decorate Sonarr calls to handle Sonarr exceptions.
 
     A decorator that wraps the passed in function, catches Sonarr errors,
     and handles the availability of the entity.
     """
 
-    async def handler(self, *args, **kwargs):
+    async def handler(self, *args, **kwargs):  # type: ignore
         try:
             await func(self, *args, **kwargs)
             self.last_update_success = True

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -68,18 +68,21 @@ async def test_sensors(
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:harddisk"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == DATA_GIGABYTES
+    assert state.attributes.get("C:\\") == "263.10/465.42GB (56.53%)"
     assert state.state == "263.10"
 
     state = hass.states.get("sensor.sonarr_queue")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:download"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "Episodes"
+    assert state.attributes.get("The Andy Griffith Show S01E01") == "100.00%"
     assert state.state == "1"
 
     state = hass.states.get("sensor.sonarr_shows")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:television"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "Series"
+    assert state.attributes.get("The Andy Griffith Show") == "0/0 Episodes"
     assert state.state == "1"
 
     state = hass.states.get("sensor.sonarr_upcoming")

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -86,6 +86,7 @@ async def test_sensors(
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:television"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "Episodes"
+    assert state.attributes.get("Bob's Burgers") == "S04E11"
     assert state.state == "1"
 
     state = hass.states.get("sensor.sonarr_wanted")

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -92,6 +92,7 @@ async def test_sensors(
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:television"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "Episodes"
+    assert state.attributes.get("The Andy Griffith Show S01E01") == "1960-10-03"
     assert state.state == "2"
 
 

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -96,6 +96,7 @@ async def test_sensors(
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:television"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "Episodes"
+    assert state.attributes.get("Bob's Burgers S04E11") == "2014-01-26"
     assert state.attributes.get("The Andy Griffith Show S01E01") == "1960-10-03"
     assert state.state == "2"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Broken out of #65349 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
