### PR TITLE
Bump pytest to 7.0.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -25,7 +25,7 @@ pytest-test-groups==1.0.3
 pytest-sugar==0.9.4
 pytest-timeout==2.1.0
 pytest-xdist==2.4.0
-pytest==6.2.5
+pytest==7.0.0
 requests_mock==1.9.2
 respx==0.19.0
 stdlib-list==0.7.0

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -39,7 +39,7 @@ def setup_comp(hass):
     )
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def teardown():
     """Restore."""
     yield

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -39,8 +39,11 @@ def setup_comp(hass):
     )
 
 
+@pytest.fixture(autouse=True, scope="function")
 def teardown():
     """Restore."""
+    yield
+
     dt_util.set_default_time_zone(ORIG_TIME_ZONE)
 
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -46,7 +46,7 @@ def setup_comp(hass):
     )
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def teardown():
     """Restore."""
     yield

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -46,8 +46,11 @@ def setup_comp(hass):
     )
 
 
+@pytest.fixture(autouse=True, scope="function")
 def teardown():
     """Restore."""
+    yield
+
     dt_util.set_default_time_zone(ORIG_TIME_ZONE)
 
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -46,7 +46,7 @@ from tests.common import async_fire_time_changed
 DEFAULT_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def teardown():
     """Stop everything that was started."""
     yield

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -46,8 +46,11 @@ from tests.common import async_fire_time_changed
 DEFAULT_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE
 
 
+@pytest.fixture(autouse=True, scope="function")
 def teardown():
     """Stop everything that was started."""
+    yield
+
     dt_util.set_default_time_zone(DEFAULT_TIME_ZONE)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,7 @@ def create_file(path):
         pass
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def teardown():
     """Clean up."""
     yield

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,8 +53,11 @@ def create_file(path):
         pass
 
 
+@pytest.fixture(autouse=True, scope="function")
 def teardown():
     """Clean up."""
+    yield
+
     dt_util.DEFAULT_TIME_ZONE = ORIG_TIMEZONE
 
     if os.path.isfile(YAML_PATH):
@@ -78,6 +81,11 @@ def teardown():
 
 async def test_create_default_config(hass):
     """Test creation of default config."""
+    assert not os.path.isfile(YAML_PATH)
+    assert not os.path.isfile(SECRET_PATH)
+    assert not os.path.isfile(VERSION_PATH)
+    assert not os.path.isfile(AUTOMATIONS_PATH)
+
     await config_util.async_create_default_config(hass)
 
     assert os.path.isfile(YAML_PATH)
@@ -91,6 +99,8 @@ async def test_ensure_config_exists_creates_config(hass):
 
     If not creates a new config file.
     """
+    assert CONFIG_DIR == "/workspaces/home-assistant/tests/testing_config"
+    assert not os.path.isfile(YAML_PATH)
     with patch("builtins.print") as mock_print:
         await config_util.async_ensure_config_exists(hass)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,7 +99,6 @@ async def test_ensure_config_exists_creates_config(hass):
 
     If not creates a new config file.
     """
-    assert CONFIG_DIR == "/workspaces/home-assistant/tests/testing_config"
     assert not os.path.isfile(YAML_PATH)
     with patch("builtins.print") as mock_print:
         await config_util.async_ensure_config_exists(hass)

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -9,8 +9,11 @@ DEFAULT_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE
 TEST_TIME_ZONE = "America/Los_Angeles"
 
 
+@pytest.fixture(autouse=True, scope="function")
 def teardown():
     """Stop everything that was started."""
+    yield
+
     dt_util.set_default_time_zone(DEFAULT_TIME_ZONE)
 
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -9,7 +9,7 @@ DEFAULT_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE
 TEST_TIME_ZONE = "America/Los_Angeles"
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def teardown():
     """Stop everything that was started."""
     yield

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -26,14 +26,14 @@ TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
 TMP_DIR = None
 
 
-def setup():
-    """Set up for tests."""
+@pytest.fixture(autouse=True, scope="function")
+def setup_and_teardown():
+    """Clean up after tests."""
     global TMP_DIR
     TMP_DIR = mkdtemp()
 
+    yield
 
-def teardown():
-    """Clean up after tests."""
     for fname in os.listdir(TMP_DIR):
         os.remove(os.path.join(TMP_DIR, fname))
     os.rmdir(TMP_DIR)

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -26,7 +26,7 @@ TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
 TMP_DIR = None
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True)
 def setup_and_teardown():
     """Clean up after tests."""
     global TMP_DIR


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pytest to v7.0.0 and convert nose style teardown function to pytest fixture.

https://github.com/pytest-dev/pytest/releases/tag/7.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
