### PR TITLE
Add diagnostics to Version integration

### DIFF
--- a/homeassistant/components/version/diagnostics.py
+++ b/homeassistant/components/version/diagnostics.py
@@ -1,0 +1,56 @@
+"""Provides diagnostics for Version."""
+from __future__ import annotations
+
+from typing import Any
+
+from attr import asdict
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    devices = []
+
+    registry_devices = dr.async_entries_for_config_entry(
+        device_registry, config_entry.entry_id
+    )
+
+    for device in registry_devices:
+        entities = []
+
+        registry_entities = er.async_entries_for_device(
+            entity_registry,
+            device_id=device.id,
+            include_disabled_entities=True,
+        )
+
+        for entity in registry_entities:
+            state_dict = None
+            if state := hass.states.get(entity.entity_id):
+                state_dict = dict(state.as_dict())
+                state_dict.pop("context", None)
+
+            entities.append({"entry": asdict(entity), "state": state_dict})
+
+        devices.append({"device": asdict(device), "entities": entities})
+
+    return {
+        "entry": config_entry.as_dict(),
+        "coordinator_data": {
+            "version": coordinator.version,
+            "version_data": coordinator.version_data,
+        },
+        "devices": devices,
+    }

--- a/tests/components/version/test_diagnostics.py
+++ b/tests/components/version/test_diagnostics.py
@@ -10,10 +10,10 @@ from .common import MOCK_VERSION, setup_version_integration
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 
 
-async def test_version_sensor(
+async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSession,
-):
+) -> None:
     """Test diagnostic information."""
     config_entry = await setup_version_integration(hass)
 

--- a/tests/components/version/test_diagnostics.py
+++ b/tests/components/version/test_diagnostics.py
@@ -20,7 +20,6 @@ async def test_version_sensor(
     diagnostics = await get_diagnostics_for_config_entry(
         hass, hass_client, config_entry
     )
-    print(diagnostics)
     assert diagnostics["entry"]["data"] == {
         "name": "",
         "channel": "stable",

--- a/tests/components/version/test_diagnostics.py
+++ b/tests/components/version/test_diagnostics.py
@@ -1,0 +1,37 @@
+"""Test version diagnostics."""
+
+
+from aioaseko import ClientSession
+
+from homeassistant.core import HomeAssistant
+
+from .common import MOCK_VERSION, setup_version_integration
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_version_sensor(
+    hass: HomeAssistant,
+    hass_client: ClientSession,
+):
+    """Test diagnostic information."""
+    config_entry = await setup_version_integration(hass)
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry
+    )
+    print(diagnostics)
+    assert diagnostics["entry"]["data"] == {
+        "name": "",
+        "channel": "stable",
+        "image": "default",
+        "board": "OVA",
+        "version_source": "Local installation",
+        "source": "local",
+    }
+
+    assert diagnostics["coordinator_data"] == {
+        "version": MOCK_VERSION,
+        "version_data": None,
+    }
+    assert len(diagnostics["devices"]) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics to Version integration.
Example output:
[config_entry-version-044467a3a91a2971112a8db9e2dbdc3d.json.txt](https://github.com/home-assistant/core/files/8014934/config_entry-version-044467a3a91a2971112a8db9e2dbdc3d.json.txt)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
