### PR TITLE
Improve roon integraton

### DIFF
--- a/homeassistant/components/roon/__init__.py
+++ b/homeassistant/components/roon/__init__.py
@@ -12,11 +12,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a roonserver from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    name = (
-        entry.data[CONF_HOST]
-        if entry.data[CONF_ROON_NAME] is None
-        else entry.data[CONF_ROON_NAME]
-    )
+    # fallback to using host for compatibility with older configs
+    name = entry.data.get(CONF_ROON_NAME, entry.data[CONF_HOST])
 
     roonserver = RoonServer(hass, entry)
 

--- a/homeassistant/components/roon/__init__.py
+++ b/homeassistant/components/roon/__init__.py
@@ -4,14 +4,20 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN
+from .const import CONF_ROON_NAME, DOMAIN
 from .server import RoonServer
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a roonserver from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    host = entry.data[CONF_HOST]
+
+    name = (
+        entry.data[CONF_HOST]
+        if entry.data[CONF_ROON_NAME] is None
+        else entry.data[CONF_ROON_NAME]
+    )
+
     roonserver = RoonServer(hass, entry)
 
     if not await roonserver.async_setup():
@@ -23,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
         manufacturer="Roonlabs",
-        name=host,
+        name=f"Roon Core ({name})",
     )
     return True
 

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required("host", default="192.168.1.X"): cv.string,
-        vol.Required("port", default="9330"): cv.port,
+        vol.Required("port", default=9330): cv.port,
     }
 )
 

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -155,6 +155,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle linking and authenticting with the roon server."""
         errors = {}
         if user_input is not None:
+            # Do not authenticate if the host is already configured
+            self._async_abort_entries_match({CONF_HOST: self._host})
+
             try:
                 info = await authenticate(
                     self.hass, self._host, self._port, self._servers

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -81,7 +81,6 @@ class RoonHub:
                 core_id = auth_api[0].core_id
                 core_name = auth_api[0].core_name
                 token = auth_api[0].token
-                core_name = auth_api[0].core_name
                 break
 
             await asyncio.sleep(AUTHENTICATE_TIMEOUT)

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -6,11 +6,13 @@ from roonapi import RoonApi, RoonDiscovery
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
 
 from .const import (
     AUTHENTICATE_TIMEOUT,
     CONF_ROON_ID,
+    CONF_ROON_NAME,
     DEFAULT_NAME,
     DOMAIN,
     ROON_APPINFO,
@@ -18,7 +20,12 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema({vol.Required("host"): str})
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("host", default="192.168.1.X"): cv.string,
+        vol.Required("port", default="9330"): cv.port,
+    }
+)
 
 TIMEOUT = 120
 
@@ -45,7 +52,7 @@ class RoonHub:
         _LOGGER.debug("Servers = %s", servers)
         return servers
 
-    async def authenticate(self, host, servers):
+    async def authenticate(self, host, port, servers):
         """Authenticate with one or more roon servers."""
 
         def stop_apis(apis):
@@ -54,6 +61,7 @@ class RoonHub:
 
         token = None
         core_id = None
+        core_name = None
         secs = 0
         if host is None:
             apis = [
@@ -61,7 +69,7 @@ class RoonHub:
                 for server in servers
             ]
         else:
-            apis = [RoonApi(ROON_APPINFO, None, host, blocking_init=False)]
+            apis = [RoonApi(ROON_APPINFO, None, host, port, blocking_init=False)]
 
         while secs <= TIMEOUT:
             # Roon can discover multiple devices - not all of which are proper servers, so try and authenticate with them all.
@@ -71,14 +79,16 @@ class RoonHub:
             secs += AUTHENTICATE_TIMEOUT
             if auth_api:
                 core_id = auth_api[0].core_id
+                core_name = auth_api[0].core_name
                 token = auth_api[0].token
+                core_name = auth_api[0].core_name
                 break
 
             await asyncio.sleep(AUTHENTICATE_TIMEOUT)
 
         await self._hass.async_add_executor_job(stop_apis, apis)
 
-        return (token, core_id)
+        return (token, core_id, core_name)
 
 
 async def discover(hass):
@@ -90,15 +100,21 @@ async def discover(hass):
     return servers
 
 
-async def authenticate(hass: core.HomeAssistant, host, servers):
+async def authenticate(hass: core.HomeAssistant, host, port, servers):
     """Connect and authenticate home assistant."""
 
     hub = RoonHub(hass)
-    (token, core_id) = await hub.authenticate(host, servers)
+    (token, core_id, core_name) = await hub.authenticate(host, port, servers)
     if token is None:
         raise InvalidAuth
 
-    return {CONF_HOST: host, CONF_ROON_ID: core_id, CONF_API_KEY: token}
+    return {
+        CONF_HOST: host,
+        CONF_PORT: port,
+        CONF_ROON_ID: core_id,
+        CONF_ROON_NAME: core_name,
+        CONF_API_KEY: token,
+    }
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -109,33 +125,42 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize the Roon flow."""
         self._host = None
+        self._port = None
         self._servers = []
 
     async def async_step_user(self, user_input=None):
         """Handle getting host details from the user."""
 
-        errors = {}
         self._servers = await discover(self.hass)
 
         # We discovered one or more  roon - so skip to authentication
         if self._servers:
             return await self.async_step_link()
 
+        return await self.async_step_fallback()
+
+    async def async_step_fallback(self, user_input=None):
+        """Handle getting host details from the user."""
+        errors = {}
+
         if user_input is not None:
             self._host = user_input["host"]
+            self._port = user_input["port"]
             return await self.async_step_link()
 
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            step_id="fallback", data_schema=DATA_SCHEMA, errors=errors
         )
 
     async def async_step_link(self, user_input=None):
         """Handle linking and authenticting with the roon server."""
-
         errors = {}
         if user_input is not None:
             try:
-                info = await authenticate(self.hass, self._host, self._servers)
+                info = await authenticate(
+                    self.hass, self._host, self._port, self._servers
+                )
+
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -128,7 +128,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._servers = []
 
     async def async_step_user(self, user_input=None):
-        """Handle getting host details from the user."""
+        """Get roon core details via discovery."""
 
         self._servers = await discover(self.hass)
 
@@ -139,7 +139,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_fallback()
 
     async def async_step_fallback(self, user_input=None):
-        """Handle getting host details from the user."""
+        """Get host and port details from the user."""
         errors = {}
 
         if user_input is not None:

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("host", default="192.168.1.X"): cv.string,
+        vol.Required("host"): cv.string,
         vol.Required("port", default=9330): cv.port,
     }
 )

--- a/homeassistant/components/roon/const.py
+++ b/homeassistant/components/roon/const.py
@@ -5,6 +5,7 @@ AUTHENTICATE_TIMEOUT = 5
 DOMAIN = "roon"
 
 CONF_ROON_ID = "roon_server_id"
+CONF_ROON_NAME = "roon_server_name"
 
 DATA_CONFIGS = "roon_configs"
 

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -3,7 +3,7 @@
   "name": "RoonLabs music player",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
-  "requirements": ["roonapi==0.0.38"],
+  "requirements": ["roonapi==0.1.0"],
   "codeowners": ["@pavoni"],
   "iot_class": "local_push",
   "loggers": ["roonapi"]

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -3,7 +3,7 @@
   "name": "RoonLabs music player",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
-  "requirements": ["roonapi==0.1.0"],
+  "requirements": ["roonapi==0.1.1"],
   "codeowners": ["@pavoni"],
   "iot_class": "local_push",
   "loggers": ["roonapi"]

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -64,7 +64,7 @@ class RoonServer:
 
         # Default to 'host' for compatibility with older configs without core_id
         self.roon_id = (
-            core_id if core_id is not None else self.config_entry.data.get(CONF_HOST)
+            core_id if core_id is not None else self.config_entry.data[CONF_HOST]
         )
 
         # initialize media_player platform

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -11,6 +11,7 @@ from homeassistant.util.dt import utcnow
 from .const import CONF_ROON_ID, ROON_APPINFO
 
 _LOGGER = logging.getLogger(__name__)
+INITIAL_SYNC_INTERVAL = 5
 FULL_SYNC_INTERVAL = 30
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
@@ -113,13 +114,14 @@ class RoonServer:
     async def async_do_loop(self):
         """Background work loop."""
         self._exit = False
+        await asyncio.sleep(INITIAL_SYNC_INTERVAL)
         while not self._exit:
             await self.async_update_players()
-            # await self.async_update_playlists()
             await asyncio.sleep(FULL_SYNC_INTERVAL)
 
     async def async_update_changed_players(self, changed_zones_ids):
         """Update the players which were reported as changed by the Roon API."""
+        _LOGGER.debug("async_update_changed_players %s", changed_zones_ids)
         for zone_id in changed_zones_ids:
             if zone_id not in self.roonapi.zones:
                 # device was removed ?
@@ -142,6 +144,7 @@ class RoonServer:
     async def async_update_players(self):
         """Periodic full scan of all devices."""
         zone_ids = self.roonapi.zones.keys()
+        _LOGGER.debug("async_update_players %s", zone_ids)
         await self.async_update_changed_players(zone_ids)
         # check for any removed devices
         all_devs = {}

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -2,9 +2,9 @@
 import asyncio
 import logging
 
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 
-from homeassistant.const import CONF_API_KEY, CONF_HOST, Platform
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, Platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util.dt import utcnow
 
@@ -33,23 +33,38 @@ class RoonServer:
 
     async def async_setup(self, tries=0):
         """Set up a roon server based on config parameters."""
-        hass = self.hass
-        # Host will be None for configs using discovery
-        host = self.config_entry.data[CONF_HOST]
-        token = self.config_entry.data[CONF_API_KEY]
-        # Default to None for compatibility with older configs
-        core_id = self.config_entry.data.get(CONF_ROON_ID)
-        _LOGGER.debug("async_setup: host=%s core_id=%s token=%s", host, core_id, token)
 
-        self.roonapi = RoonApi(
-            ROON_APPINFO, token, host, blocking_init=False, core_id=core_id
-        )
+        def get_roon_host():
+            host = self.config_entry.data.get(CONF_HOST)
+            port = self.config_entry.data.get(CONF_PORT)
+            if host:
+                _LOGGER.debug("static roon core host=%s port=%s", host, port)
+                return (host, port)
+
+            discover = RoonDiscovery(core_id)
+            server = discover.first()
+            discover.stop()
+            _LOGGER.debug("dynamic roon core core_id=%s server=%s", core_id, server)
+            return (server[0], server[1])
+
+        def get_roon_api():
+            token = self.config_entry.data[CONF_API_KEY]
+            (host, port) = get_roon_host()
+            return RoonApi(ROON_APPINFO, token, host, port, blocking_init=True)
+
+        hass = self.hass
+        core_id = self.config_entry.data.get(CONF_ROON_ID)
+
+        self.roonapi = await self.hass.async_add_executor_job(get_roon_api)
+
         self.roonapi.register_state_callback(
             self.roonapi_state_callback, event_filter=["zones_changed"]
         )
 
         # Default to 'host' for compatibility with older configs without core_id
-        self.roon_id = core_id if core_id is not None else host
+        self.roon_id = (
+            core_id if core_id is not None else self.config_entry.data.get(CONF_HOST)
+        )
 
         # initialize media_player platform
         hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)

--- a/homeassistant/components/roon/strings.json
+++ b/homeassistant/components/roon/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "user":{},
+      "user": {},
       "fallback": {
         "description": "Could not discover Roon server, please enter your Hostname and Port.",
         "data": {

--- a/homeassistant/components/roon/strings.json
+++ b/homeassistant/components/roon/strings.json
@@ -17,6 +17,9 @@
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/roon/strings.json
+++ b/homeassistant/components/roon/strings.json
@@ -17,9 +17,6 @@
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/roon/strings.json
+++ b/homeassistant/components/roon/strings.json
@@ -1,10 +1,12 @@
 {
   "config": {
     "step": {
-      "user": {
-        "description": "Could not discover Roon server, please enter your the Hostname or IP.",
+      "user":{},
+      "fallback": {
+        "description": "Could not discover Roon server, please enter your Hostname and Port.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
         }
       },
       "link": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2076,7 +2076,7 @@ rokuecp==0.16.0
 roombapy==1.6.5
 
 # homeassistant.components.roon
-roonapi==0.0.38
+roonapi==0.1.0
 
 # homeassistant.components.rova
 rova==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2076,7 +2076,7 @@ rokuecp==0.16.0
 roombapy==1.6.5
 
 # homeassistant.components.roon
-roonapi==0.1.0
+roonapi==0.1.1
 
 # homeassistant.components.rova
 rova==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1351,7 +1351,7 @@ rokuecp==0.16.0
 roombapy==1.6.5
 
 # homeassistant.components.roon
-roonapi==0.0.38
+roonapi==0.1.0
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1351,7 +1351,7 @@ rokuecp==0.16.0
 roombapy==1.6.5
 
 # homeassistant.components.roon
-roonapi==0.1.0
+roonapi==0.1.1
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -18,8 +18,13 @@ class RoonApiMock:
         """Return the roon host."""
         return "core_id"
 
+    @property
+    def core_name(self):
+        """Return the roon core name."""
+        return "Roon Core"
+
     def stop(self):
-        """Stop socket and discovery."""
+        """Stop socket."""
         return
 
 
@@ -93,8 +98,10 @@ async def test_successful_discovery_and_auth(hass):
     assert result2["title"] == "Roon Labs Music Player"
     assert result2["data"] == {
         "host": None,
+        "port": None,
         "api_key": "good_token",
         "roon_server_id": "core_id",
+        "roon_server_name": "Roon Core",
     }
 
 
@@ -119,11 +126,11 @@ async def test_unsuccessful_discovery_user_form_and_auth(hass):
 
         # Should show the form if server was not discovered
         assert result["type"] == "form"
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "fallback"
         assert result["errors"] == {}
 
         await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"host": "1.1.1.1"}
+            result["flow_id"], {"host": "1.1.1.1", "port": 9331}
         )
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
@@ -134,7 +141,10 @@ async def test_unsuccessful_discovery_user_form_and_auth(hass):
     assert result2["data"] == {
         "host": "1.1.1.1",
         "api_key": "good_token",
+        "port": 9331,
+        "api_key": "good_token",
         "roon_server_id": "core_id",
+        "roon_server_name": "Roon Core",
     }
 
 

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -153,22 +153,19 @@ async def test_unsuccessful_discovery_user_form_and_auth(hass):
 async def test_duplicate_config(hass):
     """Test user adding the host via the form for host that is already configured."""
 
+    CONFIG = {"host": "1.1.1.1"}
+
+    MockConfigEntry(domain=DOMAIN, unique_id="0123456789", data=CONFIG).add_to_hass(
+        hass
+    )
+
     with patch(
         "homeassistant.components.roon.config_flow.RoonApi",
         return_value=RoonApiMock(),
     ), patch(
         "homeassistant.components.roon.config_flow.RoonDiscovery",
         return_value=RoonDiscoveryFailedMock(),
-    ), patch(
-        "homeassistant.components.roon.async_setup_entry",
-        return_value=True,
     ):
-
-        CONFIG = {"host": "1.1.1.1"}
-
-        MockConfigEntry(domain=DOMAIN, unique_id="0123456789", data=CONFIG).add_to_hass(
-            hass
-        )
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes some outstanding issues with the roon integration.

A recent Roon Lab release changed the port number for their servers. This stopped manual setup working because pyroon used the wrong port.

The pyroon library, under some circumstances, would try and discover roon servers by default. This default discovery was not reliable - so so has been removed the in new version of the library. It is replaced by explicit discovery ( which is more reliable)

The `config_flow` is slightly cleaned up and modified to allow the user to specify a port if discovery does not work on their network.

The main roon code is now modified to  explicitly use discovery - and so work with the new library.

Lastly in making the changes above I've slightly refactored to stop blocking code from being called in the main HA event loop.

Please note that the bugfix required a new version of the library, hence the PR combining both these things.

Library changes are shown below - the `list_media` method added in 0.0.39 is not used or needed by HA. (Now bumped to 0.1.1 - improve startup speed for command line apps - but marginally better for HA)

https://github.com/pavoni/pyroon/compare/0.0.38...0.1.1

Because this fixes an issue reported by @bacumings (which prevents him using the integration) - it would be good to include in a point release  if possible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65912
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
