### PR TITLE
Use strings directly instead of Enums in version config

### DIFF
--- a/homeassistant/components/version/config_flow.py
+++ b/homeassistant/components/version/config_flow.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyhaversion.consts import HaVersionChannel, HaVersionSource
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -75,8 +74,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._entry_data.update(user_input)
 
         if not self.show_advanced_options or user_input[CONF_SOURCE] in (
-            HaVersionSource.LOCAL,
-            HaVersionSource.HAIO,
+            "local",
+            "haio",
         ):
             return self.async_create_entry(
                 title=self._config_entry_name,
@@ -92,8 +91,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the version_source step."""
         if user_input is None:
             if self._entry_data[CONF_SOURCE] in (
-                HaVersionSource.SUPERVISOR,
-                HaVersionSource.CONTAINER,
+                "supervisor",
+                "container",
             ):
                 data_schema = vol.Schema(
                     {
@@ -102,7 +101,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         ): vol.In(VALID_CHANNELS),
                     }
                 )
-                if self._entry_data[CONF_SOURCE] == HaVersionSource.SUPERVISOR:
+                if self._entry_data[CONF_SOURCE] == "supervisor":
                     data_schema = data_schema.extend(
                         {
                             vol.Required(CONF_IMAGE, default=DEFAULT_IMAGE): vol.In(
@@ -151,7 +150,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @property
     def _config_entry_name(self) -> str:
         """Return the name of the config entry."""
-        if self._entry_data[CONF_SOURCE] == HaVersionSource.LOCAL:
+        if self._entry_data[CONF_SOURCE] == "local":
             return DEFAULT_NAME_CURRENT
 
         name = self._entry_data[CONF_VERSION_SOURCE]
@@ -166,21 +165,21 @@ def _convert_imported_configuration(config: dict[str, Any]) -> Any:
     """Convert a key from the imported configuration."""
     data = DEFAULT_CONFIGURATION.copy()
     if config.get(CONF_BETA):
-        data[CONF_CHANNEL] = HaVersionChannel.BETA
+        data[CONF_CHANNEL] = "beta"
 
     if (source := config.get(CONF_SOURCE)) and source != DEFAULT_SOURCE:
         if source == SOURCE_HASSIO:
-            data[CONF_SOURCE] = HaVersionSource.SUPERVISOR
+            data[CONF_SOURCE] = "supervisor"
             data[CONF_VERSION_SOURCE] = VERSION_SOURCE_VERSIONS
         elif source == SOURCE_DOKCER:
-            data[CONF_SOURCE] = HaVersionSource.CONTAINER
+            data[CONF_SOURCE] = "container"
             data[CONF_VERSION_SOURCE] = VERSION_SOURCE_DOCKER_HUB
         else:
             data[CONF_SOURCE] = source
             data[CONF_VERSION_SOURCE] = VERSION_SOURCE_MAP_INVERTED[source]
 
     if (image := config.get(CONF_IMAGE)) and image != DEFAULT_IMAGE:
-        if data[CONF_SOURCE] == HaVersionSource.CONTAINER:
+        if data[CONF_SOURCE] == "container":
             data[CONF_IMAGE] = f"{config[CONF_IMAGE]}{POSTFIX_CONTAINER_NAME}"
         else:
             data[CONF_IMAGE] = config[CONF_IMAGE]
@@ -188,7 +187,7 @@ def _convert_imported_configuration(config: dict[str, Any]) -> Any:
     if (name := config.get(CONF_NAME)) and name != DEFAULT_NAME:
         data[CONF_NAME] = config[CONF_NAME]
     else:
-        if data[CONF_SOURCE] == HaVersionSource.LOCAL:
+        if data[CONF_SOURCE] == "local":
             data[CONF_NAME] = DEFAULT_NAME_CURRENT
         else:
             data[CONF_NAME] = DEFAULT_NAME_LATEST

--- a/homeassistant/components/version/const.py
+++ b/homeassistant/components/version/const.py
@@ -41,12 +41,12 @@ VERSION_SOURCE_VERSIONS: Final = "Home Assistant Versions"
 
 DEFAULT_BETA: Final = False
 DEFAULT_BOARD: Final = "OVA"
-DEFAULT_CHANNEL: Final[HaVersionChannel] = HaVersionChannel.STABLE
+DEFAULT_CHANNEL: Final = "stable"
 DEFAULT_IMAGE: Final = "default"
 DEFAULT_NAME_CURRENT: Final = "Current Version"
 DEFAULT_NAME_LATEST: Final = "Latest Version"
 DEFAULT_NAME: Final = ""
-DEFAULT_SOURCE: Final[HaVersionSource] = HaVersionSource.LOCAL
+DEFAULT_SOURCE: Final = "local"
 DEFAULT_CONFIGURATION: Final[dict[str, Any]] = {
     CONF_NAME: DEFAULT_NAME,
     CONF_CHANNEL: DEFAULT_CHANNEL,
@@ -81,22 +81,22 @@ BOARD_MAP: Final[dict[str, str]] = {
 
 VALID_BOARDS: Final[list[str]] = list(BOARD_MAP)
 
-VERSION_SOURCE_MAP: Final[dict[str, HaVersionSource]] = {
-    VERSION_SOURCE_LOCAL: HaVersionSource.LOCAL,
-    VERSION_SOURCE_VERSIONS: HaVersionSource.SUPERVISOR,
-    VERSION_SOURCE_HAIO: HaVersionSource.HAIO,
-    VERSION_SOURCE_DOCKER_HUB: HaVersionSource.CONTAINER,
-    VERSION_SOURCE_PYPI: HaVersionSource.PYPI,
+VERSION_SOURCE_MAP: Final[dict[str, str]] = {
+    VERSION_SOURCE_LOCAL: "local",
+    VERSION_SOURCE_VERSIONS: "supervisor",
+    VERSION_SOURCE_HAIO: "haio",
+    VERSION_SOURCE_DOCKER_HUB: "container",
+    VERSION_SOURCE_PYPI: "pypi",
 }
 
-VERSION_SOURCE_MAP_INVERTED: Final[dict[HaVersionSource, str]] = {
+VERSION_SOURCE_MAP_INVERTED: Final[dict[str, str]] = {
     value: key for key, value in VERSION_SOURCE_MAP.items()
 }
 
 
 VALID_SOURCES: Final[list[str]] = HA_VERSION_SOURCES + [
-    SOURCE_HASSIO,  # Kept to not break existing configurations
-    SOURCE_DOKCER,  # Kept to not break existing configurations
+    "hassio",  # Kept to not break existing configurations
+    "docker",  # Kept to not break existing configurations
 ]
 
 VALID_IMAGES: Final = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Using Enums in config data seems to not work as I hoped, on the first creation, it passes the enum, but on a restart, it's the string value of it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65996
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
