### PR TITLE
Correcting Waze Travel Time breaking change since last version

### DIFF
--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -6,8 +6,8 @@ from homeassistant.helpers.location import find_coordinates
 
 def is_valid_config_entry(hass, origin, destination, region):
     """Return whether the config entry data is valid."""
-    origin = find_coordinates(hass, origin)
-    destination = find_coordinates(hass, destination)
+    origin = (find_coordinates(hass, origin),origin)[find_coordinates(hass, origin)=="None"]
+    destination = (find_coordinates(hass, destination),destination)[find_coordinates(hass, origin)=="None"]
     try:
         WazeRouteCalculator(origin, destination, region).calc_all_routes_info()
     except WRCError:

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -9,22 +9,20 @@ from .const import (
 
 import re
 
+
 def is_valid_config_entry(hass, origin, destination, region):
     """Return whether the config entry data is valid."""
     cmpl_re = re.compile(ENTITY_ID_PATTERN)
-
     if cmpl_re.fullmatch(origin):
         if find_coordinates(hass, origin) is not None:
             origin = find_coordinates(hass, origin)
         else:
             origin = hass.states.get(origin).state
-
     if cmpl_re.fullmatch(destination):
         if find_coordinates(hass, destination) is not None:
             destination = find_coordinates(hass, destination)
         else:
             destination = hass.states.get(destination).state
-
     try:
         WazeRouteCalculator(origin, destination, region).calc_all_routes_info()
     except WRCError:

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -1,13 +1,11 @@
 """Helpers for Waze Travel Time integration."""
+import re
+
 from WazeRouteCalculator import WazeRouteCalculator, WRCError
 
 from homeassistant.helpers.location import find_coordinates
 
-from .const import (
-    ENTITY_ID_PATTERN,
-)
-
-import re
+from .const import ENTITY_ID_PATTERN
 
 
 def is_valid_config_entry(hass, origin, destination, region):

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -3,11 +3,28 @@ from WazeRouteCalculator import WazeRouteCalculator, WRCError
 
 from homeassistant.helpers.location import find_coordinates
 
+from .const import (
+    ENTITY_ID_PATTERN,
+)
+
+import re
 
 def is_valid_config_entry(hass, origin, destination, region):
     """Return whether the config entry data is valid."""
-    origin = (find_coordinates(hass, origin),origin)[find_coordinates(hass, origin)=="None"]
-    destination = (find_coordinates(hass, destination),destination)[find_coordinates(hass, origin)=="None"]
+    cmpl_re = re.compile(ENTITY_ID_PATTERN)
+
+    if cmpl_re.fullmatch(origin):
+        if find_coordinates(hass, origin) is not None:
+            origin = find_coordinates(hass, origin)
+        else:
+            origin = hass.states.get(origin).state
+
+    if cmpl_re.fullmatch(destination):
+        if find_coordinates(hass, destination) is not None:
+            destination = find_coordinates(hass, destination)
+        else:
+            destination = hass.states.get(destination).state
+
     try:
         WazeRouteCalculator(origin, destination, region).calc_all_routes_info()
     except WRCError:

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -179,13 +179,17 @@ class WazeTravelTime(SensorEntity):
         _LOGGER.debug("Fetching Route for %s", self._attr_name)
         # Get origin latitude and longitude from entity_id.
         if self._origin_entity_id is not None:
-            self._waze_data.origin = find_coordinates(self.hass, self._origin_entity_id)
+            if find_coordinates(self.hass, self._origin_entity_id) is not None:
+                self._waze_data.origin = find_coordinates(self.hass, self._origin_entity_id)
+            else:
+                self._waze_data.origin = self.hass.states.get(self._origin_entity_id).state
 
         # Get destination latitude and longitude from entity_id.
         if self._destination_entity_id is not None:
-            self._waze_data.destination = find_coordinates(
-                self.hass, self._destination_entity_id
-            )
+            if find_coordinates(self.hass, self._destination_entity_id) is not None:
+                self._waze_data.destination = find_coordinates(self.hass, self._destination_entity_id)
+            else:
+                self._waze_data.destination = self.hass.states.get(self._destination_entity_id).state
 
         self._waze_data.update()
 

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -81,11 +81,9 @@ async def async_setup_entry(
                 options[key] = new_data.pop(key)
             elif key in defaults:
                 options[key] = defaults[key]
-
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=options
         )
-
     destination = config_entry.data[CONF_DESTINATION]
     origin = config_entry.data[CONF_ORIGIN]
     region = config_entry.data[CONF_REGION]
@@ -130,7 +128,6 @@ class WazeTravelTime(SensorEntity):
             self._origin_entity_id = origin
         else:
             self._waze_data.origin = origin
-
         if cmpl_re.fullmatch(destination):
             _LOGGER.debug("Found destination source entity %s", destination)
             self._destination_entity_id = destination
@@ -151,7 +148,6 @@ class WazeTravelTime(SensorEntity):
         """Return the state of the sensor."""
         if self._waze_data.duration is not None:
             return round(self._waze_data.duration)
-
         return None
 
     @property
@@ -159,7 +155,6 @@ class WazeTravelTime(SensorEntity):
         """Return the state attributes of the last update."""
         if self._waze_data.duration is None:
             return None
-
         return {
             ATTR_ATTRIBUTION: "Powered by Waze",
             "duration": self._waze_data.duration,
@@ -180,17 +175,23 @@ class WazeTravelTime(SensorEntity):
         # Get origin latitude and longitude from entity_id.
         if self._origin_entity_id is not None:
             if find_coordinates(self.hass, self._origin_entity_id) is not None:
-                self._waze_data.origin = find_coordinates(self.hass, self._origin_entity_id)
+                self._waze_data.origin = find_coordinates(
+                    self.hass, self._origin_entity_id
+                )
             else:
-                self._waze_data.origin = self.hass.states.get(self._origin_entity_id).state
-
+                self._waze_data.origin = self.hass.states.get(
+                    self._origin_entity_id
+                ).state
         # Get destination latitude and longitude from entity_id.
         if self._destination_entity_id is not None:
             if find_coordinates(self.hass, self._destination_entity_id) is not None:
-                self._waze_data.destination = find_coordinates(self.hass, self._destination_entity_id)
+                self._waze_data.destination = find_coordinates(
+                    self.hass, self._destination_entity_id
+                )
             else:
-                self._waze_data.destination = self.hass.states.get(self._destination_entity_id).state
-
+                self._waze_data.destination = self.hass.states.get(
+                    self._destination_entity_id
+                ).state
         self._waze_data.update()
 
 
@@ -241,20 +242,17 @@ class WazeTravelTimeData:
                         for k, v in routes.items()
                         if incl_filter.lower() in k.lower()
                     }
-
                 if excl_filter is not None:
                     routes = {
                         k: v
                         for k, v in routes.items()
                         if excl_filter.lower() not in k.lower()
                     }
-
                 if routes:
                     route = list(routes)[0]
                 else:
                     _LOGGER.warning("No routes found")
                     return
-
                 self.duration, distance = routes[route]
 
                 if units == CONF_UNIT_SYSTEM_IMPERIAL:
@@ -262,7 +260,6 @@ class WazeTravelTimeData:
                     self.distance = distance / 1.609
                 else:
                     self.distance = distance
-
                 self.route = route
             except WRCError as exp:
                 _LOGGER.warning("Error on retrieving data: %s", exp)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since last update, find_coordinates is used instead of custom code for Waze Travel Time (#61400). This is a breaking change since there is no possibility to configure the integration with address or GPS coordinates in plaint text, or with an entity_id refering an entity that contains such information. This PR proposes a way to get these config options working, and keeps using find_coordinates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65516 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
