### PR TITLE
Get_url to prefer external URL if SSL configured

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -89,7 +89,7 @@ from .util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 # Typing imports that create a circular dependency
 if TYPE_CHECKING:
     from .auth import AuthManager
-    from .components.http import HomeAssistantHTTP
+    from .components.http import ApiConfig, HomeAssistantHTTP
     from .config_entries import ConfigEntries
 
 
@@ -1701,8 +1701,8 @@ class Config:
         # List of loaded components
         self.components: set[str] = set()
 
-        # API (HTTP) server configuration, see components.http.ApiConfig
-        self.api: Any | None = None
+        # API (HTTP) server configuration
+        self.api: ApiConfig | None = None
 
         # Directory that holds the configuration
         self.config_dir: str | None = None

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -42,12 +42,15 @@ def get_url(
     allow_external: bool = True,
     allow_cloud: bool = True,
     allow_ip: bool = True,
-    prefer_external: bool = False,
+    prefer_external: bool | None = None,
     prefer_cloud: bool = False,
 ) -> str:
     """Get a URL to this instance."""
     if require_current_request and http.current_request.get() is None:
         raise NoURLAvailableError
+
+    if prefer_external is None:
+        prefer_external = hass.config.api is not None and hass.config.api.use_ssl
 
     order = [TYPE_URL_INTERNAL, TYPE_URL_EXTERNAL]
     if prefer_external:

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -41,7 +41,7 @@ def get_url(
     allow_internal: bool = True,
     allow_external: bool = True,
     allow_cloud: bool = True,
-    allow_ip: bool = True,
+    allow_ip: bool | None = None,
     prefer_external: bool | None = None,
     prefer_cloud: bool = False,
 ) -> str:
@@ -51,6 +51,9 @@ def get_url(
 
     if prefer_external is None:
         prefer_external = hass.config.api is not None and hass.config.api.use_ssl
+
+    if allow_ip is None:
+        allow_ip = hass.config.api is None or not hass.config.api.use_ssl
 
     order = [TYPE_URL_INTERNAL, TYPE_URL_EXTERNAL]
     if prefer_external:

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -525,6 +525,19 @@ async def test_get_url(hass: HomeAssistant):
     ), pytest.raises(NoURLAvailableError):
         _get_internal_url(hass, require_current_request=True)
 
+    # Test allow_ip defaults when SSL specified
+    await async_process_ha_core_config(
+        hass,
+        {"external_url": "https://1.1.1.1"},
+    )
+    assert hass.config.external_url == "https://1.1.1.1"
+    assert get_url(hass, allow_internal=False) == "https://1.1.1.1"
+    hass.config.api = Mock(use_ssl=False)
+    assert get_url(hass, allow_internal=False) == "https://1.1.1.1"
+    hass.config.api = Mock(use_ssl=True)
+    with pytest.raises(NoURLAvailableError):
+        assert get_url(hass, allow_internal=False)
+
 
 async def test_get_request_host(hass: HomeAssistant):
     """Test getting the host of the current web request from the request context."""

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -480,6 +480,12 @@ async def test_get_url(hass: HomeAssistant):
         get_url(hass, prefer_external=True, allow_external=False)
         == "http://example.local"
     )
+    # Prefer external defaults to True if use_ssl=True
+    hass.config.api = Mock(use_ssl=True)
+    assert get_url(hass) == "https://example.com"
+    hass.config.api = Mock(use_ssl=False)
+    assert get_url(hass) == "http://example.local"
+    hass.config.api = None
 
     with pytest.raises(NoURLAvailableError):
         get_url(hass, allow_external=False, require_ssl=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


If a user has the `http` integration configured to use SSL, it only accepts HTTPS traffic. This means that the internal URL needs to be set to use HTTPS too, and for the certificate to be valid, this needs to be a domain name. A lot of integrations that we send the URL to will fail if the certificate is not valid (ie. Sonos, Cast)

To help the user get this right, the default for the `get_url` helper will now prefer the external address if SSL is configured. This has a higher chance of being correct.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a user has the `http` integration configured to use SSL, it only accepts HTTPS traffic. This means that the internal URL needs to be set to use HTTPS too, and for the certificate to be valid, this needs to be a domain name. A lot of integrations that we send the URL to will fail if the certificate is not valid (ie. Sonos, Cast)

To help the user get this right, the default for the `get_url` helper will now prefer the external address if SSL is configured. This has a higher chance of being correct.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
