### PR TITLE
Fix missing exception catch in august to prevent failed setup

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryAuthFailed from err
     except asyncio.TimeoutError as err:
         raise ConfigEntryNotReady("Timed out connecting to august api") from err
-    except (ClientResponseError, CannotConnect) as err:
+    except (AugustApiAIOHTTPError, ClientResponseError, CannotConnect) as err:
         raise ConfigEntryNotReady from err
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes
```
2022-02-07 23:08:55 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry XXXXX august
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/yalexs/api_async.py", line 316, in _raise_response_exceptions
    response.raise_for_status()
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 1004, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 502, message='Bad Gateway', url=URL('https://api-production.august.com/locks/XXXXX’)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 328, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/august/__init__.py", line 43, in async_setup_entry
    return await async_setup_august(hass, entry, august_gateway)
  File "/usr/src/homeassistant/homeassistant/components/august/__init__.py", line 83, in async_setup_august
    await data[DATA_AUGUST].async_setup()
  File "/usr/src/homeassistant/homeassistant/components/august/__init__.py", line 123, in async_setup
    await self._async_refresh_device_detail_by_ids(
  File "/usr/src/homeassistant/homeassistant/components/august/__init__.py", line 219, in _async_refresh_device_detail_by_ids
    await self._async_refresh_device_detail_by_id(device_id)
  File "/usr/src/homeassistant/homeassistant/components/august/__init__.py", line 236, in _async_refresh_device_detail_by_id
    await self._async_update_device_detail(
  File "/usr/src/homeassistant/homeassistant/components/august/__init__.py", line 266, in _async_update_device_detail
    self._device_detail_by_id[device.device_id] = await api_call(
  File "/usr/local/lib/python3.9/site-packages/yalexs/api_async.py", line 115, in async_get_lock_detail
    response = await self._async_dict_to_api(
  File "/usr/local/lib/python3.9/site-packages/yalexs/api_async.py", line 309, in _async_dict_to_api
    _raise_response_exceptions(response)
  File "/usr/local/lib/python3.9/site-packages/yalexs/api_async.py", line 330, in _raise_response_exceptions
    raise AugustApiAIOHTTPError(
yalexs.exceptions.AugustApiAIOHTTPError: The operation failed with error code 502: Bad Gateway.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
