### PR TITLE
Improve switch code quality in Overkiz and add 2 device descriptions

### DIFF
--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -61,6 +61,8 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIWidget.RTD_INDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIWidget.RTD_OUTDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIWidget.RTS_GENERIC: Platform.COVER,  # widgetName, uiClass is Generic (not supported)
+    UIWidget.STATELESS_ALARM_CONTROLLER: Platform.SWITCH,  # widgetName, uiClass is Alarm (not supported)
+    UIWidget.STATELESS_EXTERIOR_HEATING: Platform.SWITCH,  # widgetName, uiClass is ExteriorHeatingSystem (not supported)
 }
 
 # Map Overkiz camelCase to Home Assistant snake_case for translation

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -30,12 +30,13 @@ class OverkizSwitchDescriptionMixin:
 
     turn_on: Callable[[Callable[..., Awaitable[None]]], Awaitable[None]]
     turn_off: Callable[[Callable[..., Awaitable[None]]], Awaitable[None]]
-    is_on: Callable[[Callable[[str], OverkizStateType]], bool]
 
 
 @dataclass
 class OverkizSwitchDescription(SwitchEntityDescription, OverkizSwitchDescriptionMixin):
     """Class to describe an Overkiz switch."""
+
+    is_on: Callable[[Callable[[str], OverkizStateType]], bool] | None = None
 
 
 SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
@@ -75,14 +76,24 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
         turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
         turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
         icon="mdi:bell",
-        is_on=lambda select_state: False,  # Remove when is_on in SwitchEntity doesn't require a bool value anymore
     ),
     OverkizSwitchDescription(
         key=UIWidget.RTD_OUTDOOR_SIREN,
         turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
         turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
         icon="mdi:bell",
-        is_on=lambda select_state: False,  # Remove when is_on in SwitchEntity doesn't require a bool value anymore
+    ),
+    OverkizSwitchDescription(
+        key=UIWidget.STATELESS_ALARM_CONTROLLER,
+        turn_on=lambda execute_command: execute_command(OverkizCommand.ALARM_ON),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.ALARM_OFF),
+        icon="mdi:shield-lock",
+    ),
+    OverkizSwitchDescription(
+        key=UIWidget.STATELESS_EXTERIOR_HEATING,
+        turn_on=lambda execute_command: execute_command(OverkizCommand.ON),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
+        icon="mdi:radiator",
     ),
 ]
 
@@ -121,9 +132,12 @@ class OverkizSwitch(OverkizDescriptiveEntity, SwitchEntity):
     entity_description: OverkizSwitchDescription
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if entity is on."""
-        return self.entity_description.is_on(self.executor.select_state)
+        if self.entity_description.is_on:
+            return self.entity_description.is_on(self.executor.select_state)
+
+        return None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""


### PR DESCRIPTION
## Proposed change
Adds support for two more stateless devices to the switch platform. Same implementation as the stateless siren, we don't map the new devices to Alarm Control Panel and Climate because they are stateless.

Code in entity.py will set assumed state to True for these devices, based on the protocol.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
