### PR TITLE
Use upstream device information for Plugwise

### DIFF
--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -95,8 +95,8 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         self._attr_is_on = False
         self._attr_unique_id = f"{device_id}-{description.key}"
         self._attr_name = (
-            f"{coordinator.data.devices[device_id].get('name')} {description.name}"
-        )
+            f"{coordinator.data.devices[device_id].get('name', '')} {description.name}"
+        ).lstrip()
 
     @callback
     def _async_process_data(self) -> None:

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -1,6 +1,4 @@
 """Plugwise Binary Sensor component for Home Assistant."""
-from plugwise.smile import Smile
-
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -45,37 +43,32 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Smile binary_sensors from a config entry."""
-    api: Smile = hass.data[DOMAIN][config_entry.entry_id]["api"]
     coordinator: PlugwiseDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ][COORDINATOR]
 
     entities: list[PlugwiseBinarySensorEntity] = []
-    for device_id, device_properties in coordinator.data.devices.items():
-        if device_properties["class"] == "heater_central":
+    for device_id, device in coordinator.data.devices.items():
+        if device["class"] == "heater_central":
             for description in BINARY_SENSORS:
                 if (
-                    "binary_sensors" not in device_properties
-                    or description.key not in device_properties["binary_sensors"]
+                    "binary_sensors" not in device
+                    or description.key not in device["binary_sensors"]
                 ):
                     continue
 
                 entities.append(
                     PlugwiseBinarySensorEntity(
-                        api,
                         coordinator,
-                        device_properties["name"],
                         device_id,
                         description,
                     )
                 )
 
-        if device_properties["class"] == "gateway":
+        if device["class"] == "gateway":
             entities.append(
                 PlugwiseNotifyBinarySensorEntity(
-                    api,
                     coordinator,
-                    device_properties["name"],
                     device_id,
                     BinarySensorEntityDescription(
                         key="plugwise_notification",
@@ -92,25 +85,18 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        api: Smile,
         coordinator: PlugwiseDataUpdateCoordinator,
-        name: str,
-        dev_id: str,
+        device_id: str,
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialise the binary_sensor."""
-        super().__init__(api, coordinator, name, dev_id)
+        super().__init__(coordinator, device_id)
         self.entity_description = description
         self._attr_is_on = False
-        self._attr_unique_id = f"{dev_id}-{description.key}"
-
-        if dev_id == coordinator.data.gateway["heater_id"]:
-            self._entity_name = "Auxiliary"
-
-        self._name = f"{self._entity_name} {description.name}"
-
-        if dev_id == coordinator.data.gateway["gateway_id"]:
-            self._entity_name = f"Smile {self._entity_name}"
+        self._attr_unique_id = f"{device_id}-{description.key}"
+        self._attr_name = (
+            f"{coordinator.data.devices[device_id].get('name')} {description.name}"
+        )
 
     @callback
     def _async_process_data(self) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -52,17 +52,14 @@ async def async_setup_entry(
         "zone_thermostat",
         "thermostatic_radiator_valve",
     ]
-    for device_id, device_properties in coordinator.data.devices.items():
-        if device_properties["class"] not in thermostat_classes:
+    for device_id, device in coordinator.data.devices.items():
+        if device["class"] not in thermostat_classes:
             continue
 
         thermostat = PlugwiseClimateEntity(
             api,
             coordinator,
-            device_properties["name"],
             device_id,
-            device_properties["location"],
-            device_properties["class"],
         )
 
         entities.append(thermostat)
@@ -87,18 +84,16 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         self,
         api: Smile,
         coordinator: PlugwiseDataUpdateCoordinator,
-        name: str,
         device_id: str,
-        loc_id: str,
-        model: str,
     ) -> None:
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, device_id)
+        super().__init__(coordinator, device_id)
         self._attr_extra_state_attributes = {}
         self._attr_unique_id = f"{device_id}-climate"
+        self._attr_name = coordinator.data.devices[device_id].get("name")
 
         self._api = api
-        self._loc_id = loc_id
+        self._loc_id = coordinator.data.devices[device_id]["location"]
 
         self._presets = None
 

--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -1,7 +1,7 @@
 """Generic Plugwise Entity Class."""
 from __future__ import annotations
 
-from homeassistant.const import ATTR_VIA_DEVICE, CONF_HOST
+from homeassistant.const import ATTR_NAME, ATTR_VIA_DEVICE, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -26,20 +26,25 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseData]):
         if entry := self.coordinator.config_entry:
             configuration_url = f"http://{entry.data[CONF_HOST]}"
 
-        data = self.coordinator.data.devices[device_id]
+        data = coordinator.data.devices[device_id]
         self._attr_device_info = DeviceInfo(
             configuration_url=configuration_url,
             identifiers={(DOMAIN, device_id)},
             manufacturer=data.get("vendor"),
             model=data.get("model"),
-            name=data.get("name"),
+            name=f"Smile {coordinator.data.gateway['smile_name']}",
             sw_version=data.get("fw"),
         )
 
         if device_id != coordinator.data.gateway["gateway_id"]:
-            self._attr_device_info[ATTR_VIA_DEVICE] = (
-                DOMAIN,
-                str(self.coordinator.data.gateway["gateway_id"]),
+            self._attr_device_info.update(
+                {
+                    ATTR_NAME: data.get("name"),
+                    ATTR_VIA_DEVICE: (
+                        DOMAIN,
+                        str(self.coordinator.data.gateway["gateway_id"]),
+                    ),
+                }
             )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -1,14 +1,7 @@
 """Generic Plugwise Entity Class."""
 from __future__ import annotations
 
-from plugwise.smile import Smile
-
-from homeassistant.const import (
-    ATTR_CONFIGURATION_URL,
-    ATTR_MODEL,
-    ATTR_VIA_DEVICE,
-    CONF_HOST,
-)
+from homeassistant.const import ATTR_VIA_DEVICE, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -22,49 +15,32 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseData]):
 
     def __init__(
         self,
-        api: Smile,
         coordinator: PlugwiseDataUpdateCoordinator,
-        name: str,
-        dev_id: str,
+        device_id: str,
     ) -> None:
         """Initialise the gateway."""
         super().__init__(coordinator)
+        self._dev_id = device_id
 
-        self._api = api
-        self._name = name
-        self._dev_id = dev_id
-        self._entity_name = self._name
+        configuration_url: str | None = None
+        if entry := self.coordinator.config_entry:
+            configuration_url = f"http://{entry.data[CONF_HOST]}"
 
-    @property
-    def name(self) -> str | None:
-        """Return the name of the entity, if any."""
-        return self._name
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        data = self.coordinator.data.devices[self._dev_id]
-        device_information = DeviceInfo(
-            identifiers={(DOMAIN, self._dev_id)},
-            name=self._entity_name,
-            manufacturer="Plugwise",
+        data = self.coordinator.data.devices[device_id]
+        self._attr_device_info = DeviceInfo(
+            configuration_url=configuration_url,
+            identifiers={(DOMAIN, device_id)},
+            manufacturer=data.get("vendor"),
+            model=data.get("model"),
+            name=data.get("name"),
+            sw_version=data.get("fw"),
         )
 
-        if entry := self.coordinator.config_entry:
-            device_information[
-                ATTR_CONFIGURATION_URL
-            ] = f"http://{entry.data[CONF_HOST]}"
-
-        if model := data.get("model"):
-            device_information[ATTR_MODEL] = model
-
-        if self._dev_id != self.coordinator.data.gateway["gateway_id"]:
-            device_information[ATTR_VIA_DEVICE] = (
+        if device_id != coordinator.data.gateway["gateway_id"]:
+            self._attr_device_info[ATTR_VIA_DEVICE] = (
                 DOMAIN,
                 str(self.coordinator.data.gateway["gateway_id"]),
             )
-
-        return device_information
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -290,11 +290,11 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
 
     entities: list[PlugwiseSensorEnity] = []
-    for device_id, device_properties in coordinator.data.devices.items():
+    for device_id, device in coordinator.data.devices.items():
         for description in SENSORS:
             if (
-                "sensors" not in device_properties
-                or device_properties["sensors"].get(description.key) is None
+                "sensors" not in device
+                or device["sensors"].get(description.key) is None
             ):
                 continue
 
@@ -302,7 +302,6 @@ async def async_setup_entry(
                 PlugwiseSensorEnity(
                     api,
                     coordinator,
-                    device_properties["name"],
                     device_id,
                     description,
                 )
@@ -311,14 +310,13 @@ async def async_setup_entry(
         if coordinator.data.gateway["single_master_thermostat"] is False:
             # These sensors should actually be binary sensors.
             for description in INDICATE_ACTIVE_LOCAL_DEVICE_SENSORS:
-                if description.key not in device_properties:
+                if description.key not in device:
                     continue
 
                 entities.append(
                     PlugwiseAuxSensorEntity(
                         api,
                         coordinator,
-                        device_properties["name"],
                         device_id,
                         description,
                     )
@@ -335,28 +333,23 @@ class PlugwiseSensorEnity(PlugwiseEntity, SensorEntity):
         self,
         api: Smile,
         coordinator: PlugwiseDataUpdateCoordinator,
-        name: str,
         device_id: str,
         description: SensorEntityDescription,
     ) -> None:
         """Initialise the sensor."""
-        super().__init__(api, coordinator, name, device_id)
+        super().__init__(coordinator, device_id)
         self.entity_description = description
+        self._api = api
         self._attr_unique_id = f"{device_id}-{description.key}"
-
-        if device_id == coordinator.data.gateway["heater_id"]:
-            self._entity_name = "Auxiliary"
-
-        self._name = f"{self._entity_name} {description.name}"
-
-        if device_id == coordinator.data.gateway["gateway_id"]:
-            self._entity_name = f"Smile {self._entity_name}"
+        self._attr_name = (
+            f"{coordinator.data.devices[device_id].get('name')} {description.name}"
+        )
 
     @callback
     def _async_process_data(self) -> None:
         """Update the entity."""
         if not (data := self.coordinator.data.devices.get(self._dev_id)):
-            LOGGER.error("Received no data for device %s", self._entity_name)
+            LOGGER.error("Received no data for device %s", self._dev_id)
             self.async_write_ha_state()
             return
 
@@ -374,7 +367,7 @@ class PlugwiseAuxSensorEntity(PlugwiseSensorEnity):
     def _async_process_data(self) -> None:
         """Update the entity."""
         if not (data := self.coordinator.data.devices.get(self._dev_id)):
-            LOGGER.error("Received no data for device %s", self._entity_name)
+            LOGGER.error("Received no data for device %s", self._dev_id)
             self.async_write_ha_state()
             return
 

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -342,8 +342,8 @@ class PlugwiseSensorEnity(PlugwiseEntity, SensorEntity):
         self._api = api
         self._attr_unique_id = f"{device_id}-{description.key}"
         self._attr_name = (
-            f"{coordinator.data.devices[device_id].get('name')} {description.name}"
-        )
+            f"{coordinator.data.devices[device_id].get('name', '')} {description.name}"
+        ).lstrip()
 
     @callback
     def _async_process_data(self) -> None:

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -11,11 +11,11 @@ async def test_anna_climate_binary_sensor_entities(hass, mock_smile_anna):
     entry = await async_init_integration(hass, mock_smile_anna)
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("binary_sensor.auxiliary_secondary_boiler_state")
-    assert str(state.state) == STATE_OFF
+    state = hass.states.get("binary_sensor.opentherm_secondary_boiler_state")
+    assert state.state == STATE_OFF
 
-    state = hass.states.get("binary_sensor.auxiliary_dhw_state")
-    assert str(state.state) == STATE_OFF
+    state = hass.states.get("binary_sensor.opentherm_dhw_state")
+    assert state.state == STATE_OFF
 
 
 async def test_anna_climate_binary_sensor_change(hass, mock_smile_anna):
@@ -23,18 +23,18 @@ async def test_anna_climate_binary_sensor_change(hass, mock_smile_anna):
     entry = await async_init_integration(hass, mock_smile_anna)
     assert entry.state is ConfigEntryState.LOADED
 
-    hass.states.async_set("binary_sensor.auxiliary_dhw_state", STATE_ON, {})
+    hass.states.async_set("binary_sensor.opentherm_dhw_state", STATE_ON, {})
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.auxiliary_dhw_state")
-    assert str(state.state) == STATE_ON
+    state = hass.states.get("binary_sensor.opentherm_dhw_state")
+    assert state.state == STATE_ON
 
     await hass.helpers.entity_component.async_update_entity(
-        "binary_sensor.auxiliary_dhw_state"
+        "binary_sensor.opentherm_dhw_state"
     )
 
-    state = hass.states.get("binary_sensor.auxiliary_dhw_state")
-    assert str(state.state) == STATE_OFF
+    state = hass.states.get("binary_sensor.opentherm_dhw_state")
+    assert state.state == STATE_OFF
 
 
 async def test_adam_climate_binary_sensor_change(hass, mock_smile_adam):

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -17,7 +17,7 @@ async def test_adam_climate_sensor_entities(hass, mock_smile_adam):
     state = hass.states.get("sensor.cv_pomp_electricity_consumed")
     assert float(state.state) == 35.6
 
-    state = hass.states.get("sensor.auxiliary_water_temperature")
+    state = hass.states.get("sensor.onoff_water_temperature")
     assert float(state.state) == 70.0
 
     state = hass.states.get("sensor.cv_pomp_electricity_consumed_interval")
@@ -36,10 +36,10 @@ async def test_anna_as_smt_climate_sensor_entities(hass, mock_smile_anna):
     entry = await async_init_integration(hass, mock_smile_anna)
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("sensor.auxiliary_outdoor_temperature")
+    state = hass.states.get("sensor.opentherm_outdoor_temperature")
     assert float(state.state) == 3.0
 
-    state = hass.states.get("sensor.auxiliary_water_temperature")
+    state = hass.states.get("sensor.opentherm_water_temperature")
     assert float(state.state) == 29.1
 
     state = hass.states.get("sensor.anna_illuminance")
@@ -52,7 +52,7 @@ async def test_anna_climate_sensor_entities(hass, mock_smile_anna):
     entry = await async_init_integration(hass, mock_smile_anna)
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("sensor.auxiliary_outdoor_temperature")
+    state = hass.states.get("sensor.opentherm_outdoor_temperature")
     assert float(state.state) == 3.0
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adjusts the Plugwise integration to use the device information provided by the upstream library/devices instead of trying to figure that out in the integration.

This updates the `DeviceInfo` and changes the way entity names are set.
As a result of this, some devices have changed names (e.g., Auxiliary -> OpenTherm), however, since the unique ID hasn't changed, this won't be breaking.

The nice side effect of this change is that a bunch of code is removed and names are no longer passed around.

Tests have been adjusted to handle the name changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
