### PR TITLE
Update PyOverkiz to 1.3.4 in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -5,8 +5,7 @@ from datetime import timedelta
 import logging
 from typing import Final
 
-from pyoverkiz.enums import UIClass
-from pyoverkiz.enums.ui import UIWidget
+from pyoverkiz.enums import OverkizCommandParam, UIClass, UIWidget
 
 from homeassistant.const import Platform
 
@@ -67,13 +66,13 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
 
 # Map Overkiz camelCase to Home Assistant snake_case for translation
 OVERKIZ_STATE_TO_TRANSLATION: dict[str, str] = {
-    "externalGateway": "external_gateway",
-    "localUser": "local_user",
-    "lowBattery": "low_battery",
-    "LSC": "lsc",
-    "maintenanceRequired": "maintenance_required",
-    "noDefect": "no_defect",
-    "SAAC": "saac",
-    "SFC": "sfc",
-    "UPS": "ups",
+    OverkizCommandParam.EXTERNAL_GATEWAY: "external_gateway",
+    OverkizCommandParam.LOCAL_USER: "local_user",
+    OverkizCommandParam.LOW_BATTERY: "low_battery",
+    OverkizCommandParam.LSC: "lsc",
+    OverkizCommandParam.MAINTENANCE_REQUIRED: "maintenance_required",
+    OverkizCommandParam.NO_DEFECT: "no_defect",
+    OverkizCommandParam.SAAC: "saac",
+    OverkizCommandParam.SFC: "sfc",
+    OverkizCommandParam.UPS: "ups",
 }

--- a/homeassistant/components/overkiz/manifest.json
+++ b/homeassistant/components/overkiz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/overkiz",
   "requirements": [
-    "pyoverkiz==1.3.2"
+    "pyoverkiz==1.3.4"
   ],
   "zeroconf": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1746,7 +1746,7 @@ pyotgw==1.1b1
 pyotp==2.6.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.3.2
+pyoverkiz==1.3.4
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1112,7 +1112,7 @@ pyotgw==1.1b1
 pyotp==2.6.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.3.2
+pyoverkiz==1.3.4
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0


### PR DESCRIPTION
## Proposed change
Upgrades PyOverkiz to 1.3.4 to add more enums and typing. Adding enums for upcoming Alarm Control Panel PR's.

[compare v1.3.2...v1.3.4](https://github.com/iMicknl/python-overkiz-api/compare/v1.3.2...v1.3.4)
[changelog 1.3.3](https://github.com/iMicknl/python-overkiz-api/releases/tag/v1.3.3)
[changelog 1.3.4](https://github.com/iMicknl/python-overkiz-api/releases/tag/v1.3.4)

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
