### PR TITLE
Resolve zones and return state in find_coordinates

### DIFF
--- a/homeassistant/helpers/location.py
+++ b/homeassistant/helpers/location.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 import logging
 
-import voluptuous as vol
-
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import HomeAssistant, State
 from homeassistant.util import location as loc_util
@@ -48,29 +46,42 @@ def closest(latitude: float, longitude: float, states: Iterable[State]) -> State
 
 
 def find_coordinates(
-    hass: HomeAssistant, entity_id: str, recursion_history: list | None = None
+    hass: HomeAssistant, name: str, recursion_history: list | None = None
 ) -> str | None:
-    """Find the gps coordinates of the entity in the form of '90.000,180.000'."""
-    if (entity_state := hass.states.get(entity_id)) is None:
-        _LOGGER.error("Unable to find entity %s", entity_id)
-        return None
+    """Try to resolve the a location from a supplied name or entity_id.
 
-    # Check if the entity has location attributes
+    Will recursively resolve an entity if pointed to by the state of the supplied entity.
+    Returns coordinates in the form of '90.000,180.000', an address or the state of the last resolved entity.
+    """
+    # Check if a friendly name of a zone was supplied
+    if (zone_coords := resolve_zone(hass, name)) is not None:
+        return zone_coords
+
+    # Check if an entity_id was supplied.
+    if (entity_state := hass.states.get(name)) is None:
+        _LOGGER.debug("Unable to find entity %s", name)
+        return name
+
+    # Check if the entity_state has location attributes
     if has_location(entity_state):
         return _get_location_from_attributes(entity_state)
 
-    # Check if device is in a zone
+    # Check if entity_state is a zone
     zone_entity = hass.states.get(f"zone.{entity_state.state}")
     if has_location(zone_entity):  # type: ignore
         _LOGGER.debug(
-            "%s is in %s, getting zone location", entity_id, zone_entity.entity_id  # type: ignore
+            "%s is in %s, getting zone location", name, zone_entity.entity_id  # type: ignore
         )
         return _get_location_from_attributes(zone_entity)  # type: ignore
 
-    # Resolve nested entity
+    # Check if entity_state is a friendly name of a zone
+    if (zone_coords := resolve_zone(hass, entity_state.state)) is not None:
+        return zone_coords
+
+    # Check if entity_state is an entity_id
     if recursion_history is None:
         recursion_history = []
-    recursion_history.append(entity_id)
+    recursion_history.append(name)
     if entity_state.state in recursion_history:
         _LOGGER.error(
             "Circular reference detected while trying to find coordinates of an entity. The state of %s has already been checked",
@@ -83,21 +94,18 @@ def find_coordinates(
         _LOGGER.debug("Resolving nested entity_id: %s", entity_state.state)
         return find_coordinates(hass, entity_state.state, recursion_history)
 
-    # Check if state is valid coordinate set
-    try:
-        # Import here, not at top-level to avoid circular import
-        from . import config_validation as cv  # pylint: disable=import-outside-toplevel
+    # Might be an address, coordinates or anything else. This has to be checked by the caller.
+    return entity_state.state
 
-        cv.gps(entity_state.state.split(","))
-    except vol.Invalid:
-        _LOGGER.error(
-            "Entity %s does not contain a location and does not point at an entity that does: %s",
-            entity_id,
-            entity_state.state,
-        )
-        return None
-    else:
-        return entity_state.state
+
+def resolve_zone(hass: HomeAssistant, zone_name: str) -> str | None:
+    """Get a lat/long from a zones friendly_name or None if no zone is found by that friendly_name."""
+    states = hass.states.async_all("zone")
+    for state in states:
+        if state.name == zone_name:
+            return _get_location_from_attributes(state)
+
+    return None
 
 
 def _get_location_from_attributes(entity_state: State) -> str:

--- a/tests/helpers/test_location.py
+++ b/tests/helpers/test_location.py
@@ -1,5 +1,5 @@
 """Tests Home Assistant location helpers."""
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import State
 from homeassistant.helpers import location
 
@@ -73,6 +73,21 @@ async def test_coordinates_function_device_tracker_in_zone(hass):
     )
 
 
+async def test_coordinates_function_zone_friendly_name(hass):
+    """Test coordinates function."""
+    hass.states.async_set(
+        "zone.home",
+        "zoning",
+        {"latitude": 32.87336, "longitude": -117.22943, ATTR_FRIENDLY_NAME: "my_home"},
+    )
+    hass.states.async_set(
+        "test.object",
+        "my_home",
+    )
+    assert location.find_coordinates(hass, "test.object") == "32.87336,-117.22943"
+    assert location.find_coordinates(hass, "my_home") == "32.87336,-117.22943"
+
+
 async def test_coordinates_function_device_tracker_from_input_select(hass):
     """Test coordinates function."""
     hass.states.async_set(
@@ -96,15 +111,16 @@ def test_coordinates_function_returns_none_on_recursion(hass):
     assert location.find_coordinates(hass, "test.first") is None
 
 
-async def test_coordinates_function_returns_none_if_invalid_coord(hass):
+async def test_coordinates_function_returns_state_if_no_coords(hass):
     """Test test_coordinates function."""
     hass.states.async_set(
         "test.object",
         "abc",
     )
-    assert location.find_coordinates(hass, "test.object") is None
+    assert location.find_coordinates(hass, "test.object") == "abc"
 
 
-def test_coordinates_function_returns_none_if_invalid_input(hass):
+def test_coordinates_function_returns_input_if_no_coords(hass):
     """Test test_coordinates function."""
-    assert location.find_coordinates(hass, "test.abc") is None
+    assert location.find_coordinates(hass, "test.abc") == "test.abc"
+    assert location.find_coordinates(hass, "abc") == "abc"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In the PRs #61423 and #61400 the `find_coordinates` function is used instead of special/duplicate code of the `waze_travel_time` integration and `google_travel_time` integration.

However the `find_coordinates` function was missing the features
- to resolve zones by friendly_name
- to also allow addresses, not only coordinates

This PR fixes the `find_coordinates` function so that these features are supported.
To resolve the accidental breaking changes in the actual integrations I will open follow up PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #65781, #65516, #65813, #65809
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
