### PR TITLE
Fix kaiterra startup issue

### DIFF
--- a/homeassistant/components/kaiterra/api_data.py
+++ b/homeassistant/components/kaiterra/api_data.py
@@ -99,5 +99,7 @@ class KaiterraApiData:
                 self.data[self._devices_ids[i]] = device
         except IndexError as err:
             _LOGGER.error("Parsing error %s", err)
+        except TypeError as err:
+            _LOGGER.error("Type error %s", err)
 
         async_dispatcher_send(self._hass, DISPATCHER_KAITERRA)


### PR DESCRIPTION
i couldn't find any issue to reference, however without this small change, homeassistant 12.3 would not initialise kaiterra on startup at times because of `Type` error '<=' not supported between instances of 'NoneType' and 'int'` on line 91 of api_data.py
