### PR TITLE
Fix MyFox Camera Shutter entity in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -56,7 +56,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform] = {
     UIClass.VENETIAN_BLIND: Platform.COVER,
     UIClass.WINDOW: Platform.COVER,
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
-    UIWidget.MY_FOX_SECURITY_CAMERA: Platform.COVER,  # widgetName, uiClass is Camera (not supported)
+    UIWidget.MY_FOX_SECURITY_CAMERA: Platform.SWITCH,  # widgetName, uiClass is Camera (not supported)
     UIWidget.RTD_INDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIWidget.RTD_OUTDOOR_SIREN: Platform.SWITCH,  # widgetName, uiClass is Siren (not supported)
     UIWidget.RTS_GENERIC: Platform.COVER,  # widgetName, uiClass is Generic (not supported)

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -102,7 +102,8 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
         turn_off=lambda execute_command: execute_command(OverkizCommand.CLOSE),
         icon="mdi:camera-lock",
         is_on=lambda select_state: (
-            select_state(OverkizState.MYFOX_SHUTTER_STATUS) == "opened"
+            select_state(OverkizState.MYFOX_SHUTTER_STATUS)
+            == OverkizCommandParam.OPENED
         ),
     ),
 ]

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -95,6 +95,16 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
         turn_off=lambda execute_command: execute_command(OverkizCommand.OFF),
         icon="mdi:radiator",
     ),
+    OverkizSwitchDescription(
+        key=UIWidget.MY_FOX_SECURITY_CAMERA,
+        name="Camera Shutter",
+        turn_on=lambda execute_command: execute_command(OverkizCommand.OPEN),
+        turn_off=lambda execute_command: execute_command(OverkizCommand.CLOSE),
+        icon="mdi:camera-lock",
+        is_on=lambda select_state: (
+            select_state(OverkizState.MYFOX_SHUTTER_STATUS) == "opened"
+        ),
+    ),
 ]
 
 SUPPORTED_DEVICES = {

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -17,6 +17,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
@@ -105,6 +106,7 @@ SWITCH_DESCRIPTIONS: list[OverkizSwitchDescription] = [
             select_state(OverkizState.MYFOX_SHUTTER_STATUS)
             == OverkizCommandParam.OPENED
         ),
+        entity_category=EntityCategory.CONFIG,
     ),
 ]
 


### PR DESCRIPTION
## Breaking change
Previously the Myfox Camera Shutter was mapped to a (non functional) cover entity. This is now mapped to a switch entity.

## Proposed change
Maps Myfox Camera to the switch platform, instead of the cover platform. This feature allows users to open/close the privacy shutter of a camera. It was previously (wrongly) mapped to the cover platform, which doesn't support this device / states.

In theory it would be a breaking change since we switch from cover entity to switch entity, however the cover entity has never been functional and thus I wouldn't see this as a breaking change. Happy to mark it as breaking if someone disagrees.

(this device is not very popular, thus I think this is the reason why no one reported this on GitHub yet as well)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
