### PR TITLE
Add a `max_timeslice` parameter to the Riemann sum integrator

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-
 from decimal import Decimal, DecimalException
 import logging
 
@@ -81,7 +80,7 @@ PLATFORM_SCHEMA = vol.All(
             ),
             # No default for the max timeslice, everyone has different sensors
             # with different expected update intervals.
-            vol.optional(CONF_MAX_TIMESLICE, default=None): vol.All(
+            vol.Optional(CONF_MAX_TIMESLICE, default=None): vol.All(
                 cv.time_period, cv.positive_timedelta
             ),
         }
@@ -217,7 +216,7 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
                     #   too late in the night for me to go re-learn Python
                     #   again.
                     max_timeslice = self._max_timeslice.total_seconds()
-                    
+
                     # Divide the time that has passed since the last update
                     # into zero or more "max-timeslices" of the specified
                     # width, and the remainder is the last one in the streak of


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new parameter, `max_timeslice`, which approximates how long the sensor can normally go without a state change. (It doesn't harm to update it faster than this timeslice.) This makes it possible to use the more precise trapezoidal integration
method with devices like kettles and boilers.

### The problem
When the trapezoidal or right integration method sees an extended period of zero state changes, it attributes the new state change to that whole period (the trapezoidal one has half as much of an impact). For example:
- You have the Riemann sum integrator attached to a smart outlet with a wattmeter, and an electric kettle plugged in
- When the kettle is off, the wattage gets rounded down to 0 by the smart outlet, generating zero state changes over extended periods of time (tens of minutes, often hours)
- When the kettle suddenly turns on and starts drawing upwards of 1 kW of power, the right and trapezoidal integration methods attribute that new value to the whole massive time period

### The solution
This new option, `max_timeslice`, allows breaks that time interval into one or more fixed "max-slices". This simulates the effect that the sensor has been providing values all along, but they never changed, so the integrator should solely sample the old value for them.

Note that the integration still only happens when the state changes. If I were a little more familiar with the Home Assistant codebase, I'd hook it up to a timer instead, but that would add one cycle eater per integrator with this feature enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I don't actually have a proper Python development environment on the machine I wrote this on, so I couldn't run the tests or the formatter. I followed the formatting to the best of my ability though, and I'm fairly sure that this change is too small for any tests whatsoever to make sense for it. I'm also not particularly familiar with the codebase, so I don't think I can help with other PRs though. (I'll edit the PR description if I review those two PRs though.)

- Documentation PR: [#21569](https://github.com/home-assistant/home-assistant.io/pull/21569).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

*it does not*

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
