### PR TITLE
Add helper for media players to handle HA hosted media

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -59,7 +59,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
-    datetime,
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
@@ -67,7 +66,8 @@ from homeassistant.helpers.network import get_url
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
-from .const import (
+from .browse_media import BrowseMedia, async_process_play_media_url  # noqa: F401
+from .const import (  # noqa: F401
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_GROUP_MEMBERS,
@@ -97,6 +97,7 @@ from .const import (
     ATTR_MEDIA_VOLUME_MUTED,
     ATTR_SOUND_MODE,
     ATTR_SOUND_MODE_LIST,
+    CONTENT_AUTH_EXPIRY_TIME,
     DOMAIN,
     MEDIA_CLASS_DIRECTORY,
     REPEAT_MODES,
@@ -1204,74 +1205,3 @@ async def websocket_browse_media(hass, connection, msg):
         _LOGGER.warning("Browse Media should use new BrowseMedia class")
 
     connection.send_result(msg["id"], payload)
-
-
-class BrowseMedia:
-    """Represent a browsable media file."""
-
-    def __init__(
-        self,
-        *,
-        media_class: str,
-        media_content_id: str,
-        media_content_type: str,
-        title: str,
-        can_play: bool,
-        can_expand: bool,
-        children: list[BrowseMedia] | None = None,
-        children_media_class: str | None = None,
-        thumbnail: str | None = None,
-    ) -> None:
-        """Initialize browse media item."""
-        self.media_class = media_class
-        self.media_content_id = media_content_id
-        self.media_content_type = media_content_type
-        self.title = title
-        self.can_play = can_play
-        self.can_expand = can_expand
-        self.children = children
-        self.children_media_class = children_media_class
-        self.thumbnail = thumbnail
-
-    def as_dict(self, *, parent: bool = True) -> dict:
-        """Convert Media class to browse media dictionary."""
-        if self.children_media_class is None:
-            self.calculate_children_class()
-
-        response = {
-            "title": self.title,
-            "media_class": self.media_class,
-            "media_content_type": self.media_content_type,
-            "media_content_id": self.media_content_id,
-            "can_play": self.can_play,
-            "can_expand": self.can_expand,
-            "children_media_class": self.children_media_class,
-            "thumbnail": self.thumbnail,
-        }
-
-        if not parent:
-            return response
-
-        if self.children:
-            response["children"] = [
-                child.as_dict(parent=False) for child in self.children
-            ]
-        else:
-            response["children"] = []
-
-        return response
-
-    def calculate_children_class(self) -> None:
-        """Count the children media classes and calculate the correct class."""
-        if self.children is None or len(self.children) == 0:
-            return
-
-        self.children_media_class = MEDIA_CLASS_DIRECTORY
-
-        proposed_class = self.children[0].media_class
-        if all(child.media_class == proposed_class for child in self.children):
-            self.children_media_class = proposed_class
-
-    def __repr__(self):
-        """Return representation of browse media."""
-        return f"<BrowseMedia {self.title} ({self.media_class})>"

--- a/homeassistant/components/media_player/browse_media.py
+++ b/homeassistant/components/media_player/browse_media.py
@@ -1,0 +1,112 @@
+"""Browse media features for media player."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from urllib.parse import quote
+
+import yarl
+
+from homeassistant.components.http.auth import async_sign_path
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.network import get_url, is_hass_url
+
+from .const import CONTENT_AUTH_EXPIRY_TIME, MEDIA_CLASS_DIRECTORY
+
+
+@callback
+def async_process_play_media_url(hass: HomeAssistant, media_content_id: str) -> str:
+    """Update a media URL with authentication if it points at Home Assistant."""
+    if media_content_id[0] != "/" and not is_hass_url(hass, media_content_id):
+        return media_content_id
+
+    parsed = yarl.URL(media_content_id)
+
+    if parsed.query:
+        logging.getLogger(__name__).debug(
+            "Not signing path for content with query param"
+        )
+    else:
+        signed_path = async_sign_path(
+            hass,
+            quote(parsed.path),
+            timedelta(seconds=CONTENT_AUTH_EXPIRY_TIME),
+        )
+        media_content_id = str(parsed.join(yarl.URL(signed_path)))
+
+    # prepend external URL
+    if media_content_id[0] == "/":
+        media_content_id = f"{get_url(hass)}{media_content_id}"
+
+    return media_content_id
+
+
+class BrowseMedia:
+    """Represent a browsable media file."""
+
+    def __init__(
+        self,
+        *,
+        media_class: str,
+        media_content_id: str,
+        media_content_type: str,
+        title: str,
+        can_play: bool,
+        can_expand: bool,
+        children: list[BrowseMedia] | None = None,
+        children_media_class: str | None = None,
+        thumbnail: str | None = None,
+    ) -> None:
+        """Initialize browse media item."""
+        self.media_class = media_class
+        self.media_content_id = media_content_id
+        self.media_content_type = media_content_type
+        self.title = title
+        self.can_play = can_play
+        self.can_expand = can_expand
+        self.children = children
+        self.children_media_class = children_media_class
+        self.thumbnail = thumbnail
+
+    def as_dict(self, *, parent: bool = True) -> dict:
+        """Convert Media class to browse media dictionary."""
+        if self.children_media_class is None:
+            self.calculate_children_class()
+
+        response = {
+            "title": self.title,
+            "media_class": self.media_class,
+            "media_content_type": self.media_content_type,
+            "media_content_id": self.media_content_id,
+            "can_play": self.can_play,
+            "can_expand": self.can_expand,
+            "children_media_class": self.children_media_class,
+            "thumbnail": self.thumbnail,
+        }
+
+        if not parent:
+            return response
+
+        if self.children:
+            response["children"] = [
+                child.as_dict(parent=False) for child in self.children
+            ]
+        else:
+            response["children"] = []
+
+        return response
+
+    def calculate_children_class(self) -> None:
+        """Count the children media classes and calculate the correct class."""
+        if self.children is None or len(self.children) == 0:
+            return
+
+        self.children_media_class = MEDIA_CLASS_DIRECTORY
+
+        proposed_class = self.children[0].media_class
+        if all(child.media_class == proposed_class for child in self.children):
+            self.children_media_class = proposed_class
+
+    def __repr__(self) -> str:
+        """Return representation of browse media."""
+        return f"<BrowseMedia {self.title} ({self.media_class})>"

--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -1,4 +1,6 @@
 """Provides the constants needed for component."""
+# How long our auth signature on the content should be valid for
+CONTENT_AUTH_EXPIRY_TIME = 3600 * 24
 
 ATTR_APP_ID = "app_id"
 ATTR_APP_NAME = "app_name"

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.components import frontend, websocket_api
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_ID,
+    CONTENT_AUTH_EXPIRY_TIME,
     BrowseError,
     BrowseMedia,
 )
@@ -27,8 +28,6 @@ from . import local_source
 from .const import DOMAIN, URI_SCHEME, URI_SCHEME_REGEX
 from .error import MediaSourceError, Unresolvable
 from .models import BrowseMediaSource, MediaSourceItem, PlayMedia
-
-DEFAULT_EXPIRY_TIME = 3600 * 24
 
 __all__ = [
     "DOMAIN",
@@ -147,7 +146,7 @@ async def websocket_browse_media(
     {
         vol.Required("type"): "media_source/resolve_media",
         vol.Required(ATTR_MEDIA_CONTENT_ID): str,
-        vol.Optional("expires", default=DEFAULT_EXPIRY_TIME): int,
+        vol.Optional("expires", default=CONTENT_AUTH_EXPIRY_TIME): int,
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -17,6 +17,7 @@ from soco.core import (
 )
 from soco.data_structures import DidlFavorite
 import voluptuous as vol
+import yarl
 
 from homeassistant.components import media_source, spotify
 from homeassistant.components.http.auth import async_sign_path
@@ -570,11 +571,16 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             # If media ID is a relative URL, we serve it from HA.
             # Create a signed path.
             if media_id[0] == "/" or is_hass_url(self.hass, media_id):
-                media_id = async_sign_path(
-                    self.hass,
-                    quote(media_id),
-                    datetime.timedelta(seconds=media_source.DEFAULT_EXPIRY_TIME),
-                )
+                parsed = yarl.URL(media_id)
+
+                if parsed.query:
+                    _LOGGER.debug("Not signing path for content with query param")
+                else:
+                    media_id = async_sign_path(
+                        self.hass,
+                        quote(media_id),
+                        datetime.timedelta(seconds=media_source.DEFAULT_EXPIRY_TIME),
+                    )
 
                 # prepend external URL
                 if media_id[0] == "/":

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -56,7 +56,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform, service
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.network import get_url
+from homeassistant.helpers.network import get_url, is_hass_url
 
 from . import media_browser
 from .const import (
@@ -569,7 +569,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         elif media_type in (MEDIA_TYPE_MUSIC, MEDIA_TYPE_TRACK):
             # If media ID is a relative URL, we serve it from HA.
             # Create a signed path.
-            if media_id[0] == "/":
+            if media_id[0] == "/" or is_hass_url(self.hass, media_id):
                 media_id = async_sign_path(
                     self.hass,
                     quote(media_id),
@@ -577,8 +577,8 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 )
 
                 # prepend external URL
-                hass_url = get_url(self.hass, prefer_external=True)
-                media_id = f"{hass_url}{media_id}"
+                if media_id[0] == "/":
+                    media_id = f"{get_url(self.hass)}{media_id}"
 
             if kwargs.get(ATTR_MEDIA_ENQUEUE):
                 soco.add_uri_to_queue(media_id)

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -6,7 +6,6 @@ import datetime
 import json
 import logging
 from typing import Any
-from urllib.parse import quote
 
 from soco import alarms
 from soco.core import (
@@ -17,11 +16,12 @@ from soco.core import (
 )
 from soco.data_structures import DidlFavorite
 import voluptuous as vol
-import yarl
 
 from homeassistant.components import media_source, spotify
-from homeassistant.components.http.auth import async_sign_path
-from homeassistant.components.media_player import MediaPlayerEntity
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    async_process_play_media_url,
+)
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_ENQUEUE,
     MEDIA_TYPE_ALBUM,
@@ -57,7 +57,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform, service
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.network import get_url, is_hass_url
 
 from . import media_browser
 from .const import (
@@ -569,22 +568,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 soco.play_from_queue(0)
         elif media_type in (MEDIA_TYPE_MUSIC, MEDIA_TYPE_TRACK):
             # If media ID is a relative URL, we serve it from HA.
-            # Create a signed path.
-            if media_id[0] == "/" or is_hass_url(self.hass, media_id):
-                parsed = yarl.URL(media_id)
-
-                if parsed.query:
-                    _LOGGER.debug("Not signing path for content with query param")
-                else:
-                    media_id = async_sign_path(
-                        self.hass,
-                        quote(media_id),
-                        datetime.timedelta(seconds=media_source.DEFAULT_EXPIRY_TIME),
-                    )
-
-                # prepend external URL
-                if media_id[0] == "/":
-                    media_id = f"{get_url(self.hass)}{media_id}"
+            media_id = async_process_play_media_url(self.hass, media_id)
 
             if kwargs.get(ATTR_MEDIA_ENQUEUE):
                 soco.add_uri_to_queue(media_id)

--- a/tests/components/media_player/test_browse_media.py
+++ b/tests/components/media_player/test_browse_media.py
@@ -1,0 +1,60 @@
+"""Test media browser helpers for media player."""
+from unittest.mock import Mock, patch
+
+import pytest
+
+from homeassistant.components.media_player.browse_media import (
+    async_process_play_media_url,
+)
+from homeassistant.config import async_process_ha_core_config
+
+
+@pytest.fixture
+def mock_sign_path():
+    """Mock sign path."""
+    with patch(
+        "homeassistant.components.media_player.browse_media.async_sign_path",
+        side_effect=lambda _, url, _2: url + "?authSig=bla",
+    ):
+        yield
+
+
+async def test_process_play_media_url(hass, mock_sign_path):
+    """Test it prefixes and signs urls."""
+    await async_process_ha_core_config(
+        hass,
+        {"internal_url": "http://example.local:8123"},
+    )
+    hass.config.api = Mock(use_ssl=False, port=8123, local_ip="192.168.123.123")
+
+    # Not changing a url that is not a hass url
+    assert (
+        async_process_play_media_url(hass, "https://not-hass.com/path")
+        == "https://not-hass.com/path"
+    )
+
+    # Testing signing hass URLs
+    assert (
+        async_process_play_media_url(hass, "/path")
+        == "http://example.local:8123/path?authSig=bla"
+    )
+    assert (
+        async_process_play_media_url(hass, "http://example.local:8123/path")
+        == "http://example.local:8123/path?authSig=bla"
+    )
+    assert (
+        async_process_play_media_url(hass, "http://192.168.123.123:8123/path")
+        == "http://192.168.123.123:8123/path?authSig=bla"
+    )
+
+    # Test skip signing URLs that have a query param
+    assert (
+        async_process_play_media_url(hass, "/path?hello=world")
+        == "http://example.local:8123/path?hello=world"
+    )
+    assert (
+        async_process_play_media_url(
+            hass, "http://192.168.123.123:8123/path?hello=world"
+        )
+        == "http://192.168.123.123:8123/path?hello=world"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create a helper for the sign URL logic from #65977. Apply it to Sonos and all other places that had already adopted it. Ensure all HASS URLs are signed, even if passed in as absolute URLs. Guards in case URLs already has query params (because not supported by URL signing)

Drops prefer external from get_url. This is no longer needed because the defaults of get_url have been updated in #66039 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
