### PR TITLE
Fix system is loaded flag during reboot/shutdown of Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/common.py
+++ b/homeassistant/components/synology_dsm/common.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 
-from .const import CONF_DEVICE_TOKEN
+from .const import CONF_DEVICE_TOKEN, DOMAIN, SYSTEM_LOADED
 
 LOGGER = logging.getLogger(__name__)
 
@@ -218,6 +218,11 @@ class SynoApi:
             )
             self.surveillance_station = self.dsm.surveillance_station
 
+    def _set_system_loaded(self, state: bool = False) -> None:
+        """Set system loaded flag."""
+        dsm_device = self._hass.data[DOMAIN].get(self.information.serial)
+        dsm_device[SYSTEM_LOADED] = state
+
     async def _syno_api_executer(self, api_call: Callable) -> None:
         """Synology api call wrapper."""
         try:
@@ -231,10 +236,12 @@ class SynoApi:
     async def async_reboot(self) -> None:
         """Reboot NAS."""
         await self._syno_api_executer(self.system.reboot)
+        self._set_system_loaded()
 
     async def async_shutdown(self) -> None:
         """Shutdown NAS."""
         await self._syno_api_executer(self.system.shutdown)
+        self._set_system_loaded()
 
     async def async_unload(self) -> None:
         """Stop interacting with the NAS and prepare for removal from hass."""

--- a/homeassistant/components/synology_dsm/service.py
+++ b/homeassistant/components/synology_dsm/service.py
@@ -15,7 +15,6 @@ from .const import (
     SERVICE_SHUTDOWN,
     SERVICES,
     SYNO_API,
-    SYSTEM_LOADED,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -57,7 +56,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
             dsm_api: SynoApi = dsm_device[SYNO_API]
             try:
-                dsm_device[SYSTEM_LOADED] = False
                 await getattr(dsm_api, f"async_{call.service}")()
             except SynologyDSMException as ex:
                 LOGGER.error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will fix the setting of the `SYSTEM_LOADED` flag, since the buttons does not trigger the service methods, but direct the SynoAPI methods.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65688
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
