### PR TITLE
Add select platform to roku

### DIFF
--- a/homeassistant/components/roku/__init__.py
+++ b/homeassistant/components/roku/__init__.py
@@ -24,6 +24,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.MEDIA_PLAYER,
     Platform.REMOTE,
+    Platform.SELECT,
     Platform.SENSOR,
 ]
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/roku/browse_media.py
+++ b/homeassistant/components/roku/browse_media.py
@@ -21,6 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import is_internal_request
 
 from .coordinator import RokuDataUpdateCoordinator
+from .helpers import format_channel_name
 
 CONTENT_TYPE_MEDIA_CLASS = {
     MEDIA_TYPE_APP: MEDIA_CLASS_APP,
@@ -191,11 +192,12 @@ def build_item_response(
         title = "TV Channels"
         media = [
             {
-                "channel_number": item.number,
-                "title": item.name,
+                "channel_number": channel.number,
+                "title": format_channel_name(channel.number, channel.name),
                 "type": MEDIA_TYPE_CHANNEL,
             }
-            for item in coordinator.data.channels
+            for channel in coordinator.data.channels
+            if channel.number is not None and channel.number != ""
         ]
         children_media_class = MEDIA_CLASS_CHANNEL
 

--- a/homeassistant/components/roku/browse_media.py
+++ b/homeassistant/components/roku/browse_media.py
@@ -197,7 +197,6 @@ def build_item_response(
                 "type": MEDIA_TYPE_CHANNEL,
             }
             for channel in coordinator.data.channels
-            if channel.number is not None and channel.number != ""
         ]
         children_media_class = MEDIA_CLASS_CHANNEL
 

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -1,0 +1,10 @@
+"""Helpers for Roku."""
+from __future__ import annotations
+
+
+def format_channel_name(channel_number: str, channel_name: str | None = None) -> str:
+    """Format a Roku Channel name."""
+    if channel_name is not None and channel_name != "":
+        return f"{channel_name} ({channel_number})"
+
+    return channel_number

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -2,7 +2,7 @@
   "domain": "roku",
   "name": "Roku",
   "documentation": "https://www.home-assistant.io/integrations/roku",
-  "requirements": ["rokuecp==0.13.1"],
+  "requirements": ["rokuecp==0.13.2"],
   "homekit": {
     "models": ["3810X", "4660X", "7820X", "C105X", "C135X"]
   },

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -58,6 +58,7 @@ from .const import (
 )
 from .coordinator import RokuDataUpdateCoordinator
 from .entity import RokuEntity
+from .helpers import format_channel_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -212,10 +213,9 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         if self.app_id != "tvinput.dtv" or self.coordinator.data.channel is None:
             return None
 
-        if self.coordinator.data.channel.name is not None:
-            return f"{self.coordinator.data.channel.name} ({self.coordinator.data.channel.number})"
+        channel = self.coordinator.data.channel
 
-        return self.coordinator.data.channel.number
+        return format_channel_name(channel.number, channel.name)
 
     @property
     def media_title(self) -> str | None:

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -75,7 +75,7 @@ async def _tune_channel(device: RokuDevice, roku: Roku, value: str) -> None:
             for channel in device.channels
             if (
                 channel.name is not None
-                and value == f"{channel.name} ({channel.number})"
+                and value == format_channel_name(channel.number, channel.name)
             )
             or value == channel.number
         ),
@@ -101,6 +101,7 @@ ENTITIES: tuple[RokuSelectEntityDescription, ...] = (
         set_fn=_launch_application,
         value_fn=_get_application_name,
         options_fn=_get_applications,
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -83,7 +83,7 @@ async def _tune_channel(device: RokuDevice, roku: Roku, value: str) -> None:
         None,
     )
 
-    if _channel is not None and _channel.number is not None:
+    if _channel is not None:
         await roku.tune(_channel.number)
 
 

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -1,0 +1,175 @@
+"""Support for Roku selects."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from rokuecp import Roku
+from rokuecp.models import Device as RokuDevice
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import roku_exception_handler
+from .const import DOMAIN
+from .coordinator import RokuDataUpdateCoordinator
+from .entity import RokuEntity
+from .helpers import format_channel_name
+
+
+@dataclass
+class RokuSelectEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    options_fn: Callable[[RokuDevice], list[str]]
+    value_fn: Callable[[RokuDevice], str | None]
+    set_fn: Callable[[RokuDevice, Roku, str], Awaitable[None]]
+
+
+def _get_application_name(device: RokuDevice) -> str | None:
+    if device.app is None or device.app.name is None:
+        return None
+
+    if device.app.name == "Roku":
+        return "Home"
+
+    return device.app.name
+
+
+def _get_applications(device: RokuDevice) -> list[str]:
+    return ["Home"] + sorted(app.name for app in device.apps if app.name is not None)
+
+
+def _get_channel_name(device: RokuDevice) -> str | None:
+    if device.channel is None:
+        return None
+
+    return format_channel_name(device.channel.number, device.channel.name)
+
+
+def _get_channels(device: RokuDevice) -> list[str]:
+    return sorted(
+        format_channel_name(channel.number, channel.name)
+        for channel in device.channels
+        if channel.name is not None and channel.number is not None
+    )
+
+
+async def _launch_application(device: RokuDevice, roku: Roku, value: str) -> None:
+    if value == "Home":
+        await roku.remote("home")
+
+    appl = next(
+        (app for app in device.apps if value == app.name),
+        None,
+    )
+
+    if appl is not None and appl.app_id is not None:
+        await roku.launch(appl.app_id)
+
+
+async def _tune_channel(device: RokuDevice, roku: Roku, value: str) -> None:
+    _channel = next(
+        (
+            channel
+            for channel in device.channels
+            if (
+                channel.name is not None
+                and value == f"{channel.name} ({channel.number})"
+            )
+            or (channel.number is not None and value == channel.number)
+        ),
+        None,
+    )
+
+    if _channel is not None and _channel.number is not None:
+        await roku.tune(_channel.number)
+
+
+@dataclass
+class RokuSelectEntityDescription(
+    SelectEntityDescription, RokuSelectEntityDescriptionMixin
+):
+    """Describes Roku select entity."""
+
+
+ENTITIES: tuple[RokuSelectEntityDescription, ...] = (
+    RokuSelectEntityDescription(
+        key="application",
+        name="Application",
+        icon="mdi:application",
+        set_fn=_launch_application,
+        value_fn=_get_application_name,
+        options_fn=_get_applications,
+    ),
+)
+
+CHANNEL_ENTITY = RokuSelectEntityDescription(
+    key="channel",
+    name="Channel",
+    icon="mdi:television",
+    set_fn=_tune_channel,
+    value_fn=_get_channel_name,
+    options_fn=_get_channels,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Roku select based on a config entry."""
+    coordinator: RokuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    device: RokuDevice = coordinator.data
+    unique_id = device.info.serial_number
+
+    entities: list[RokuSelectEntity] = []
+
+    for description in ENTITIES:
+        entities.append(
+            RokuSelectEntity(
+                device_id=unique_id,
+                coordinator=coordinator,
+                description=description,
+            )
+        )
+
+    if len(device.channels) > 0:
+        entities.append(
+            RokuSelectEntity(
+                device_id=unique_id,
+                coordinator=coordinator,
+                description=CHANNEL_ENTITY,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class RokuSelectEntity(RokuEntity, SelectEntity):
+    """Defines a Roku select entity."""
+
+    entity_description: RokuSelectEntityDescription
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current value."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return self.entity_description.options_fn(self.coordinator.data)
+
+    @roku_exception_handler
+    async def async_select_option(self, option: str) -> None:
+        """Set the option."""
+        await self.entity_description.set_fn(
+            self.coordinator.data,
+            self.coordinator.roku,
+            option,
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -53,7 +53,7 @@ def _get_channels(device: RokuDevice) -> list[str]:
     return sorted(
         format_channel_name(channel.number, channel.name)
         for channel in device.channels
-        if channel.name is not None and channel.number is not None
+        if channel.name is not None
     )
 
 
@@ -79,7 +79,7 @@ async def _tune_channel(device: RokuDevice, roku: Roku, value: str) -> None:
                 channel.name is not None
                 and value == f"{channel.name} ({channel.number})"
             )
-            or (channel.number is not None and value == channel.number)
+            or value == channel.number
         ),
         None,
     )

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -53,7 +53,6 @@ def _get_channels(device: RokuDevice) -> list[str]:
     return sorted(
         format_channel_name(channel.number, channel.name)
         for channel in device.channels
-        if channel.name is not None
     )
 
 

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -51,8 +51,7 @@ def _get_channel_name(device: RokuDevice) -> str | None:
 
 def _get_channels(device: RokuDevice) -> list[str]:
     return sorted(
-        format_channel_name(channel.number, channel.name)
-        for channel in device.channels
+        format_channel_name(channel.number, channel.name) for channel in device.channels
     )
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2117,7 +2117,7 @@ rjpl==0.3.6
 rocketchat-API==0.6.1
 
 # homeassistant.components.roku
-rokuecp==0.13.1
+rokuecp==0.13.2
 
 # homeassistant.components.roomba
 roombapy==1.6.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1306,7 +1306,7 @@ rflink==0.0.62
 ring_doorbell==0.7.2
 
 # homeassistant.components.roku
-rokuecp==0.13.1
+rokuecp==0.13.2
 
 # homeassistant.components.roomba
 roombapy==1.6.5

--- a/tests/components/roku/conftest.py
+++ b/tests/components/roku/conftest.py
@@ -38,38 +38,44 @@ def mock_setup_entry() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def mock_roku_config_flow(
+async def mock_device(
     request: pytest.FixtureRequest,
-) -> Generator[None, MagicMock, None]:
-    """Return a mocked Roku client."""
+) -> RokuDevice:
+    """Return the mocked roku device."""
     fixture: str = "roku/roku3.json"
     if hasattr(request, "param") and request.param:
         fixture = request.param
 
-    device = RokuDevice(json.loads(load_fixture(fixture)))
+    return RokuDevice(json.loads(load_fixture(fixture)))
+
+
+@pytest.fixture
+def mock_roku_config_flow(
+    mock_device: RokuDevice,
+) -> Generator[None, MagicMock, None]:
+    """Return a mocked Roku client."""
+
     with patch(
         "homeassistant.components.roku.config_flow.Roku", autospec=True
     ) as roku_mock:
         client = roku_mock.return_value
         client.app_icon_url.side_effect = app_icon_url
-        client.update.return_value = device
+        client.update.return_value = mock_device
         yield client
 
 
 @pytest.fixture
-def mock_roku(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_roku(
+    request: pytest.FixtureRequest, mock_device: RokuDevice
+) -> Generator[None, MagicMock, None]:
     """Return a mocked Roku client."""
-    fixture: str = "roku/roku3.json"
-    if hasattr(request, "param") and request.param:
-        fixture = request.param
 
-    device = RokuDevice(json.loads(load_fixture(fixture)))
     with patch(
         "homeassistant.components.roku.coordinator.Roku", autospec=True
     ) as roku_mock:
         client = roku_mock.return_value
         client.app_icon_url.side_effect = app_icon_url
-        client.update.return_value = device
+        client.update.return_value = mock_device
         yield client
 
 

--- a/tests/components/roku/fixtures/rokutv-7820x.json
+++ b/tests/components/roku/fixtures/rokutv-7820x.json
@@ -167,6 +167,18 @@
       "name": "QVC",
       "type": "air-digital",
       "user-hidden": "false"
+    },
+    {
+      "number": "14.3",
+      "name": "getTV",
+      "type": "air-digital",
+      "user-hidden": "false"
+    },
+    {
+      "number": "99.1",
+      "name": "",
+      "type": "air-digital",
+      "user-hidden": "false"
     }
   ],
   "media": {

--- a/tests/components/roku/test_binary_sensor.py
+++ b/tests/components/roku/test_binary_sensor.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from rokuecp import Device as RokuDevice
 
 from homeassistant.components.binary_sensor import STATE_OFF, STATE_ON
 from homeassistant.components.roku.const import DOMAIN
@@ -82,10 +83,11 @@ async def test_roku_binary_sensors(
     assert device_entry.suggested_area is None
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_rokutv_binary_sensors(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
+    mock_device: RokuDevice,
     mock_roku: MagicMock,
 ) -> None:
     """Test the Roku binary sensors."""

--- a/tests/components/roku/test_config_flow.py
+++ b/tests/components/roku/test_config_flow.py
@@ -158,9 +158,7 @@ async def test_homekit_unknown_error(
     assert result["reason"] == "unknown"
 
 
-@pytest.mark.parametrize(
-    "mock_roku_config_flow", ["roku/rokutv-7820x.json"], indirect=True
-)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_homekit_discovery(
     hass: HomeAssistant,
     mock_roku_config_flow: MagicMock,

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -115,7 +115,7 @@ async def test_setup(hass: HomeAssistant, init_integration: MockConfigEntry) -> 
     assert device_entry.suggested_area is None
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/roku3-idle.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/roku3-idle.json"], indirect=True)
 async def test_idle_setup(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -127,7 +127,7 @@ async def test_idle_setup(
     assert state.state == STATE_STANDBY
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_tv_setup(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -215,7 +215,7 @@ async def test_supported_features(
     )
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_tv_supported_features(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -254,7 +254,7 @@ async def test_attributes(
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Roku"
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/roku3-app.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/roku3-app.json"], indirect=True)
 async def test_attributes_app(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -271,7 +271,9 @@ async def test_attributes_app(
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Netflix"
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/roku3-media-playing.json"], indirect=True)
+@pytest.mark.parametrize(
+    "mock_device", ["roku/roku3-media-playing.json"], indirect=True
+)
 async def test_attributes_app_media_playing(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -290,7 +292,7 @@ async def test_attributes_app_media_playing(
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Pluto TV - It's Free TV"
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/roku3-media-paused.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/roku3-media-paused.json"], indirect=True)
 async def test_attributes_app_media_paused(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -309,7 +311,7 @@ async def test_attributes_app_media_paused(
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Pluto TV - It's Free TV"
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/roku3-screensaver.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/roku3-screensaver.json"], indirect=True)
 async def test_attributes_screensaver(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -326,7 +328,7 @@ async def test_attributes_screensaver(
     assert state.attributes.get(ATTR_INPUT_SOURCE) == "Roku"
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_tv_attributes(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
@@ -557,7 +559,7 @@ async def test_services_play_media_local_source(
     assert "/media/local/Epic%20Sax%20Guy%2010%20Hours.mp4?authSig=" in call_args[0]
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_tv_services(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -836,7 +838,7 @@ async def test_media_browse_local_source(
     )
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_tv_media_browse(
     hass,
     init_integration,
@@ -933,10 +935,10 @@ async def test_tv_media_browse(
     assert msg["result"]["children_media_class"] == MEDIA_CLASS_CHANNEL
     assert msg["result"]["can_expand"]
     assert not msg["result"]["can_play"]
-    assert len(msg["result"]["children"]) == 2
+    assert len(msg["result"]["children"]) == 4
     assert msg["result"]["children_media_class"] == MEDIA_CLASS_CHANNEL
 
-    assert msg["result"]["children"][0]["title"] == "WhatsOn"
+    assert msg["result"]["children"][0]["title"] == "WhatsOn (1.1)"
     assert msg["result"]["children"][0]["media_content_type"] == MEDIA_TYPE_CHANNEL
     assert msg["result"]["children"][0]["media_content_id"] == "1.1"
     assert msg["result"]["children"][0]["can_play"]

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from rokuecp import Application, Device as RokuDevice, RokuError
 
+from homeassistant.components.roku.const import DOMAIN
 from homeassistant.components.roku.coordinator import SCAN_INTERVAL
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.select.const import ATTR_OPTION, ATTR_OPTIONS
@@ -17,12 +18,24 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_application_state(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
     mock_device: RokuDevice,
     mock_roku: MagicMock,
 ) -> None:
     """Test the creation and values of the Roku selects."""
     entity_registry = er.async_get(hass)
+
+    entity_registry.async_get_or_create(
+        SELECT_DOMAIN,
+        DOMAIN,
+        "1GU48T017973_application",
+        suggested_object_id="my_roku_3_application",
+        disabled_by=None,
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get("select.my_roku_3_application")
     assert state
@@ -91,11 +104,25 @@ async def test_application_state(
 
 async def test_application_select_error(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
     mock_roku: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the Roku selects."""
+    entity_registry = er.async_get(hass)
+
+    entity_registry.async_get_or_create(
+        SELECT_DOMAIN,
+        DOMAIN,
+        "1GU48T017973_application",
+        suggested_object_id="my_roku_3_application",
+        disabled_by=None,
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
     mock_roku.launch.side_effect = RokuError
 
     await hass.services.async_call(

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -1,0 +1,214 @@
+"""Tests for the Roku select platform."""
+from unittest.mock import MagicMock
+
+import pytest
+from rokuecp import Application, Device as RokuDevice, RokuError
+
+from homeassistant.components.roku.coordinator import SCAN_INTERVAL
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.components.select.const import ATTR_OPTION, ATTR_OPTIONS
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, SERVICE_SELECT_OPTION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_application_state(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_device: RokuDevice,
+    mock_roku: MagicMock,
+) -> None:
+    """Test the creation and values of the Roku selects."""
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("select.my_roku_3_application")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:application"
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "Home",
+        "Amazon Video on Demand",
+        "Free FrameChannel Service",
+        "MLB.TV" + "\u00AE",
+        "Mediafly",
+        "Netflix",
+        "Pandora",
+        "Pluto TV - It's Free TV",
+        "Roku Channel Store",
+    ]
+    assert state.state == "Home"
+
+    entry = entity_registry.async_get("select.my_roku_3_application")
+    assert entry
+    assert entry.unique_id == "1GU48T017973_application"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.my_roku_3_application",
+            ATTR_OPTION: "Netflix",
+        },
+        blocking=True,
+    )
+
+    assert mock_roku.launch.call_count == 1
+    mock_roku.launch.assert_called_with("12")
+    mock_device.app = mock_device.apps[1]
+
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.my_roku_3_application")
+    assert state
+
+    assert state.state == "Netflix"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.my_roku_3_application",
+            ATTR_OPTION: "Home",
+        },
+        blocking=True,
+    )
+
+    assert mock_roku.remote.call_count == 1
+    mock_roku.remote.assert_called_with("home")
+    mock_device.app = Application(
+        app_id=None, name="Roku", version=None, screensaver=None
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + (SCAN_INTERVAL * 2))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.my_roku_3_application")
+    assert state
+    assert state.state == "Home"
+
+
+async def test_application_select_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_roku: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test error handling of the Roku selects."""
+    mock_roku.launch.side_effect = RokuError
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.my_roku_3_application",
+            ATTR_OPTION: "Netflix",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("select.my_roku_3_application")
+    assert state
+    assert state.state == "Home"
+    assert "Invalid response from API" in caplog.text
+    assert mock_roku.launch.call_count == 1
+    mock_roku.launch.assert_called_with("12")
+
+
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
+async def test_channel_state(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_device: RokuDevice,
+    mock_roku: MagicMock,
+) -> None:
+    """Test the creation and values of the Roku selects."""
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("select.58_onn_roku_tv_channel")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:television"
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "99.1",
+        "QVC (1.3)",
+        "WhatsOn (1.1)",
+        "getTV (14.3)",
+    ]
+    assert state.state == "getTV (14.3)"
+
+    entry = entity_registry.async_get("select.58_onn_roku_tv_channel")
+    assert entry
+    assert entry.unique_id == "YN00H5555555_channel"
+
+    # channel name
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.58_onn_roku_tv_channel",
+            ATTR_OPTION: "WhatsOn (1.1)",
+        },
+        blocking=True,
+    )
+
+    assert mock_roku.tune.call_count == 1
+    mock_roku.tune.assert_called_with("1.1")
+    mock_device.channel = mock_device.channels[0]
+
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.58_onn_roku_tv_channel")
+    assert state
+    assert state.state == "WhatsOn (1.1)"
+
+    # channel number
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.58_onn_roku_tv_channel",
+            ATTR_OPTION: "99.1",
+        },
+        blocking=True,
+    )
+
+    assert mock_roku.tune.call_count == 2
+    mock_roku.tune.assert_called_with("99.1")
+    mock_device.channel = mock_device.channels[3]
+
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.58_onn_roku_tv_channel")
+    assert state
+    assert state.state == "99.1"
+
+
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
+async def test_channel_select_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_roku: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test error handling of the Roku selects."""
+    mock_roku.tune.side_effect = RokuError
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.58_onn_roku_tv_channel",
+            ATTR_OPTION: "99.1",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("select.58_onn_roku_tv_channel")
+    assert state
+    assert state.state == "getTV (14.3)"
+    assert "Invalid response from API" in caplog.text
+    assert mock_roku.tune.call_count == 1
+    mock_roku.tune.assert_called_with("99.1")

--- a/tests/components/roku/test_sensor.py
+++ b/tests/components/roku/test_sensor.py
@@ -65,7 +65,7 @@ async def test_roku_sensors(
     assert device_entry.suggested_area is None
 
 
-@pytest.mark.parametrize("mock_roku", ["roku/rokutv-7820x.json"], indirect=True)
+@pytest.mark.parametrize("mock_device", ["roku/rokutv-7820x.json"], indirect=True)
 async def test_rokutv_sensors(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This originated from a feature request on the forums for application selector decoupled from media player.

very small rokuecp update included
https://github.com/ctalkington/python-rokuecp/releases/tag/0.13.2


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21561

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
