### PR TITLE
Allow stream log level to change at runtime

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -120,10 +120,8 @@ CONFIG_SCHEMA = vol.Schema(
 def filter_libav_logging() -> None:
     """Filter libav logging to only log when the stream logger is at DEBUG."""
 
-    stream_debug_enabled = logging.getLogger(__name__).isEnabledFor(logging.DEBUG)
-
     def libav_filter(record: logging.LogRecord) -> bool:
-        return stream_debug_enabled
+        return logging.getLogger(__name__).isEnabledFor(logging.DEBUG)
 
     for logging_namespace in (
         "libav.mp4",

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -6,6 +6,5 @@
   "dependencies": ["http"],
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
   "quality_scale": "internal",
-  "iot_class": "local_push",
-  "loggers": ["av"]
+  "iot_class": "local_push"
 }

--- a/tests/components/stream/test_init.py
+++ b/tests/components/stream/test_init.py
@@ -1,0 +1,46 @@
+"""Test stream init."""
+
+import logging
+
+import av
+
+from homeassistant.components.stream import __name__ as stream_name
+from homeassistant.setup import async_setup_component
+
+
+async def test_log_levels(hass, caplog):
+    """Test that the worker logs the url without username and password."""
+
+    logging.getLogger(stream_name).setLevel(logging.INFO)
+
+    await async_setup_component(hass, "stream", {"stream": {}})
+
+    # These namespaces should only pass log messages when the stream logger
+    # is at logging.DEBUG or below
+    namespaces_to_toggle = (
+        "mp4",
+        "h264",
+        "hevc",
+        "rtsp",
+        "tcp",
+        "tls",
+        "mpegts",
+        "NULL",
+    )
+
+    # Since logging is at INFO, these should not pass
+    for namespace in namespaces_to_toggle:
+        av.logging.log(av.logging.ERROR, namespace, "SHOULD NOT PASS")
+
+    logging.getLogger(stream_name).setLevel(logging.DEBUG)
+
+    # Since logging is now at DEBUG, these should now pass
+    for namespace in namespaces_to_toggle:
+        av.logging.log(av.logging.ERROR, namespace, "SHOULD PASS")
+
+    # Even though logging is at DEBUG, these should not pass
+    av.logging.log(av.logging.WARNING, "mp4", "SHOULD NOT PASS")
+    av.logging.log(av.logging.WARNING, "swscaler", "SHOULD NOT PASS")
+
+    assert "SHOULD PASS" in caplog.text
+    assert "SHOULD NOT PASS" not in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/architecture/discussions/715 proposes to enable/disable debug logging in the integration config. Although it's unclear whether this feature will affect stream as it is does not have a config_flow, this PR:
1) Removes the incorrect entry for "av" in manifest.json which was noted here: https://github.com/home-assistant/core/pull/65083#issuecomment-1023961364
2) Changes the log filter to allow for runtime changes in the stream log level
3) Adds a test to confirm the log behavior

Depending on the implementation of the broader debug logger toggling this can be revisited. Specifically, having a callback function that sets and unsets the log levels in PyAV when the debug log level is changed is probably much more efficient than doing this on every log message through a filter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
