### PR TITLE
Fix controlling nested groups

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -57,6 +57,8 @@ KEY_POSITION = "position"
 
 DEFAULT_NAME = "Cover Group"
 
+# No limit on parallel updates to enable a group calling another group
+PARALLEL_UPDATES = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -52,6 +52,8 @@ SUPPORTED_FLAGS = {SUPPORT_SET_SPEED, SUPPORT_DIRECTION, SUPPORT_OSCILLATE}
 
 DEFAULT_NAME = "Fan Group"
 
+# No limit on parallel updates to enable a group calling another group
+PARALLEL_UPDATES = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -58,6 +58,9 @@ from .util import find_state_attributes, mean_tuple, reduce_attribute
 
 DEFAULT_NAME = "Light Group"
 
+# No limit on parallel updates to enable a group calling another group
+PARALLEL_UPDATES = 0
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -1,6 +1,7 @@
 """The tests for the Media group platform."""
 from unittest.mock import patch
 
+import async_timeout
 import pytest
 
 from homeassistant.components.group import DOMAIN
@@ -486,12 +487,12 @@ async def test_service_calls(hass, mock_media_seek):
 
 async def test_nested_group(hass):
     """Test nested media group."""
-    hass.states.async_set("media_player.player_1", "on")
     await async_setup_component(
         hass,
         MEDIA_DOMAIN,
         {
             MEDIA_DOMAIN: [
+                {"platform": "demo"},
                 {
                     "platform": DOMAIN,
                     "entities": ["media_player.group_1"],
@@ -499,7 +500,7 @@ async def test_nested_group(hass):
                 },
                 {
                     "platform": DOMAIN,
-                    "entities": ["media_player.player_1", "media_player.player_2"],
+                    "entities": ["media_player.bedroom", "media_player.kitchen"],
                     "name": "Group 1",
                 },
             ]
@@ -511,13 +512,28 @@ async def test_nested_group(hass):
 
     state = hass.states.get("media_player.group_1")
     assert state is not None
-    assert state.state == STATE_ON
+    assert state.state == STATE_PLAYING
     assert state.attributes.get(ATTR_ENTITY_ID) == [
-        "media_player.player_1",
-        "media_player.player_2",
+        "media_player.bedroom",
+        "media_player.kitchen",
     ]
 
     state = hass.states.get("media_player.nested_group")
     assert state is not None
-    assert state.state == STATE_ON
+    assert state.state == STATE_PLAYING
     assert state.attributes.get(ATTR_ENTITY_ID) == ["media_player.group_1"]
+
+    # Test controlling the nested group
+    async with async_timeout.timeout(0.5):
+        await hass.services.async_call(
+            MEDIA_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "media_player.group_1"},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    assert hass.states.get("media_player.bedroom").state == STATE_OFF
+    assert hass.states.get("media_player.kitchen").state == STATE_OFF
+    assert hass.states.get("media_player.group_1").state == STATE_OFF
+    assert hass.states.get("media_player.nested_group").state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix deadlock when controlling nested cover, fan and light groups

Add tests for controlling nested cover, fan, light and media_player groups

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #65119
  - fixes #65766
  - fixes #65872
  - fixes #65885
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
