### PR TITLE
Refactor Plugwise command handling

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -18,16 +18,10 @@ from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    DEFAULT_MAX_TEMP,
-    DEFAULT_MIN_TEMP,
-    DOMAIN,
-    LOGGER,
-    SCHEDULE_OFF,
-    SCHEDULE_ON,
-)
+from .const import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP, DOMAIN, SCHEDULE_OFF, SCHEDULE_ON
 from .coordinator import PlugwiseDataUpdateCoordinator
-from .entity import PlugwiseEntity, plugwise_exception_handler
+from .entity import PlugwiseEntity
+from .util import plugwise_command
 
 HVAC_MODES_HEAT_ONLY = [HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF]
 HVAC_MODES_HEAT_COOL = [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_AUTO, HVAC_MODE_OFF]
@@ -74,20 +68,17 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
 
         self._loc_id = coordinator.data.devices[device_id]["location"]
 
-    @plugwise_exception_handler
+    @plugwise_command
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
-        if (temperature is not None) and (
+        if ((temperature := kwargs.get(ATTR_TEMPERATURE)) is not None) and (
             self._attr_min_temp < temperature < self._attr_max_temp
         ):
             await self.coordinator.api.set_temperature(self._loc_id, temperature)
-            self._attr_target_temperature = temperature
-            self.async_write_ha_state()
         else:
-            LOGGER.error("Invalid temperature requested")
+            raise ValueError("Invalid temperature requested")
 
-    @plugwise_exception_handler
+    @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set the hvac mode."""
         state = SCHEDULE_OFF
@@ -103,19 +94,14 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         await self.coordinator.api.set_schedule_state(
             self._loc_id, climate_data.get("last_used"), state
         )
-        self._attr_hvac_mode = hvac_mode
-        self.async_write_ha_state()
 
-    @plugwise_exception_handler
+    @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if not (presets := self.coordinator.data.devices[self._dev_id].get("presets")):
+        if not self.coordinator.data.devices[self._dev_id].get("presets"):
             raise ValueError("No presets available")
 
         await self.coordinator.api.set_preset(self._loc_id, preset_mode)
-        self._attr_preset_mode = preset_mode
-        self._attr_target_temperature = presets.get(preset_mode, "none")[0]
-        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -71,12 +71,11 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if ((temperature := kwargs.get(ATTR_TEMPERATURE)) is not None) and (
-            self._attr_min_temp < temperature < self._attr_max_temp
+        if ((temperature := kwargs.get(ATTR_TEMPERATURE)) is None) or (
+            self._attr_max_temp < temperature < self._attr_min_temp
         ):
-            await self.coordinator.api.set_temperature(self._loc_id, temperature)
-        else:
             raise ValueError("Invalid temperature requested")
+        await self.coordinator.api.set_temperature(self._loc_id, temperature)
 
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:

--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -1,41 +1,12 @@
 """Generic Plugwise Entity Class."""
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
-from typing import Any, TypeVar
-
-from plugwise.exceptions import PlugwiseException
-
 from homeassistant.const import ATTR_NAME, ATTR_VIA_DEVICE, CONF_HOST
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PlugwiseData, PlugwiseDataUpdateCoordinator
-
-T = TypeVar("T")
-
-
-def plugwise_exception_handler(
-    func: Callable[..., Coroutine[Any, Any, T]]
-) -> Callable[..., Coroutine[Any, Any, T]]:
-    """Decorate Plugwise calls to handle Plugwise exceptions.
-
-    A decorator that wraps the passed in function, catches Plugwise errors,
-    and requests an coordinator update to update status of the devices asap.
-    """
-
-    async def handler(self, *args: Any, **kwargs: Any) -> T:
-        try:
-            return await func(self, *args, **kwargs)
-        except PlugwiseException as error:
-            await self.coordinator.async_request_refresh()
-            raise HomeAssistantError(
-                f"Error communicating with API: {error}"
-            ) from error
-
-    return handler
 
 
 class PlugwiseEntity(CoordinatorEntity[PlugwiseData]):

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -10,7 +10,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER
 from .coordinator import PlugwiseDataUpdateCoordinator
-from .entity import PlugwiseEntity, plugwise_exception_handler
+from .entity import PlugwiseEntity
+from .util import plugwise_command
 
 SWITCHES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
@@ -52,29 +53,25 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
         self._attr_unique_id = f"{device_id}-{description.key}"
         self._attr_name = coordinator.data.devices[device_id].get("name")
 
-    @plugwise_exception_handler
+    @plugwise_command
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        if await self.coordinator.api.set_switch_state(
+        await self.coordinator.api.set_switch_state(
             self._dev_id,
             self.coordinator.data.devices[self._dev_id].get("members"),
             self.entity_description.key,
             "on",
-        ):
-            self._attr_is_on = True
-            self.async_write_ha_state()
+        )
 
-    @plugwise_exception_handler
+    @plugwise_command
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        if await self.coordinator.api.set_switch_state(
+        await self.coordinator.api.set_switch_state(
             self._dev_id,
             self.coordinator.data.devices[self._dev_id].get("members"),
             self.entity_description.key,
             "off",
-        ):
-            self._attr_is_on = False
-            self.async_write_ha_state()
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/plugwise/util.py
+++ b/homeassistant/components/plugwise/util.py
@@ -1,0 +1,36 @@
+"""Utilities for Plugwise."""
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, TypeVar
+
+from plugwise.exceptions import PlugwiseException
+from typing_extensions import Concatenate, ParamSpec
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .entity import PlugwiseEntity
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_T = TypeVar("_T", bound=PlugwiseEntity)
+
+
+def plugwise_command(
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]]  # type: ignore[misc]
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:  # type: ignore[misc]
+    """Decorate Plugwise calls that send commands/make changes to the device.
+
+    A decorator that wraps the passed in function, catches Plugwise errors,
+    and requests an coordinator update to update status of the devices asap.
+    """
+
+    async def handler(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return await func(self, *args, **kwargs)
+        except PlugwiseException as error:
+            raise HomeAssistantError(
+                f"Error communicating with API: {error}"
+            ) from error
+        finally:
+            await self.coordinator.async_request_refresh()
+
+    return handler

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -1,6 +1,7 @@
 """Tests for the Plugwise Climate integration."""
 
 from plugwise.exceptions import PlugwiseException
+import pytest
 
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
@@ -8,6 +9,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
 )
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.components.plugwise.common import async_init_integration
 
@@ -56,32 +58,38 @@ async def test_adam_climate_adjust_negative_testing(hass, mock_smile_adam):
     entry = await async_init_integration(hass, mock_smile_adam)
     assert entry.state is ConfigEntryState.LOADED
 
-    await hass.services.async_call(
-        "climate",
-        "set_temperature",
-        {"entity_id": "climate.zone_lisa_wk", "temperature": 25},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {"entity_id": "climate.zone_lisa_wk", "temperature": 25},
+            blocking=True,
+        )
     state = hass.states.get("climate.zone_lisa_wk")
     attrs = state.attributes
     assert attrs["temperature"] == 21.5
 
-    await hass.services.async_call(
-        "climate",
-        "set_preset_mode",
-        {"entity_id": "climate.zone_thermostat_jessie", "preset_mode": "home"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "climate",
+            "set_preset_mode",
+            {"entity_id": "climate.zone_thermostat_jessie", "preset_mode": "home"},
+            blocking=True,
+        )
     state = hass.states.get("climate.zone_thermostat_jessie")
     attrs = state.attributes
     assert attrs["preset_mode"] == "asleep"
 
-    await hass.services.async_call(
-        "climate",
-        "set_hvac_mode",
-        {"entity_id": "climate.zone_thermostat_jessie", "hvac_mode": HVAC_MODE_AUTO},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {
+                "entity_id": "climate.zone_thermostat_jessie",
+                "hvac_mode": HVAC_MODE_AUTO,
+            },
+            blocking=True,
+        )
     state = hass.states.get("climate.zone_thermostat_jessie")
     attrs = state.attributes
 

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -105,10 +105,11 @@ async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
         {"entity_id": "climate.zone_lisa_wk", "temperature": 25},
         blocking=True,
     )
-    state = hass.states.get("climate.zone_lisa_wk")
-    attrs = state.attributes
 
-    assert attrs["temperature"] == 25.0
+    assert mock_smile_adam.set_temperature.call_count == 1
+    mock_smile_adam.set_temperature.assert_called_with(
+        "c50f167537524366a5af7aa3942feb1e", 25.0
+    )
 
     await hass.services.async_call(
         "climate",
@@ -116,12 +117,11 @@ async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
         {"entity_id": "climate.zone_lisa_wk", "preset_mode": "away"},
         blocking=True,
     )
-    state = hass.states.get("climate.zone_lisa_wk")
-    attrs = state.attributes
 
-    assert attrs["preset_mode"] == "away"
-
-    assert attrs["supported_features"] == 17
+    assert mock_smile_adam.set_preset.call_count == 1
+    mock_smile_adam.set_preset.assert_called_with(
+        "c50f167537524366a5af7aa3942feb1e", "away"
+    )
 
     await hass.services.async_call(
         "climate",
@@ -130,10 +130,10 @@ async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
         blocking=True,
     )
 
-    state = hass.states.get("climate.zone_thermostat_jessie")
-    attrs = state.attributes
-
-    assert attrs["temperature"] == 25.0
+    assert mock_smile_adam.set_temperature.call_count == 2
+    mock_smile_adam.set_temperature.assert_called_with(
+        "82fa13f017d240daa0d0ea1775420f24", 25.0
+    )
 
     await hass.services.async_call(
         "climate",
@@ -141,10 +141,11 @@ async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
         {"entity_id": "climate.zone_thermostat_jessie", "preset_mode": "home"},
         blocking=True,
     )
-    state = hass.states.get("climate.zone_thermostat_jessie")
-    attrs = state.attributes
 
-    assert attrs["preset_mode"] == "home"
+    assert mock_smile_adam.set_preset.call_count == 2
+    mock_smile_adam.set_preset.assert_called_with(
+        "82fa13f017d240daa0d0ea1775420f24", "home"
+    )
 
 
 async def test_anna_climate_entity_attributes(hass, mock_smile_anna):
@@ -184,10 +185,10 @@ async def test_anna_climate_entity_climate_changes(hass, mock_smile_anna):
         blocking=True,
     )
 
-    state = hass.states.get("climate.anna")
-    attrs = state.attributes
-
-    assert attrs["temperature"] == 25.0
+    assert mock_smile_anna.set_temperature.call_count == 1
+    mock_smile_anna.set_temperature.assert_called_with(
+        "c784ee9fdab44e1395b8dee7d7a497d5", 25.0
+    )
 
     await hass.services.async_call(
         "climate",
@@ -196,10 +197,10 @@ async def test_anna_climate_entity_climate_changes(hass, mock_smile_anna):
         blocking=True,
     )
 
-    state = hass.states.get("climate.anna")
-    attrs = state.attributes
-
-    assert attrs["preset_mode"] == "away"
+    assert mock_smile_anna.set_preset.call_count == 1
+    mock_smile_anna.set_preset.assert_called_with(
+        "c784ee9fdab44e1395b8dee7d7a497d5", "away"
+    )
 
     await hass.services.async_call(
         "climate",
@@ -208,7 +209,8 @@ async def test_anna_climate_entity_climate_changes(hass, mock_smile_anna):
         blocking=True,
     )
 
-    state = hass.states.get("climate.anna")
-    attrs = state.attributes
-
-    assert state.state == "heat_cool"
+    assert mock_smile_anna.set_temperature.call_count == 1
+    assert mock_smile_anna.set_schedule_state.call_count == 1
+    mock_smile_anna.set_schedule_state.assert_called_with(
+        "c784ee9fdab44e1395b8dee7d7a497d5", None, "false"
+    )

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -1,10 +1,11 @@
 """Tests for the Plugwise switch integration."""
-
 from plugwise.exceptions import PlugwiseException
+import pytest
 
 from homeassistant.components.plugwise.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
@@ -29,21 +30,24 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
     entry = await async_init_integration(hass, mock_smile_adam)
     assert entry.state is ConfigEntryState.LOADED
 
-    await hass.services.async_call(
-        "switch",
-        "turn_off",
-        {"entity_id": "switch.cv_pomp"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "switch",
+            "turn_off",
+            {"entity_id": "switch.cv_pomp"},
+            blocking=True,
+        )
+
     state = hass.states.get("switch.cv_pomp")
     assert str(state.state) == "on"
 
-    await hass.services.async_call(
-        "switch",
-        "turn_on",
-        {"entity_id": "switch.fibaro_hc2"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "switch",
+            "turn_on",
+            {"entity_id": "switch.fibaro_hc2"},
+            blocking=True,
+        )
     state = hass.states.get("switch.fibaro_hc2")
     assert str(state.state) == "on"
 

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -38,8 +38,10 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
             blocking=True,
         )
 
-    state = hass.states.get("switch.cv_pomp")
-    assert str(state.state) == "on"
+    assert mock_smile_adam.set_switch_state.call_count == 1
+    mock_smile_adam.set_switch_state.assert_called_with(
+        "78d1126fc4c743db81b61c20e88342a7", None, "relay", "off"
+    )
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -48,8 +50,11 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
             {"entity_id": "switch.fibaro_hc2"},
             blocking=True,
         )
-    state = hass.states.get("switch.fibaro_hc2")
-    assert str(state.state) == "on"
+
+    assert mock_smile_adam.set_switch_state.call_count == 2
+    mock_smile_adam.set_switch_state.assert_called_with(
+        "a28f588dc4a049a483fd03a30361ad3a", None, "relay", "on"
+    )
 
 
 async def test_adam_climate_switch_changes(hass, mock_smile_adam):
@@ -63,8 +68,11 @@ async def test_adam_climate_switch_changes(hass, mock_smile_adam):
         {"entity_id": "switch.cv_pomp"},
         blocking=True,
     )
-    state = hass.states.get("switch.cv_pomp")
-    assert str(state.state) == "off"
+
+    assert mock_smile_adam.set_switch_state.call_count == 1
+    mock_smile_adam.set_switch_state.assert_called_with(
+        "78d1126fc4c743db81b61c20e88342a7", None, "relay", "off"
+    )
 
     await hass.services.async_call(
         "switch",
@@ -72,17 +80,23 @@ async def test_adam_climate_switch_changes(hass, mock_smile_adam):
         {"entity_id": "switch.fibaro_hc2"},
         blocking=True,
     )
-    state = hass.states.get("switch.fibaro_hc2")
-    assert str(state.state) == "off"
+
+    assert mock_smile_adam.set_switch_state.call_count == 2
+    mock_smile_adam.set_switch_state.assert_called_with(
+        "a28f588dc4a049a483fd03a30361ad3a", None, "relay", "off"
+    )
 
     await hass.services.async_call(
         "switch",
-        "toggle",
+        "turn_on",
         {"entity_id": "switch.fibaro_hc2"},
         blocking=True,
     )
-    state = hass.states.get("switch.fibaro_hc2")
-    assert str(state.state) == "on"
+
+    assert mock_smile_adam.set_switch_state.call_count == 3
+    mock_smile_adam.set_switch_state.assert_called_with(
+        "a28f588dc4a049a483fd03a30361ad3a", None, "relay", "on"
+    )
 
 
 async def test_stretch_switch_entities(hass, mock_stretch):
@@ -108,9 +122,10 @@ async def test_stretch_switch_changes(hass, mock_stretch):
         {"entity_id": "switch.koelkast_92c4a"},
         blocking=True,
     )
-
-    state = hass.states.get("switch.koelkast_92c4a")
-    assert str(state.state) == "off"
+    assert mock_stretch.set_switch_state.call_count == 1
+    mock_stretch.set_switch_state.assert_called_with(
+        "e1c884e7dede431dadee09506ec4f859", None, "relay", "off"
+    )
 
     await hass.services.async_call(
         "switch",
@@ -118,17 +133,21 @@ async def test_stretch_switch_changes(hass, mock_stretch):
         {"entity_id": "switch.droger_52559"},
         blocking=True,
     )
-    state = hass.states.get("switch.droger_52559")
-    assert str(state.state) == "off"
+    assert mock_stretch.set_switch_state.call_count == 2
+    mock_stretch.set_switch_state.assert_called_with(
+        "cfe95cf3de1948c0b8955125bf754614", None, "relay", "off"
+    )
 
     await hass.services.async_call(
         "switch",
-        "toggle",
+        "turn_on",
         {"entity_id": "switch.droger_52559"},
         blocking=True,
     )
-    state = hass.states.get("switch.droger_52559")
-    assert str(state.state) == "on"
+    assert mock_stretch.set_switch_state.call_count == 3
+    mock_stretch.set_switch_state.assert_called_with(
+        "cfe95cf3de1948c0b8955125bf754614", None, "relay", "on"
+    )
 
 
 async def test_unique_id_migration_plug_relay(hass, mock_smile_adam):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR moves additional handling needed around each Plugwise command into a decorator.

Errors are now raised so they will actually show up in the Home Assistant UI and make automations fails if the service call fails (as opposed to silently ignoring the raised error).

An intermediate local state isn't set anymore, instead, a coordinator refresh is requested called.

Tests have been adjusted to verify the actual calls made in these cases.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
