### PR TITLE
Add opt-in device auto cleanup to config entries

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -185,6 +185,7 @@ class ConfigEntry:
         "reason",
         "_async_cancel_retry_setup",
         "_on_unload",
+        "device_auto_cleanup",
     )
 
     def __init__(
@@ -270,6 +271,21 @@ class ConfigEntry:
 
         # Hold list for functions to call on unload.
         self._on_unload: list[CALLBACK_TYPE] | None = None
+
+        self.device_auto_cleanup = False
+
+    @callback
+    def async_enable_device_auto_cleanup(self) -> None:
+        """Enable automatic device cleanup.
+
+        Controls how the system considers a device orphaned
+        when considering to cleanup devices.
+
+        Orphaned devices are defined by not have any entities
+        referenced and no config entries with auto cleanup
+        disabled (default).
+        """
+        self.device_auto_cleanup = True
 
     async def async_setup(
         self,

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -765,8 +765,13 @@ def async_cleanup(
     ent_reg: entity_registry.EntityRegistry,
 ) -> None:
     """Clean up device registry."""
-    # Find all devices that are referenced by a config_entry.
-    config_entry_ids = {entry.entry_id for entry in hass.config_entries.async_entries()}
+    # Find all devices that are referenced by a config_entry that
+    # do not have auto cleanup enabled
+    config_entry_ids = {
+        entry.entry_id
+        for entry in hass.config_entries.async_entries()
+        if not entry.device_auto_cleanup
+    }
     references_config_entries = {
         device.id
         for device in dev_reg.devices.values()

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -767,11 +767,12 @@ def async_cleanup(
     """Clean up device registry."""
     # Find all devices that are referenced by a config_entry that
     # do not have auto cleanup enabled
-    config_entry_ids = {
+    config_entry_ids_without_auto_cleanup = {
         entry.entry_id
         for entry in hass.config_entries.async_entries()
         if not entry.device_auto_cleanup
     }
+    config_entry_ids = {entry.entry_id for entry in hass.config_entries.async_entries()}
     references_config_entries = {
         device.id
         for device in dev_reg.devices.values()
@@ -791,7 +792,7 @@ def async_cleanup(
     # This shouldn't happen but have not been able to track down the bug :(
     for device in list(dev_reg.devices.values()):
         for config_entry_id in device.config_entries:
-            if config_entry_id not in config_entry_ids:
+            if config_entry_id not in config_entry_ids_without_auto_cleanup:
                 dev_reg.async_update_device(
                     device.id, remove_config_entry_id=config_entry_id
                 )

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -777,7 +777,7 @@ def async_cleanup(
         device.id
         for device in dev_reg.devices.values()
         for config_entry_id in device.config_entries
-        if config_entry_id in config_entry_ids
+        if config_entry_id in config_entry_ids_without_auto_cleanup
     }
 
     # Find all devices that are referenced in the entity registry.
@@ -792,7 +792,7 @@ def async_cleanup(
     # This shouldn't happen but have not been able to track down the bug :(
     for device in list(dev_reg.devices.values()):
         for config_entry_id in device.config_entries:
-            if config_entry_id not in config_entry_ids_without_auto_cleanup:
+            if config_entry_id not in config_entry_ids:
                 dev_reg.async_update_device(
                     device.id, remove_config_entry_id=config_entry_id
                 )

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1115,8 +1115,8 @@ async def test_cleanup_device_registry_auto_cleanup(hass, registry):
     )
 
     ent_reg = entity_registry.async_get(hass)
-    device_registry.async_cleanup(hass, registry, ent_reg)
     ent_reg.async_get_or_create("light", "hue", "e3", device_id=d3.id)
+    device_registry.async_cleanup(hass, registry, ent_reg)
 
     assert registry.async_get_device({("hue", "d1")}) is None
     assert registry.async_get_device({("hue", "d2")}) is None

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1101,13 +1101,13 @@ async def test_cleanup_device_registry_auto_cleanup(hass, registry):
     config_entry.async_enable_device_auto_cleanup()
     assert config_entry.device_auto_cleanup is True
 
-    d1 = registry.async_get_or_create(
+    registry.async_get_or_create(
         identifiers={("hue", "d1")}, config_entry_id=config_entry.entry_id
     )
     registry.async_get_or_create(
         identifiers={("hue", "d2")}, config_entry_id=config_entry.entry_id
     )
-    d3 = registry.async_get_or_create(
+    registry.async_get_or_create(
         identifiers={("hue", "d3")}, config_entry_id=config_entry.entry_id
     )
     registry.async_get_or_create(
@@ -1115,10 +1115,6 @@ async def test_cleanup_device_registry_auto_cleanup(hass, registry):
     )
 
     ent_reg = entity_registry.async_get(hass)
-    ent_reg.async_get_or_create("light", "hue", "e1", device_id=d1.id)
-    ent_reg.async_get_or_create("light", "hue", "e2", device_id=d1.id)
-    ent_reg.async_get_or_create("light", "hue", "e3", device_id=d3.id)
-
     device_registry.async_cleanup(hass, registry, ent_reg)
 
     assert registry.async_get_device({("hue", "d1")}) is None
@@ -1151,11 +1147,11 @@ async def test_cleanup_device_registry_auto_cleanup_one_with_one_without(
         identifiers={("hue", "d1")}, config_entry_id=no_auto_cleanup_entry.entry_id
     )
     registry.async_get_or_create(
-        identifiers={("auto_cleanup", "d2")},
+        identifiers={("hue", "d2")},
         config_entry_id=auto_cleanup_entry.entry_id,
     )
     d3 = registry.async_get_or_create(
-        identifiers={("auto_cleanup", "d3")},
+        identifiers={("hue", "d3")},
         config_entry_id=auto_cleanup_entry.entry_id,
     )
     registry.async_get_or_create(
@@ -1174,7 +1170,9 @@ async def test_cleanup_device_registry_auto_cleanup_one_with_one_without(
     assert registry.async_get_device({("hue", "d1")}) is not None
 
     assert registry.async_get_device({("hue", "d2")}) is None
-    assert registry.async_get_device({("hue", "d3")}) is None
+
+    # d3 still has an entity so it should not get removed
+    assert registry.async_get_device({("hue", "d3")}) is not None
     assert registry.async_get_device({("something", "d4")}) is None
 
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1107,7 +1107,7 @@ async def test_cleanup_device_registry_auto_cleanup(hass, registry):
     registry.async_get_or_create(
         identifiers={("hue", "d2")}, config_entry_id=config_entry.entry_id
     )
-    registry.async_get_or_create(
+    d3 = registry.async_get_or_create(
         identifiers={("hue", "d3")}, config_entry_id=config_entry.entry_id
     )
     registry.async_get_or_create(
@@ -1116,10 +1116,11 @@ async def test_cleanup_device_registry_auto_cleanup(hass, registry):
 
     ent_reg = entity_registry.async_get(hass)
     device_registry.async_cleanup(hass, registry, ent_reg)
+    ent_reg.async_get_or_create("light", "hue", "e3", device_id=d3.id)
 
     assert registry.async_get_device({("hue", "d1")}) is None
     assert registry.async_get_device({("hue", "d2")}) is None
-    assert registry.async_get_device({("hue", "d3")}) is None
+    assert registry.async_get_device({("hue", "d3")}) is not None
     assert registry.async_get_device({("something", "d4")}) is None
 
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1066,6 +1066,7 @@ async def test_cleanup_device_registry(hass, registry):
     """Test cleanup works."""
     config_entry = MockConfigEntry(domain="hue")
     config_entry.add_to_hass(hass)
+    assert config_entry.device_auto_cleanup is False
 
     d1 = registry.async_get_or_create(
         identifiers={("hue", "d1")}, config_entry_id=config_entry.entry_id
@@ -1093,10 +1094,95 @@ async def test_cleanup_device_registry(hass, registry):
     assert registry.async_get_device({("something", "d4")}) is None
 
 
+async def test_cleanup_device_registry_auto_cleanup(hass, registry):
+    """Test config entries with auto cleanup are not considered for orphaned state."""
+    config_entry = MockConfigEntry(domain="hue")
+    config_entry.add_to_hass(hass)
+    config_entry.async_enable_device_auto_cleanup()
+    assert config_entry.device_auto_cleanup is True
+
+    d1 = registry.async_get_or_create(
+        identifiers={("hue", "d1")}, config_entry_id=config_entry.entry_id
+    )
+    registry.async_get_or_create(
+        identifiers={("hue", "d2")}, config_entry_id=config_entry.entry_id
+    )
+    d3 = registry.async_get_or_create(
+        identifiers={("hue", "d3")}, config_entry_id=config_entry.entry_id
+    )
+    registry.async_get_or_create(
+        identifiers={("something", "d4")}, config_entry_id="non_existing"
+    )
+
+    ent_reg = entity_registry.async_get(hass)
+    ent_reg.async_get_or_create("light", "hue", "e1", device_id=d1.id)
+    ent_reg.async_get_or_create("light", "hue", "e2", device_id=d1.id)
+    ent_reg.async_get_or_create("light", "hue", "e3", device_id=d3.id)
+
+    device_registry.async_cleanup(hass, registry, ent_reg)
+
+    assert registry.async_get_device({("hue", "d1")}) is None
+    assert registry.async_get_device({("hue", "d2")}) is None
+    assert registry.async_get_device({("hue", "d3")}) is None
+    assert registry.async_get_device({("something", "d4")}) is None
+
+
+async def test_cleanup_device_registry_auto_cleanup_one_with_one_without(
+    hass, registry
+):
+    """Test config entries with auto cleanup are not considered for orphaned state.
+
+    Ensure device that still has config entries only if
+    auto cleanup is enabled on all of the referenced config entries
+    """
+    auto_cleanup_entry = MockConfigEntry(domain="hue")
+    auto_cleanup_entry.add_to_hass(hass)
+    auto_cleanup_entry.async_enable_device_auto_cleanup()
+    assert auto_cleanup_entry.device_auto_cleanup is True
+
+    no_auto_cleanup_entry = MockConfigEntry(domain="hue")
+    no_auto_cleanup_entry.add_to_hass(hass)
+    assert no_auto_cleanup_entry.device_auto_cleanup is False
+
+    d1 = registry.async_get_or_create(
+        identifiers={("hue", "d1")}, config_entry_id=auto_cleanup_entry.entry_id
+    )
+    registry.async_get_or_create(
+        identifiers={("hue", "d1")}, config_entry_id=no_auto_cleanup_entry.entry_id
+    )
+    registry.async_get_or_create(
+        identifiers={("auto_cleanup", "d2")},
+        config_entry_id=auto_cleanup_entry.entry_id,
+    )
+    d3 = registry.async_get_or_create(
+        identifiers={("auto_cleanup", "d3")},
+        config_entry_id=auto_cleanup_entry.entry_id,
+    )
+    registry.async_get_or_create(
+        identifiers={("something", "d4")}, config_entry_id="non_existing"
+    )
+
+    ent_reg = entity_registry.async_get(hass)
+    ent_reg.async_get_or_create("light", "hue", "e1", device_id=d1.id)
+    ent_reg.async_get_or_create("light", "hue", "e2", device_id=d1.id)
+    ent_reg.async_get_or_create("light", "hue", "e3", device_id=d3.id)
+
+    device_registry.async_cleanup(hass, registry, ent_reg)
+
+    # d1 is referenced by two config entries
+    # and one of them does not have auto cleanup turned on
+    assert registry.async_get_device({("hue", "d1")}) is not None
+
+    assert registry.async_get_device({("hue", "d2")}) is None
+    assert registry.async_get_device({("hue", "d3")}) is None
+    assert registry.async_get_device({("something", "d4")}) is None
+
+
 async def test_cleanup_device_registry_removes_expired_orphaned_devices(hass, registry):
     """Test cleanup removes expired orphaned devices."""
     config_entry = MockConfigEntry(domain="hue")
     config_entry.add_to_hass(hass)
+    assert config_entry.device_auto_cleanup is False
 
     registry.async_get_or_create(
         identifiers={("hue", "d1")}, config_entry_id=config_entry.entry_id

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2991,3 +2991,11 @@ async def test_deprecated_disabled_by_str_set(hass, manager, caplog):
     )
     assert entry.disabled_by is config_entries.ConfigEntryDisabler.USER
     assert " str for config entry disabled_by. This is deprecated " in caplog.text
+
+
+async def test_enable_device_auto_cleanup(hass, caplog):
+    """Test we can enable device auto cleanup."""
+    entry = MockConfigEntry()
+    assert entry.device_auto_cleanup is False
+    entry.async_enable_device_auto_cleanup()
+    assert entry.device_auto_cleanup is True


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Config entries can now call entry.async_enable_device_auto_cleanup()

This call controls how the system considers a device orphaned
when considering to cleanup devices.

Orphaned devices are defined by not have any entities
referenced and no config entries with auto cleanup
disabled (default).

Implements
https://community.home-assistant.io/t/delete-individual-device-and-entity-from-integration/157428

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
