### PR TITLE
Enable basic type checking in template

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -61,7 +61,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def _process_config(hass, hass_config):
+async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
     """Process config."""
     coordinators: list[TriggerUpdateCoordinator] | None = hass.data.pop(DOMAIN, None)
 
@@ -126,7 +126,7 @@ class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
         if self._unsub_trigger:
             self._unsub_trigger()
 
-    async def async_setup(self: HomeAssistant, hass_config: ConfigType) -> bool:
+    async def async_setup(self, hass_config: ConfigType) -> None:
         """Set up the trigger and create entities."""
         if self.hass.state == CoreState.running:
             await self._attach_triggers()

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
@@ -300,12 +300,12 @@ class TriggerBinarySensorEntity(TriggerEntity, BinarySensorEntity):
                 self._to_render_simple.append(key)
                 self._parse_result.add(key)
 
-        self._delay_cancel = None
+        self._delay_cancel: CALLBACK_TYPE | None = None
         self._auto_off_cancel = None
-        self._state = None
+        self._state: bool | None = None
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return state of the sensor."""
         return self._state
 

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -63,7 +63,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the template button."""
-    if "coordinator" in discovery_info:
+    if not discovery_info or "coordinator" in discovery_info:
         raise PlatformNotReady(
             "The template button platform doesn't support trigger entities"
         )
@@ -86,6 +86,7 @@ class TemplateButtonEntity(TemplateEntity, ButtonEntity):
     ) -> None:
         """Initialize the button."""
         super().__init__(hass, config=config, unique_id=unique_id)
+        assert self._attr_name is not None
         self._command_press = Script(hass, config[CONF_PRESS], self._attr_name, DOMAIN)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_state = None

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -63,7 +64,6 @@ CONF_SET_DIRECTION_ACTION = "set_direction"
 CONF_SET_PRESET_MODE_ACTION = "set_preset_mode"
 
 _VALID_STATES = [STATE_ON, STATE_OFF]
-_VALID_OSC = [True, False]
 _VALID_DIRECTIONS = [DIRECTION_FORWARD, DIRECTION_REVERSE]
 
 FAN_SCHEMA = vol.All(
@@ -273,8 +273,7 @@ class TemplateFan(TemplateEntity, FanEntity):
         elif speed is not None:
             await self.async_set_speed(speed)
 
-    # pylint: disable=arguments-differ
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self._off_script.async_run(context=self._context)
         self._state = STATE_OFF
@@ -316,17 +315,10 @@ class TemplateFan(TemplateEntity, FanEntity):
         if self._set_oscillating_script is None:
             return
 
-        if oscillating in _VALID_OSC:
-            self._oscillating = oscillating
-            await self._set_oscillating_script.async_run(
-                {ATTR_OSCILLATING: oscillating}, context=self._context
-            )
-        else:
-            _LOGGER.error(
-                "Received invalid oscillating value: %s. Expected: %s",
-                oscillating,
-                ", ".join(_VALID_OSC),
-            )
+        self._oscillating = oscillating
+        await self._set_oscillating_script.async_run(
+            {ATTR_OSCILLATING: oscillating}, context=self._context
+        )
 
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -108,6 +108,7 @@ class TemplateNumber(TemplateEntity, NumberEntity):
     ) -> None:
         """Initialize the number."""
         super().__init__(hass, config=config, unique_id=unique_id)
+        assert self._attr_name
         self._value_template = config[CONF_STATE]
         self._command_set_value = Script(
             hass, config[CONF_SET_VALUE], self._attr_name, DOMAIN

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -108,7 +108,7 @@ class TemplateNumber(TemplateEntity, NumberEntity):
     ) -> None:
         """Initialize the number."""
         super().__init__(hass, config=config, unique_id=unique_id)
-        assert self._attr_name
+        assert self._attr_name is not None
         self._value_template = config[CONF_STATE]
         self._command_set_value = Script(
             hass, config[CONF_SET_VALUE], self._attr_name, DOMAIN

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -102,13 +102,14 @@ class TemplateSelect(TemplateEntity, SelectEntity):
     ) -> None:
         """Initialize the select."""
         super().__init__(hass, config=config, unique_id=unique_id)
+        assert self._attr_name is not None
         self._value_template = config[CONF_STATE]
         self._command_select_option = Script(
             hass, config[CONF_SELECT_OPTION], self._attr_name, DOMAIN
         )
         self._options_template = config[ATTR_OPTIONS]
         self._attr_assumed_state = self._optimistic = config[CONF_OPTIMISTIC]
-        self._attr_options = None
+        self._attr_options = []
         self._attr_current_option = None
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -94,7 +94,7 @@ LEGACY_FIELDS = {
 
 def rewrite_common_legacy_to_modern_conf(
     entity_cfg: dict[str, Any], extra_legacy_fields: dict[str, str] = None
-) -> list[dict]:
+) -> dict[str, Any]:
     """Rewrite legacy config."""
     entity_cfg = {**entity_cfg}
     if extra_legacy_fields is None:

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -16,13 +16,13 @@ from homeassistant.const import (
     CONF_ICON,
     CONF_ICON_TEMPLATE,
     CONF_NAME,
+    EVENT_HOMEASSISTANT_START,
 )
-from homeassistant.core import EVENT_HOMEASSISTANT_START, CoreState, callback
+from homeassistant.core import CoreState, Event, callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
-    Event,
     TrackTemplate,
     TrackTemplateResult,
     async_track_template_result,
@@ -176,10 +176,12 @@ class _TemplateAttribute:
             if self.none_on_template_error:
                 self._default_update(result)
             else:
+                assert self.on_update
                 self.on_update(result)
             return
 
         if not self.validator:
+            assert self.on_update
             self.on_update(result)
             return
 
@@ -197,9 +199,11 @@ class _TemplateAttribute:
                 self._entity.entity_id,
                 ex.msg,
             )
+            assert self.on_update
             self.on_update(None)
             return
 
+        assert self.on_update
         self.on_update(validated)
         return
 
@@ -321,11 +325,11 @@ class TemplateEntity(Entity):
         """
         assert self.hass is not None, "hass cannot be None"
         template.hass = self.hass
-        attribute = _TemplateAttribute(
+        template_attribute = _TemplateAttribute(
             self, attribute, template, validator, on_update, none_on_template_error
         )
         self._template_attrs.setdefault(template, [])
-        self._template_attrs[template].append(attribute)
+        self._template_attrs[template].append(template_attribute)
 
     @callback
     def _handle_results(
@@ -362,7 +366,7 @@ class TemplateEntity(Entity):
         self.async_write_ha_state()
 
     async def _async_template_startup(self, *_) -> None:
-        template_var_tups = []
+        template_var_tups: list[TrackTemplate] = []
         has_availability_template = False
         for template, attributes in self._template_attrs.items():
             template_var_tup = TrackTemplate(template, None)

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template, update_coordinator
 
 from . import TriggerUpdateCoordinator
@@ -36,6 +37,7 @@ class TriggerEntity(update_coordinator.CoordinatorEntity):
 
         entity_unique_id = config.get(CONF_UNIQUE_ID)
 
+        self._unique_id: str | None
         if entity_unique_id and coordinator.unique_id:
             self._unique_id = f"{coordinator.unique_id}-{entity_unique_id}"
         else:
@@ -45,7 +47,7 @@ class TriggerEntity(update_coordinator.CoordinatorEntity):
 
         self._static_rendered = {}
         self._to_render_simple = []
-        self._to_render_complex = []
+        self._to_render_complex: list[str] = []
 
         for itm in (
             CONF_NAME,
@@ -148,7 +150,7 @@ class TriggerEntity(update_coordinator.CoordinatorEntity):
                 )
 
             self._rendered = rendered
-        except template.TemplateError as err:
+        except TemplateError as err:
             logging.getLogger(f"{__package__}.{self.entity_id.split('.')[0]}").error(
                 "Error rendering %s template for %s: %s", key, self.entity_id, err
             )

--- a/mypy.ini
+++ b/mypy.ini
@@ -2652,9 +2652,6 @@ ignore_errors = true
 [mypy-homeassistant.components.telegram_bot.polling]
 ignore_errors = true
 
-[mypy-homeassistant.components.template]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.number]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2661,9 +2661,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template.sensor]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.weather]
-ignore_errors = true
-
 [mypy-homeassistant.components.toon]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2655,9 +2655,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.fan]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.number]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2661,9 +2661,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template.sensor]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.template_entity]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.trigger_entity]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2655,9 +2655,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.button]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.fan]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2661,9 +2661,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template.sensor]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.trigger_entity]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.weather]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2655,9 +2655,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.binary_sensor]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.button]
 ignore_errors = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2658,9 +2658,6 @@ ignore_errors = true
 [mypy-homeassistant.components.template.number]
 ignore_errors = true
 
-[mypy-homeassistant.components.template.select]
-ignore_errors = true
-
 [mypy-homeassistant.components.template.sensor]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -193,7 +193,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.template",
     "homeassistant.components.template.number",
     "homeassistant.components.template.sensor",
-    "homeassistant.components.template.template_entity",
     "homeassistant.components.template.trigger_entity",
     "homeassistant.components.template.weather",
     "homeassistant.components.toon",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -192,7 +192,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.telegram_bot.polling",
     "homeassistant.components.template",
     "homeassistant.components.template.number",
-    "homeassistant.components.template.select",
     "homeassistant.components.template.sensor",
     "homeassistant.components.template.template_entity",
     "homeassistant.components.template.trigger_entity",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -191,7 +191,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.system_health",
     "homeassistant.components.telegram_bot.polling",
     "homeassistant.components.template",
-    "homeassistant.components.template.binary_sensor",
     "homeassistant.components.template.button",
     "homeassistant.components.template.fan",
     "homeassistant.components.template.number",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -191,7 +191,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.system_health",
     "homeassistant.components.telegram_bot.polling",
     "homeassistant.components.template",
-    "homeassistant.components.template.button",
     "homeassistant.components.template.fan",
     "homeassistant.components.template.number",
     "homeassistant.components.template.select",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -191,7 +191,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.system_health",
     "homeassistant.components.telegram_bot.polling",
     "homeassistant.components.template",
-    "homeassistant.components.template.fan",
     "homeassistant.components.template.number",
     "homeassistant.components.template.select",
     "homeassistant.components.template.sensor",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -193,7 +193,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.template",
     "homeassistant.components.template.number",
     "homeassistant.components.template.sensor",
-    "homeassistant.components.template.weather",
     "homeassistant.components.toon",
     "homeassistant.components.toon.config_flow",
     "homeassistant.components.toon.models",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -190,7 +190,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.sonos.statistics",
     "homeassistant.components.system_health",
     "homeassistant.components.telegram_bot.polling",
-    "homeassistant.components.template",
     "homeassistant.components.template.number",
     "homeassistant.components.template.sensor",
     "homeassistant.components.toon",

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -193,7 +193,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.template",
     "homeassistant.components.template.number",
     "homeassistant.components.template.sensor",
-    "homeassistant.components.template.trigger_entity",
     "homeassistant.components.template.weather",
     "homeassistant.components.toon",
     "homeassistant.components.toon.config_flow",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable basic type checking in `template`.

For now, I am leaving number and sensor platforms due to the following issues which I plan to solve in a separate PR:
```
homeassistant/components/template/sensor.py:240: error: Cannot override final attribute "unit_of_measurement" (previously declared in base class "SensorEntity")  [misc]
homeassistant/components/template/number.py:120: error: Incompatible types in assignment (expression has type "None", variable has type "float")  [assignment]
homeassistant/components/template/number.py:121: error: Incompatible types in assignment (expression has type "None", variable has type "float")  [assignment]
homeassistant/components/template/number.py:122: error: Incompatible types in assignment (expression has type "None", variable has type "float")  [assignment]
homeassistant/components/template/number.py:123: error: Incompatible types in assignment (expression has type "None", variable has type "float")  [assignment]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
