### PR TITLE
More cleanup in Plugwise switch

### DIFF
--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -1,6 +1,8 @@
 """Generic Plugwise Entity Class."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.const import ATTR_NAME, ATTR_VIA_DEVICE, CONF_HOST
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -52,6 +54,11 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseData]):
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self._dev_id in self.coordinator.data.devices
+
+    @property
+    def device(self) -> dict[str, Any]:
+        """Return data for this device."""
+        return self.coordinator.data.devices[self._dev_id]
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -17,10 +17,10 @@ async def test_adam_climate_switch_entities(hass, mock_smile_adam):
     entry = await async_init_integration(hass, mock_smile_adam)
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("switch.cv_pomp")
+    state = hass.states.get("switch.cv_pomp_relay")
     assert str(state.state) == "on"
 
-    state = hass.states.get("switch.fibaro_hc2")
+    state = hass.states.get("switch.fibaro_hc2_relay")
     assert str(state.state) == "on"
 
 
@@ -34,7 +34,7 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
         await hass.services.async_call(
             "switch",
             "turn_off",
-            {"entity_id": "switch.cv_pomp"},
+            {"entity_id": "switch.cv_pomp_relay"},
             blocking=True,
         )
 
@@ -47,7 +47,7 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
         await hass.services.async_call(
             "switch",
             "turn_on",
-            {"entity_id": "switch.fibaro_hc2"},
+            {"entity_id": "switch.fibaro_hc2_relay"},
             blocking=True,
         )
 
@@ -65,7 +65,7 @@ async def test_adam_climate_switch_changes(hass, mock_smile_adam):
     await hass.services.async_call(
         "switch",
         "turn_off",
-        {"entity_id": "switch.cv_pomp"},
+        {"entity_id": "switch.cv_pomp_relay"},
         blocking=True,
     )
 
@@ -77,7 +77,7 @@ async def test_adam_climate_switch_changes(hass, mock_smile_adam):
     await hass.services.async_call(
         "switch",
         "toggle",
-        {"entity_id": "switch.fibaro_hc2"},
+        {"entity_id": "switch.fibaro_hc2_relay"},
         blocking=True,
     )
 
@@ -89,7 +89,7 @@ async def test_adam_climate_switch_changes(hass, mock_smile_adam):
     await hass.services.async_call(
         "switch",
         "turn_on",
-        {"entity_id": "switch.fibaro_hc2"},
+        {"entity_id": "switch.fibaro_hc2_relay"},
         blocking=True,
     )
 
@@ -104,10 +104,10 @@ async def test_stretch_switch_entities(hass, mock_stretch):
     entry = await async_init_integration(hass, mock_stretch)
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("switch.koelkast_92c4a")
+    state = hass.states.get("switch.koelkast_92c4a_relay")
     assert str(state.state) == "on"
 
-    state = hass.states.get("switch.droger_52559")
+    state = hass.states.get("switch.droger_52559_relay")
     assert str(state.state) == "on"
 
 
@@ -119,7 +119,7 @@ async def test_stretch_switch_changes(hass, mock_stretch):
     await hass.services.async_call(
         "switch",
         "turn_off",
-        {"entity_id": "switch.koelkast_92c4a"},
+        {"entity_id": "switch.koelkast_92c4a_relay"},
         blocking=True,
     )
     assert mock_stretch.set_switch_state.call_count == 1
@@ -130,7 +130,7 @@ async def test_stretch_switch_changes(hass, mock_stretch):
     await hass.services.async_call(
         "switch",
         "toggle",
-        {"entity_id": "switch.droger_52559"},
+        {"entity_id": "switch.droger_52559_relay"},
         blocking=True,
     )
     assert mock_stretch.set_switch_state.call_count == 2
@@ -141,7 +141,7 @@ async def test_stretch_switch_changes(hass, mock_stretch):
     await hass.services.async_call(
         "switch",
         "turn_on",
-        {"entity_id": "switch.droger_52559"},
+        {"entity_id": "switch.droger_52559_relay"},
         blocking=True,
     )
     assert mock_stretch.set_switch_state.call_count == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some final cleanups for Plugwise switches (before introducing additional switch entities).

- The base entity now provides a property to get to the device data quicker, reducing the syntax in the integration overall.
- Removes the need for using `_handle_coordinator_update`, instead, it directly uses property methods.
- Switch names have been adjusted to take into account multiple entity descriptions can be present (and also makes it consistent with other platforms like the binary sensor).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
