### PR TITLE
Support browsing multiple Spotify accounts

### DIFF
--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -30,7 +30,11 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from . import config_flow
 from .browse_media import async_browse_media
 from .const import DOMAIN, LOGGER, SPOTIFY_SCOPES
-from .util import is_spotify_media_type, resolve_spotify_media_type
+from .util import (
+    is_spotify_media_type,
+    resolve_spotify_media_type,
+    spotify_uri_from_media_browser_url,
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -50,6 +54,7 @@ PLATFORMS = [Platform.MEDIA_PLAYER]
 __all__ = [
     "async_browse_media",
     "DOMAIN",
+    "spotify_uri_from_media_browser_url",
     "is_spotify_media_type",
     "resolve_spotify_media_type",
 ]

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from . import config_flow
-from .browse_media import async_browse_media
+from .browse_media import async_browse_media, async_get_media_browser_root_object
 from .const import DOMAIN, LOGGER, SPOTIFY_SCOPES
 from .util import is_spotify_media_type, resolve_spotify_media_type
 
@@ -49,6 +49,7 @@ PLATFORMS = [Platform.MEDIA_PLAYER]
 
 __all__ = [
     "async_browse_media",
+    "async_get_media_browser_root_object",
     "DOMAIN",
     "is_spotify_media_type",
     "resolve_spotify_media_type",

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from . import config_flow
-from .browse_media import async_browse_media, async_get_media_browser_root_object
+from .browse_media import async_browse_media
 from .const import DOMAIN, LOGGER, SPOTIFY_SCOPES
 from .util import is_spotify_media_type, resolve_spotify_media_type
 
@@ -49,7 +49,6 @@ PLATFORMS = [Platform.MEDIA_PLAYER]
 
 __all__ = [
     "async_browse_media",
-    "async_get_media_browser_root_object",
     "DOMAIN",
     "is_spotify_media_type",
     "resolve_spotify_media_type",

--- a/homeassistant/components/spotify/browse_media.py
+++ b/homeassistant/components/spotify/browse_media.py
@@ -143,19 +143,18 @@ async def async_browse_media(
     media_content_id: str | None,
     *,
     can_play_artist: bool = True,
-) -> BrowseMedia | list[BrowseMedia]:
+) -> BrowseMedia:
     """Browse Spotify media."""
     parsed_url = None
     info = None
 
     # Check if caller is requesting the root nodes
     if media_content_type is None and media_content_id is None:
-        items = []
+        children = []
         for config_entry_id, info in hass.data[DOMAIN].items():
             config_entry = hass.config_entries.async_get_entry(config_entry_id)
-            if not config_entry:
-                raise BrowseError("No config entry found for spotify account")
-            items.append(
+            assert config_entry is not None
+            children.append(
                 BrowseMedia(
                     title=config_entry.title,
                     media_class=MEDIA_CLASS_APP,
@@ -166,6 +165,16 @@ async def async_browse_media(
                     can_expand=True,
                 )
             )
+        return BrowseMedia(
+            title="Spotify",
+            media_class=MEDIA_CLASS_APP,
+            media_content_id="spotify://",
+            media_content_type="spotify",
+            thumbnail="https://brands.home-assistant.io/_/spotify/logo.png",
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
 
     # Check for config entry specifier, and extract Spotify URI
     if media_content_id and media_content_id.startswith(MEDIA_PLAYER_PREFIX):

--- a/homeassistant/components/spotify/browse_media.py
+++ b/homeassistant/components/spotify/browse_media.py
@@ -1,19 +1,18 @@
 """Support for Spotify media browsing."""
 from __future__ import annotations
 
-from urllib.parse import parse_qs, urlparse
-
 from functools import partial
 import logging
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from spotipy import Spotify
 
 from homeassistant.backports.enum import StrEnum
 from homeassistant.components.media_player import BrowseError, BrowseMedia
-from homeassistant.components.media_player.const import MEDIA_CLASS_APP
 from homeassistant.components.media_player.const import (
     MEDIA_CLASS_ALBUM,
+    MEDIA_CLASS_APP,
     MEDIA_CLASS_ARTIST,
     MEDIA_CLASS_DIRECTORY,
     MEDIA_CLASS_EPISODE,
@@ -208,6 +207,7 @@ async def async_browse_media(
                     urlparse(child.media_content_id)._replace(query=query).geturl()
                 )
     return result
+
 
 async def async_browse_media_internal(
     hass: HomeAssistant,

--- a/homeassistant/components/spotify/util.py
+++ b/homeassistant/components/spotify/util.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import yarl
+
 from .const import MEDIA_PLAYER_PREFIX
 
 
@@ -22,3 +24,11 @@ def fetch_image_url(item: dict[str, Any], key="images") -> str | None:
         return item.get(key, [])[0].get("url")
     except IndexError:
         return None
+
+
+def spotify_uri_from_media_browser_url(media_content_id: str) -> str:
+    """Extract spotify URI from media browser URL."""
+    if media_content_id and media_content_id.startswith(MEDIA_PLAYER_PREFIX):
+        parsed_url = yarl.URL(media_content_id)
+        media_content_id = parsed_url.name
+    return media_content_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support browsing multiple Spotify accounts

The Spotify account is included as a query in the media_id
To get root nodes, call `spotify.async_get_media_browser_root_object` which will return a list of `BrowseMedia` objects, one item for each config entry,

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
