### PR TITLE
Add World Message/MOTD support for MinecraftServer Integration

### DIFF
--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -180,7 +180,7 @@ class MinecraftServer:
             self.players_online = status_response.players.online
             self.players_max = status_response.players.max
             self.latency_time = status_response.latency
-            self.motd = (status_response.description).get('text')
+            self.motd = (status_response.description).get("text")
             self.players_list = []
             if status_response.players.sample is not None:
                 for player in status_response.players.sample:

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -95,6 +95,7 @@ class MinecraftServer:
         self.players_online = None
         self.players_max = None
         self.players_list = None
+        self.motd = None
 
         # Dispatcher signal name
         self.signal_name = f"{SIGNAL_NAME_PREFIX}_{self.unique_id}"
@@ -179,6 +180,7 @@ class MinecraftServer:
             self.players_online = status_response.players.online
             self.players_max = status_response.players.max
             self.latency_time = status_response.latency
+            self.motd = (status_response.description).get('text')
             self.players_list = []
             if status_response.players.sample is not None:
                 for player in status_response.players.sample:
@@ -201,6 +203,7 @@ class MinecraftServer:
             self.players_max = None
             self.latency_time = None
             self.players_list = None
+            self.motd = None
 
             # Inform user once about failed update if necessary.
             if not self._last_status_request_failed:

--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -14,6 +14,7 @@ ICON_PLAYERS_ONLINE = "mdi:account-multiple"
 ICON_PROTOCOL_VERSION = "mdi:numeric"
 ICON_STATUS = "mdi:lan"
 ICON_VERSION = "mdi:numeric"
+ICON_MOTD = "mdi:minecraft"
 
 KEY_SERVERS = "servers"
 
@@ -25,6 +26,7 @@ NAME_PLAYERS_ONLINE = "Players Online"
 NAME_PROTOCOL_VERSION = "Protocol Version"
 NAME_STATUS = "Status"
 NAME_VERSION = "Version"
+NAME_MOTD = "World Message"
 
 SCAN_INTERVAL = 60
 
@@ -36,3 +38,4 @@ UNIT_PLAYERS_MAX = "players"
 UNIT_PLAYERS_ONLINE = "players"
 UNIT_PROTOCOL_VERSION = None
 UNIT_VERSION = None
+UNIT_MOTD = None

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -14,22 +14,22 @@ from .const import (
     ATTR_PLAYERS_LIST,
     DOMAIN,
     ICON_LATENCY_TIME,
+    ICON_MOTD,
     ICON_PLAYERS_MAX,
     ICON_PLAYERS_ONLINE,
     ICON_PROTOCOL_VERSION,
     ICON_VERSION,
-    ICON_MOTD,
     NAME_LATENCY_TIME,
+    NAME_MOTD,
     NAME_PLAYERS_MAX,
     NAME_PLAYERS_ONLINE,
     NAME_PROTOCOL_VERSION,
     NAME_VERSION,
-    NAME_MOTD,
+    UNIT_MOTD,
     UNIT_PLAYERS_MAX,
     UNIT_PLAYERS_ONLINE,
     UNIT_PROTOCOL_VERSION,
     UNIT_VERSION,
-    UNIT_MOTD
 )
 
 
@@ -48,7 +48,7 @@ async def async_setup_entry(
         MinecraftServerLatencyTimeSensor(server),
         MinecraftServerPlayersOnlineSensor(server),
         MinecraftServerPlayersMaxSensor(server),
-        MinecraftServerMOTDSensor(server)
+        MinecraftServerMOTDSensor(server),
     ]
 
     # Add sensor entities.
@@ -180,6 +180,7 @@ class MinecraftServerPlayersMaxSensor(MinecraftServerSensorEntity):
     async def async_update(self) -> None:
         """Update maximum number of players."""
         self._state = self._server.players_max
+
 
 class MinecraftServerMOTDSensor(MinecraftServerSensorEntity):
     """Representation of a Minecraft Server MOTD sensor."""

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -18,15 +18,18 @@ from .const import (
     ICON_PLAYERS_ONLINE,
     ICON_PROTOCOL_VERSION,
     ICON_VERSION,
+    ICON_MOTD,
     NAME_LATENCY_TIME,
     NAME_PLAYERS_MAX,
     NAME_PLAYERS_ONLINE,
     NAME_PROTOCOL_VERSION,
     NAME_VERSION,
+    NAME_MOTD,
     UNIT_PLAYERS_MAX,
     UNIT_PLAYERS_ONLINE,
     UNIT_PROTOCOL_VERSION,
     UNIT_VERSION,
+    UNIT_MOTD
 )
 
 
@@ -45,6 +48,7 @@ async def async_setup_entry(
         MinecraftServerLatencyTimeSensor(server),
         MinecraftServerPlayersOnlineSensor(server),
         MinecraftServerPlayersMaxSensor(server),
+        MinecraftServerMOTDSensor(server)
     ]
 
     # Add sensor entities.
@@ -176,3 +180,19 @@ class MinecraftServerPlayersMaxSensor(MinecraftServerSensorEntity):
     async def async_update(self) -> None:
         """Update maximum number of players."""
         self._state = self._server.players_max
+
+class MinecraftServerMOTDSensor(MinecraftServerSensorEntity):
+    """Representation of a Minecraft Server MOTD sensor."""
+
+    def __init__(self, server: MinecraftServer) -> None:
+        """Initialize MOTD sensor."""
+        super().__init__(
+            server=server,
+            type_name=NAME_MOTD,
+            icon=ICON_MOTD,
+            unit=UNIT_MOTD,
+        )
+
+    async def async_update(self) -> None:
+        """Update MOTD."""
+        self._state = self._server.motd


### PR DESCRIPTION
Add support for pulling in the Message of the Day (MOTD) from the Minecraft Server.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No breaking changes

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for server's message of the day as sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21591 
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
