### PR TITLE
Enable fallback polling for Sonos microphone binary_sensor

### DIFF
--- a/homeassistant/components/sonos/binary_sensor.py
+++ b/homeassistant/components/sonos/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import SONOS_CREATE_BATTERY, SONOS_CREATE_MIC_SENSOR
 from .entity import SonosEntity
+from .helpers import soco_error
 from .speaker import SonosSpeaker
 
 ATTR_BATTERY_POWER_SOURCE = "power_source"
@@ -99,7 +100,13 @@ class SonosMicrophoneSensorEntity(SonosEntity, BinarySensorEntity):
         self._attr_name = f"{self.speaker.zone_name} Microphone"
 
     async def _async_fallback_poll(self) -> None:
-        """Stub for abstract class implementation. Not a pollable attribute."""
+        """Handle polling when subscription fails."""
+        await self.hass.async_add_executor_job(self.poll_state)
+
+    @soco_error()
+    def poll_state(self) -> None:
+        """Poll the current state of the microphone."""
+        self.speaker.mic_enabled = self.soco.mic_enabled
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -263,6 +263,10 @@ class SonosSpeaker:
             )
             dispatcher_send(self.hass, SONOS_CREATE_BATTERY, self)
 
+        if (mic_enabled := self.soco.mic_enabled) is not None:
+            self.mic_enabled = mic_enabled
+            dispatcher_send(self.hass, SONOS_CREATE_MIC_SENSOR, self)
+
         if new_alarms := [
             alarm.alarm_id for alarm in self.alarms if alarm.zone.uid == self.soco.uid
         ]:

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -111,6 +111,7 @@ def soco_fixture(
         mock_soco.audio_delay = 2
         mock_soco.bass = 1
         mock_soco.treble = -1
+        mock_soco.mic_enabled = False
         mock_soco.sub_enabled = False
         mock_soco.surround_enabled = True
         mock_soco.soundbar_audio_input_format = "Dolby 5.1"

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -165,13 +165,16 @@ async def test_microphone_binary_sensor(
 ):
     """Test microphone binary sensor."""
     entity_registry = ent_reg.async_get(hass)
-    assert "binary_sensor.zone_a_microphone" not in entity_registry.entities
+    assert "binary_sensor.zone_a_microphone" in entity_registry.entities
+
+    mic_binary_sensor = entity_registry.entities["binary_sensor.zone_a_microphone"]
+    mic_binary_sensor_state = hass.states.get(mic_binary_sensor.entity_id)
+    assert mic_binary_sensor_state.state == STATE_OFF
 
     # Update the speaker with a callback event
     subscription = soco.deviceProperties.subscribe.return_value
     subscription.callback(device_properties_event)
     await hass.async_block_till_done()
 
-    mic_binary_sensor = entity_registry.entities["binary_sensor.zone_a_microphone"]
     mic_binary_sensor_state = hass.states.get(mic_binary_sensor.entity_id)
     assert mic_binary_sensor_state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously the microphone `binary_sensor` could only update using callback events. With a feature recently added to `soco`, it is now possible to poll the state on demand. This allows the addition of fallback polling when subscriptions fail.

This also enables the sensor for installations where subscriptions do not work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
