### PR TITLE
Fix WiZ bulb being offline if kelvin limits cannot be obtained

### DIFF
--- a/homeassistant/components/wiz/__init__.py
+++ b/homeassistant/components/wiz/__init__.py
@@ -48,19 +48,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         scenes = await bulb.getSupportedScenes()
         await bulb.getMac()
-        # ValueError gets thrown if the bulb type
-        # cannot be determined on the first try.
-        # This is likely because way the library
-        # processes responses and can be cleaned up
-        # in the future.
-    except WizLightNotKnownBulb:
-        # This is only thrown on IndexError when the
-        # bulb responds with invalid data? It may
-        # not actually be possible anymore
-        _LOGGER.warning("The WiZ bulb type could not be determined for %s", ip_address)
-        return False
-    except (ValueError, *WIZ_EXCEPTIONS) as err:
-        raise ConfigEntryNotReady from err
+    except (WizLightNotKnownBulb, *WIZ_EXCEPTIONS) as err:
+        raise ConfigEntryNotReady(f"{ip_address}: {err}") from err
 
     async def _async_update() -> None:
         """Update the WiZ device."""

--- a/homeassistant/components/wiz/manifest.json
+++ b/homeassistant/components/wiz/manifest.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/wiz",
-  "requirements": ["pywizlight==0.5.5"],
+  "requirements": ["pywizlight==0.5.6"],
   "iot_class": "local_push",
   "codeowners": ["@sbidy"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2057,7 +2057,7 @@ pywemo==0.7.0
 pywilight==0.0.70
 
 # homeassistant.components.wiz
-pywizlight==0.5.5
+pywizlight==0.5.6
 
 # homeassistant.components.xeoma
 pyxeoma==1.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1282,7 +1282,7 @@ pywemo==0.7.0
 pywilight==0.0.70
 
 # homeassistant.components.wiz
-pywizlight==0.5.5
+pywizlight==0.5.6
 
 # homeassistant.components.zerproc
 pyzerproc==0.4.8


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix WiZ bulb being offline if kelvin limits cannot be obtained

- Setup is now retried later in case the wifi was
  unstable for a moment during setup

Requires https://github.com/sbidy/pywizlight/pull/121

Changelog: https://github.com/sbidy/pywizlight/compare/v0.5.5...v0.5.6 (unreleased)

Fixes
```
2022-02-10 18:07:19 ERROR (MainThread) [homeassistant.components.light] Error while setting up wiz platform for light
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 249, in _async_setup_platform
    await asyncio.shield(task)
  File "/Users/bdraco/home-assistant/homeassistant/components/wiz/light.py", line 69, in async_setup_entry
    async_add_entities([WizBulbEntity(wiz_data, entry.title)])
  File "/Users/bdraco/home-assistant/homeassistant/components/wiz/light.py", line 94, in __init__
    bulb_type.kelvin_range.max
AttributeError: NoneType object has no attribute max
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
