### PR TITLE
Add guard for invalid EntityCategory value

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -223,7 +223,10 @@ def convert_to_entity_category(
                 "EntityCategory instead" % (type(value).__name__, value),
                 error_if_core=False,
             )
-        return EntityCategory(value)
+        try:
+            return EntityCategory(value)
+        except ValueError:
+            return None
     return value
 
 

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1138,3 +1138,15 @@ async def test_deprecated_entity_category_str(hass, registry, caplog):
 
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
     assert " should be updated to use EntityCategory" in caplog.text
+
+
+async def test_invalid_entity_category_str(hass, registry, caplog):
+    """Test use of invalid entity category."""
+    entry = er.RegistryEntry(
+        "light",
+        "hue",
+        "5678",
+        entity_category="invalid",
+    )
+
+    assert entry.entity_category is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When an invalid entity category is set in the entity registry, Home Assistant does **NOT** start at all.
This comes from a custom integration, but since the value is _already_ in the entity registry, the damage is already done and removing that integration does not help at all, leaving the user with a broken system that needs manually changing `.storage/core.entity_registry`  to get it working again.

```
2022-02-11 11:51:11 ERROR (MainThread) [root] Uncaught exception
Traceback (most recent call last):
  File "/usr/local/bin/hass", line 33, in <module>
    sys.exit(load_entry_point('homeassistant', 'console_scripts', 'hass')())
  File "/workspaces/core/homeassistant/__main__.py", line 191, in main
    exit_code = runner.run(runtime_conf)
  File "/workspaces/core/homeassistant/runner.py", line 119, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/workspaces/core/homeassistant/runner.py", line 101, in setup_and_run_hass
    hass = await bootstrap.async_setup_hass(runtime_config)
  File "/workspaces/core/homeassistant/bootstrap.py", line 131, in async_setup_hass
    await async_from_config_dict(config_dict, hass) is not None
  File "/workspaces/core/homeassistant/bootstrap.py", line 241, in async_from_config_dict
    await _async_set_up_integrations(hass, config)
  File "/workspaces/core/homeassistant/bootstrap.py", line 534, in _async_set_up_integrations
    await asyncio.gather(
  File "/workspaces/core/homeassistant/helpers/entity_registry.py", line 715, in async_load
    await hass.data[DATA_REGISTRY].async_load()
  File "/workspaces/core/homeassistant/helpers/entity_registry.py", line 631, in async_load
    entity_category=_convert_to_entity_category(
  File "/workspaces/core/homeassistant/helpers/entity_registry.py", line 103, in _convert_to_entity_category
    return convert_to_entity_category(value, raise_report=raise_report)
  File "/workspaces/core/homeassistant/helpers/entity.py", line 226, in convert_to_entity_category
    return EntityCategory(value)
  File "/usr/local/lib/python3.9/enum.py", line 384, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.9/enum.py", line 702, in __new__
    raise ve_exc
ValueError: 'invalid' is not a valid EntityCategory

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
