### PR TITLE
Fix webostv restored supported features turn on

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -326,7 +326,11 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
     def supported_features(self) -> int:
         """Flag media player features that are supported."""
         if self.state == STATE_OFF and self._supported_features is not None:
-            return self._supported_features
+            return (
+                self._supported_features | SUPPORT_TURN_ON
+                if self._wrapper.turn_on
+                else self._supported_features & ~SUPPORT_TURN_ON
+            )
 
         supported = SUPPORT_WEBOSTV
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -326,11 +326,10 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
     def supported_features(self) -> int:
         """Flag media player features that are supported."""
         if self.state == STATE_OFF and self._supported_features is not None:
-            return (
-                self._supported_features | SUPPORT_TURN_ON
-                if self._wrapper.turn_on
-                else self._supported_features & ~SUPPORT_TURN_ON
-            )
+            if self._wrapper.turn_on:
+                return self._supported_features | SUPPORT_TURN_ON
+
+            return self._supported_features & ~SUPPORT_TURN_ON
 
         supported = SUPPORT_WEBOSTV
 

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -59,6 +59,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
@@ -67,7 +68,7 @@ from homeassistant.util import dt
 from . import setup_webostv
 from .const import CHANNEL_2, ENTITY_ID, TV_NAME
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_time_changed, mock_restore_cache
 
 
 @pytest.mark.parametrize(
@@ -562,14 +563,27 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     """Test test supported features."""
     monkeypatch.setattr(client, "is_on", False)
     monkeypatch.setattr(client, "sound_output", None)
+    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_TURN_ON
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                ENTITY_ID,
+                STATE_OFF,
+                attributes={
+                    ATTR_SUPPORTED_FEATURES: supported,
+                },
+            )
+        ],
+    )
     await setup_webostv(hass)
     await client.mock_state_update()
 
-    # TV off, support volume mute, step, set
-    supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET
+    # TV off, restored state supports mute, step
+    # validate SUPPORT_TURN_ON is not cached
     attrs = hass.states.get(ENTITY_ID).attributes
 
-    assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported & ~SUPPORT_TURN_ON
 
     # TV on, support volume mute, step
     monkeypatch.setattr(client, "is_on", True)
@@ -601,7 +615,7 @@ async def test_cached_supported_features(hass, client, monkeypatch):
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
-    # TV off, support volume mute, step, step, set
+    # TV off, support volume mute, step, set
     monkeypatch.setattr(client, "is_on", False)
     monkeypatch.setattr(client, "sound_output", None)
     await client.mock_state_update()
@@ -610,3 +624,31 @@ async def test_cached_supported_features(hass, client, monkeypatch):
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
+
+    # Test support turn on is updated on cached state
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "webostv.turn_on",
+                        "entity_id": ENTITY_ID,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": ENTITY_ID,
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                },
+            ],
+        },
+    )
+    await client.mock_state_update()
+
+    attrs = hass.states.get(ENTITY_ID).attributes
+
+    assert attrs[ATTR_SUPPORTED_FEATURES] == supported | SUPPORT_TURN_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When restoring supported features (https://github.com/home-assistant/core/pull/65930) we should not restore the `SUPPORT_TURN_ON` flag as it is depended on user automation and not device capabilities. I encountered a scenario that if you add a trigger automation for turn on while the device is off the supported features is not updated so it will not be possible to turn on the device via the frontend. It can also happen that the user deleted the automation while the device is off.

Updated the test to increase coverage from 99% to 100%.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
