### PR TITLE
Move configuration for tcp under the integration domain key

### DIFF
--- a/homeassistant/components/tcp/__init__.py
+++ b/homeassistant/components/tcp/__init__.py
@@ -1,1 +1,97 @@
 """The tcp component."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_BINARY_SENSORS,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PAYLOAD,
+    CONF_PORT,
+    CONF_SENSORS,
+    CONF_SSL,
+    CONF_TIMEOUT,
+    CONF_UNIT_OF_MEASUREMENT,
+    CONF_VALUE_TEMPLATE,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    CONF_BUFFER_SIZE,
+    CONF_VALUE_ON,
+    DEFAULT_BUFFER_SIZE,
+    DEFAULT_NAME,
+    DEFAULT_SSL,
+    DEFAULT_TIMEOUT,
+    DEFAULT_VERIFY_SSL,
+)
+
+DOMAIN = "tcp"
+
+PLATFORMS = ["binary_sensor", "sensor"]
+
+HOST_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PORT): cv.port,
+        vol.Optional(CONF_BUFFER_SIZE, default=DEFAULT_BUFFER_SIZE): cv.positive_int,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+    }
+)
+
+BASE_SENSOR_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PAYLOAD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    }
+)
+
+SENSOR_SCHEMA = BASE_SENSOR_SCHEMA.extend(
+    {vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string}
+)
+
+BINARY_SENSOR_SCHEMA = BASE_SENSOR_SCHEMA.extend(
+    {vol.Optional(CONF_VALUE_ON): cv.string}
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(
+            cv.ensure_list,
+            [
+                HOST_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_SENSORS, default=[]): vol.All(
+                            cv.ensure_list, [SENSOR_SCHEMA]
+                        ),
+                        vol.Optional(CONF_BINARY_SENSORS, default=[]): vol.All(
+                            cv.ensure_list, [BINARY_SENSOR_SCHEMA]
+                        ),
+                    }
+                )
+            ],
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the TCP component."""
+    for discovery_info in config[DOMAIN]:
+        for platform in PLATFORMS:
+            hass.async_create_task(
+                discovery.async_load_platform(
+                    hass, platform, DOMAIN, discovery_info, config
+                )
+            )
+
+    return True

--- a/homeassistant/components/tcp/__init__.py
+++ b/homeassistant/components/tcp/__init__.py
@@ -86,6 +86,8 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the TCP component."""
+    if DOMAIN not in config:
+        return True
     for discovery_info in config[DOMAIN]:
         for platform in PLATFORMS:
             hass.async_create_task(

--- a/homeassistant/components/tcp/__init__.py
+++ b/homeassistant/components/tcp/__init__.py
@@ -48,8 +48,8 @@ HOST_SCHEMA = vol.Schema(
 
 BASE_SENSOR_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_PAYLOAD): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Required(CONF_PAYLOAD): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     }
 )

--- a/homeassistant/components/tcp/binary_sensor.py
+++ b/homeassistant/components/tcp/binary_sensor.py
@@ -1,30 +1,32 @@
 """Provides a binary sensor which gets its values from a TCP socket."""
 from __future__ import annotations
 
-from typing import Final
-
-from homeassistant.components.binary_sensor import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
-    BinarySensorEntity,
-)
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .common import TCP_PLATFORM_SCHEMA, TcpEntity
+from . import HOST_SCHEMA
+from .common import TcpEntity
 from .const import CONF_VALUE_ON
 
-PLATFORM_SCHEMA: Final = PARENT_PLATFORM_SCHEMA.extend(TCP_PLATFORM_SCHEMA)
 
-
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the TCP binary sensor."""
-    add_entities([TcpBinarySensor(hass, config)])
+    if discovery_info is None:
+        return
+
+    host_config = {key: discovery_info[key] for key in HOST_SCHEMA.schema.keys()}
+    entities = [
+        TcpBinarySensor(hass, entity_config, host_config)
+        for entity_config in discovery_info["binary_sensors"]
+    ]
+    async_add_entities(entities)
 
 
 class TcpBinarySensor(TcpEntity, BinarySensorEntity):

--- a/homeassistant/components/tcp/binary_sensor.py
+++ b/homeassistant/components/tcp/binary_sensor.py
@@ -1,14 +1,30 @@
 """Provides a binary sensor which gets its values from a TCP socket."""
 from __future__ import annotations
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from typing import Final
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import (
+    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
+    BinarySensorEntity,
+)
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import HOST_SCHEMA
-from .common import TcpEntity
+from . import BINARY_SENSOR_SCHEMA, HOST_SCHEMA
+from .common import TCP_PLATFORM_SCHEMA, TcpEntity
 from .const import CONF_VALUE_ON
+
+PLATFORM_SCHEMA: Final = vol.All(
+    *(
+        cv.deprecated(key)
+        for key in TCP_PLATFORM_SCHEMA.keys() | PARENT_PLATFORM_SCHEMA.schema.keys()
+    ),
+    PARENT_PLATFORM_SCHEMA.extend(TCP_PLATFORM_SCHEMA),
+)
 
 
 async def async_setup_platform(
@@ -19,13 +35,27 @@ async def async_setup_platform(
 ) -> None:
     """Set up the TCP binary sensor."""
     if discovery_info is None:
-        return
+        # Deprecated branch
+        host_config = {
+            key: config[key] for key in HOST_SCHEMA.schema.keys() if key in config
+        }
+        entity_config = {
+            key: config[key]
+            for key in BINARY_SENSOR_SCHEMA.schema.keys()
+            if key in config
+        }
+        entities = [TcpBinarySensor(hass, entity_config, host_config)]
+    else:
+        host_config = {
+            key: discovery_info[key]
+            for key in HOST_SCHEMA.schema.keys()
+            if key in discovery_info
+        }
+        entities = [
+            TcpBinarySensor(hass, entity_config, host_config)
+            for entity_config in discovery_info["binary_sensors"]
+        ]
 
-    host_config = {key: discovery_info[key] for key in HOST_SCHEMA.schema.keys()}
-    entities = [
-        TcpBinarySensor(hass, entity_config, host_config)
-        for entity_config in discovery_info["binary_sensors"]
-    ]
     async_add_entities(entities)
 
 

--- a/homeassistant/components/tcp/common.py
+++ b/homeassistant/components/tcp/common.py
@@ -5,9 +5,7 @@ import logging
 import select
 import socket
 import ssl
-from typing import Any, Final
-
-import voluptuous as vol
+from typing import Final
 
 from homeassistant.const import (
     CONF_HOST,
@@ -22,46 +20,23 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_BUFFER_SIZE,
-    CONF_VALUE_ON,
-    DEFAULT_BUFFER_SIZE,
-    DEFAULT_NAME,
-    DEFAULT_SSL,
-    DEFAULT_TIMEOUT,
-    DEFAULT_VERIFY_SSL,
-)
+from .const import CONF_BUFFER_SIZE, CONF_VALUE_ON
 from .model import TcpSensorConfig
 
 _LOGGER: Final = logging.getLogger(__name__)
 
 
-TCP_PLATFORM_SCHEMA: Final[dict[vol.Marker, Any]] = {
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_PORT): cv.port,
-    vol.Required(CONF_PAYLOAD): cv.string,
-    vol.Optional(CONF_BUFFER_SIZE, default=DEFAULT_BUFFER_SIZE): cv.positive_int,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-    vol.Optional(CONF_VALUE_ON): cv.string,
-    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-}
-
-
 class TcpEntity(Entity):
     """Base entity class for TCP platform."""
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(
+        self, hass: HomeAssistant, config: ConfigType, host_config: ConfigType
+    ) -> None:
         """Set all the config values if they exist and get initial state."""
-
         value_template: Template | None = config.get(CONF_VALUE_TEMPLATE)
         if value_template is not None:
             value_template.hass = hass
@@ -69,16 +44,16 @@ class TcpEntity(Entity):
         self._hass = hass
         self._config: TcpSensorConfig = {
             CONF_NAME: config[CONF_NAME],
-            CONF_HOST: config[CONF_HOST],
-            CONF_PORT: config[CONF_PORT],
-            CONF_TIMEOUT: config[CONF_TIMEOUT],
+            CONF_HOST: host_config[CONF_HOST],
+            CONF_PORT: host_config[CONF_PORT],
+            CONF_TIMEOUT: host_config[CONF_TIMEOUT],
             CONF_PAYLOAD: config[CONF_PAYLOAD],
             CONF_UNIT_OF_MEASUREMENT: config.get(CONF_UNIT_OF_MEASUREMENT),
             CONF_VALUE_TEMPLATE: value_template,
             CONF_VALUE_ON: config.get(CONF_VALUE_ON),
-            CONF_BUFFER_SIZE: config[CONF_BUFFER_SIZE],
-            CONF_SSL: config[CONF_SSL],
-            CONF_VERIFY_SSL: config[CONF_VERIFY_SSL],
+            CONF_BUFFER_SIZE: host_config[CONF_BUFFER_SIZE],
+            CONF_SSL: host_config[CONF_SSL],
+            CONF_VERIFY_SSL: host_config[CONF_VERIFY_SSL],
         }
 
         self._ssl_context: ssl.SSLContext | None = None
@@ -145,7 +120,9 @@ class TcpEntity(Entity):
         value_template = self._config[CONF_VALUE_TEMPLATE]
         if value_template is not None:
             try:
-                self._state = value_template.render(parse_result=False, value=value)
+                self._state = value_template.async_render(
+                    parse_result=False, value=value
+                )
                 return
             except TemplateError:
                 _LOGGER.error(

--- a/homeassistant/components/tcp/common.py
+++ b/homeassistant/components/tcp/common.py
@@ -5,7 +5,9 @@ import logging
 import select
 import socket
 import ssl
-from typing import Final
+from typing import Any, Final
+
+import voluptuous as vol
 
 from homeassistant.const import (
     CONF_HOST,
@@ -20,14 +22,38 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_BUFFER_SIZE, CONF_VALUE_ON
+from .const import (
+    CONF_BUFFER_SIZE,
+    CONF_VALUE_ON,
+    DEFAULT_BUFFER_SIZE,
+    DEFAULT_NAME,
+    DEFAULT_SSL,
+    DEFAULT_TIMEOUT,
+    DEFAULT_VERIFY_SSL,
+)
 from .model import TcpSensorConfig
 
 _LOGGER: Final = logging.getLogger(__name__)
+
+
+TCP_PLATFORM_SCHEMA: Final[dict[vol.Marker, Any]] = {
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.port,
+    vol.Required(CONF_PAYLOAD): cv.string,
+    vol.Optional(CONF_BUFFER_SIZE, default=DEFAULT_BUFFER_SIZE): cv.positive_int,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_VALUE_ON): cv.string,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+}
 
 
 class TcpEntity(Entity):

--- a/homeassistant/components/tcp/const.py
+++ b/homeassistant/components/tcp/const.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Final
 
-CONF_HOST_ID = "host_id"
 CONF_BUFFER_SIZE: Final = "buffer_size"
 CONF_VALUE_ON: Final = "value_on"
 

--- a/homeassistant/components/tcp/const.py
+++ b/homeassistant/components/tcp/const.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Final
 
+CONF_HOST_ID = "host_id"
 CONF_BUFFER_SIZE: Final = "buffer_size"
 CONF_VALUE_ON: Final = "value_on"
 

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -1,14 +1,30 @@
 """Support for TCP socket based sensors."""
 from __future__ import annotations
 
-from homeassistant.components.sensor import SensorEntity
+from typing import Final
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import (
+    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
+    SensorEntity,
+)
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
-from . import HOST_SCHEMA
-from .common import TcpEntity
+from . import HOST_SCHEMA, SENSOR_SCHEMA
+from .common import TCP_PLATFORM_SCHEMA, TcpEntity
+
+PLATFORM_SCHEMA: Final = vol.All(
+    *(
+        cv.deprecated(key)
+        for key in TCP_PLATFORM_SCHEMA.keys() | PARENT_PLATFORM_SCHEMA.schema.keys()
+    ),
+    PARENT_PLATFORM_SCHEMA.extend(TCP_PLATFORM_SCHEMA),
+)
 
 
 async def async_setup_platform(
@@ -19,13 +35,24 @@ async def async_setup_platform(
 ) -> None:
     """Set up the TCP Sensor."""
     if discovery_info is None:
-        return
-
-    host_config = {key: discovery_info[key] for key in HOST_SCHEMA.schema.keys()}
-    entities = [
-        TcpSensor(hass, entity_config, host_config)
-        for entity_config in discovery_info["sensors"]
-    ]
+        # Deprecated branch
+        host_config = {
+            key: config[key] for key in HOST_SCHEMA.schema.keys() if key in config
+        }
+        entity_config = {
+            key: config[key] for key in SENSOR_SCHEMA.schema.keys() if key in config
+        }
+        entities = [TcpSensor(hass, entity_config, host_config)]
+    else:
+        host_config = {
+            key: discovery_info[key]
+            for key in HOST_SCHEMA.schema.keys()
+            if key in discovery_info
+        }
+        entities = [
+            TcpSensor(hass, entity_config, host_config)
+            for entity_config in discovery_info["sensors"]
+        ]
     async_add_entities(entities)
 
 

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -1,30 +1,32 @@
 """Support for TCP socket based sensors."""
 from __future__ import annotations
 
-from typing import Final
-
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
-    SensorEntity,
-)
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
-from .common import TCP_PLATFORM_SCHEMA, TcpEntity
+from . import HOST_SCHEMA
+from .common import TcpEntity
 
-PLATFORM_SCHEMA: Final = PARENT_PLATFORM_SCHEMA.extend(TCP_PLATFORM_SCHEMA)
 
-
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the TCP Sensor."""
-    add_entities([TcpSensor(hass, config)])
+    if discovery_info is None:
+        return
+
+    host_config = {key: discovery_info[key] for key in HOST_SCHEMA.schema.keys()}
+    entities = [
+        TcpSensor(hass, entity_config, host_config)
+        for entity_config in discovery_info["sensors"]
+    ]
+    async_add_entities(entities)
 
 
 class TcpSensor(TcpEntity, SensorEntity):

--- a/tests/components/tcp/conftest.py
+++ b/tests/components/tcp/conftest.py
@@ -1,0 +1,88 @@
+"""Test configuration and mocks for TCP integration."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.tcp import DOMAIN
+import homeassistant.components.tcp.common as tcp
+from homeassistant.util.dt import utcnow
+
+socket_test_value = "value"
+
+HOST_TEST_CONFIG = {
+    tcp.CONF_HOST: "test_host",
+    tcp.CONF_PORT: 12345,
+    tcp.CONF_TIMEOUT: tcp.DEFAULT_TIMEOUT + 1,
+    tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE + 1,
+}
+
+SENSOR_TEST_CONFIG = {
+    tcp.CONF_NAME: "test_name",
+    tcp.CONF_PAYLOAD: "test_payload",
+    tcp.CONF_VALUE_TEMPLATE: "{{ 'test_' + value }}",
+    tcp.CONF_UNIT_OF_MEASUREMENT: "test_unit",
+}
+
+BINARY_SENSOR_TEST_CONFIG = {
+    tcp.CONF_NAME: "test_name",
+    tcp.CONF_PAYLOAD: "test_payload",
+    tcp.CONF_VALUE_TEMPLATE: "{{ 'test_' + value }}",
+    tcp.CONF_VALUE_ON: "test_on",
+}
+
+TEST_CONFIG_COMPONENTS = {
+    "sensor": {"platform": "tcp", **HOST_TEST_CONFIG, **SENSOR_TEST_CONFIG},
+    "binary_sensor": {
+        "platform": "tcp",
+        **HOST_TEST_CONFIG,
+        **BINARY_SENSOR_TEST_CONFIG,
+    },
+}
+
+TEST_CONFIG = {
+    DOMAIN: [
+        {
+            **HOST_TEST_CONFIG,
+            "sensors": [SENSOR_TEST_CONFIG],
+            "binary_sensors": [BINARY_SENSOR_TEST_CONFIG],
+        }
+    ]
+}
+
+
+@pytest.fixture(name="mock_socket")
+def mock_socket_fixture(mock_select):
+    """Mock socket."""
+    with patch("homeassistant.components.tcp.common.socket.socket") as mock_socket:
+        socket_instance = mock_socket.return_value.__enter__.return_value
+        socket_instance.recv.return_value = socket_test_value.encode()
+        yield socket_instance
+
+
+@pytest.fixture(name="mock_select")
+def mock_select_fixture():
+    """Mock select."""
+    with patch(
+        "homeassistant.components.tcp.common.select.select",
+        return_value=(True, False, False),
+    ) as mock_select:
+        yield mock_select
+
+
+@pytest.fixture(name="mock_ssl_context")
+def mock_ssl_context_fixture():
+    """Mock select."""
+    with patch(
+        "homeassistant.components.tcp.common.ssl.create_default_context",
+    ) as mock_ssl_context:
+        mock_ssl_context.return_value.wrap_socket.return_value.recv.return_value = (
+            socket_test_value + "_ssl"
+        ).encode()
+        yield mock_ssl_context
+
+
+@pytest.fixture
+def now():
+    """Return datetime UTC now."""
+    return utcnow()

--- a/tests/components/tcp/test_binary_sensor.py
+++ b/tests/components/tcp/test_binary_sensor.py
@@ -1,44 +1,47 @@
 """The tests for the TCP binary sensor platform."""
+from copy import deepcopy
 from datetime import timedelta
-from unittest.mock import call, patch
+from unittest.mock import call
 
 import pytest
 
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.components.tcp import DOMAIN
+from homeassistant.components.tcp.const import CONF_VALUE_ON, DEFAULT_NAME
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_SSL,
+    CONF_TIMEOUT,
+    CONF_VALUE_TEMPLATE,
+    CONF_VERIFY_SSL,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.setup import async_setup_component
-from homeassistant.util.dt import utcnow
+
+from .conftest import (
+    BINARY_SENSOR_TEST_CONFIG,
+    HOST_TEST_CONFIG,
+    TEST_CONFIG,
+    TEST_CONFIG_COMPONENTS,
+)
 
 from tests.common import assert_setup_component, async_fire_time_changed
-import tests.components.tcp.test_sensor as test_tcp
 
-BINARY_SENSOR_CONFIG = test_tcp.TEST_CONFIG["sensor"]
-TEST_CONFIG = {"binary_sensor": BINARY_SENSOR_CONFIG}
 TEST_ENTITY = "binary_sensor.test_name"
 
-
-@pytest.fixture(name="mock_socket")
-def mock_socket_fixture():
-    """Mock the socket."""
-    with patch(
-        "homeassistant.components.tcp.common.socket.socket"
-    ) as mock_socket, patch(
-        "homeassistant.components.tcp.common.select.select",
-        return_value=(True, False, False),
-    ):
-        # yield the return value of the socket context manager
-        yield mock_socket.return_value.__enter__.return_value
-
-
-@pytest.fixture
-def now():
-    """Return datetime UTC now."""
-    return utcnow()
+KEYS_AND_DEFAULTS = {
+    CONF_NAME: DEFAULT_NAME,
+    CONF_VALUE_TEMPLATE: None,
+    CONF_VALUE_ON: None,
+}
 
 
 async def test_setup_platform_valid_config(hass, mock_socket):
     """Check a valid configuration."""
     with assert_setup_component(1, "binary_sensor"):
-        assert await async_setup_component(hass, "binary_sensor", TEST_CONFIG)
+        assert await async_setup_component(
+            hass, "binary_sensor", TEST_CONFIG_COMPONENTS
+        )
         await hass.async_block_till_done()
 
 
@@ -53,26 +56,63 @@ async def test_setup_platform_invalid_config(hass, mock_socket):
         await hass.async_block_till_done()
 
 
-async def test_state(hass, mock_socket, now):
-    """Check the state and update of the binary sensor."""
-    mock_socket.recv.return_value = b"off"
-    assert await async_setup_component(hass, "binary_sensor", TEST_CONFIG)
+@pytest.mark.parametrize(
+    "ssl, verify_ssl, expected_state",
+    [(False, False, STATE_OFF), (True, False, STATE_OFF), (True, True, STATE_OFF)],
+)
+async def test_state(
+    hass,
+    mock_socket,
+    mock_select,
+    mock_ssl_context,
+    now,
+    ssl,
+    verify_ssl,
+    expected_state,
+):
+    """Return the contents of _state, updated over SSL."""
+    config = deepcopy(TEST_CONFIG)
+    config[DOMAIN][0][CONF_SSL] = "on" if ssl else "off"
+    config[DOMAIN][0][CONF_VERIFY_SSL] = "on" if verify_ssl else "off"
+
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)
 
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == expected_state
+
     assert mock_socket.connect.called
     assert mock_socket.connect.call_args == call(
-        (BINARY_SENSOR_CONFIG["host"], BINARY_SENSOR_CONFIG["port"])
+        (HOST_TEST_CONFIG["host"], HOST_TEST_CONFIG["port"])
     )
-    assert mock_socket.send.called
-    assert mock_socket.send.call_args == call(BINARY_SENSOR_CONFIG["payload"].encode())
-    assert mock_socket.recv.called
-    assert mock_socket.recv.call_args == call(BINARY_SENSOR_CONFIG["buffer_size"])
 
-    mock_socket.recv.return_value = b"on"
+    if not ssl:
+        assert mock_socket.send.called
+        assert mock_socket.send.call_args == call(
+            BINARY_SENSOR_TEST_CONFIG["payload"].encode()
+        )
+        assert mock_select.call_args == call(
+            [mock_socket], [], [], HOST_TEST_CONFIG[CONF_TIMEOUT]
+        )
+
+        mock_socket.recv.return_value = b"on"
+    else:
+        assert mock_ssl_context.called
+        assert bool(mock_ssl_context.return_value.check_hostname) == verify_ssl
+        mock_ssl_socket = mock_ssl_context.return_value.wrap_socket.return_value
+        assert mock_ssl_socket.send.called
+        assert mock_ssl_socket.send.call_args == call(
+            BINARY_SENSOR_TEST_CONFIG["payload"].encode()
+        )
+        assert mock_select.call_args == call(
+            [mock_ssl_socket], [], [], HOST_TEST_CONFIG[CONF_TIMEOUT]
+        )
+        assert mock_ssl_socket.recv.called
+        assert mock_ssl_socket.recv.call_args == call(HOST_TEST_CONFIG["buffer_size"])
+
+        mock_ssl_socket.recv.return_value = b"on"
 
     async_fire_time_changed(hass, now + timedelta(seconds=45))
     await hass.async_block_till_done()
@@ -81,3 +121,50 @@ async def test_state(hass, mock_socket, now):
 
     assert state
     assert state.state == STATE_ON
+
+
+async def test_config_uses_defaults(hass, mock_socket):
+    """Check if defaults were set."""
+    config = deepcopy(TEST_CONFIG)
+
+    for key in KEYS_AND_DEFAULTS:
+        del config[DOMAIN][0]["binary_sensors"][0][key]
+
+    with assert_setup_component(1, DOMAIN) as result_config:
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.tcp_sensor")
+
+    assert state
+    assert state.state == STATE_OFF
+
+    for key, default in KEYS_AND_DEFAULTS.items():
+        assert result_config[DOMAIN][0]["binary_sensors"][0].get(key) == default
+
+
+async def test_update_select_fails(hass, mock_socket, mock_select):
+    """Test select fails to return a socket for reading."""
+    mock_select.return_value = (False, False, False)
+
+    assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+
+    assert state
+    assert state.state == STATE_OFF
+
+
+async def test_update_returns_if_template_render_fails(hass, mock_socket):
+    """Return None if rendering the template fails."""
+    config = deepcopy(TEST_CONFIG)
+    config[DOMAIN][0]["binary_sensors"][0][CONF_VALUE_TEMPLATE] = "{{ value / 0 }}"
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+
+    assert state
+    assert state.state == STATE_OFF

--- a/tests/components/tcp/test_init.py
+++ b/tests/components/tcp/test_init.py
@@ -1,0 +1,46 @@
+"""Test init of TCP integration."""
+from copy import deepcopy
+
+from homeassistant.components.tcp import DOMAIN
+import homeassistant.components.tcp.common as tcp
+from homeassistant.setup import async_setup_component
+
+from .conftest import TEST_CONFIG
+
+from tests.common import assert_setup_component
+
+KEYS_AND_DEFAULTS = {
+    tcp.CONF_TIMEOUT: tcp.DEFAULT_TIMEOUT,
+    tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE,
+}
+
+
+async def test_setup_platform_valid_config(hass, mock_socket):
+    """Check a valid configuration and call add_entities with sensor."""
+    with assert_setup_component(1, DOMAIN):
+        assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
+        await hass.async_block_till_done()
+
+
+async def test_setup_platform_invalid_config(hass, mock_socket):
+    """Check an invalid configuration."""
+    with assert_setup_component(0):
+        assert not await async_setup_component(
+            hass, DOMAIN, {DOMAIN: {"host": "test_host", "porrt": 1234}}
+        )
+        await hass.async_block_till_done()
+
+
+async def test_config_uses_defaults(hass, mock_socket):
+    """Check if defaults were set."""
+    config = deepcopy(TEST_CONFIG)
+
+    for key in KEYS_AND_DEFAULTS:
+        del config[DOMAIN][0][key]
+
+    with assert_setup_component(1, DOMAIN) as result_config:
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    for key, default in KEYS_AND_DEFAULTS.items():
+        assert result_config[DOMAIN][0].get(key) == default

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -118,7 +118,7 @@ async def test_config_uses_defaults(hass, mock_socket):
     for key in KEYS_AND_DEFAULTS:
         del config[key]
 
-    with assert_setup_component(1) as result_config:
+    with assert_setup_component(1, "sensor") as result_config:
         assert await async_setup_component(hass, "sensor", {"sensor": config})
         await hass.async_block_till_done()
 

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -1,78 +1,43 @@
 """The tests for the TCP sensor platform."""
-from copy import copy
-from unittest.mock import call, patch
+from copy import deepcopy
+from unittest.mock import call
 
 import pytest
 
-import homeassistant.components.tcp.common as tcp
+from homeassistant.components.tcp import DOMAIN
+from homeassistant.components.tcp.const import DEFAULT_NAME
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_SSL,
+    CONF_TIMEOUT,
+    CONF_UNIT_OF_MEASUREMENT,
+    CONF_VALUE_TEMPLATE,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.setup import async_setup_component
+
+from .conftest import (
+    HOST_TEST_CONFIG,
+    SENSOR_TEST_CONFIG,
+    TEST_CONFIG,
+    TEST_CONFIG_COMPONENTS,
+)
 
 from tests.common import assert_setup_component
 
-TEST_CONFIG = {
-    "sensor": {
-        "platform": "tcp",
-        tcp.CONF_NAME: "test_name",
-        tcp.CONF_HOST: "test_host",
-        tcp.CONF_PORT: 12345,
-        tcp.CONF_TIMEOUT: tcp.DEFAULT_TIMEOUT + 1,
-        tcp.CONF_PAYLOAD: "test_payload",
-        tcp.CONF_UNIT_OF_MEASUREMENT: "test_unit",
-        tcp.CONF_VALUE_TEMPLATE: "{{ 'test_' + value }}",
-        tcp.CONF_VALUE_ON: "test_on",
-        tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE + 1,
-    }
-}
-SENSOR_TEST_CONFIG = TEST_CONFIG["sensor"]
 TEST_ENTITY = "sensor.test_name"
 
 KEYS_AND_DEFAULTS = {
-    tcp.CONF_NAME: tcp.DEFAULT_NAME,
-    tcp.CONF_TIMEOUT: tcp.DEFAULT_TIMEOUT,
-    tcp.CONF_UNIT_OF_MEASUREMENT: None,
-    tcp.CONF_VALUE_TEMPLATE: None,
-    tcp.CONF_VALUE_ON: None,
-    tcp.CONF_BUFFER_SIZE: tcp.DEFAULT_BUFFER_SIZE,
+    CONF_NAME: DEFAULT_NAME,
+    CONF_UNIT_OF_MEASUREMENT: None,
+    CONF_VALUE_TEMPLATE: None,
 }
-
-socket_test_value = "value"
-
-
-@pytest.fixture(name="mock_socket")
-def mock_socket_fixture(mock_select):
-    """Mock socket."""
-    with patch("homeassistant.components.tcp.common.socket.socket") as mock_socket:
-        socket_instance = mock_socket.return_value.__enter__.return_value
-        socket_instance.recv.return_value = socket_test_value.encode()
-        yield socket_instance
-
-
-@pytest.fixture(name="mock_select")
-def mock_select_fixture():
-    """Mock select."""
-    with patch(
-        "homeassistant.components.tcp.common.select.select",
-        return_value=(True, False, False),
-    ) as mock_select:
-        yield mock_select
-
-
-@pytest.fixture(name="mock_ssl_context")
-def mock_ssl_context_fixture():
-    """Mock select."""
-    with patch(
-        "homeassistant.components.tcp.common.ssl.create_default_context",
-    ) as mock_ssl_context:
-        mock_ssl_context.return_value.wrap_socket.return_value.recv.return_value = (
-            socket_test_value + "_ssl"
-        ).encode()
-        yield mock_ssl_context
 
 
 async def test_setup_platform_valid_config(hass, mock_socket):
     """Check a valid configuration and call add_entities with sensor."""
     with assert_setup_component(1, "sensor"):
-        assert await async_setup_component(hass, "sensor", TEST_CONFIG)
+        assert await async_setup_component(hass, "sensor", TEST_CONFIG_COMPONENTS)
         await hass.async_block_till_done()
 
 
@@ -85,41 +50,67 @@ async def test_setup_platform_invalid_config(hass, mock_socket):
         await hass.async_block_till_done()
 
 
-async def test_state(hass, mock_socket, mock_select):
-    """Return the contents of _state."""
-    assert await async_setup_component(hass, "sensor", TEST_CONFIG)
+@pytest.mark.parametrize(
+    "ssl, verify_ssl, expected_state",
+    [
+        (False, False, "test_value"),
+        (True, False, "test_value_ssl"),
+        (True, True, "test_value_ssl"),
+    ],
+)
+async def test_state(
+    hass, mock_socket, mock_select, mock_ssl_context, ssl, verify_ssl, expected_state
+):
+    """Return the contents of _state, updated over SSL."""
+    config = deepcopy(TEST_CONFIG)
+    config[DOMAIN][0][CONF_SSL] = "on" if ssl else "off"
+    config[DOMAIN][0][CONF_VERIFY_SSL] = "on" if verify_ssl else "off"
+
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)
 
     assert state
-    assert state.state == "test_value"
-    assert (
-        state.attributes["unit_of_measurement"]
-        == SENSOR_TEST_CONFIG[tcp.CONF_UNIT_OF_MEASUREMENT]
-    )
+    assert state.state == expected_state
+
     assert mock_socket.connect.called
     assert mock_socket.connect.call_args == call(
-        (SENSOR_TEST_CONFIG["host"], SENSOR_TEST_CONFIG["port"])
+        (HOST_TEST_CONFIG["host"], HOST_TEST_CONFIG["port"])
     )
-    assert mock_socket.send.called
-    assert mock_socket.send.call_args == call(SENSOR_TEST_CONFIG["payload"].encode())
-    assert mock_select.call_args == call(
-        [mock_socket], [], [], SENSOR_TEST_CONFIG[tcp.CONF_TIMEOUT]
-    )
-    assert mock_socket.recv.called
-    assert mock_socket.recv.call_args == call(SENSOR_TEST_CONFIG["buffer_size"])
+
+    if not ssl:
+        assert mock_socket.send.called
+        assert mock_socket.send.call_args == call(
+            SENSOR_TEST_CONFIG["payload"].encode()
+        )
+        assert mock_select.call_args == call(
+            [mock_socket], [], [], HOST_TEST_CONFIG[CONF_TIMEOUT]
+        )
+    else:
+        assert mock_ssl_context.called
+        assert bool(mock_ssl_context.return_value.check_hostname) == verify_ssl
+        mock_ssl_socket = mock_ssl_context.return_value.wrap_socket.return_value
+        assert mock_ssl_socket.send.called
+        assert mock_ssl_socket.send.call_args == call(
+            SENSOR_TEST_CONFIG["payload"].encode()
+        )
+        assert mock_select.call_args == call(
+            [mock_ssl_socket], [], [], HOST_TEST_CONFIG[CONF_TIMEOUT]
+        )
+        assert mock_ssl_socket.recv.called
+        assert mock_ssl_socket.recv.call_args == call(HOST_TEST_CONFIG["buffer_size"])
 
 
 async def test_config_uses_defaults(hass, mock_socket):
     """Check if defaults were set."""
-    config = copy(SENSOR_TEST_CONFIG)
+    config = deepcopy(TEST_CONFIG)
 
     for key in KEYS_AND_DEFAULTS:
-        del config[key]
+        del config[DOMAIN][0]["sensors"][0][key]
 
-    with assert_setup_component(1, "sensor") as result_config:
-        assert await async_setup_component(hass, "sensor", {"sensor": config})
+    with assert_setup_component(1, DOMAIN) as result_config:
+        assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.tcp_sensor")
@@ -128,7 +119,7 @@ async def test_config_uses_defaults(hass, mock_socket):
     assert state.state == "value"
 
     for key, default in KEYS_AND_DEFAULTS.items():
-        assert result_config["sensor"][0].get(key) == default
+        assert result_config[DOMAIN][0]["sensors"][0].get(key) == default
 
 
 @pytest.mark.parametrize("sock_attr", ["connect", "send"])
@@ -137,7 +128,7 @@ async def test_update_socket_error(hass, mock_socket, sock_attr):
     socket_method = getattr(mock_socket, sock_attr)
     socket_method.side_effect = OSError("Boom")
 
-    assert await async_setup_component(hass, "sensor", TEST_CONFIG)
+    assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)
@@ -150,7 +141,7 @@ async def test_update_select_fails(hass, mock_socket, mock_select):
     """Test select fails to return a socket for reading."""
     mock_select.return_value = (False, False, False)
 
-    assert await async_setup_component(hass, "sensor", TEST_CONFIG)
+    assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)
@@ -161,76 +152,13 @@ async def test_update_select_fails(hass, mock_socket, mock_select):
 
 async def test_update_returns_if_template_render_fails(hass, mock_socket):
     """Return None if rendering the template fails."""
-    config = copy(SENSOR_TEST_CONFIG)
-    config[tcp.CONF_VALUE_TEMPLATE] = "{{ value / 0 }}"
+    config = deepcopy(TEST_CONFIG)
+    config[DOMAIN][0]["sensors"][0][CONF_VALUE_TEMPLATE] = "{{ value / 0 }}"
 
-    assert await async_setup_component(hass, "sensor", {"sensor": config})
+    assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)
 
     assert state
     assert state.state == "unknown"
-
-
-async def test_ssl_state(hass, mock_socket, mock_select, mock_ssl_context):
-    """Return the contents of _state, updated over SSL."""
-    config = copy(SENSOR_TEST_CONFIG)
-    config[tcp.CONF_SSL] = "on"
-
-    assert await async_setup_component(hass, "sensor", {"sensor": config})
-    await hass.async_block_till_done()
-
-    state = hass.states.get(TEST_ENTITY)
-
-    assert state
-    assert state.state == "test_value_ssl"
-    assert mock_socket.connect.called
-    assert mock_socket.connect.call_args == call(
-        (SENSOR_TEST_CONFIG["host"], SENSOR_TEST_CONFIG["port"])
-    )
-    assert not mock_socket.send.called
-    assert mock_ssl_context.called
-    assert mock_ssl_context.return_value.check_hostname
-    mock_ssl_socket = mock_ssl_context.return_value.wrap_socket.return_value
-    assert mock_ssl_socket.send.called
-    assert mock_ssl_socket.send.call_args == call(
-        SENSOR_TEST_CONFIG["payload"].encode()
-    )
-    assert mock_select.call_args == call(
-        [mock_ssl_socket], [], [], SENSOR_TEST_CONFIG[tcp.CONF_TIMEOUT]
-    )
-    assert mock_ssl_socket.recv.called
-    assert mock_ssl_socket.recv.call_args == call(SENSOR_TEST_CONFIG["buffer_size"])
-
-
-async def test_ssl_state_verify_off(hass, mock_socket, mock_select, mock_ssl_context):
-    """Return the contents of _state, updated over SSL (verify_ssl disabled)."""
-    config = copy(SENSOR_TEST_CONFIG)
-    config[tcp.CONF_SSL] = "on"
-    config[tcp.CONF_VERIFY_SSL] = "off"
-
-    assert await async_setup_component(hass, "sensor", {"sensor": config})
-    await hass.async_block_till_done()
-
-    state = hass.states.get(TEST_ENTITY)
-
-    assert state
-    assert state.state == "test_value_ssl"
-    assert mock_socket.connect.called
-    assert mock_socket.connect.call_args == call(
-        (SENSOR_TEST_CONFIG["host"], SENSOR_TEST_CONFIG["port"])
-    )
-    assert not mock_socket.send.called
-    assert mock_ssl_context.called
-    assert not mock_ssl_context.return_value.check_hostname
-    mock_ssl_socket = mock_ssl_context.return_value.wrap_socket.return_value
-    assert mock_ssl_socket.send.called
-    assert mock_ssl_socket.send.call_args == call(
-        SENSOR_TEST_CONFIG["payload"].encode()
-    )
-    assert mock_select.call_args == call(
-        [mock_ssl_socket], [], [], SENSOR_TEST_CONFIG[tcp.CONF_TIMEOUT]
-    )
-    assert mock_ssl_socket.recv.called
-    assert mock_ssl_socket.recv.call_args == call(SENSOR_TEST_CONFIG["buffer_size"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The configuration for TCP has been moved under the integration domain key in configuration YAML. The previous configuration is marked as deprecated.
See the [documentation for the TCP integration](https://www.home-assistant.io/integrations/tcp/) for help on how to re-configure the integration.

The changes reflect the [Architecture Decision Record ADR0007](https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md).



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The configuration for TCP is moved under the integration domain key in configuration YAML.
The changes reflect the [Architecture Decision Record ADR0007](https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md).

Configuration example:
```yaml
tcp:
  - host: 192.168.1.100
    port: 8888
    timeout: 5

    sensors:
      - name: Sensor
        payload: "payload to send"
        value_template: "{{ value }}"

    binary_sensor:
      - name: BinarySensor
        payload: "payload to send"
        value_template: "{{ value }}"
        value_on: "on"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21600

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
