### PR TITLE
Fix PVOutput when no data is available

### DIFF
--- a/homeassistant/components/pvoutput/config_flow.py
+++ b/homeassistant/components/pvoutput/config_flow.py
@@ -23,7 +23,7 @@ async def validate_input(hass: HomeAssistant, *, api_key: str, system_id: int) -
         api_key=api_key,
         system_id=system_id,
     )
-    await pvoutput.status()
+    await pvoutput.system()
 
 
 class PVOutputFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/pvoutput/coordinator.py
+++ b/homeassistant/components/pvoutput/coordinator.py
@@ -1,14 +1,14 @@
 """DataUpdateCoordinator for the PVOutput integration."""
 from __future__ import annotations
 
-from pvo import PVOutput, PVOutputAuthenticationError, Status
+from pvo import PVOutput, PVOutputAuthenticationError, PVOutputNoDataError, Status
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_SYSTEM_ID, DOMAIN, LOGGER, SCAN_INTERVAL
 
@@ -33,5 +33,7 @@ class PVOutputDataUpdateCoordinator(DataUpdateCoordinator[Status]):
         """Fetch system status from PVOutput."""
         try:
             return await self.pvoutput.status()
+        except PVOutputNoDataError as err:
+            raise UpdateFailed("PVOutput has no data available") from err
         except PVOutputAuthenticationError as err:
             raise ConfigEntryAuthFailed from err

--- a/homeassistant/components/pvoutput/manifest.json
+++ b/homeassistant/components/pvoutput/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/pvoutput",
   "config_flow": true,
   "codeowners": ["@fabaff", "@frenck"],
-  "requirements": ["pvo==0.2.1"],
+  "requirements": ["pvo==0.2.2"],
   "iot_class": "cloud_polling",
   "quality_scale": "platinum"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1313,7 +1313,7 @@ pushbullet.py==0.11.0
 pushover_complete==1.1.1
 
 # homeassistant.components.pvoutput
-pvo==0.2.1
+pvo==0.2.2
 
 # homeassistant.components.rpi_gpio_pwm
 pwmled==1.6.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -820,7 +820,7 @@ pure-python-adb[async]==0.3.0.dev0
 pushbullet.py==0.11.0
 
 # homeassistant.components.pvoutput
-pvo==0.2.1
+pvo==0.2.2
 
 # homeassistant.components.canary
 py-canary==0.5.1

--- a/tests/components/pvoutput/test_config_flow.py
+++ b/tests/components/pvoutput/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_full_user_flow(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 1
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
 
 
 async def test_full_flow_with_authentication_error(
@@ -68,7 +68,7 @@ async def test_full_flow_with_authentication_error(
     assert result.get("step_id") == SOURCE_USER
     assert "flow_id" in result
 
-    mock_pvoutput_config_flow.status.side_effect = PVOutputAuthenticationError
+    mock_pvoutput_config_flow.system.side_effect = PVOutputAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
@@ -83,9 +83,9 @@ async def test_full_flow_with_authentication_error(
     assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 1
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
 
-    mock_pvoutput_config_flow.status.side_effect = None
+    mock_pvoutput_config_flow.system.side_effect = None
     result3 = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
         user_input={
@@ -102,14 +102,14 @@ async def test_full_flow_with_authentication_error(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 2
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 2
 
 
 async def test_connection_error(
     hass: HomeAssistant, mock_pvoutput_config_flow: MagicMock
 ) -> None:
     """Test API connection error."""
-    mock_pvoutput_config_flow.status.side_effect = PVOutputConnectionError
+    mock_pvoutput_config_flow.system.side_effect = PVOutputConnectionError
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -123,7 +123,7 @@ async def test_connection_error(
     assert result.get("type") == RESULT_TYPE_FORM
     assert result.get("errors") == {"base": "cannot_connect"}
 
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 1
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
 
 
 async def test_already_configured(
@@ -175,7 +175,7 @@ async def test_import_flow(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 1
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
 
 
 async def test_reauth_flow(
@@ -214,7 +214,7 @@ async def test_reauth_flow(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 1
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
 
 
 async def test_reauth_with_authentication_error(
@@ -243,7 +243,7 @@ async def test_reauth_with_authentication_error(
     assert result.get("step_id") == "reauth_confirm"
     assert "flow_id" in result
 
-    mock_pvoutput_config_flow.status.side_effect = PVOutputAuthenticationError
+    mock_pvoutput_config_flow.system.side_effect = PVOutputAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_API_KEY: "invalid_key"},
@@ -256,9 +256,9 @@ async def test_reauth_with_authentication_error(
     assert "flow_id" in result2
 
     assert len(mock_setup_entry.mock_calls) == 0
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 1
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 1
 
-    mock_pvoutput_config_flow.status.side_effect = None
+    mock_pvoutput_config_flow.system.side_effect = None
     result3 = await hass.config_entries.flow.async_configure(
         result2["flow_id"],
         user_input={CONF_API_KEY: "valid_key"},
@@ -273,7 +273,7 @@ async def test_reauth_with_authentication_error(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_pvoutput_config_flow.status.mock_calls) == 2
+    assert len(mock_pvoutput_config_flow.system.mock_calls) == 2
 
 
 async def test_reauth_api_error(
@@ -297,7 +297,7 @@ async def test_reauth_api_error(
     assert result.get("step_id") == "reauth_confirm"
     assert "flow_id" in result
 
-    mock_pvoutput_config_flow.status.side_effect = PVOutputConnectionError
+    mock_pvoutput_config_flow.system.side_effect = PVOutputConnectionError
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_API_KEY: "some_new_key"},

--- a/tests/components/pvoutput/test_init.py
+++ b/tests/components/pvoutput/test_init.py
@@ -1,7 +1,11 @@
 """Tests for the PVOutput integration."""
 from unittest.mock import MagicMock
 
-from pvo import PVOutputAuthenticationError, PVOutputConnectionError
+from pvo import (
+    PVOutputAuthenticationError,
+    PVOutputConnectionError,
+    PVOutputNoDataError,
+)
 import pytest
 
 from homeassistant.components.pvoutput.const import CONF_SYSTEM_ID, DOMAIN
@@ -35,13 +39,15 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
+@pytest.mark.parametrize("side_effect", [PVOutputConnectionError, PVOutputNoDataError])
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_pvoutput: MagicMock,
+    side_effect: Exception,
 ) -> None:
     """Test the PVOutput configuration entry not ready."""
-    mock_pvoutput.status.side_effect = PVOutputConnectionError
+    mock_pvoutput.status.side_effect = side_effect
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


PVOutput's API just throws up an HTTP 400, when there is no data available 😭 

This PR bumps the library to handle that case.

`pvo` version v0.2.2
Release notes: <https://github.com/frenck/python-pvoutput/releases/tag/v0.2.2>

To not make the config flow more complicated, it now uses a different call to test if authentication is successful. The `DataUpdateCoordinator` has been adjusted to handle the new error that can be raised by the library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65046
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
