### PR TITLE
Prepare for new aiohomekit lifecycle API

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -94,6 +94,7 @@ homeassistant.components.homekit_controller.const
 homeassistant.components.homekit_controller.lock
 homeassistant.components.homekit_controller.select
 homeassistant.components.homekit_controller.storage
+homeassistant.components.homekit_controller.utils
 homeassistant.components.homewizard.*
 homeassistant.components.http.*
 homeassistant.components.huawei_lte.*

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -14,7 +14,6 @@ from aiohomekit.model.characteristics import (
 )
 from aiohomekit.model.services import Service, ServicesTypes
 
-from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
@@ -24,8 +23,9 @@ from homeassistant.helpers.typing import ConfigType
 
 from .config_flow import normalize_hkid
 from .connection import HKDevice, valid_serial_number
-from .const import CONTROLLER, ENTITY_MAP, KNOWN_DEVICES, TRIGGERS
+from .const import ENTITY_MAP, KNOWN_DEVICES, TRIGGERS
 from .storage import EntityMapStorage
+from .utils import async_get_controller
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -208,10 +208,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     map_storage = hass.data[ENTITY_MAP] = EntityMapStorage(hass)
     await map_storage.async_initialize()
 
-    async_zeroconf_instance = await zeroconf.async_get_async_instance(hass)
-    hass.data[CONTROLLER] = aiohomekit.Controller(
-        async_zeroconf_instance=async_zeroconf_instance
-    )
+    await async_get_controller(hass)
+
     hass.data[KNOWN_DEVICES] = {}
     hass.data[TRIGGERS] = {}
 
@@ -246,10 +244,10 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     # Remove cached type data from .storage/homekit_controller-entity-map
     hass.data[ENTITY_MAP].async_delete_map(hkid)
 
+    controller = await async_get_controller(hass)
+
     # Remove the pairing on the device, making the device discoverable again.
     # Don't reuse any objects in hass.data as they are already unloaded
-    async_zeroconf_instance = await zeroconf.async_get_async_instance(hass)
-    controller = aiohomekit.Controller(async_zeroconf_instance=async_zeroconf_instance)
     controller.load_pairing(hkid, dict(entry.data))
     try:
         await controller.remove_pairing(hkid)

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.device_registry import (
 )
 
 from .const import DOMAIN, KNOWN_DEVICES
+from .utils import async_get_controller
 
 HOMEKIT_DIR = ".homekit"
 HOMEKIT_BRIDGE_DOMAIN = "homekit"
@@ -104,10 +105,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_setup_controller(self):
         """Create the controller."""
-        async_zeroconf_instance = await zeroconf.async_get_async_instance(self.hass)
-        self.controller = aiohomekit.Controller(
-            async_zeroconf_instance=async_zeroconf_instance
-        )
+        self.controller = await async_get_controller(self.hass)
 
     async def async_step_user(self, user_input=None):
         """Handle a flow start."""

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==0.7.5"],
+  "requirements": ["aiohomekit==0.7.7"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],

--- a/homeassistant/components/homekit_controller/utils.py
+++ b/homeassistant/components/homekit_controller/utils.py
@@ -1,0 +1,40 @@
+"""Helper functions for the homekit_controller component."""
+from typing import cast
+
+from aiohomekit import Controller
+
+from homeassistant.components import zeroconf
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant
+
+from .const import CONTROLLER
+
+
+async def async_get_controller(hass: HomeAssistant) -> Controller:
+    """Get or create an aiohomekit Controller instance."""
+    if existing := hass.data.get(CONTROLLER):
+        return cast(Controller, existing)
+
+    async_zeroconf_instance = await zeroconf.async_get_async_instance(hass)
+
+    # In theory another call to async_get_controller could have run while we were
+    # trying to get the zeroconf instance. So we check again to make sure we
+    # don't leak a Controller instance here.
+    if existing := hass.data.get(CONTROLLER):
+        return cast(Controller, existing)
+
+    controller = Controller(async_zeroconf_instance=async_zeroconf_instance)
+
+    hass.data[CONTROLLER] = controller
+
+    async def _async_stop_homekit_controller(event: Event) -> None:
+        # Pop first so that in theory another controller /could/ start
+        # While this one was shutting down
+        hass.data.pop(CONTROLLER, None)
+        await controller.async_stop()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_homekit_controller)
+
+    await controller.async_start()
+
+    return controller

--- a/homeassistant/components/homekit_controller/utils.py
+++ b/homeassistant/components/homekit_controller/utils.py
@@ -33,6 +33,8 @@ async def async_get_controller(hass: HomeAssistant) -> Controller:
         hass.data.pop(CONTROLLER, None)
         await controller.async_stop()
 
+    # Right now _async_stop_homekit_controller is only called on HA exiting
+    # So we don't have to worry about leaking a callback here.
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_homekit_controller)
 
     await controller.async_start()

--- a/mypy.ini
+++ b/mypy.ini
@@ -851,6 +851,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.homekit_controller.utils]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.homewizard.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -184,7 +184,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.7.5
+aiohomekit==0.7.7
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.7.5
+aiohomekit==0.7.7
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -174,7 +174,9 @@ async def setup_platform(hass):
     """Load the platform but with a fake Controller API."""
     config = {"discovery": {}}
 
-    with mock.patch("aiohomekit.Controller") as controller:
+    with mock.patch(
+        "homeassistant.components.homekit_controller.utils.Controller"
+    ) as controller:
         fake_controller = controller.return_value = FakeController()
         await async_setup_component(hass, DOMAIN, config)
 

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -27,7 +27,10 @@ def utcnow(request):
 def controller(hass):
     """Replace aiohomekit.Controller with an instance of aiohomekit.testing.FakeController."""
     instance = FakeController()
-    with unittest.mock.patch("aiohomekit.Controller", return_value=instance):
+    with unittest.mock.patch(
+        "homeassistant.components.homekit_controller.utils.Controller",
+        return_value=instance,
+    ):
         yield instance
 
 

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
-from aiohomekit.testing import FakeController
 
 from homeassistant.components.homekit_controller.const import ENTITY_MAP
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -35,19 +34,16 @@ async def test_unload_on_stop(hass, utcnow):
 async def test_async_remove_entry(hass: HomeAssistant):
     """Test unpairing a component."""
     helper = await setup_test_component(hass, create_motion_sensor_service)
+    controller = helper.pairing.controller
 
     hkid = "00:00:00:00:00:00"
 
-    with patch("aiohomekit.Controller") as controller_cls:
-        # Setup a fake controller with 1 pairing
-        controller = controller_cls.return_value = FakeController()
-        await controller.add_paired_device([helper.accessory], hkid)
-        assert len(controller.pairings) == 1
+    assert len(controller.pairings) == 1
 
-        assert hkid in hass.data[ENTITY_MAP].storage_data
+    assert hkid in hass.data[ENTITY_MAP].storage_data
 
-        # Remove it via config entry and number of pairings should go down
-        await helper.config_entry.async_remove(hass)
-        assert len(controller.pairings) == 0
+    # Remove it via config entry and number of pairings should go down
+    await helper.config_entry.async_remove(hass)
+    assert len(controller.pairings) == 0
 
-        assert hkid not in hass.data[ENTITY_MAP].storage_data
+    assert hkid not in hass.data[ENTITY_MAP].storage_data


### PR DESCRIPTION
## Proposed change

In aiohomekit 1.0.0 we are refactoring and hiding some implementation details that are specific to `_hap._tcp.local` devices. In the new API the controller needs to be started and stopped.

To keep the "1.0.0" API switch PR small I have backported the API into the current stable release so that we can prepare homekit_controller for this change. Note that in 0.7.7 the API is there but is a no-op, so this doesn't enable any new functionality.

I will be doing a few more of these to keep the final PR as small as possible.

https://github.com/Jc2k/aiohomekit/releases/tag/0.7.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
