### PR TITLE
Add button to wake august locks from deep sleep

### DIFF
--- a/homeassistant/components/august/button.py
+++ b/homeassistant/components/august/button.py
@@ -1,0 +1,39 @@
+"""Support for August buttons."""
+from yalexs.lock import Lock
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import AugustData
+from .const import DATA_AUGUST, DOMAIN
+from .entity import AugustEntityMixin
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up August lock wake buttons."""
+    data: AugustData = hass.data[DOMAIN][config_entry.entry_id][DATA_AUGUST]
+    async_add_entities([AugustWakeLockButton(data, lock) for lock in data.locks])
+
+
+class AugustWakeLockButton(AugustEntityMixin, ButtonEntity):
+    """Representation of an August lock wake button."""
+
+    def __init__(self, data: AugustData, device: Lock) -> None:
+        """Initialize the lock wake button."""
+        super().__init__(data, device)
+        self._attr_name = f"{device.device_name} Wake"
+        self._attr_unique_id = f"{self._device_id:s}_wake"
+
+    async def async_press(self, **kwargs):
+        """Wake the device."""
+        await self._data.async_status_async(self._device_id, self._hyper_bridge)
+
+    @callback
+    def _update_from_data(self):
+        """Nothing to update as buttons are stateless."""

--- a/homeassistant/components/august/button.py
+++ b/homeassistant/components/august/button.py
@@ -28,7 +28,7 @@ class AugustWakeLockButton(AugustEntityMixin, ButtonEntity):
         """Initialize the lock wake button."""
         super().__init__(data, device)
         self._attr_name = f"{device.device_name} Wake"
-        self._attr_unique_id = f"{self._device_id:s}_wake"
+        self._attr_unique_id = f"{self._device_id}_wake"
 
     async def async_press(self, **kwargs):
         """Wake the device."""

--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -37,8 +37,6 @@ class AugustCamera(AugustEntityMixin, Camera):
     def __init__(self, data, device, session, timeout):
         """Initialize a August security camera."""
         super().__init__(data, device)
-        self._data = data
-        self._device = device
         self._timeout = timeout
         self._session = session
         self._image_url = None

--- a/homeassistant/components/august/const.py
+++ b/homeassistant/components/august/const.py
@@ -46,6 +46,7 @@ ACTIVITY_UPDATE_INTERVAL = timedelta(seconds=10)
 LOGIN_METHODS = ["phone", "email"]
 
 PLATFORMS = [
+    Platform.BUTTON,
     Platform.CAMERA,
     Platform.BINARY_SENSOR,
     Platform.LOCK,

--- a/homeassistant/components/august/entity.py
+++ b/homeassistant/components/august/entity.py
@@ -36,6 +36,11 @@ class AugustEntityMixin(Entity):
     def _detail(self):
         return self._data.get_device_detail(self._device.device_id)
 
+    @property
+    def _hyper_bridge(self):
+        """Check if the lock has a paired hyper bridge."""
+        return bool(self._detail.bridge and self._detail.bridge.hyper_bridge)
+
     @callback
     def _update_from_data_and_write_state(self):
         self._update_from_data()

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -39,17 +39,10 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
     def __init__(self, data, device):
         """Initialize the lock."""
         super().__init__(data, device)
-        self._data = data
-        self._device = device
         self._lock_status = None
         self._attr_name = device.device_name
         self._attr_unique_id = f"{self._device_id:s}_lock"
         self._update_from_data()
-
-    @property
-    def _hyper_bridge(self):
-        """Check if the lock has a paired hyper bridge."""
-        return bool(self._detail.bridge and self._detail.bridge.hyper_bridge)
 
     async def async_lock(self, **kwargs):
         """Lock the device."""

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -75,7 +75,16 @@ async def _mock_setup_august(
     return entry
 
 
-async def _create_august_with_devices(  # noqa: C901
+async def _create_august_with_devices(
+    hass, devices, api_call_side_effects=None, activities=None, pubnub=None
+):
+    entry, api_instance = await _create_august_api_with_devices(
+        hass, devices, api_call_side_effects, activities, pubnub
+    )
+    return entry
+
+
+async def _create_august_api_with_devices(  # noqa: C901
     hass, devices, api_call_side_effects=None, activities=None, pubnub=None
 ):
     if api_call_side_effects is None:
@@ -171,7 +180,7 @@ async def _create_august_with_devices(  # noqa: C901
         # are any locks
         assert api_instance.async_status_async.mock_calls
 
-    return entry
+    return entry, api_instance
 
 
 async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, pubnub):

--- a/tests/components/august/test_button.py
+++ b/tests/components/august/test_button.py
@@ -1,0 +1,27 @@
+"""The button tests for the august platform."""
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
+
+from tests.components.august.mocks import (
+    _create_august_api_with_devices,
+    _mock_lock_from_fixture,
+)
+
+
+async def test_wake_lock(hass):
+    """Test creation of a lock and wake it."""
+    lock_one = await _mock_lock_from_fixture(
+        hass, "get_lock.online_with_doorsense.json"
+    )
+    _, api_instance = await _create_august_api_with_devices(hass, [lock_one])
+    entity_id = "button.online_with_doorsense_name_wake"
+    binary_sensor_online_with_doorsense_name = hass.states.get(entity_id)
+    assert binary_sensor_online_with_doorsense_name is not None
+    api_instance.async_status_async.reset_mock()
+    assert await hass.services.async_call(
+        BUTTON_DOMAIN, SERVICE_PRESS, {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    await hass.async_block_till_done()
+    api_instance.async_status_async.assert_called_once()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add button to wake august locks from deep sleep

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #66306
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
