### PR TITLE
Fix uncaught exception during WiZ discovery during firmware update

### DIFF
--- a/homeassistant/components/wiz/__init__.py
+++ b/homeassistant/components/wiz/__init__.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 from pywizlight import wizlight
-from pywizlight.exceptions import WizLightNotKnownBulb
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
@@ -16,7 +15,13 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DISCOVER_SCAN_TIMEOUT, DISCOVERY_INTERVAL, DOMAIN, WIZ_EXCEPTIONS
+from .const import (
+    DISCOVER_SCAN_TIMEOUT,
+    DISCOVERY_INTERVAL,
+    DOMAIN,
+    WIZ_CONNECT_EXCEPTIONS,
+    WIZ_EXCEPTIONS,
+)
 from .discovery import async_discover_devices, async_trigger_discovery
 from .models import WizData
 
@@ -48,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         scenes = await bulb.getSupportedScenes()
         await bulb.getMac()
-    except (WizLightNotKnownBulb, *WIZ_EXCEPTIONS) as err:
+    except WIZ_CONNECT_EXCEPTIONS as err:
         raise ConfigEntryNotReady(f"{ip_address}: {err}") from err
 
     async def _async_update() -> None:

--- a/homeassistant/components/wiz/config_flow.py
+++ b/homeassistant/components/wiz/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.util.network import is_ip_address
 
-from .const import DEFAULT_NAME, DISCOVER_SCAN_TIMEOUT, DOMAIN, WIZ_EXCEPTIONS
+from .const import DEFAULT_NAME, DISCOVER_SCAN_TIMEOUT, DOMAIN, WIZ_CONNECT_EXCEPTIONS
 from .discovery import async_discover_devices
 from .utils import _short_mac, name_from_bulb_type_and_mac
 
@@ -70,7 +70,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         bulb = wizlight(device.ip_address)
         try:
             bulbtype = await bulb.get_bulbtype()
-        except WIZ_EXCEPTIONS as ex:
+        except WIZ_CONNECT_EXCEPTIONS as ex:
             raise AbortFlow("cannot_connect") from ex
         self._name = name_from_bulb_type_and_mac(bulbtype, device.mac_address)
 
@@ -110,7 +110,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             bulb = wizlight(device.ip_address)
             try:
                 bulbtype = await bulb.get_bulbtype()
-            except WIZ_EXCEPTIONS:
+            except WIZ_CONNECT_EXCEPTIONS:
                 return self.async_abort(reason="cannot_connect")
             else:
                 return self.async_create_entry(

--- a/homeassistant/components/wiz/const.py
+++ b/homeassistant/components/wiz/const.py
@@ -1,7 +1,11 @@
 """Constants for the WiZ Platform integration."""
 from datetime import timedelta
 
-from pywizlight.exceptions import WizLightConnectionError, WizLightTimeOutError
+from pywizlight.exceptions import (
+    WizLightConnectionError,
+    WizLightNotKnownBulb,
+    WizLightTimeOutError,
+)
 
 DOMAIN = "wiz"
 DEFAULT_NAME = "WiZ"
@@ -16,3 +20,4 @@ WIZ_EXCEPTIONS = (
     WizLightConnectionError,
     ConnectionRefusedError,
 )
+WIZ_CONNECT_EXCEPTIONS = (WizLightNotKnownBulb, *WIZ_EXCEPTIONS)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- When the devices are first connected they update their firmware
  to the latest version. In this case the device is unavailable
  to respond during the update which results in an exception
  during discovery.  Once the firmware update is completed, the
  device will broadcast and be discovered again if push updates
  are working

Fixes
```
2022-02-12 00:45:06 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 203, in async_init
    flow, result = await task
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 230, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data, init_done)
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 325, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/usr/src/homeassistant/homeassistant/components/wiz/config_flow.py", line 52, in async_step_integration_discovery
    return await self._async_handle_discovery()
  File "/usr/src/homeassistant/homeassistant/components/wiz/config_flow.py", line 63, in _async_handle_discovery
    await self._async_connect_discovered_or_abort()
  File "/usr/src/homeassistant/homeassistant/components/wiz/config_flow.py", line 72, in _async_connect_discovered_or_abort
    bulbtype = await bulb.get_bulbtype()
  File "/usr/local/lib/python3.9/site-packages/pywizlight/bulb.py", line 472, in get_bulbtype
    self.bulbtype = BulbType.from_data(
  File "/usr/local/lib/python3.9/site-packages/pywizlight/bulblibrary.py", line 108, in from_data
    raise WizLightNotKnownBulb(
pywizlight.exceptions.WizLightNotKnownBulb: Unable to determine required kelvin range for a RGB Tunable device
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
