### PR TITLE
Add additional sensors for dmaker.airfresh.a1/t2017 to xiaomi_miio

### DIFF
--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     POWER_WATT,
     PRESSURE_HPA,
     TEMP_CELSIUS,
+    TIME_DAYS,
     TIME_HOURS,
     TIME_SECONDS,
     VOLUME_CUBIC_METERS,
@@ -93,9 +94,15 @@ ATTR_AQI = "aqi"
 ATTR_BATTERY = "battery"
 ATTR_CARBON_DIOXIDE = "co2"
 ATTR_CHARGING = "charging"
+ATTR_CONTROL_SPEED = "control_speed"
 ATTR_DISPLAY_CLOCK = "display_clock"
+ATTR_FAVORITE_SPEED = "favorite_speed"
 ATTR_FILTER_LIFE_REMAINING = "filter_life_remaining"
 ATTR_FILTER_HOURS_USED = "filter_hours_used"
+ATTR_DUST_FILTER_LIFE_REMAINING = "dust_filter_life_remaining"
+ATTR_DUST_FILTER_LIFE_REMAINING_DAYS = "dust_filter_life_remaining_days"
+ATTR_UPPER_FILTER_LIFE_REMAINING = "upper_filter_life_remaining"
+ATTR_UPPER_FILTER_LIFE_REMAINING_DAYS = "upper_filter_life_remaining_days"
 ATTR_FILTER_USE = "filter_use"
 ATTR_HUMIDITY = "humidity"
 ATTR_ILLUMINANCE = "illuminance"
@@ -107,6 +114,7 @@ ATTR_NIGHT_MODE = "night_mode"
 ATTR_NIGHT_TIME_BEGIN = "night_time_begin"
 ATTR_NIGHT_TIME_END = "night_time_end"
 ATTR_PM25 = "pm25"
+ATTR_PM25_2 = "pm25_2"
 ATTR_POWER = "power"
 ATTR_PRESSURE = "pressure"
 ATTR_PURIFY_VOLUME = "purify_volume"
@@ -183,6 +191,22 @@ SENSOR_TYPES = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    ATTR_CONTROL_SPEED: XiaomiMiioSensorDescription(
+        key=ATTR_CONTROL_SPEED,
+        name="Control Speed",
+        native_unit_of_measurement="rpm",
+        icon="mdi:fast-forward",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ATTR_FAVORITE_SPEED: XiaomiMiioSensorDescription(
+        key=ATTR_FAVORITE_SPEED,
+        name="Favorite Speed",
+        native_unit_of_measurement="rpm",
+        icon="mdi:fast-forward",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     ATTR_MOTOR_SPEED: XiaomiMiioSensorDescription(
         key=ATTR_MOTOR_SPEED,
         name="Motor Speed",
@@ -235,6 +259,13 @@ SENSOR_TYPES = {
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    ATTR_PM25_2: XiaomiMiioSensorDescription(
+        key=ATTR_PM25,
+        name="PM2.5",
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        device_class=SensorDeviceClass.PM25,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
     ATTR_FILTER_LIFE_REMAINING: XiaomiMiioSensorDescription(
         key=ATTR_FILTER_LIFE_REMAINING,
         name="Filter Life Remaining",
@@ -248,6 +279,40 @@ SENSOR_TYPES = {
         key=ATTR_FILTER_HOURS_USED,
         name="Filter Use",
         native_unit_of_measurement=TIME_HOURS,
+        icon="mdi:clock-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ATTR_DUST_FILTER_LIFE_REMAINING: XiaomiMiioSensorDescription(
+        key=ATTR_DUST_FILTER_LIFE_REMAINING,
+        name="Dust filter life remaining",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:air-filter",
+        state_class=SensorStateClass.MEASUREMENT,
+        attributes=("filter_type",),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ATTR_DUST_FILTER_LIFE_REMAINING_DAYS: XiaomiMiioSensorDescription(
+        key=ATTR_DUST_FILTER_LIFE_REMAINING_DAYS,
+        name="Dust filter life remaining days",
+        native_unit_of_measurement=TIME_DAYS,
+        icon="mdi:clock-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ATTR_UPPER_FILTER_LIFE_REMAINING: XiaomiMiioSensorDescription(
+        key=ATTR_UPPER_FILTER_LIFE_REMAINING,
+        name="Upper filter life remaining",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:air-filter",
+        state_class=SensorStateClass.MEASUREMENT,
+        attributes=("filter_type",),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ATTR_UPPER_FILTER_LIFE_REMAINING_DAYS: XiaomiMiioSensorDescription(
+        key=ATTR_UPPER_FILTER_LIFE_REMAINING_DAYS,
+        name="Upper filter life remaining days",
+        native_unit_of_measurement=TIME_DAYS,
         icon="mdi:clock-outline",
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -379,11 +444,23 @@ AIRFRESH_SENSORS = (
 )
 AIRFRESH_SENSORS_A1 = (
     ATTR_CARBON_DIOXIDE,
+    ATTR_DUST_FILTER_LIFE_REMAINING,
+    ATTR_DUST_FILTER_LIFE_REMAINING_DAYS,
+    ATTR_PM25_2,
     ATTR_TEMPERATURE,
+    ATTR_CONTROL_SPEED,
+    ATTR_FAVORITE_SPEED,
 )
 AIRFRESH_SENSORS_T2017 = (
     ATTR_CARBON_DIOXIDE,
+    ATTR_DUST_FILTER_LIFE_REMAINING,
+    ATTR_DUST_FILTER_LIFE_REMAINING_DAYS,
+    ATTR_UPPER_FILTER_LIFE_REMAINING,
+    ATTR_UPPER_FILTER_LIFE_REMAINING_DAYS,
+    ATTR_PM25_2,
     ATTR_TEMPERATURE,
+    ATTR_CONTROL_SPEED,
+    ATTR_FAVORITE_SPEED,
 )
 FAN_V2_V3_SENSORS = (
     ATTR_BATTERY,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Next step after https://github.com/home-assistant/core/pull/66331 I have added sensors like:
| Name                                         | Units | Comment                                                                                                                           | 
| ---------------------------------- | ------ | ---------------------------------------------------------------------------------------------- | 
| Dust filter life remaining           | %        | Maybe it must be `Filter life remaining` in the future, I use name from the library |
| Dust filter life remaining days   | d       | Maybe it must be `Filter life remaining days` in the future, I use name from the library |
| Upper filter life remaining         | %        | Exist only in the dmaker.airfresh.t2017 |
| Upper filter life remaining days | d         | Exist only in the dmaker.airfresh.t2017 |
| PM2.5                                       | µg/m³ | Other devices use `aqi` for this attribute but dmaker.airfresh. use `pm25` not sure why |
| Control Speed                           | rpm | Maybe it must be `Actual Speed` in the future, I use name from the library |
| Favorite Speed                          | rpm | Speed that will be setup in the `Favorite` mode |

Perhaps some of these properties should be renamed inside the library, but this requires a lot of refactoring. And I prefer to look at it somewhere in the future. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21538

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
