### PR TITLE
Remove entities when config entry is removed from device

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -463,8 +463,9 @@ class EntityRegistry:
             self, event.data["device_id"], include_disabled_entities=True
         )
         for entity in entities:
-            if entity.config_entry_id not in device.config_entries:
-                self.async_remove(entity.entity_id)
+            if entity.config_entry_id is not None:
+                if entity.config_entry_id not in device.config_entries:
+                    self.async_remove(entity.entity_id)
 
         # Re-enable disabled entities if the device is no longer disabled
         if not device.disabled:

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -446,13 +446,28 @@ class EntityRegistry:
             return
 
         if event.data["action"] != "update":
+            # Ignore "create" action
             return
 
         device_registry = dr.async_get(self.hass)
         device = device_registry.async_get(event.data["device_id"])
 
-        # The device may be deleted already if the event handling is late
-        if not device or not device.disabled:
+        # The device may be deleted already if the event handling is late, do nothing
+        # in that case. Entities will be removed when we get the "remove" event.
+        if not device:
+            return
+
+        # Remove entities which belong to config entries no longer associated with the
+        # device
+        entities = async_entries_for_device(
+            self, event.data["device_id"], include_disabled_entities=True
+        )
+        for entity in entities:
+            if entity.config_entry_id not in device.config_entries:
+                self.async_remove(entity.entity_id)
+
+        # Re-enable disabled entities if the device is no longer disabled
+        if not device.disabled:
             entities = async_entries_for_device(
                 self, event.data["device_id"], include_disabled_entities=True
             )
@@ -462,11 +477,12 @@ class EntityRegistry:
                 self.async_update_entity(entity.entity_id, disabled_by=None)
             return
 
+        # Ignore device disabled by config entry, this is handled by
+        # async_config_entry_disabled
         if device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY:
-            # Handled by async_config_entry_disabled
             return
 
-        # Fetch entities which are not already disabled
+        # Fetch entities which are not already disabled and disable them
         entities = async_entries_for_device(self, event.data["device_id"])
         for entity in entities:
             self.async_update_entity(

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -463,9 +463,11 @@ class EntityRegistry:
             self, event.data["device_id"], include_disabled_entities=True
         )
         for entity in entities:
-            if entity.config_entry_id is not None:
-                if entity.config_entry_id not in device.config_entries:
-                    self.async_remove(entity.entity_id)
+            if (
+                entity.config_entry_id is not None
+                and entity.config_entry_id not in device.config_entries
+            ):
+                self.async_remove(entity.entity_id)
 
         # Re-enable disabled entities if the device is no longer disabled
         if not device.disabled:

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -873,6 +873,46 @@ async def test_remove_config_entry_from_device_removes_entities(hass, registry):
     assert not registry.async_is_registered(entry_2.entity_id)
 
 
+async def test_remove_config_entry_from_device_removes_entities_2(hass, registry):
+    """Test that we don't remove entities with no config entry when device is modified."""
+    device_registry = mock_device_registry(hass)
+    config_entry_1 = MockConfigEntry(domain="hue")
+    config_entry_2 = MockConfigEntry(domain="device_tracker")
+
+    # Create device with two config entries
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry_1.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry_2.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    assert device_entry.config_entries == {
+        config_entry_1.entry_id,
+        config_entry_2.entry_id,
+    }
+
+    # Create one entity for each config entry
+    entry_1 = registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        device_id=device_entry.id,
+    )
+
+    assert registry.async_is_registered(entry_1.entity_id)
+
+    # Remove the first config entry from the device
+    device_registry.async_update_device(
+        device_entry.id, remove_config_entry_id=config_entry_1.entry_id
+    )
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(device_entry.id)
+    assert registry.async_is_registered(entry_1.entity_id)
+
+
 async def test_update_device_race(hass, registry):
     """Test race when a device is created, updated and removed."""
     device_registry = mock_device_registry(hass)

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -862,7 +862,7 @@ async def test_remove_config_entry_from_device_removes_entities(hass, registry):
     assert registry.async_is_registered(entry_2.entity_id)
 
     # Remove the second config entry from the device, the entity associated with it
-    # (and the device itself)should be removed
+    # (and the device itself) should be removed
     device_registry.async_update_device(
         device_entry.id, remove_config_entry_id=config_entry_2.entry_id
     )

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -810,6 +810,69 @@ async def test_remove_device_removes_entities(hass, registry):
     assert not registry.async_is_registered(entry.entity_id)
 
 
+async def test_remove_config_entry_from_device_removes_entities(hass, registry):
+    """Test that we remove entities tied to a device when config entry is removed."""
+    device_registry = mock_device_registry(hass)
+    config_entry_1 = MockConfigEntry(domain="hue")
+    config_entry_2 = MockConfigEntry(domain="device_tracker")
+
+    # Create device with two config entries
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry_1.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry_2.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    assert device_entry.config_entries == {
+        config_entry_1.entry_id,
+        config_entry_2.entry_id,
+    }
+
+    # Create one entity for each config entry
+    entry_1 = registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=config_entry_1,
+        device_id=device_entry.id,
+    )
+
+    entry_2 = registry.async_get_or_create(
+        "sensor",
+        "device_tracker",
+        "6789",
+        config_entry=config_entry_2,
+        device_id=device_entry.id,
+    )
+
+    assert registry.async_is_registered(entry_1.entity_id)
+    assert registry.async_is_registered(entry_2.entity_id)
+
+    # Remove the first config entry from the device, the entity associated with it
+    # should be removed
+    device_registry.async_update_device(
+        device_entry.id, remove_config_entry_id=config_entry_1.entry_id
+    )
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(device_entry.id)
+    assert not registry.async_is_registered(entry_1.entity_id)
+    assert registry.async_is_registered(entry_2.entity_id)
+
+    # Remove the second config entry from the device, the entity associated with it
+    # (and the device itself)should be removed
+    device_registry.async_update_device(
+        device_entry.id, remove_config_entry_id=config_entry_2.entry_id
+    )
+    await hass.async_block_till_done()
+
+    assert not device_registry.async_get(device_entry.id)
+    assert not registry.async_is_registered(entry_1.entity_id)
+    assert not registry.async_is_registered(entry_2.entity_id)
+
+
 async def test_update_device_race(hass, registry):
     """Test race when a device is created, updated and removed."""
     device_registry = mock_device_registry(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove entities from entity registry when a config entry is removed from a device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
