### PR TITLE
Fix Spotify session token refresh

### DIFF
--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -107,6 +107,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady
 
     async def _update_devices() -> list[dict[str, Any]]:
+        if not session.valid_token:
+            await session.async_ensure_token_valid()
+            await hass.async_add_executor_job(
+                spotify.set_auth, session.token["access_token"]
+            )
+
         try:
             devices: dict[str, Any] | None = await hass.async_add_executor_job(
                 spotify.devices

--- a/homeassistant/components/spotify/browse_media.py
+++ b/homeassistant/components/spotify/browse_media.py
@@ -172,7 +172,11 @@ async def async_browse_media_internal(
             partial(library_payload, can_play_artist=can_play_artist)
         )
 
-    await session.async_ensure_token_valid()
+    if not session.valid_token:
+        await session.async_ensure_token_valid()
+        await hass.async_add_executor_job(
+            spotify.set_auth, session.token["access_token"]
+        )
 
     # Strip prefix
     if media_content_type:

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 
 import requests
-from spotipy import Spotify, SpotifyException
+from spotipy import SpotifyException
 from yarl import URL
 
 from homeassistant.components.media_player import BrowseMedia, MediaPlayerEntity
@@ -367,7 +367,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
             run_coroutine_threadsafe(
                 self.data.session.async_ensure_token_valid(), self.hass.loop
             ).result()
-            self.data.client = Spotify(auth=self.data.session.token["access_token"])
+            self.data.client.set_auth(auth=self.data.session.token["access_token"])
 
         current = self.data.client.current_playback()
         self._currently_playing = current or {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Regression was introduced in #66315 and #66314.

The Spotify token isn't refreshed for the `DataUpdateCoordinator` for devices, causing issues after an hour (when the tokens expire, as reported in #66373).

Unfortunately, the Spotify integration creates new clients, which was needed back then. Meanwhile, the Spotipy library added support for replacing the token in an existing client 🎉 

This PR makes use of that, to prevent different clients being spawned and used. 

Additionally, while reviewing the places that do a token refresh, I noticed how growing media does refresh the token but does not put it into use. If the browse media would have triggered a token refresh, Spotify would have been non-functional for an hour 😓 

This PR fixes all these cases.

The Spotify token is valid for an hour, I've tested this PR for 2,5 hours and monitored for token changes to ensure it now works as expected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66373
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
