### PR TITLE
Replace use of deprecated APIs in aiohomekit

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==0.7.11"],
+  "requirements": ["aiohomekit==0.7.13"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -184,7 +184,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.7.11
+aiohomekit==0.7.13
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.7.11
+aiohomekit==0.7.13
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -86,13 +86,11 @@ def _setup_flow_handler(hass, pairing=None):
 
     discovery = mock.Mock()
     discovery.device_id = "00:00:00:00:00:00"
-    discovery.start_pairing = unittest.mock.AsyncMock(return_value=finish_pairing)
+    discovery.async_start_pairing = unittest.mock.AsyncMock(return_value=finish_pairing)
 
     flow.controller = mock.Mock()
     flow.controller.pairings = {}
-    flow.controller.find_ip_by_device_id = unittest.mock.AsyncMock(
-        return_value=discovery
-    )
+    flow.controller.async_find = unittest.mock.AsyncMock(return_value=discovery)
 
     return flow
 
@@ -520,7 +518,7 @@ async def test_pair_abort_errors_on_start(hass, controller, exception, expected)
 
     # User initiates pairing - device refuses to enter pairing mode
     test_exc = exception("error")
-    with patch.object(device, "start_pairing", side_effect=test_exc):
+    with patch.object(device, "async_start_pairing", side_effect=test_exc):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert result["type"] == "abort"
     assert result["reason"] == expected
@@ -542,7 +540,7 @@ async def test_pair_try_later_errors_on_start(hass, controller, exception, expec
 
     # User initiates pairing - device refuses to enter pairing mode but may be successful after entering pairing mode or rebooting
     test_exc = exception("error")
-    with patch.object(device, "start_pairing", side_effect=test_exc):
+    with patch.object(device, "async_start_pairing", side_effect=test_exc):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"])
     assert result2["step_id"] == expected
     assert result2["type"] == "form"
@@ -585,7 +583,7 @@ async def test_pair_form_errors_on_start(hass, controller, exception, expected):
 
     # User initiates pairing - device refuses to enter pairing mode
     test_exc = exception("error")
-    with patch.object(device, "start_pairing", side_effect=test_exc):
+    with patch.object(device, "async_start_pairing", side_effect=test_exc):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={"pairing_code": "111-22-333"}
         )
@@ -634,7 +632,7 @@ async def test_pair_abort_errors_on_finish(hass, controller, exception, expected
     # User initiates pairing - this triggers the device to show a pairing code
     # and then HA to show a pairing form
     finish_pairing = unittest.mock.AsyncMock(side_effect=exception("error"))
-    with patch.object(device, "start_pairing", return_value=finish_pairing):
+    with patch.object(device, "async_start_pairing", return_value=finish_pairing):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == "form"
@@ -674,7 +672,7 @@ async def test_pair_form_errors_on_finish(hass, controller, exception, expected)
     # User initiates pairing - this triggers the device to show a pairing code
     # and then HA to show a pairing form
     finish_pairing = unittest.mock.AsyncMock(side_effect=exception("error"))
-    with patch.object(device, "start_pairing", return_value=finish_pairing):
+    with patch.object(device, "async_start_pairing", return_value=finish_pairing):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] == "form"
@@ -789,7 +787,7 @@ async def test_user_no_unpaired_devices(hass, controller):
     device = setup_mock_accessory(controller)
 
     # Pair the mock device so that it shows as paired in discovery
-    finish_pairing = await device.start_pairing(device.device_id)
+    finish_pairing = await device.async_start_pairing(device.device_id)
     await finish_pairing(device.pairing_code)
 
     # Device discovery is requested


### PR DESCRIPTION
## Proposed change

In aiohomekit 1.0.0 i've renamed a few methods whilst preparing for multiple backends:

* `Controller.find_ip_by_device_id` is a bad name for a method that can handle BLE devices. It is now `Controller.async_find`.
* `Controller.discover_ip` is a bad name for a method that can handle BLE devices as well. So it is now `Controller.async_discover`.
* I renamed a few other methods on the discovery object so they were consistent with HA naming so we now have `IpDiscovery.async_start_pairing` and `IpDiscover.async_identify`.

To keep the PR for aiohomekit 1.0.0 small I have added aliases to the curent stable release. This PR switches HA to those aliases ready for the eventual switch.

Changelog: https://github.com/Jc2k/aiohomekit/compare/0.7.11...0.7.13

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
