### PR TITLE
Add SetSystemDateandTime Button

### DIFF
--- a/homeassistant/components/onvif/button.py
+++ b/homeassistant/components/onvif/button.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/onvif/button.py
+++ b/homeassistant/components/onvif/button.py
@@ -1,9 +1,9 @@
 """ONVIF Buttons."""
-from datetime import datetime
+from datetime import datetime, timezone
+import time
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -46,7 +46,7 @@ class RebootButton(ONVIFBaseEntity, ButtonEntity):
 class SetSystemDateAndTimeButton(ONVIFBaseEntity, ButtonEntity):
     """Defines a ONVIF SetSystemDateAndTime button."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, device: ONVIFDevice) -> None:
         """Initialize the button entity."""
@@ -57,18 +57,18 @@ class SetSystemDateAndTimeButton(ONVIFBaseEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Send out a SetSystemDateAndTime command."""
         device_mgmt = self.device.device.create_devicemgmt_service()
-        now = datetime.now()
+        now_utc = datetime.now(timezone.utc)
         current = await device_mgmt.GetSystemDateAndTime()
 
         dt_param = device_mgmt.create_type("SetSystemDateAndTime")
         dt_param.DateTimeType = "Manual"
-        dt_param.DaylightSavings = current.DaylightSavings
-        dt_param.TimeZone = current.TimeZone
+        dt_param.DaylightSavings = bool(time.localtime().tm_isdst)
+        dt_param.TimeZone = str(now_utc.astimezone().tzinfo)
         dt_param.UTCDateTime = current.UTCDateTime
-        dt_param.UTCDateTime.Date.Year = now.year
-        dt_param.UTCDateTime.Date.Month = now.month
-        dt_param.UTCDateTime.Date.Day = now.day
-        dt_param.UTCDateTime.Time.Hour = now.hour
-        dt_param.UTCDateTime.Time.Minute = now.minute
-        dt_param.UTCDateTime.Time.Second = now.second
+        dt_param.UTCDateTime.Date.Year = now_utc.year
+        dt_param.UTCDateTime.Date.Month = now_utc.month
+        dt_param.UTCDateTime.Date.Day = now_utc.day
+        dt_param.UTCDateTime.Time.Hour = now_utc.hour
+        dt_param.UTCDateTime.Time.Minute = now_utc.minute
+        dt_param.UTCDateTime.Time.Second = now_utc.second
         await device_mgmt.SetSystemDateAndTime(dt_param)

--- a/homeassistant/components/onvif/button.py
+++ b/homeassistant/components/onvif/button.py
@@ -1,7 +1,4 @@
 """ONVIF Buttons."""
-from datetime import datetime, timezone
-import time
-
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -56,19 +53,4 @@ class SetSystemDateAndTimeButton(ONVIFBaseEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Send out a SetSystemDateAndTime command."""
-        device_mgmt = self.device.device.create_devicemgmt_service()
-        now_utc = datetime.now(timezone.utc)
-        current = await device_mgmt.GetSystemDateAndTime()
-
-        dt_param = device_mgmt.create_type("SetSystemDateAndTime")
-        dt_param.DateTimeType = "Manual"
-        dt_param.DaylightSavings = bool(time.localtime().tm_isdst)
-        dt_param.TimeZone = str(now_utc.astimezone().tzinfo)
-        dt_param.UTCDateTime = current.UTCDateTime
-        dt_param.UTCDateTime.Date.Year = now_utc.year
-        dt_param.UTCDateTime.Date.Month = now_utc.month
-        dt_param.UTCDateTime.Date.Day = now_utc.day
-        dt_param.UTCDateTime.Time.Hour = now_utc.hour
-        dt_param.UTCDateTime.Time.Minute = now_utc.minute
-        dt_param.UTCDateTime.Time.Second = now_utc.second
-        await device_mgmt.SetSystemDateAndTime(dt_param)
+        await self.device.async_manually_set_date_and_time()

--- a/tests/components/onvif/test_button.py
+++ b/tests/components/onvif/test_button.py
@@ -38,3 +38,33 @@ async def test_reboot_button_press(hass):
     await hass.async_block_till_done()
 
     devicemgmt.SystemReboot.assert_called_once()
+
+
+async def test_set_dateandtime_button(hass):
+    """Test states of the SetDateAndTime button."""
+    await setup_onvif_integration(hass)
+
+    state = hass.states.get("button.testcamera_set_system_date_and_time")
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    registry = er.async_get(hass)
+    entry = registry.async_get("button.testcamera_set_system_date_and_time")
+    assert entry
+    assert entry.unique_id == f"{MAC}_setsystemdatetime"
+
+
+async def test_set_dateandtime_button_press(hass):
+    """Test SetDateAndTime button press."""
+    _, camera, device = await setup_onvif_integration(hass)
+    device.async_manually_set_date_and_time = AsyncMock(return_value=True)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        "press",
+        {ATTR_ENTITY_ID: "button.testcamera_set_system_date_and_time"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    device.async_manually_set_date_and_time.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a button that synchronises the system date and time of the ONVIFCamera device with the HA system. 
I've a camera for which I can't set an NTP server, so this works to sync the date time of the device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
