### PR TITLE
Update nest camera to pull still images from stream component

### DIFF
--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -209,8 +209,7 @@ class NestCamera(Camera):
             return await stream.async_get_image(width, height)
         if self.frontend_stream_type != STREAM_TYPE_WEB_RTC:
             return None
-        # Nest Web RTC cams only have image previews for events, and not
-        # for "now" by design to save battery, and need a placeholder.
+        # Use a placeholder image for WebRTC cameras with no thumbnail
         if not self._placeholder_image:
             self._placeholder_image = await self.hass.async_add_executor_job(
                 PLACEHOLDER.read_bytes

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -230,6 +230,12 @@ class NestCamera(Camera):
                     PLACEHOLDER.read_bytes
                 )
             return self._placeholder_image
+        # Use the thumbnail in the active rtsp stream if present
+        if self.stream:
+            content = await self.stream.get_image(width, height)
+            if content:
+                return content
+        # Fetch a single frame initiating a new stream session
         return await async_get_image(self.hass, stream_url, output_format=IMAGE_JPEG)
 
     async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -203,13 +203,11 @@ class NestCamera(Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        # Use the thumbnail from RTSP stream
+        # Use the thumbnail from RTSP stream, or a placeholder if stream is
+        # not supported (e.g. WebRTC)
         stream = await self.async_create_stream()
         if stream:
             return await stream.async_get_image(width, height)
-        if self.frontend_stream_type != STREAM_TYPE_WEB_RTC:
-            return None
-        # Use a placeholder image for WebRTC cameras with no thumbnail
         if not self._placeholder_image:
             self._placeholder_image = await self.hass.async_add_executor_job(
                 PLACEHOLDER.read_bytes

--- a/tests/components/nest/test_camera_sdm.py
+++ b/tests/components/nest/test_camera_sdm.py
@@ -7,7 +7,7 @@ pubsub subscriber.
 
 import datetime
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import aiohttp
 from google_nest_sdm.device import Device
@@ -57,6 +57,7 @@ EVENT_SESSION_ID = "CjY5Y3VKaTZwR3o4Y19YbTVfMF..."
 # Tests can assert that image bytes came from an event or was decoded
 # from the live stream.
 IMAGE_BYTES_FROM_EVENT = b"test url image bytes"
+IMAGE_BYTES_FROM_FFMPEG = b"test ffmpeg image bytes"
 IMAGE_BYTES_FROM_STREAM = b"test stream image bytes"
 
 TEST_IMAGE_URL = "https://domain/sdm_event_snapshot/dGTZwR3o4Y1..."
@@ -146,7 +147,7 @@ async def async_get_image(hass, width=None, height=None):
     with patch(
         "homeassistant.components.ffmpeg.ImageFrame.get_image",
         autopatch=True,
-        return_value=IMAGE_BYTES_FROM_STREAM,
+        return_value=IMAGE_BYTES_FROM_FFMPEG,
     ):
         return await camera.async_get_image(
             hass, "camera.my_camera", width=width, height=height
@@ -209,7 +210,7 @@ async def test_camera_stream(hass, auth):
     assert stream_source == "rtsp://some/url?auth=g.0.streamingToken"
 
     image = await async_get_image(hass)
-    assert image.content == IMAGE_BYTES_FROM_STREAM
+    assert image.content == IMAGE_BYTES_FROM_FFMPEG
 
 
 async def test_camera_ws_stream(hass, auth, hass_ws_client):
@@ -223,8 +224,12 @@ async def test_camera_ws_stream(hass, auth, hass_ws_client):
     assert cam.state == STATE_STREAMING
     assert cam.attributes["frontend_stream_type"] == STREAM_TYPE_HLS
 
-    with patch("homeassistant.components.camera.create_stream") as mock_stream:
-        mock_stream().endpoint_url.return_value = "http://home.assistant/playlist.m3u8"
+    with patch(
+        "homeassistant.components.camera.create_stream", autospec=True
+    ) as mock_stream:
+        mock_stream.return_value.endpoint_url.return_value = (
+            "http://home.assistant/playlist.m3u8"
+        )
         client = await hass_ws_client(hass)
         await client.send_json(
             {
@@ -235,10 +240,17 @@ async def test_camera_ws_stream(hass, auth, hass_ws_client):
         )
         msg = await client.receive_json()
 
-    assert msg["id"] == 2
-    assert msg["type"] == TYPE_RESULT
-    assert msg["success"]
-    assert msg["result"]["url"] == "http://home.assistant/playlist.m3u8"
+        assert msg["id"] == 2
+        assert msg["type"] == TYPE_RESULT
+        assert msg["success"]
+        assert msg["result"]["url"] == "http://home.assistant/playlist.m3u8"
+
+        # Getting an image now pulls from the active stream instead of ffmpeg
+        mock_stream.return_value.get_image = AsyncMock()
+        mock_stream.return_value.get_image.return_value = IMAGE_BYTES_FROM_STREAM
+
+        image = await async_get_image(hass)
+        assert image.content == IMAGE_BYTES_FROM_STREAM
 
 
 async def test_camera_ws_stream_failure(hass, auth, hass_ws_client):
@@ -567,7 +579,7 @@ async def test_camera_image_from_event_not_supported(hass, auth):
     auth.responses = [make_stream_url_response()]
 
     image = await async_get_image(hass)
-    assert image.content == IMAGE_BYTES_FROM_STREAM
+    assert image.content == IMAGE_BYTES_FROM_FFMPEG
 
 
 async def test_generate_event_image_url_failure(hass, auth):
@@ -587,7 +599,7 @@ async def test_generate_event_image_url_failure(hass, auth):
     ]
 
     image = await async_get_image(hass)
-    assert image.content == IMAGE_BYTES_FROM_STREAM
+    assert image.content == IMAGE_BYTES_FROM_FFMPEG
 
 
 async def test_fetch_event_image_failure(hass, auth):
@@ -609,7 +621,7 @@ async def test_fetch_event_image_failure(hass, auth):
     ]
 
     image = await async_get_image(hass)
-    assert image.content == IMAGE_BYTES_FROM_STREAM
+    assert image.content == IMAGE_BYTES_FROM_FFMPEG
 
 
 async def test_event_image_expired(hass, auth):
@@ -627,7 +639,7 @@ async def test_event_image_expired(hass, auth):
     auth.responses = [make_stream_url_response()]
 
     image = await async_get_image(hass)
-    assert image.content == IMAGE_BYTES_FROM_STREAM
+    assert image.content == IMAGE_BYTES_FROM_FFMPEG
 
 
 async def test_multiple_event_images(hass, auth):
@@ -847,7 +859,7 @@ async def test_camera_multiple_streams(hass, auth, hass_ws_client):
     assert stream_source == "rtsp://some/url?auth=g.0.streamingToken"
 
     image = await async_get_image(hass)
-    assert image.content == IMAGE_BYTES_FROM_STREAM
+    assert image.content == IMAGE_BYTES_FROM_FFMPEG
 
     # WebRTC stream
     client = await hass_ws_client(hass)

--- a/tests/components/nest/test_camera_sdm.py
+++ b/tests/components/nest/test_camera_sdm.py
@@ -54,9 +54,6 @@ DOMAIN = "nest"
 MOTION_EVENT_ID = "FWWVQVUdGNUlTU2V4MGV2aTNXV..."
 EVENT_SESSION_ID = "CjY5Y3VKaTZwR3o4Y19YbTVfMF..."
 
-# Tests can assert that image bytes came from an event or was decoded
-# from the live stream.
-IMAGE_BYTES_FROM_EVENT = b"test url image bytes"
 IMAGE_BYTES_FROM_STREAM = b"test stream image bytes"
 
 TEST_IMAGE_URL = "https://domain/sdm_event_snapshot/dGTZwR3o4Y1..."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Older Nest cameras no longer use thumbnail images from events, and instead always use the live stream. You should use the newer [Nest Media Source APIs](https://www.home-assistant.io/integrations/nest/#media-source) to fetch media for events.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update nest camera to pull still images from stream component using the stream worker. Delete the code that pulls the image from a recent event, now that we have media stream APIs for events. This has the side effect of effectively pre-loading the stream and significantly improving stream load latency, does not appear have a meaningful difference in network bandwidth and there are also fewer inconsistencies between the image and the stream.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #60353
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
