### PR TITLE
Improve zwave_js device automation strings for config parameters

### DIFF
--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -53,6 +53,7 @@ from .const import (
 from .device_automation_helpers import (
     CONF_SUBTYPE,
     VALUE_ID_REGEX,
+    generate_config_parameter_name,
     get_config_parameter_value_schema,
 )
 from .helpers import async_get_node_from_device_id
@@ -165,7 +166,7 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
                 CONF_TYPE: SERVICE_SET_CONFIG_PARAMETER,
                 ATTR_CONFIG_PARAMETER: config_value.property_,
                 ATTR_CONFIG_PARAMETER_BITMASK: config_value.property_key,
-                CONF_SUBTYPE: f"{config_value.value_id} ({config_value.property_name})",
+                CONF_SUBTYPE: generate_config_parameter_name(config_value),
             }
             for config_value in node.get_configuration_values().values()
         ]

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -53,7 +53,7 @@ from .const import (
 from .device_automation_helpers import (
     CONF_SUBTYPE,
     VALUE_ID_REGEX,
-    generate_config_parameter_name,
+    generate_config_parameter_subtype,
     get_config_parameter_value_schema,
 )
 from .helpers import async_get_node_from_device_id
@@ -166,7 +166,7 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
                 CONF_TYPE: SERVICE_SET_CONFIG_PARAMETER,
                 ATTR_CONFIG_PARAMETER: config_value.property_,
                 ATTR_CONFIG_PARAMETER_BITMASK: config_value.property_key,
-                CONF_SUBTYPE: generate_config_parameter_name(config_value),
+                CONF_SUBTYPE: generate_config_parameter_subtype(config_value),
             }
             for config_value in node.get_configuration_values().values()
         ]

--- a/homeassistant/components/zwave_js/device_automation_helpers.py
+++ b/homeassistant/components/zwave_js/device_automation_helpers.py
@@ -38,6 +38,6 @@ def generate_config_parameter_subtype(config_value: ConfigurationValue) -> str:
     """Generate the config parameter name used in a device automation subtype."""
     parameter = str(config_value.property_)
     if config_value.property_key:
-        parameter = f"{parameter}.{hex(config_value.property_key)}"
+        parameter = f"{parameter}[{hex(config_value.property_key)}]"
 
     return f"{parameter} ({config_value.property_name})"

--- a/homeassistant/components/zwave_js/device_automation_helpers.py
+++ b/homeassistant/components/zwave_js/device_automation_helpers.py
@@ -34,8 +34,8 @@ def get_config_parameter_value_schema(node: Node, value_id: str) -> vol.Schema |
     return None
 
 
-def generate_config_parameter_name(config_value: ConfigurationValue) -> str:
-    """Generate a config parameter name."""
+def generate_config_parameter_subtype(config_value: ConfigurationValue) -> str:
+    """Generate the config parameter name used in a device automation subtype."""
     parameter = str(config_value.property_)
     if config_value.property_key:
         parameter = f"{parameter}.{hex(config_value.property_key)}"

--- a/homeassistant/components/zwave_js/device_automation_helpers.py
+++ b/homeassistant/components/zwave_js/device_automation_helpers.py
@@ -32,3 +32,12 @@ def get_config_parameter_value_schema(node: Node, value_id: str) -> vol.Schema |
         return vol.In({int(k): v for k, v in config_value.metadata.states.items()})
 
     return None
+
+
+def generate_config_parameter_name(config_value: ConfigurationValue) -> str:
+    """Generate a config parameter name."""
+    parameter = str(config_value.property_)
+    if config_value.property_key:
+        parameter = f"{parameter}.{hex(config_value.property_key)}"
+
+    return f"{parameter} ({config_value.property_name})"

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -29,6 +29,7 @@ from .device_automation_helpers import (
     CONF_SUBTYPE,
     CONF_VALUE_ID,
     NODE_STATUSES,
+    generate_config_parameter_name,
     get_config_parameter_value_schema,
 )
 from .helpers import (
@@ -140,17 +141,18 @@ async def async_get_conditions(
     conditions.append({**base_condition, CONF_TYPE: NODE_STATUS_TYPE})
 
     # Config parameter conditions
-    conditions.extend(
-        [
-            {
-                **base_condition,
-                CONF_VALUE_ID: config_value.value_id,
-                CONF_TYPE: CONFIG_PARAMETER_TYPE,
-                CONF_SUBTYPE: f"{config_value.value_id} ({config_value.property_name})",
-            }
-            for config_value in node.get_configuration_values().values()
-        ]
-    )
+    for config_value in node.get_configuration_values().values():
+        conditions.extend(
+            [
+                {
+                    **base_condition,
+                    CONF_VALUE_ID: config_value.value_id,
+                    CONF_TYPE: CONFIG_PARAMETER_TYPE,
+                    CONF_SUBTYPE: generate_config_parameter_name(config_value),
+                }
+                for config_value in node.get_configuration_values().values()
+            ]
+        )
 
     return conditions
 

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -29,7 +29,7 @@ from .device_automation_helpers import (
     CONF_SUBTYPE,
     CONF_VALUE_ID,
     NODE_STATUSES,
-    generate_config_parameter_name,
+    generate_config_parameter_subtype,
     get_config_parameter_value_schema,
 )
 from .helpers import (
@@ -148,7 +148,7 @@ async def async_get_conditions(
                     **base_condition,
                     CONF_VALUE_ID: config_value.value_id,
                     CONF_TYPE: CONFIG_PARAMETER_TYPE,
-                    CONF_SUBTYPE: generate_config_parameter_name(config_value),
+                    CONF_SUBTYPE: generate_config_parameter_subtype(config_value),
                 }
                 for config_value in node.get_configuration_values().values()
             ]

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -49,7 +49,11 @@ from .const import (
     ZWAVE_JS_NOTIFICATION_EVENT,
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
 )
-from .device_automation_helpers import CONF_SUBTYPE, NODE_STATUSES
+from .device_automation_helpers import (
+    CONF_SUBTYPE,
+    NODE_STATUSES,
+    generate_config_parameter_name,
+)
 from .helpers import (
     async_get_node_from_device_id,
     async_get_node_status_sensor_entity_id,
@@ -353,7 +357,7 @@ async def async_get_triggers(
                 ATTR_PROPERTY_KEY: config_value.property_key,
                 ATTR_ENDPOINT: config_value.endpoint,
                 ATTR_COMMAND_CLASS: config_value.command_class,
-                CONF_SUBTYPE: f"{config_value.value_id} ({config_value.property_name})",
+                CONF_SUBTYPE: generate_config_parameter_name(config_value),
             }
             for config_value in node.get_configuration_values().values()
         ]

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -52,7 +52,7 @@ from .const import (
 from .device_automation_helpers import (
     CONF_SUBTYPE,
     NODE_STATUSES,
-    generate_config_parameter_name,
+    generate_config_parameter_subtype,
 )
 from .helpers import (
     async_get_node_from_device_id,
@@ -357,7 +357,7 @@ async def async_get_triggers(
                 ATTR_PROPERTY_KEY: config_value.property_key,
                 ATTR_ENDPOINT: config_value.endpoint,
                 ATTR_COMMAND_CLASS: config_value.command_class,
-                CONF_SUBTYPE: generate_config_parameter_name(config_value),
+                CONF_SUBTYPE: generate_config_parameter_subtype(config_value),
             }
             for config_value in node.get_configuration_values().values()
         ]

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -67,7 +67,7 @@ async def test_get_actions(
             "device_id": device.id,
             "parameter": 3,
             "bitmask": None,
-            "subtype": f"{node.node_id}-112-0-3 (Beeper)",
+            "subtype": "3 (Beeper)",
         },
     ]
     actions = await async_get_device_automations(
@@ -161,7 +161,7 @@ async def test_actions(
                         "device_id": device.id,
                         "parameter": 1,
                         "bitmask": None,
-                        "subtype": "2-112-0-3 (Beeper)",
+                        "subtype": "3 (Beeper)",
                         "value": 1,
                     },
                 },
@@ -328,7 +328,6 @@ async def test_get_action_capabilities(
     integration: ConfigEntry,
 ):
     """Test we get the expected action capabilities."""
-    node = climate_radio_thermostat_ct100_plus
     dev_reg = device_registry.async_get(hass)
     device = device_registry.async_entries_for_config_entry(
         dev_reg, integration.entry_id
@@ -423,7 +422,7 @@ async def test_get_action_capabilities(
             "type": "set_config_parameter",
             "parameter": 1,
             "bitmask": None,
-            "subtype": f"{node.node_id}-112-0-1 (Temperature Reporting Threshold)",
+            "subtype": "1 (Temperature Reporting Threshold)",
         },
     )
     assert capabilities and "extra_fields" in capabilities
@@ -455,7 +454,7 @@ async def test_get_action_capabilities(
             "type": "set_config_parameter",
             "parameter": 10,
             "bitmask": None,
-            "subtype": f"{node.node_id}-112-0-10 (Temperature Reporting Filter)",
+            "subtype": "10 (Temperature Reporting Filter)",
         },
     )
     assert capabilities and "extra_fields" in capabilities
@@ -482,7 +481,7 @@ async def test_get_action_capabilities(
             "type": "set_config_parameter",
             "parameter": 2,
             "bitmask": None,
-            "subtype": f"{node.node_id}-112-0-2 (HVAC Settings)",
+            "subtype": "2 (HVAC Settings)",
         },
     )
     assert not capabilities

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -52,7 +52,7 @@ async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> 
             "type": "config_parameter",
             "device_id": device.id,
             "value_id": value_id,
-            "subtype": f"{value_id} ({name})",
+            "subtype": f"{config_value.property_} ({name})",
         },
         {
             "condition": "device",
@@ -250,7 +250,7 @@ async def test_config_parameter_state(
                             "device_id": device.id,
                             "type": "config_parameter",
                             "value_id": f"{lock_schlage_be469.node_id}-112-0-3",
-                            "subtype": f"{lock_schlage_be469.node_id}-112-0-3 (Beeper)",
+                            "subtype": "3 (Beeper)",
                             "value": 255,
                         }
                     ],
@@ -270,7 +270,7 @@ async def test_config_parameter_state(
                             "device_id": device.id,
                             "type": "config_parameter",
                             "value_id": f"{lock_schlage_be469.node_id}-112-0-6",
-                            "subtype": f"{lock_schlage_be469.node_id}-112-0-6 (User Slot Status)",
+                            "subtype": "6 (User Slot Status)",
                             "value": 1,
                         }
                     ],
@@ -483,7 +483,7 @@ async def test_get_condition_capabilities_config_parameter(
             "device_id": device.id,
             "type": "config_parameter",
             "value_id": f"{node.node_id}-112-0-1",
-            "subtype": f"{node.node_id}-112-0-1 (Temperature Reporting Threshold)",
+            "subtype": "1 (Temperature Reporting Threshold)",
         },
     )
     assert capabilities and "extra_fields" in capabilities
@@ -514,7 +514,7 @@ async def test_get_condition_capabilities_config_parameter(
             "device_id": device.id,
             "type": "config_parameter",
             "value_id": f"{node.node_id}-112-0-10",
-            "subtype": f"{node.node_id}-112-0-10 (Temperature Reporting Filter)",
+            "subtype": "10 (Temperature Reporting Filter)",
         },
     )
     assert capabilities and "extra_fields" in capabilities
@@ -540,7 +540,7 @@ async def test_get_condition_capabilities_config_parameter(
             "device_id": device.id,
             "type": "config_parameter",
             "value_id": f"{node.node_id}-112-0-2",
-            "subtype": f"{node.node_id}-112-0-2 (HVAC Settings)",
+            "subtype": "2 (HVAC Settings)",
         },
     )
     assert not capabilities

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -1120,7 +1120,6 @@ async def test_get_value_updated_config_parameter_triggers(
     hass, client, lock_schlage_be469, integration
 ):
     """Test we get the zwave_js.value_updated.config_parameter trigger from a zwave_js device."""
-    node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
     expected_trigger = {
@@ -1132,7 +1131,7 @@ async def test_get_value_updated_config_parameter_triggers(
         "property_key": None,
         "endpoint": 0,
         "command_class": CommandClass.CONFIGURATION.value,
-        "subtype": f"{node.node_id}-112-0-3 (Beeper)",
+        "subtype": "3 (Beeper)",
     }
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -1163,7 +1162,7 @@ async def test_if_value_updated_config_parameter_fires(
                         "property_key": None,
                         "endpoint": 0,
                         "command_class": CommandClass.CONFIGURATION.value,
-                        "subtype": f"{node.node_id}-112-0-3 (Beeper)",
+                        "subtype": "3 (Beeper)",
                         "from": 255,
                     },
                     "action": {
@@ -1212,7 +1211,6 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
     hass, client, lock_schlage_be469, integration
 ):
     """Test we get the expected capabilities from a range zwave_js.value_updated.config_parameter trigger."""
-    node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1226,7 +1224,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
             "property_key": None,
             "endpoint": 0,
             "command_class": CommandClass.CONFIGURATION.value,
-            "subtype": f"{node.node_id}-112-0-6 (User Slot Status)",
+            "subtype": "6 (User Slot Status)",
         },
     )
     assert capabilities and "extra_fields" in capabilities
@@ -1255,7 +1253,6 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
     hass, client, lock_schlage_be469, integration
 ):
     """Test we get the expected capabilities from an enumerated zwave_js.value_updated.config_parameter trigger."""
-    node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1269,7 +1266,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
             "property_key": None,
             "endpoint": 0,
             "command_class": CommandClass.CONFIGURATION.value,
-            "subtype": f"{node.node_id}-112-0-3 (Beeper)",
+            "subtype": "3 (Beeper)",
         },
     )
     assert capabilities and "extra_fields" in capabilities


### PR DESCRIPTION
## Proposed change
Currently for config parameter device automations (triggers, conditions, and actions) we show the value ID which means nothing to the user. In this change we show just the parameter number (e.g. `Config parameter 1 (Beeper) value`), and if it's a partial parameter, we show the hex value for the partial (e.g. `Config parameter 1.0xffff (Beeper 1) value`). This matches with Z-Wave JS's device DB and will make it easier for users to understand.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
