### PR TITLE
Update homekit_controller to use the new typed discovery data

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==0.7.13"],
+  "requirements": ["aiohomekit==0.7.14"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -184,7 +184,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.7.13
+aiohomekit==0.7.14
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aioguardian==2021.11.0
 aioharmony==0.2.9
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.7.13
+aiohomekit==0.7.14
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -85,7 +85,7 @@ def _setup_flow_handler(hass, pairing=None):
     finish_pairing = unittest.mock.AsyncMock(return_value=pairing)
 
     discovery = mock.Mock()
-    discovery.device_id = "00:00:00:00:00:00"
+    discovery.description.id = "00:00:00:00:00:00"
     discovery.async_start_pairing = unittest.mock.AsyncMock(return_value=finish_pairing)
 
     flow.controller = mock.Mock()
@@ -136,22 +136,21 @@ def get_device_discovery_info(
     device, upper_case_props=False, missing_csharp=False
 ) -> zeroconf.ZeroconfServiceInfo:
     """Turn a aiohomekit format zeroconf entry into a homeassistant one."""
-    record = device.info
     result = zeroconf.ZeroconfServiceInfo(
-        host=record["address"],
-        addresses=[record["address"]],
-        hostname=record["name"],
-        name=record["name"],
-        port=record["port"],
+        host="127.0.0.1",
+        hostname=device.description.name,
+        name=device.description.name,
+        addresses=["127.0.0.1"],
+        port=8080,
         properties={
-            "md": record["md"],
-            "pv": record["pv"],
-            zeroconf.ATTR_PROPERTIES_ID: device.device_id,
-            "c#": record["c#"],
-            "s#": record["s#"],
-            "ff": record["ff"],
-            "ci": record["ci"],
-            "sf": 0x01,  # record["sf"],
+            "md": device.description.model,
+            "pv": "1.0",
+            zeroconf.ATTR_PROPERTIES_ID: device.description.id,
+            "c#": device.description.config_num,
+            "s#": device.description.state_num,
+            "ff": "0",
+            "ci": "0",
+            "sf": "1",
             "sh": "",
         },
         type="_hap._tcp.local.",
@@ -787,7 +786,7 @@ async def test_user_no_unpaired_devices(hass, controller):
     device = setup_mock_accessory(controller)
 
     # Pair the mock device so that it shows as paired in discovery
-    finish_pairing = await device.async_start_pairing(device.device_id)
+    finish_pairing = await device.async_start_pairing(device.description.id)
     await finish_pairing(device.pairing_code)
 
     # Device discovery is requested
@@ -807,7 +806,7 @@ async def test_unignore_works(hass, controller):
     result = await hass.config_entries.flow.async_init(
         "homekit_controller",
         context={"source": config_entries.SOURCE_UNIGNORE},
-        data={"unique_id": device.device_id},
+        data={"unique_id": device.description.id},
     )
     assert result["type"] == "form"
     assert result["step_id"] == "pair"


### PR DESCRIPTION
## Proposed change

This is part of the prep for aiohomekit==1.0.0. Instead of fishing around in a untyped dict that happens to be exposed by one transport, use a new typed dataclass that is now available. The old interface will be removed in 1.0.0.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
