### PR TITLE
Add config flow to zamg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1584,6 +1584,7 @@ omit =
     homeassistant/components/zabbix/*
     homeassistant/components/zamg/__init__.py
     homeassistant/components/zamg/const.py
+    homeassistant/components/zamg/coordinator.py
     homeassistant/components/zamg/sensor.py
     homeassistant/components/zamg/weather.py
     homeassistant/components/zengge/light.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1582,6 +1582,8 @@ omit =
     homeassistant/components/youless/const.py
     homeassistant/components/youless/sensor.py
     homeassistant/components/zabbix/*
+    homeassistant/components/zamg/__init__.py
+    homeassistant/components/zamg/const.py
     homeassistant/components/zamg/sensor.py
     homeassistant/components/zamg/weather.py
     homeassistant/components/zengge/light.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1318,6 +1318,8 @@ build.json @home-assistant/supervisor
 /tests/components/yolink/ @matrixd2
 /homeassistant/components/youless/ @gjong
 /tests/components/youless/ @gjong
+/homeassistant/components/zamg/ @killer0071234
+/tests/components/zamg/ @killer0071234
 /homeassistant/components/zengge/ @emontnemery
 /homeassistant/components/zeroconf/ @bdraco
 /tests/components/zeroconf/ @bdraco

--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     # Set up all platforms for this device/entry.
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -1,1 +1,57 @@
 """The zamg component."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import CONF_STATION_ID, DOMAIN, LOGGER, MIN_TIME_BETWEEN_UPDATES
+from .sensor import ZamgData
+
+PLATFORMS = (Platform.WEATHER, Platform.SENSOR)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Zamg from config entry."""
+    station_id = entry.data[CONF_STATION_ID]
+    zamg_client = ZamgData(station_id)
+
+    async def async_update_data():
+        """Obtain data from zamg."""
+        try:
+            await hass.async_add_executor_job(zamg_client.update)
+            return zamg_client.data
+        except (ValueError, TypeError) as err:
+            raise UpdateFailed(f"Error while retrieving data: {err}") from err
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name=f"ZAMG weather for {entry.title} ({station_id})",
+        update_method=async_update_data,
+        update_interval=MIN_TIME_BETWEEN_UPDATES,
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    # Set up all platforms for this device/entry.
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    # Reload entry when its updated.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Cybro config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when it changed."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -48,7 +48,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Cybro config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
 
 

--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -40,19 +40,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up all platforms for this device/entry.
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-    # Reload entry when its updated.
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload Cybro config entry."""
+    """Unload ZAMG config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the config entry when it changed."""
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -13,7 +13,7 @@ PLATFORMS = (Platform.WEATHER, Platform.SENSOR)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Zamg from config entry."""
-    coordinator = ZamgDataUpdateCoordinator(hass)
+    coordinator = ZamgDataUpdateCoordinator(hass, entry=entry)
     station_id = entry.data[CONF_STATION_ID]
     coordinator.zamg.set_default_station(station_id)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/zamg/__init__.py
+++ b/homeassistant/components/zamg/__init__.py
@@ -23,9 +23,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up all platforms for this device/entry.
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-    # Reload entry when its updated.
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
     return True
 
 
@@ -34,8 +31,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the config entry when it changed."""
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -56,7 +56,8 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.async_add_executor_job(self._client.update)
         except (ValueError, TypeError) as err:
             LOGGER.error("Config_flow: Received error from ZAMG: %s", err)
-            return self.async_abort(reason="unknown")
+            errors["base"] = "unknown"
+            return self.async_abort(reason="unknown", description_placeholders=errors)
 
         # Check if already configured
         await self.async_set_unique_id(station_id)

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -35,10 +35,9 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             closest_station_id = await self._client.closest_station(
                 self.hass.config.latitude,
                 self.hass.config.longitude,
-                self.hass.config.config_dir,
             )
             LOGGER.debug("config_flow: closest station = %s", str(closest_station_id))
-            stations = await self._client.zamg_stations(self.hass.config.config_dir)
+            stations = await self._client.zamg_stations()
             user_input = {}
 
             schema = vol.Schema(
@@ -72,7 +71,7 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_create_entry(
-            title=self._client.get_data("Name"),
+            title=self._client.get_station_name,
             data={CONF_STATION_ID: station_id},
         )
 
@@ -93,6 +92,6 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="unknown")
 
         return self.async_create_entry(
-            title=self._client.get_data("Name"),
+            title=self._client.get_station_name,
             data={CONF_STATION_ID: config[CONF_STATION_ID]},
         )

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -1,0 +1,87 @@
+"""Config Flow for zamg the Austrian "Zentralanstalt für Meteorologie und Geodynamik" integration."""
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import CONF_STATION_ID, DOMAIN, LOGGER
+from .sensor import ZamgData, closest_station
+
+
+class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for zamg integration."""
+
+    VERSION = 1
+
+    _client: ZamgData
+
+    def _show_setup_form(self, user_input=None, errors=None, station_id: str = ""):
+        """Show the setup form to the user."""
+        if user_input is None:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_STATION_ID,
+                        default=user_input.get(CONF_STATION_ID, station_id),
+                    ): str
+                }
+            ),
+            errors=errors or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        station_id = await self.hass.async_add_executor_job(
+            closest_station,
+            self.hass.config.latitude,
+            self.hass.config.longitude,
+            self.hass.config.config_dir,
+        )
+
+        if user_input is None:
+            return self._show_setup_form(user_input, errors, station_id)
+
+        station_id = user_input[CONF_STATION_ID]
+
+        try:
+            self._client = ZamgData(station_id)
+            await self.hass.async_add_executor_job(self._client.update)
+        except (ValueError, TypeError) as err:
+            LOGGER.error("Config_flow: Received error from ZAMG: %s", err)
+            return self.async_abort(reason="unknown")
+
+        # Check if already configured
+        await self.async_set_unique_id(station_id)
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=self._client.get_data("station_name"),
+            data={CONF_STATION_ID: station_id},
+        )
+
+    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+        """Handle Nanoleaf configuration import."""
+        self._async_abort_entries_match({CONF_STATION_ID: config[CONF_STATION_ID]})
+        LOGGER.debug(
+            "Importing zamg on %s from your configuration.yaml", config[CONF_STATION_ID]
+        )
+
+        try:
+            self._client = ZamgData(config[CONF_STATION_ID])
+            await self.hass.async_add_executor_job(self._client.update)
+        except (ValueError, TypeError) as err:
+            LOGGER.error("Received error from ZAMG: %s", err)
+            return self.async_abort(reason="unknown")
+
+        return self.async_create_entry(
+            title=self._client.get_data("station_name"),
+            data={CONF_STATION_ID: config[CONF_STATION_ID]},
+        )

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -1,4 +1,6 @@
 """Config Flow for zamg the Austrian "Zentralanstalt für Meteorologie und Geodynamik" integration."""
+from __future__ import annotations
+
 from typing import Any
 
 import voluptuous as vol
@@ -17,7 +19,12 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _client: ZamgData
 
-    def _show_setup_form(self, user_input=None, errors=None, station_id: str = ""):
+    def _show_setup_form(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+        station_id: str = "",
+    ):
         """Show the setup form to the user."""
         if user_input is None:
             user_input = {}
@@ -35,9 +42,9 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle a flow initiated by the user."""
-        errors = {}
+        errors: dict[str, Any] = {}
 
         station_id = await self.hass.async_add_executor_job(
             closest_station,

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -92,7 +92,7 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user(
             user_input={
-                CONF_STATION_ID: int(config[CONF_STATION_ID]),
-                CONF_NAME: config.get(CONF_NAME, ""),
+                CONF_STATION_ID: int(station_id),
+                CONF_NAME: config.get(CONF_NAME) or station_id,
             }
         )

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -72,7 +72,7 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_create_entry(
-            title=user_input.get(CONF_NAME, self._client.get_station_name),
+            title=user_input.get(CONF_NAME) or self._client.get_station_name,
             data={CONF_STATION_ID: station_id},
         )
 

--- a/homeassistant/components/zamg/config_flow.py
+++ b/homeassistant/components/zamg/config_flow.py
@@ -20,7 +20,9 @@ class ZamgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _client: ZamgData | None = None
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
         errors: dict[str, Any] = {}
 

--- a/homeassistant/components/zamg/const.py
+++ b/homeassistant/components/zamg/const.py
@@ -21,5 +21,7 @@ CONF_STATION_ID = "station_id"
 
 DEFAULT_NAME = "zamg"
 
+MANUFACTURER_URL = "https://www.zamg.ac.at"
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
 VIENNA_TIME_ZONE = dt_util.get_time_zone("Europe/Vienna")

--- a/homeassistant/components/zamg/const.py
+++ b/homeassistant/components/zamg/const.py
@@ -1,0 +1,25 @@
+"""Constants for zamg the Austrian "Zentralanstalt für Meteorologie und Geodynamik" integration."""
+
+from datetime import timedelta
+import logging
+
+from homeassistant.const import Platform
+from homeassistant.util import dt as dt_util
+
+DOMAIN = "zamg"
+
+CONF_STATION_ID = "station_id"
+PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
+
+LOGGER = logging.getLogger(__package__)
+
+ATTR_STATION = "station"
+ATTR_UPDATED = "updated"
+ATTRIBUTION = "Data provided by ZAMG"
+
+CONF_STATION_ID = "station_id"
+
+DEFAULT_NAME = "zamg"
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
+VIENNA_TIME_ZONE = dt_util.get_time_zone("Europe/Vienna")

--- a/homeassistant/components/zamg/const.py
+++ b/homeassistant/components/zamg/const.py
@@ -8,7 +8,6 @@ from homeassistant.util import dt as dt_util
 
 DOMAIN = "zamg"
 
-CONF_STATION_ID = "station_id"
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
 
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, LOGGER, MIN_TIME_BETWEEN_UPDATES
+from .const import CONF_STATION_ID, DOMAIN, LOGGER, MIN_TIME_BETWEEN_UPDATES
 
 
 class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
@@ -17,10 +17,10 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
     config_entry: ConfigEntry
     data: dict = {}
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, *, entry: ConfigEntry) -> None:
         """Initialize global ZAMG data updater."""
         self.zamg = ZamgDevice(session=async_get_clientsession(hass))
-
+        self.zamg.set_default_station(entry.data[CONF_STATION_ID])
         super().__init__(
             hass,
             LOGGER,
@@ -36,9 +36,11 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
     async def _async_update_data(self) -> ZamgDevice:
         """Fetch data from ZAMG api."""
         try:
+            await self.zamg.zamg_stations()
             device = await self.zamg.update()
         except ValueError as error:
             raise UpdateFailed(f"Invalid response from API: {error}") from error
         self.data = device
         self.data["last_update"] = self.zamg.last_update
+        self.data["Name"] = self.zamg.get_station_name
         return device

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -22,14 +22,10 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
         hass: HomeAssistant,
         *,
         entry: ConfigEntry | None = None,
-        station_id: str | None = None,
     ) -> None:
         """Initialize global ZAMG data updater."""
         self.zamg = ZamgDevice(session=async_get_clientsession(hass))
-        if entry:
-            self.zamg.set_default_station(entry.data[CONF_STATION_ID])
-        if station_id:
-            self.zamg.set_default_station(station_id)
+        self.zamg.set_default_station(entry.data[CONF_STATION_ID])
         super().__init__(
             hass,
             LOGGER,

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -1,0 +1,44 @@
+"""Data Update coordinator for ZAMG weather data."""
+from __future__ import annotations
+
+from zamg import ZamgData as ZamgDevice
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LOGGER, MIN_TIME_BETWEEN_UPDATES
+
+
+class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
+    """Class to manage fetching ZAMG weather data."""
+
+    config_entry: ConfigEntry
+    data: dict = {}
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize global ZAMG data updater."""
+        self.zamg = ZamgDevice(session=async_get_clientsession(hass))
+
+        super().__init__(
+            hass,
+            LOGGER,
+            name=DOMAIN,
+            update_interval=MIN_TIME_BETWEEN_UPDATES,
+        )
+
+    def update_listeners(self) -> None:
+        """Call update on all listeners."""
+        for update_callback in self._listeners:
+            update_callback()
+
+    async def _async_update_data(self) -> ZamgDevice:
+        """Fetch data from ZAMG api."""
+        try:
+            device = await self.zamg.update()
+        except ValueError as error:
+            raise UpdateFailed(f"Invalid response from API: {error}") from error
+        self.data = device
+        self.data["last_update"] = self.zamg.last_update
+        return device

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -21,7 +21,7 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
         self,
         hass: HomeAssistant,
         *,
-        entry: ConfigEntry | None = None,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize global ZAMG data updater."""
         self.zamg = ZamgDevice(session=async_get_clientsession(hass))

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -17,10 +17,19 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
     config_entry: ConfigEntry
     data: dict = {}
 
-    def __init__(self, hass: HomeAssistant, *, entry: ConfigEntry) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry: ConfigEntry | None = None,
+        station_id: str | None = None,
+    ) -> None:
         """Initialize global ZAMG data updater."""
         self.zamg = ZamgDevice(session=async_get_clientsession(hass))
-        self.zamg.set_default_station(entry.data[CONF_STATION_ID])
+        if entry:
+            self.zamg.set_default_station(entry.data[CONF_STATION_ID])
+        if station_id:
+            self.zamg.set_default_station(station_id)
         super().__init__(
             hass,
             LOGGER,

--- a/homeassistant/components/zamg/coordinator.py
+++ b/homeassistant/components/zamg/coordinator.py
@@ -28,11 +28,6 @@ class ZamgDataUpdateCoordinator(DataUpdateCoordinator[ZamgDevice]):
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )
 
-    def update_listeners(self) -> None:
-        """Call update on all listeners."""
-        for update_callback in self._listeners:
-            update_callback()
-
     async def _async_update_data(self) -> ZamgDevice:
         """Fetch data from ZAMG api."""
         try:

--- a/homeassistant/components/zamg/manifest.json
+++ b/homeassistant/components/zamg/manifest.json
@@ -3,5 +3,6 @@
   "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)",
   "documentation": "https://www.home-assistant.io/integrations/zamg",
   "codeowners": [],
+  "config_flow": true,
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/zamg/manifest.json
+++ b/homeassistant/components/zamg/manifest.json
@@ -2,7 +2,8 @@
   "domain": "zamg",
   "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)",
   "documentation": "https://www.home-assistant.io/integrations/zamg",
-  "codeowners": [],
+  "requirements": ["zamg==0.0.3"],
+  "codeowners": ["@killer0071234"],
   "config_flow": true,
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/zamg/manifest.json
+++ b/homeassistant/components/zamg/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zamg",
   "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)",
   "documentation": "https://www.home-assistant.io/integrations/zamg",
-  "requirements": ["zamg==0.0.3"],
+  "requirements": ["zamg==0.1.0"],
   "codeowners": ["@killer0071234"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/zamg/manifest.json
+++ b/homeassistant/components/zamg/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zamg",
   "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)",
   "documentation": "https://www.home-assistant.io/integrations/zamg",
-  "requirements": ["zamg==0.1.0"],
+  "requirements": ["zamg==0.1.1"],
   "codeowners": ["@killer0071234"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -35,7 +35,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -287,7 +287,7 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
         )
 
     @property
-    def native_value(self):
+    def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.coordinator.data[self.station_id].get(
             self.entity_description.para_name

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -49,6 +50,7 @@ from .const import (
     CONF_STATION_ID,
     DEFAULT_NAME,
     DOMAIN,
+    MANUFACTURER_URL,
     MIN_TIME_BETWEEN_UPDATES,
     VIENNA_TIME_ZONE,
 )
@@ -76,6 +78,8 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="pressure",
         name="Pressure",
         native_unit_of_measurement=PRESSURE_HPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading="LDstat hPa",
         dtype=float,
     ),
@@ -83,6 +87,8 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="pressure_sealevel",
         name="Pressure at Sea Level",
         native_unit_of_measurement=PRESSURE_HPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading="LDred hPa",
         dtype=float,
     ),
@@ -90,6 +96,8 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="humidity",
         name="Humidity",
         native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading="RF %",
         dtype=int,
     ),
@@ -97,6 +105,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="wind_speed",
         name="Wind Speed",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"WG {SPEED_KILOMETERS_PER_HOUR}",
         dtype=float,
     ),
@@ -104,6 +113,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="wind_bearing",
         name="Wind Bearing",
         native_unit_of_measurement=DEGREE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"WR {DEGREE}",
         dtype=int,
     ),
@@ -111,6 +121,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="wind_max_speed",
         name="Top Wind Speed",
         native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"WSG {SPEED_KILOMETERS_PER_HOUR}",
         dtype=float,
     ),
@@ -118,6 +129,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="wind_max_bearing",
         name="Top Wind Bearing",
         native_unit_of_measurement=DEGREE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"WSR {DEGREE}",
         dtype=int,
     ),
@@ -125,6 +137,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="sun_last_hour",
         name="Sun Last Hour",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"SO {PERCENTAGE}",
         dtype=int,
     ),
@@ -133,6 +146,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         name="Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"T {TEMP_CELSIUS}",
         dtype=float,
     ),
@@ -140,6 +154,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="precipitation",
         name="Precipitation",
         native_unit_of_measurement=f"l/{AREA_SQUARE_METERS}",
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"N l/{AREA_SQUARE_METERS}",
         dtype=float,
     ),
@@ -148,6 +163,7 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         name="Dew Point",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
         col_heading=f"TP {TEMP_CELSIUS}",
         dtype=float,
     ),
@@ -176,6 +192,12 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         key="update_time",
         name="Update Time",
         col_heading="Zeit",
+        dtype=str,
+    ),
+    ZamgSensorEntityDescription(
+        key="station_id",
+        name="Station id",
+        col_heading="Station",
         dtype=str,
     ),
 )
@@ -271,8 +293,10 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self.coordinator = coordinator
-        self._attr_name = f"{name} {description.key}"
-        self._attr_unique_id = f"{self.coordinator.data.station_id()}_{description.key}"
+        self._attr_name = f"{name} {description.name}"
+        self._attr_unique_id = (
+            f"{self.coordinator.data.get('station_id')}_{description.key}"
+        )
 
     @property
     def device_info(self):
@@ -280,8 +304,8 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
         return DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
-            # manufacturer=,
-            # model=MODEL,
+            manufacturer=DOMAIN,
+            configuration_url=MANUFACTURER_URL,
             name=self.coordinator.name,
         )
 

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     AREA_SQUARE_METERS,
+    ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_MONITORED_CONDITIONS,

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -283,7 +283,6 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        # self.coordinator = coordinator
         self._attr_name = f"{name} {description.name}"
         self._attr_unique_id = (
             f"{coordinator.data.get(CONF_STATION_ID)}_{description.key}"
@@ -295,11 +294,6 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
             configuration_url=MANUFACTURER_URL,
             name=coordinator.name,
         )
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return self._attr_device_info
 
     @property
     def native_value(self):

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -194,12 +194,6 @@ SENSOR_TYPES: tuple[ZamgSensorEntityDescription, ...] = (
         col_heading="Zeit",
         dtype=str,
     ),
-    ZamgSensorEntityDescription(
-        key="station_id",
-        name="Station id",
-        col_heading="Station",
-        dtype=str,
-    ),
 )
 
 SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
@@ -274,11 +268,8 @@ async def async_setup_entry(
         coordinator.config_entry = entry
 
     async_add_entities(
-        [
-            ZamgSensor(coordinator, entry.title, description)
-            for description in SENSOR_TYPES
-        ],
-        False,
+        ZamgSensor(coordinator, entry.title, description)
+        for description in SENSOR_TYPES
     )
 
 
@@ -292,22 +283,23 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self.coordinator = coordinator
+        # self.coordinator = coordinator
         self._attr_name = f"{name} {description.name}"
         self._attr_unique_id = (
-            f"{self.coordinator.data.get('station_id')}_{description.key}"
+            f"{coordinator.data.get(CONF_STATION_ID)}_{description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, coordinator.data.get(CONF_STATION_ID))},
+            manufacturer=ATTRIBUTION,
+            configuration_url=MANUFACTURER_URL,
+            name=coordinator.name,
         )
 
     @property
     def device_info(self):
         """Return the device info."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
-            manufacturer=DOMAIN,
-            configuration_url=MANUFACTURER_URL,
-            name=self.coordinator.name,
-        )
+        return self._attr_device_info
 
     @property
     def native_value(self):

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -328,10 +328,6 @@ class ZamgSensor(CoordinatorEntity, SensorEntity):
             ATTR_UPDATED: update_time.isoformat(),
         }
 
-    def update(self) -> None:
-        """Delegate update to probe."""
-        self.coordinator.data.update()
-
 
 @dataclass
 class ZamgData:

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Union
 
 import voluptuous as vol
-from zamg import ZamgData
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -31,12 +30,10 @@ from homeassistant.const import (
     TIME_SECONDS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -47,7 +44,6 @@ from .const import (
     CONF_STATION_ID,
     DEFAULT_NAME,
     DOMAIN,
-    LOGGER,
     MANUFACTURER_URL,
 )
 
@@ -219,38 +215,11 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the ZAMG sensor platform."""
-
-    probe = ZamgData(session=async_get_clientsession(hass))
-
-    latitude = config.get(CONF_LATITUDE, hass.config.latitude)
-    longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    station_id = config.get(CONF_STATION_ID)
-    if station_id not in await probe.zamg_stations():
-        LOGGER.warning(
-            "Configured station_id %s could not be found at zamg, adding the nearest weather station instead",
-            station_id,
-        )
-        station_id = await probe.closest_station(latitude, longitude)
-    probe.set_default_station(station_id)
-
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecated_yaml",
-        breaks_in_ha_version="2023.1.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-    )
-
-    # No config entry exists and configuration.yaml config exists, trigger the import flow.
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.data.get(CONF_STATION_ID):
-            return
+    # trigger import flow
     await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_IMPORT},
-        data={CONF_STATION_ID: station_id, CONF_NAME: config.get(CONF_NAME, "")},
+        data=config,
     )
 
 

--- a/homeassistant/components/zamg/strings.json
+++ b/homeassistant/components/zamg/strings.json
@@ -10,11 +10,11 @@
       }
     },
     "error": {
+      "unknown": "[%key:common::config_flow::error::unknown%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "unknown": "[%key:common::config_flow::abort::unknown%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
   }

--- a/homeassistant/components/zamg/strings.json
+++ b/homeassistant/components/zamg/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "description": "Set up your ZAMG to integrate with Home Assistant.",
+        "description": "Set up ZAMG to integrate with Home Assistant.",
         "data": {
           "station_id": "Station ID (Defaults to nearest station)"
         }

--- a/homeassistant/components/zamg/strings.json
+++ b/homeassistant/components/zamg/strings.json
@@ -5,7 +5,7 @@
       "user": {
         "description": "Set up your ZAMG to integrate with Home Assistant.",
         "data": {
-          "station_id": "[%key:common::config_flow::data::host%]"
+          "station_id": "Station ID (Defaults to nearest station)"
         }
       }
     },

--- a/homeassistant/components/zamg/strings.json
+++ b/homeassistant/components/zamg/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "description": "Set up your ZAMG to integrate with Home Assistant.",
+        "data": {
+          "station_id": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "unknown": "[%key:common::config_flow::abort::unknown%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    }
+  }
+}

--- a/homeassistant/components/zamg/strings.json
+++ b/homeassistant/components/zamg/strings.json
@@ -16,5 +16,11 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
+  },
+  "issues": {
+    "deprecated_yaml": {
+      "title": "The ZAMG YAML configuration is being removed",
+      "description": "Configuring ZAMG using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the ZAMG YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
   }
 }

--- a/homeassistant/components/zamg/strings.json
+++ b/homeassistant/components/zamg/strings.json
@@ -10,7 +10,6 @@
       }
     },
     "error": {
-      "unknown": "[%key:common::config_flow::error::unknown%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {

--- a/homeassistant/components/zamg/translations/de.json
+++ b/homeassistant/components/zamg/translations/de.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "abort": {
-            "unknown": "ID der Wetterstation ist unbekannt",
             "already_configured": "Wetterstation ist bereits konfiguriert",
             "cannot_connect": "Verbindung fehlgeschlagen"
         },
         "error": {
+            "unknown": "ID der Wetterstation ist unbekannt",
             "cannot_connect": "Verbindung fehlgeschlagen"
         },
         "flow_title": "{name}",

--- a/homeassistant/components/zamg/translations/de.json
+++ b/homeassistant/components/zamg/translations/de.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "unknown": "ID der Wetterstation ist unbekannt",
+            "already_configured": "Wetterstation ist bereits konfiguriert",
+            "cannot_connect": "Verbindung fehlgeschlagen"
+        },
+        "error": {
+            "cannot_connect": "Verbindung fehlgeschlagen"
+        },
+        "flow_title": "{name}",
+        "step": {
+            "user": {
+                "data": {
+                    "station_id": "ID der Wetterstation (nächstgelegene Station as Defaultwert)"
+                },
+                "description": "Richte zamg f\u00fcr die Integration mit Home Assistant ein."
+            }
+        }
+    }
+}

--- a/homeassistant/components/zamg/translations/en.json
+++ b/homeassistant/components/zamg/translations/en.json
@@ -1,20 +1,20 @@
 {
     "config": {
         "abort": {
-            "unknown": "Station id is unknown",
-            "already_configured": "Station is already configured",
+            "already_configured": "Device is already configured",
             "cannot_connect": "Failed to connect"
         },
         "error": {
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
         },
         "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {
-                    "station_id": "Zamg weather station id"
+                    "station_id": "Host"
                 },
-                "description": "Set up zamg to integrate with Home Assistant."
+                "description": "Set up your ZAMG to integrate with Home Assistant."
             }
         }
     }

--- a/homeassistant/components/zamg/translations/en.json
+++ b/homeassistant/components/zamg/translations/en.json
@@ -5,8 +5,7 @@
             "cannot_connect": "Failed to connect"
         },
         "error": {
-            "cannot_connect": "Failed to connect",
-            "unknown": "Unexpected error"
+            "cannot_connect": "Failed to connect"
         },
         "flow_title": "{name}",
         "step": {
@@ -16,6 +15,12 @@
                 },
                 "description": "Set up ZAMG to integrate with Home Assistant."
             }
+        }
+    },
+    "issues": {
+        "deprecated_yaml": {
+            "description": "Configuring ZAMG using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the ZAMG YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",
+            "title": "The ZAMG YAML configuration is being removed"
         }
     }
 }

--- a/homeassistant/components/zamg/translations/en.json
+++ b/homeassistant/components/zamg/translations/en.json
@@ -12,9 +12,9 @@
         "step": {
             "user": {
                 "data": {
-                    "station_id": "Host"
+                    "station_id": "Station ID (Defaults to nearest station)"
                 },
-                "description": "Set up your ZAMG to integrate with Home Assistant."
+                "description": "Set up ZAMG to integrate with Home Assistant."
             }
         }
     }

--- a/homeassistant/components/zamg/translations/en.json
+++ b/homeassistant/components/zamg/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "unknown": "Station id is unknown",
+            "already_configured": "Station is already configured",
+            "cannot_connect": "Failed to connect"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect"
+        },
+        "flow_title": "{name}",
+        "step": {
+            "user": {
+                "data": {
+                    "station_id": "Zamg weather station id"
+                },
+                "description": "Set up zamg to integrate with Home Assistant."
+            }
+        }
+    }
+}

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -87,9 +87,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the ZAMG weather platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-
-    async_add_entities([ZamgWeather(coordinator)], False)
+    async_add_entities([ZamgWeather(hass.data[DOMAIN][entry.entry_id])])
 
 
 class ZamgWeather(CoordinatorEntity, WeatherEntity):
@@ -102,19 +100,20 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
     def __init__(self, zamg_data, stationname=None):
         """Initialise the platform with a data instance and station name."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{self.coordinator.data.get('station_id')}"
-        self._attr_name = f"{self.coordinator.data.get('station_name')}"
+        self._attr_unique_id = f"{coordinator.data.get(CONF_STATION_ID)}"
+        self._attr_name = f"{coordinator.data.get('station_name')}"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, coordinator.data.get(CONF_STATION_ID))},
+            manufacturer=ATTRIBUTION,
+            configuration_url=MANUFACTURER_URL,
+            name=coordinator.name,
+        )
 
     @property
     def device_info(self):
         """Return the device info."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
-            manufacturer=ATTRIBUTION,
-            configuration_url=MANUFACTURER_URL,
-            name=self.coordinator.name,
-        )
+        return self._attr_device_info
 
     @property
     def name(self):

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -101,7 +101,7 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
         """Initialise the platform with a data instance and station name."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.data.get(CONF_STATION_ID)}"
-        self._attr_name = f"{coordinator.data.get('station_name')}"
+        self._attr_name = f"ZAMG {coordinator.data.get('station_name')}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, coordinator.data.get(CONF_STATION_ID))},
@@ -109,16 +109,6 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
             configuration_url=MANUFACTURER_URL,
             name=coordinator.name,
         )
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return self._attr_device_info
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"ZAMG {self.coordinator.data.get('station_name')}"
 
     @property
     def condition(self):

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -24,6 +24,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
@@ -31,7 +33,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import ATTRIBUTION, CONF_STATION_ID, DOMAIN
+from .const import ATTRIBUTION, CONF_STATION_ID, DOMAIN, MANUFACTURER_URL
 from .sensor import closest_station
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,12 +102,24 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
     def __init__(self, zamg_data, stationname=None):
         """Initialise the platform with a data instance and station name."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{self.coordinator.data.station_id()}"
+        self._attr_unique_id = f"{self.coordinator.data.get('station_id')}"
+        self._attr_name = f"{self.coordinator.data.get('station_name')}"
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
+            manufacturer=ATTRIBUTION,
+            configuration_url=MANUFACTURER_URL,
+            name=self.coordinator.name,
+        )
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"ZAMG {self.coordinator.config_entry.title}"
+        return f"ZAMG {self.coordinator.data.get('station_name')}"
 
     @property
     def condition(self):

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -95,7 +95,6 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
             configuration_url=MANUFACTURER_URL,
             name=coordinator.name,
         )
-        # self._attr_unique_id = f"{station_id}_{description.key}"
 
     @property
     def condition(self):

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -1,24 +1,16 @@
 """Sensor for zamg the Austrian "Zentralanstalt für Meteorologie und Geodynamik" integration."""
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
+from zamg import ZamgData
 
-from homeassistant.components.weather import (
-    ATTR_WEATHER_HUMIDITY,
-    ATTR_WEATHER_PRESSURE,
-    ATTR_WEATHER_TEMPERATURE,
-    ATTR_WEATHER_WIND_BEARING,
-    ATTR_WEATHER_WIND_SPEED,
-    PLATFORM_SCHEMA,
-    WeatherEntity,
-)
+from homeassistant.components.weather import PLATFORM_SCHEMA, WeatherEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_NAME,
-    PRESSURE_HPA,
+    DEGREE,
     SPEED_KILOMETERS_PER_HOUR,
     TEMP_CELSIUS,
 )
@@ -28,15 +20,10 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, CONF_STATION_ID, DOMAIN, MANUFACTURER_URL
-from .sensor import closest_station
-
-_LOGGER = logging.getLogger(__name__)
+from .const import ATTRIBUTION, CONF_STATION_ID, DOMAIN, LOGGER, MANUFACTURER_URL
+from .coordinator import ZamgDataUpdateCoordinator
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -55,31 +42,28 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the ZAMG weather platform."""
-    _LOGGER.warning(
+    LOGGER.warning(
         "Configuration of the zamg integration in YAML is deprecated and "
         "will be removed in a further release of Home Assistant; Your existing configuration "
         "has been imported into the UI automatically and can be safely removed "
         "from your configuration.yaml file"
     )
 
+    probe = ZamgData()
+
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    station_id = config.get(CONF_STATION_ID) or await hass.async_add_executor_job(
-        closest_station,
-        latitude,
-        longitude,
-        hass.config.config_dir,
+    station_id = config.get(CONF_STATION_ID) or probe.closest_station(
+        latitude, longitude, hass.config.config_dir
     )
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={CONF_STATION_ID: station_id},
-        )
+    probe.set_default_station(station_id)
+
+    async_add_entities(
+        [ZamgWeather(probe, probe.get_data("Name", station_id), station_id)]
     )
 
 
@@ -87,28 +71,31 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the ZAMG weather platform."""
-    async_add_entities([ZamgWeather(hass.data[DOMAIN][entry.entry_id])])
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [ZamgWeather(coordinator, entry.title, entry.data[CONF_STATION_ID])]
+    )
 
 
 class ZamgWeather(CoordinatorEntity, WeatherEntity):
     """Representation of a weather condition."""
 
-    _attr_native_pressure_unit = PRESSURE_HPA
-    _attr_native_temperature_unit = TEMP_CELSIUS
-    _attr_native_wind_speed_unit = SPEED_KILOMETERS_PER_HOUR
-
-    def __init__(self, zamg_data, stationname=None):
+    def __init__(
+        self, coordinator: ZamgDataUpdateCoordinator, name, station_id
+    ) -> None:
         """Initialise the platform with a data instance and station name."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.data.get(CONF_STATION_ID)}"
-        self._attr_name = f"ZAMG {coordinator.data.get('station_name')}"
+        self._attr_unique_id = f"{name}_{station_id}"
+        self._attr_name = f"ZAMG {name}"
+        self.station_id = f"{station_id}"
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, coordinator.data.get(CONF_STATION_ID))},
+            identifiers={(DOMAIN, station_id)},
             manufacturer=ATTRIBUTION,
             configuration_url=MANUFACTURER_URL,
             name=coordinator.name,
         )
+        # self._attr_unique_id = f"{station_id}_{description.key}"
 
     @property
     def condition(self):
@@ -123,24 +110,40 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
     @property
     def native_temperature(self):
         """Return the platform temperature."""
-        return self.coordinator.data.get(ATTR_WEATHER_TEMPERATURE)
+        return float(
+            str(
+                self.coordinator.data[self.station_id].get(f"T {TEMP_CELSIUS}")
+            ).replace(",", ".")
+        )
 
     @property
     def native_pressure(self):
         """Return the pressure."""
-        return self.coordinator.data.get(ATTR_WEATHER_PRESSURE)
+        return float(
+            str(self.coordinator.data[self.station_id].get("LDstat hPa")).replace(
+                ",", "."
+            )
+        )
 
     @property
     def humidity(self):
         """Return the humidity."""
-        return self.coordinator.data.get(ATTR_WEATHER_HUMIDITY)
+        return float(
+            str(self.coordinator.data[self.station_id].get("RF %")).replace(",", ".")
+        )
 
     @property
     def native_wind_speed(self):
         """Return the wind speed."""
-        return self.coordinator.data.get(ATTR_WEATHER_WIND_SPEED)
+        return float(
+            str(
+                self.coordinator.data[self.station_id].get(
+                    f"WG {SPEED_KILOMETERS_PER_HOUR}"
+                )
+            ).replace(",", ".")
+        )
 
     @property
     def wind_bearing(self):
         """Return the wind bearing."""
-        return self.coordinator.data.get(ATTR_WEATHER_WIND_BEARING)
+        return self.coordinator.data[self.station_id].get(f"WR {DEGREE}")

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -155,7 +155,3 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
     def wind_bearing(self):
         """Return the wind bearing."""
         return self.coordinator.data.get(ATTR_WEATHER_WIND_BEARING)
-
-    def update(self) -> None:
-        """Update current conditions."""
-        self.coordinator.data.update()

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -461,6 +461,7 @@ FLOWS = {
         "yeelight",
         "yolink",
         "youless",
+        "zamg",
         "zerproc",
         "zha",
         "zwave_js",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6091,10 +6091,9 @@
       "iot_class": "local_polling"
     },
     "zamg": {
-      "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "cloud_polling"
+      "config_flow": true,
+      "iot_class": "cloud_polling",
+      "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)"
     },
     "zengge": {
       "name": "Zengge",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6091,9 +6091,10 @@
       "iot_class": "local_polling"
     },
     "zamg": {
+      "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)",
+      "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling",
-      "name": "Zentralanstalt f\u00fcr Meteorologie und Geodynamik (ZAMG)"
+      "iot_class": "cloud_polling"
     },
     "zengge": {
       "name": "Zengge",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2597,6 +2597,9 @@ youless-api==0.16
 # homeassistant.components.media_extractor
 youtube_dl==2021.12.17
 
+# homeassistant.components.zamg
+zamg==0.0.3
+
 # homeassistant.components.zengge
 zengge==0.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2598,7 +2598,7 @@ youless-api==0.16
 youtube_dl==2021.12.17
 
 # homeassistant.components.zamg
-zamg==0.1.0
+zamg==0.1.1
 
 # homeassistant.components.zengge
 zengge==0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2598,7 +2598,7 @@ youless-api==0.16
 youtube_dl==2021.12.17
 
 # homeassistant.components.zamg
-zamg==0.0.3
+zamg==0.1.0
 
 # homeassistant.components.zengge
 zengge==0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1801,6 +1801,9 @@ yolink-api==0.1.0
 # homeassistant.components.youless
 youless-api==0.16
 
+# homeassistant.components.zamg
+zamg==0.0.3
+
 # homeassistant.components.zeroconf
 zeroconf==0.39.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1802,7 +1802,7 @@ yolink-api==0.1.0
 youless-api==0.16
 
 # homeassistant.components.zamg
-zamg==0.0.3
+zamg==0.1.0
 
 # homeassistant.components.zeroconf
 zeroconf==0.39.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1802,7 +1802,7 @@ yolink-api==0.1.0
 youless-api==0.16
 
 # homeassistant.components.zamg
-zamg==0.1.0
+zamg==0.1.1
 
 # homeassistant.components.zeroconf
 zeroconf==0.39.2

--- a/tests/components/zamg/__init__.py
+++ b/tests/components/zamg/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ZAMG component."""

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -4,9 +4,9 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from zamg import ZamgData as ZamgDevice
 
 from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN
-from homeassistant.components.zamg.sensor import ZamgData as ZamgDevice
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -62,7 +62,6 @@ def mock_zamg(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None
             "11244": (46.8722229, 15.90361118, "BAD GLEICHENBERG"),
         }
         zamg.closest_station.return_value = TEST_STATION_ID
-        # zamg.get_data.data = {TEST_STATION_ID: {"Name": TEST_STATION_NAME}}
         zamg.get_data.return_value = TEST_STATION_ID
         yield zamg
 
@@ -84,7 +83,6 @@ def mock_zamg_stations(
 
 @pytest.fixture
 async def init_integration(
-    #    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_zamg: MagicMock
     hass: HomeAssistant,
 ) -> MockConfigEntry:
     """Set up the Zamg integration for testing."""

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -67,6 +67,19 @@ def mock_zamg(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None
 
 
 @pytest.fixture
+def mock_zamg_stations(
+    request: pytest.FixtureRequest,
+) -> Generator[None, MagicMock, None]:
+    """Return a mocked Zamg client."""
+    with patch("homeassistant.components.zamg.sensor.zamg_stations") as zamg_mock:
+        zamg_mock.return_value = {
+            "11240": (46.99305556, 15.43916667, "GRAZ-FLUGHAFEN"),
+            "11244": (46.87222222, 15.90361111, "BAD GLEICHENBERG"),
+        }
+        yield zamg_mock
+
+
+@pytest.fixture
 def mock_closest_station(
     request: pytest.FixtureRequest,
 ) -> Generator[None, MagicMock, None]:

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -63,6 +63,7 @@ def mock_zamg(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None
         }
         zamg.closest_station.return_value = TEST_STATION_ID
         zamg.get_data.return_value = TEST_STATION_ID
+        zamg.get_station_name = TEST_STATION_NAME
         yield zamg
 
 

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -1,0 +1,93 @@
+"""Fixtures for Zamg integration tests."""
+from collections.abc import Generator
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN
+from homeassistant.components.zamg.sensor import ZamgData as ZamgDevice
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry, load_fixture
+
+TEST_STATION_ID = "11240"
+TEST_STATION_NAME = "Graz/Flughafen"
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_STATION_ID: TEST_STATION_ID},
+        unique_id=TEST_STATION_ID,
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[None, None, None]:
+    """Mock setting up a config entry."""
+    with patch("homeassistant.components.zamg.async_setup_entry", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_zamg_config_flow(
+    request: pytest.FixtureRequest,
+) -> Generator[None, MagicMock, None]:
+    """Return a mocked Zamg client."""
+    with patch(
+        "homeassistant.components.zamg.sensor.ZamgData", autospec=True
+    ) as zamg_mock:
+        zamg = zamg_mock.return_value
+        zamg.update.return_value = ZamgDevice(
+            json.loads(load_fixture("zamg/data.json"))
+        )
+        zamg.get_data.return_value = zamg.get_data(TEST_STATION_ID)
+        yield zamg
+
+
+@pytest.fixture
+def mock_zamg(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+    """Return a mocked Zamg client."""
+    fixture: str = "zamg/data.json"
+    if hasattr(request, "param") and request.param:
+        fixture = request.param
+
+    device = ZamgDevice(json.loads(load_fixture(fixture)))
+    with patch(
+        "homeassistant.components.zamg.sensor.ZamgData", autospec=True
+    ) as zamg_mock:
+        zamg = zamg_mock.return_value
+        zamg.update.return_value = device
+        zamg.get_data.return_value = device.get_data(TEST_STATION_ID)
+        zamg.current_observations.return_value = ValueError()
+        yield zamg
+
+
+@pytest.fixture
+def mock_closest_station(
+    request: pytest.FixtureRequest,
+) -> Generator[None, MagicMock, None]:
+    """Return a mocked Zamg client."""
+    with patch(
+        "homeassistant.components.zamg.sensor.closest_station", autospec=True
+    ) as zamg_mock:
+        zamg = zamg_mock.return_value
+        zamg.update.return_value = TEST_STATION_ID
+        yield zamg
+
+
+@pytest.fixture
+async def init_integration(
+    #    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_zamg: MagicMock
+    hass: HomeAssistant,
+) -> MockConfigEntry:
+    """Set up the Zamg integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/zamg/fixtures/data.json
+++ b/tests/components/zamg/fixtures/data.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "station_id": "11240",
+    "station_name": "Graz/Flughafen"
+  }
+}

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -1,0 +1,133 @@
+"""Tests for the Zamg config flow."""
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from .conftest import TEST_STATION_ID, TEST_STATION_NAME
+
+
+async def test_full_user_flow_implementation(
+    hass: HomeAssistant,
+    mock_closest_station: MagicMock,
+    mock_zamg: MagicMock,
+    mock_setup_entry: None,
+) -> None:
+    """Test the full manual user flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result.get("step_id") == "user"
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert "flow_id" in result
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_STATION_ID: TEST_STATION_ID}
+    )
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert "data" in result
+    assert result["data"][CONF_STATION_ID] == TEST_STATION_ID
+    assert "result" in result
+    assert result["result"].unique_id == TEST_STATION_ID
+
+
+async def test_full_import_flow_implementation(
+    hass: HomeAssistant,
+    mock_closest_station: MagicMock,
+    mock_zamg: MagicMock,
+    mock_setup_entry: None,
+) -> None:
+    """Test the full import flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_STATION_ID: TEST_STATION_ID, CONF_NAME: TEST_STATION_NAME},
+    )
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result.get("data") == {CONF_STATION_ID: TEST_STATION_ID}
+
+
+async def test_user_flow_not_found(
+    hass: HomeAssistant,
+    mock_closest_station: MagicMock,
+    mock_setup_entry: None,
+) -> None:
+    """Test the full manual user flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result.get("step_id") == "user"
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert "flow_id" in result
+    with patch(
+        "homeassistant.components.zamg.config_flow.ZamgData",
+        side_effect=ValueError(TEST_STATION_ID),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_STATION_ID: ""}
+        )
+        assert result.get("type") == RESULT_TYPE_ABORT
+        assert result.get("reason") == "unknown"
+
+
+async def test_import_flow_not_found(
+    hass: HomeAssistant,
+    mock_closest_station: MagicMock,
+    mock_setup_entry: None,
+) -> None:
+    """Test the full manual user flow from start to finish."""
+    with patch(
+        "homeassistant.components.zamg.config_flow.ZamgData",
+        side_effect=ValueError(TEST_STATION_ID),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_STATION_ID: TEST_STATION_ID, CONF_NAME: TEST_STATION_NAME},
+        )
+        assert result.get("type") == RESULT_TYPE_ABORT
+        assert result.get("reason") == "unknown"
+
+
+async def test_user_flow_duplicate(
+    hass: HomeAssistant,
+    mock_closest_station: MagicMock,
+    mock_zamg: MagicMock,
+    mock_setup_entry: None,
+) -> None:
+    """Test the full manual user flow from start to finish."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result.get("step_id") == "user"
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert "flow_id" in result
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_STATION_ID: TEST_STATION_ID}
+    )
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert "data" in result
+    assert result["data"][CONF_STATION_ID] == TEST_STATION_ID
+    assert "result" in result
+    assert result["result"].unique_id == TEST_STATION_ID
+    # try to add another instance
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result.get("step_id") == "user"
+    assert result.get("type") == RESULT_TYPE_FORM
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_STATION_ID: TEST_STATION_ID}
+    )
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "already_configured"

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -16,7 +16,6 @@ from .conftest import TEST_STATION_ID, TEST_STATION_NAME
 
 async def test_full_user_flow_implementation(
     hass: HomeAssistant,
-    mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,
 ) -> None:
@@ -43,7 +42,6 @@ async def test_full_user_flow_implementation(
 
 async def test_error_update(
     hass: HomeAssistant,
-    mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,
 ) -> None:
@@ -68,7 +66,6 @@ async def test_error_update(
 
 async def test_full_import_flow_implementation(
     hass: HomeAssistant,
-    mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,
 ) -> None:
@@ -103,7 +100,6 @@ async def test_import_flow_not_found(
 
 async def test_user_flow_duplicate(
     hass: HomeAssistant,
-    mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,
 ) -> None:

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the Zamg config flow."""
 from unittest.mock import MagicMock, patch
 
-from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN
+from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN, LOGGER
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -16,7 +16,6 @@ from .conftest import TEST_STATION_ID, TEST_STATION_NAME
 
 async def test_full_user_flow_implementation(
     hass: HomeAssistant,
-    mock_closest_station: MagicMock,
     mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,
@@ -28,13 +27,9 @@ async def test_full_user_flow_implementation(
     )
     assert result.get("step_id") == "user"
     assert result.get("type") == RESULT_TYPE_FORM
+    LOGGER.debug(result)
+    assert result.get("data_schema") != ""
     assert "flow_id" in result
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=None,
-    )
-    # assert result.get("data_schema") == "test"
-    assert result.get("type") == RESULT_TYPE_FORM
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_STATION_ID: int(TEST_STATION_ID)},
@@ -46,9 +41,33 @@ async def test_full_user_flow_implementation(
     assert result["result"].unique_id == TEST_STATION_ID
 
 
+async def test_error_update(
+    hass: HomeAssistant,
+    mock_zamg_stations: MagicMock,
+    mock_zamg: MagicMock,
+    mock_setup_entry: None,
+) -> None:
+    """Test with error of reading from Zamg."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result.get("step_id") == "user"
+    assert result.get("type") == RESULT_TYPE_FORM
+    LOGGER.debug(result)
+    assert result.get("data_schema") != ""
+    mock_zamg.update.side_effect = ValueError
+    assert "flow_id" in result
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_STATION_ID: int(TEST_STATION_ID)},
+    )
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "cannot_connect"
+
+
 async def test_full_import_flow_implementation(
     hass: HomeAssistant,
-    mock_closest_station: MagicMock,
     mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,
@@ -63,35 +82,8 @@ async def test_full_import_flow_implementation(
     assert result.get("data") == {CONF_STATION_ID: TEST_STATION_ID}
 
 
-async def test_user_flow_not_found(
-    hass: HomeAssistant,
-    mock_closest_station: MagicMock,
-    mock_zamg_stations: MagicMock,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
-    """Test the full manual user flow from start to finish."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-    assert result.get("step_id") == "user"
-    assert result.get("type") == RESULT_TYPE_FORM
-    assert "flow_id" in result
-    with patch(
-        "homeassistant.components.zamg.config_flow.ZamgData",
-        side_effect=ValueError(TEST_STATION_ID),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_STATION_ID: int(TEST_STATION_ID)}
-        )
-        assert result.get("type") == RESULT_TYPE_ABORT
-        assert result.get("reason") == "cannot_connect"
-
-
 async def test_import_flow_not_found(
     hass: HomeAssistant,
-    mock_closest_station: MagicMock,
     mock_zamg_stations: MagicMock,
     mock_setup_entry: None,
 ) -> None:
@@ -111,7 +103,6 @@ async def test_import_flow_not_found(
 
 async def test_user_flow_duplicate(
     hass: HomeAssistant,
-    mock_closest_station: MagicMock,
     mock_zamg_stations: MagicMock,
     mock_zamg: MagicMock,
     mock_setup_entry: None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The zamg weather client now support config flow out from the gui.
Any old weather entry in configuration.yaml is imported automatically
Changelog of zamg library: https://github.com/killer0071234/python-zamg/releases/tag/v0.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Added config flow into zamg component, to get away from deprecated configuration.yaml file.
As proposed in the conversation of PR #66290 

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21685

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
