### PR TITLE
Add sensors for next Picnic deliveries

### DIFF
--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -22,6 +22,7 @@ ATTRIBUTION = "Data provided by Picnic"
 ADDRESS = "address"
 CART_DATA = "cart_data"
 SLOT_DATA = "slot_data"
+NEXT_DELIVERY_DATA = "next_delivery_data"
 LAST_ORDER_DATA = "last_order_data"
 
 SENSOR_CART_ITEMS_COUNT = "cart_items_count"
@@ -33,18 +34,22 @@ SENSOR_SELECTED_SLOT_MIN_ORDER_VALUE = "selected_slot_min_order_value"
 SENSOR_LAST_ORDER_SLOT_START = "last_order_slot_start"
 SENSOR_LAST_ORDER_SLOT_END = "last_order_slot_end"
 SENSOR_LAST_ORDER_STATUS = "last_order_status"
-SENSOR_LAST_ORDER_ETA_START = "last_order_eta_start"
-SENSOR_LAST_ORDER_ETA_END = "last_order_eta_end"
 SENSOR_LAST_ORDER_MAX_ORDER_TIME = "last_order_max_order_time"
 SENSOR_LAST_ORDER_DELIVERY_TIME = "last_order_delivery_time"
 SENSOR_LAST_ORDER_TOTAL_PRICE = "last_order_total_price"
+SENSOR_NEXT_DELIVERY_ETA_START = "next_delivery_eta_start"
+SENSOR_NEXT_DELIVERY_ETA_END = "next_delivery_eta_end"
+SENSOR_NEXT_DELIVERY_SLOT_START = "next_delivery_slot_start"
+SENSOR_NEXT_DELIVERY_SLOT_END = "next_delivery_slot_end"
 
 
 @dataclass
 class PicnicRequiredKeysMixin:
     """Mixin for required keys."""
 
-    data_type: Literal["cart_data", "slot_data", "last_order_data"]
+    data_type: Literal[
+        "cart_data", "slot_data", "next_delivery_data", "last_order_data"
+    ]
     value_fn: Callable[[Any], StateType | datetime]
 
 
@@ -131,26 +136,6 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         value_fn=lambda last_order: last_order.get("status"),
     ),
     PicnicSensorEntityDescription(
-        key=SENSOR_LAST_ORDER_ETA_START,
-        device_class=SensorDeviceClass.TIMESTAMP,
-        icon="mdi:clock-start",
-        entity_registry_enabled_default=True,
-        data_type="last_order_data",
-        value_fn=lambda last_order: dt_util.parse_datetime(
-            str(last_order.get("eta", {}).get("start"))
-        ),
-    ),
-    PicnicSensorEntityDescription(
-        key=SENSOR_LAST_ORDER_ETA_END,
-        device_class=SensorDeviceClass.TIMESTAMP,
-        icon="mdi:clock-end",
-        entity_registry_enabled_default=True,
-        data_type="last_order_data",
-        value_fn=lambda last_order: dt_util.parse_datetime(
-            str(last_order.get("eta", {}).get("end"))
-        ),
-    ),
-    PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_MAX_ORDER_TIME,
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-alert-outline",
@@ -176,5 +161,43 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:cash-marker",
         data_type="last_order_data",
         value_fn=lambda last_order: last_order.get("total_price", 0) / 100,
+    ),
+    PicnicSensorEntityDescription(
+        key=SENSOR_NEXT_DELIVERY_ETA_START,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock-start",
+        entity_registry_enabled_default=True,
+        data_type="next_delivery_data",
+        value_fn=lambda next_delivery: dt_util.parse_datetime(
+            str(next_delivery.get("eta", {}).get("start"))
+        ),
+    ),
+    PicnicSensorEntityDescription(
+        key=SENSOR_NEXT_DELIVERY_ETA_END,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock-end",
+        entity_registry_enabled_default=True,
+        data_type="next_delivery_data",
+        value_fn=lambda next_delivery: dt_util.parse_datetime(
+            str(next_delivery.get("eta", {}).get("end"))
+        ),
+    ),
+    PicnicSensorEntityDescription(
+        key=SENSOR_NEXT_DELIVERY_SLOT_START,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:calendar-start",
+        data_type="next_delivery_data",
+        value_fn=lambda next_delivery: dt_util.parse_datetime(
+            str(next_delivery.get("slot", {}).get("window_start"))
+        ),
+    ),
+    PicnicSensorEntityDescription(
+        key=SENSOR_NEXT_DELIVERY_SLOT_END,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:calendar-end",
+        data_type="next_delivery_data",
+        value_fn=lambda next_delivery: dt_util.parse_datetime(
+            str(next_delivery.get("slot", {}).get("window_end"))
+        ),
     ),
 )

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import ADDRESS, CART_DATA, LAST_ORDER_DATA, SLOT_DATA
+from .const import ADDRESS, CART_DATA, LAST_ORDER_DATA, NEXT_DELIVERY_DATA, SLOT_DATA
 
 
 class PicnicUpdateCoordinator(DataUpdateCoordinator):
@@ -64,13 +64,14 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         if not cart:
             raise UpdateFailed("API response doesn't contain expected data.")
 
-        last_order = self._get_last_order()
+        next_delivery, last_order = self._get_order_data()
         slot_data = self._get_slot_data(cart)
 
         return {
             ADDRESS: self._get_address(),
             CART_DATA: cart,
             SLOT_DATA: slot_data,
+            NEXT_DELIVERY_DATA: next_delivery,
             LAST_ORDER_DATA: last_order,
         }
 
@@ -98,47 +99,55 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
 
         return {}
 
-    def _get_last_order(self) -> dict:
+    def _get_order_data(self) -> tuple[dict, dict]:
         """Get data of the last order from the list of deliveries."""
         # Get the deliveries
         deliveries = self.picnic_api_client.get_deliveries(summary=True)
 
         # Determine the last order and return an empty dict if there is none
         try:
+            # Filter on status CURRENT and select the last on the list which is the first one to be delivered
+            # Make a deepcopy because some references are local
+            next_deliveries = list(
+                filter(lambda d: d["status"] == "CURRENT", deliveries)
+            )
+            next_delivery = (
+                copy.deepcopy(next_deliveries[-1]) if next_deliveries else {}
+            )
             last_order = copy.deepcopy(deliveries[0])
-        except KeyError:
-            return {}
+        except (KeyError, TypeError):
+            # A KeyError or TypeError indicate that the response contains unexpected data
+            return {}, {}
 
-        #  Get the position details if the order is not delivered yet
+        #  Get the next order's position details if there is an undelivered order
         delivery_position = {}
-        if not last_order.get("delivery_time"):
+        if next_delivery and not next_delivery.get("delivery_time"):
             try:
                 delivery_position = self.picnic_api_client.get_delivery_position(
-                    last_order["delivery_id"]
+                    next_delivery["delivery_id"]
                 )
             except ValueError:
                 # No information yet can mean an empty response
                 pass
 
         # Determine the ETA, if available, the one from the delivery position API is more precise
-        # but it's only available shortly before the actual delivery.
-        last_order["eta"] = delivery_position.get(
-            "eta_window", last_order.get("eta2", {})
+        # but, it's only available shortly before the actual delivery.
+        next_delivery["eta"] = delivery_position.get(
+            "eta_window", next_delivery.get("eta2", {})
         )
+        if "eta2" in next_delivery:
+            del next_delivery["eta2"]
 
         # Determine the total price by adding up the total price of all sub-orders
         total_price = 0
         for order in last_order.get("orders", []):
             total_price += order.get("total_price", 0)
-
-        # Sanitise the object
         last_order["total_price"] = total_price
-        last_order.setdefault("delivery_time", {})
-        if "eta2" in last_order:
-            del last_order["eta2"]
 
-        # Make a copy because some references are local
-        return last_order
+        # Make sure delivery_time is a dict
+        last_order.setdefault("delivery_time", {})
+
+        return next_delivery, last_order
 
     @callback
     def _update_auth_token(self):

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -239,16 +239,6 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         )
         self._assert_sensor("sensor.picnic_last_order_status", "COMPLETED")
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_start",
-            "2021-02-26T19:54:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
-            "sensor.picnic_last_order_eta_end",
-            "2021-02-26T20:14:00+00:00",
-            cls=SensorDeviceClass.TIMESTAMP,
-        )
-        self._assert_sensor(
             "sensor.picnic_last_order_max_order_time",
             "2021-02-25T21:00:00+00:00",
             cls=SensorDeviceClass.TIMESTAMP,
@@ -261,6 +251,26 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor(
             "sensor.picnic_last_order_total_price", "41.33", unit=CURRENCY_EURO
         )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_eta_start",
+            "unknown",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_eta_end",
+            "unknown",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_slot_start",
+            "unknown",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_slot_end",
+            "unknown",
+            cls=SensorDeviceClass.TIMESTAMP,
+        )
 
     async def test_sensors_setup_disabled_by_default(self):
         """Test that some sensors are disabled by default."""
@@ -271,6 +281,8 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor("sensor.picnic_last_order_slot_end", disabled=True)
         self._assert_sensor("sensor.picnic_last_order_status", disabled=True)
         self._assert_sensor("sensor.picnic_last_order_total_price", disabled=True)
+        self._assert_sensor("sensor.picnic_next_delivery_slot_start", disabled=True)
+        self._assert_sensor("sensor.picnic_next_delivery_slot_end", disabled=True)
 
     async def test_sensors_no_selected_time_slot(self):
         """Test sensor states with no explicit selected time slot."""
@@ -295,11 +307,12 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
             "sensor.picnic_selected_slot_min_order_value", STATE_UNKNOWN
         )
 
-    async def test_sensors_last_order_in_future(self):
+    async def test_next_delivery_sensors(self):
         """Test sensor states when last order is not yet delivered."""
         # Adjust default delivery response
         delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
         del delivery_response["delivery_time"]
+        delivery_response["status"] = "CURRENT"
 
         # Set mock responses
         self.picnic_mock().get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
@@ -311,10 +324,16 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         # Assert delivery time is not available, but eta is
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
+            "sensor.picnic_next_delivery_eta_start", "2021-02-26T19:54:00+00:00"
         )
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
+            "sensor.picnic_next_delivery_eta_end", "2021-02-26T20:14:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_slot_start", "2021-02-26T19:15:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_slot_end", "2021-02-26T20:15:00+00:00"
         )
 
     async def test_sensors_eta_date_malformed(self):
@@ -329,12 +348,13 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         }
         delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
         delivery_response["eta2"] = eta_dates
+        delivery_response["status"] = "CURRENT"
         self.picnic_mock().get_deliveries.return_value = [delivery_response]
         await self._coordinator.async_refresh()
 
         # Assert eta times are not available due to malformed date strings
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_next_delivery_eta_start", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_next_delivery_eta_end", STATE_UNKNOWN)
 
     async def test_sensors_use_detailed_eta_if_available(self):
         """Test sensor states when last order is not yet delivered."""
@@ -344,6 +364,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         # Provide a delivery position response with different ETA and remove delivery time from response
         delivery_response = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
         del delivery_response["delivery_time"]
+        delivery_response["status"] = "CURRENT"
         self.picnic_mock().get_deliveries.return_value = [delivery_response]
         self.picnic_mock().get_delivery_position.return_value = {
             "eta_window": {
@@ -358,10 +379,10 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
             delivery_response["delivery_id"]
         )
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_start", "2021-03-05T10:19:20+00:00"
+            "sensor.picnic_next_delivery_eta_start", "2021-03-05T10:19:20+00:00"
         )
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_end", "2021-03-05T10:39:20+00:00"
+            "sensor.picnic_next_delivery_eta_end", "2021-03-05T10:39:20+00:00"
         )
 
     async def test_sensors_no_data(self):
@@ -387,12 +408,12 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self._assert_sensor(
             "sensor.picnic_selected_slot_min_order_value", STATE_UNAVAILABLE
         )
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNAVAILABLE)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNAVAILABLE)
         self._assert_sensor(
             "sensor.picnic_last_order_max_order_time", STATE_UNAVAILABLE
         )
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_next_delivery_eta_start", STATE_UNAVAILABLE)
+        self._assert_sensor("sensor.picnic_next_delivery_eta_end", STATE_UNAVAILABLE)
 
     async def test_sensors_malformed_delivery_data(self):
         """Test sensor states when the delivery api returns not a list."""
@@ -405,10 +426,10 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
 
         # Assert all last-order sensors have STATE_UNAVAILABLE because the delivery info fetch failed
         assert self._coordinator.last_update_success is True
-        self._assert_sensor("sensor.picnic_last_order_eta_start", STATE_UNKNOWN)
-        self._assert_sensor("sensor.picnic_last_order_eta_end", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_max_order_time", STATE_UNKNOWN)
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_next_delivery_eta_start", STATE_UNKNOWN)
+        self._assert_sensor("sensor.picnic_next_delivery_eta_end", STATE_UNKNOWN)
 
     async def test_sensors_malformed_response(self):
         """Test coordinator update fails when API yields ValueError."""
@@ -422,6 +443,55 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
 
         # Assert coordinator update failed
         assert self._coordinator.last_update_success is False
+
+    async def test_multiple_active_orders(self):
+        """Test that the sensors get the right values when there are multiple active orders."""
+        # Create 2 undelivered orders
+        undelivered_order = copy.deepcopy(DEFAULT_DELIVERY_RESPONSE)
+        del undelivered_order["delivery_time"]
+        undelivered_order["status"] = "CURRENT"
+        undelivered_order["slot"]["window_start"] = "2022-03-01T09:15:00.000+01:00"
+        undelivered_order["slot"]["window_end"] = "2022-03-01T10:15:00.000+01:00"
+        undelivered_order["eta2"]["start"] = "2022-03-01T09:30:00.000+01:00"
+        undelivered_order["eta2"]["end"] = "2022-03-01T09:45:00.000+01:00"
+
+        undelivered_order_2 = copy.deepcopy(undelivered_order)
+        undelivered_order_2["slot"]["window_start"] = "2022-03-08T13:15:00.000+01:00"
+        undelivered_order_2["slot"]["window_end"] = "2022-03-08T14:15:00.000+01:00"
+        undelivered_order_2["eta2"]["start"] = "2022-03-08T13:30:00.000+01:00"
+        undelivered_order_2["eta2"]["end"] = "2022-03-08T13:45:00.000+01:00"
+
+        deliveries_response = [
+            undelivered_order_2,
+            undelivered_order,
+            copy.deepcopy(DEFAULT_DELIVERY_RESPONSE),
+        ]
+
+        # Set mock responses
+        self.picnic_mock().get_user.return_value = copy.deepcopy(DEFAULT_USER_RESPONSE)
+        self.picnic_mock().get_cart.return_value = copy.deepcopy(DEFAULT_CART_RESPONSE)
+        self.picnic_mock().get_deliveries.return_value = deliveries_response
+        self.picnic_mock().get_delivery_position.return_value = {}
+        await self._setup_platform()
+
+        self._assert_sensor(
+            "sensor.picnic_last_order_slot_start", "2022-03-08T12:15:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_last_order_slot_end", "2022-03-08T13:15:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_slot_start", "2022-03-01T08:15:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_slot_end", "2022-03-01T09:15:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_eta_start", "2022-03-01T08:30:00+00:00"
+        )
+        self._assert_sensor(
+            "sensor.picnic_next_delivery_eta_end", "2022-03-01T08:45:00+00:00"
+        )
 
     async def test_device_registry_entry(self):
         """Test if device registry entry is populated correctly."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The sensors for the 'last order ETA start/end' have been renamed to 'next delivery ETA start/end' and will now contain the ETA of the first upcoming delivery. If there are multiple deliveries planned, the `next_delivery_*` sensors contain information about the first upcoming delivery, while the `last_order_*` sensors contain information about the last placed order.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add some sensors that are specifically for the next delivery instead of the last order.
The ETA sensors only make sense for undelivered orders anyway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66057
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#21632
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
