### PR TITLE
IntelliFire Integration - Switch Entity for Control 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -545,10 +545,11 @@ omit =
     homeassistant/components/insteon/switch.py
     homeassistant/components/insteon/utils.py
     homeassistant/components/intellifire/__init__.py
-    homeassistant/components/intellifire/coordinator.py
     homeassistant/components/intellifire/binary_sensor.py
-    homeassistant/components/intellifire/sensor.py
+    homeassistant/components/intellifire/coordinator.py
     homeassistant/components/intellifire/entity.py
+    homeassistant/components/intellifire/sensor.py
+    homeassistant/components/intellifire/switch.py
     homeassistant/components/incomfort/*
     homeassistant/components/intesishome/*
     homeassistant/components/ios/__init__.py

--- a/homeassistant/components/intellifire/__init__.py
+++ b/homeassistant/components/intellifire/__init__.py
@@ -1,16 +1,27 @@
 """The IntelliFire integration."""
 from __future__ import annotations
 
-from intellifire4py import IntellifireAsync
+from intellifire4py import IntellifireAsync, IntellifireControlAsync
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, LOGGER
 from .coordinator import IntellifireDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -18,16 +29,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     LOGGER.debug("Setting up config entry: %s", entry.unique_id)
 
     # Define the API Object
-    api_object = IntellifireAsync(entry.data[CONF_HOST])
+    read_object = IntellifireAsync(entry.data[CONF_HOST])
+
+    ift_control = IntellifireControlAsync(
+        fireplace_ip=entry.data[CONF_HOST],
+        use_http=(not entry.data[CONF_SSL]),
+        verify_ssl=entry.data[CONF_VERIFY_SSL],
+    )
+    try:
+        await ift_control.login(
+            username=entry.data[CONF_USERNAME],
+            password=entry.data[CONF_PASSWORD],
+        )
+    finally:
+        await ift_control.close()
 
     # Define the update coordinator
     coordinator = IntellifireDataUpdateCoordinator(
-        hass=hass,
-        api=api_object,
+        hass=hass, read_api=read_object, control_api=ift_control
     )
+
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
@@ -37,5 +60,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
-
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+
+    if config_entry.version == 1:
+        # There is no migration path from v1-2 as we need more data
+        LOGGER.warning(
+            "Intellifire must be reconfigured - Migration from v1 to v2 not possible"
+        )
+        return False
+
+    return False

--- a/homeassistant/components/intellifire/config_flow.py
+++ b/homeassistant/components/intellifire/config_flow.py
@@ -4,20 +4,36 @@ from __future__ import annotations
 from typing import Any
 
 from aiohttp import ClientConnectionError
-from intellifire4py import IntellifireAsync
+from aiohttp.client_reqrep import ConnectionKey
+from intellifire4py import IntellifireAsync, IntellifireControlAsync
+from intellifire4py.control import LoginException
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
-STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_SSL, default=True): bool,
+        vol.Required(CONF_VERIFY_SSL, default=True): bool,
+    }
+)
 
 
-async def validate_input(hass: HomeAssistant, host: str) -> str:
+async def validate_host_input(hass: HomeAssistant, host: str) -> str:
     """Validate the user input allows us to connect.
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
@@ -29,10 +45,28 @@ async def validate_input(hass: HomeAssistant, host: str) -> str:
     return api.data.serial
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+async def validate_api_access(hass: HomeAssistant, user_input: dict[str, Any]):
+    """Validate username/password against api."""
+    ift_control = IntellifireControlAsync(
+        fireplace_ip=user_input[CONF_HOST],
+        use_http=(not user_input[CONF_SSL]),
+        verify_ssl=user_input[CONF_VERIFY_SSL],
+    )
+    try:
+        await ift_control.login(
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+        )
+        await ift_control.get_username()
+
+    finally:
+        await ift_control.close()
+
+
+class IntellifireConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for IntelliFire."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -45,18 +79,38 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         try:
-            serial = await validate_input(self.hass, user_input[CONF_HOST])
-        except (ConnectionError, ClientConnectionError):
+            serial = await validate_host_input(self.hass, user_input[CONF_HOST])
+            # If we don't throw an error everything is peachy!
+            await validate_api_access(self.hass, user_input)
+        except (ConnectionError, ClientConnectionError) as error:
             errors["base"] = "cannot_connect"
+            if len(error.args) > 0:
+                if isinstance(error.args[0], ConnectionKey):
+                    arg0: ConnectionKey = error.args[0]
+                    if arg0.host == "iftapi.net":
+                        errors["base"] = "iftapi_connect"
+        except LoginException:
+            errors["base"] = "api_error"
         else:
             await self.async_set_unique_id(serial)
             self._abort_if_unique_id_configured(
-                updates={CONF_HOST: user_input[CONF_HOST]}
+                updates={
+                    CONF_HOST: user_input[CONF_HOST],
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    CONF_SSL: user_input[CONF_SSL],
+                    CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+                }
             )
-
             return self.async_create_entry(
                 title="Fireplace",
-                data={CONF_HOST: user_input[CONF_HOST]},
+                data={
+                    CONF_HOST: user_input[CONF_HOST],
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    CONF_SSL: user_input[CONF_SSL],
+                    CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+                },
             )
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors

--- a/homeassistant/components/intellifire/coordinator.py
+++ b/homeassistant/components/intellifire/coordinator.py
@@ -5,7 +5,11 @@ from datetime import timedelta
 
 from aiohttp import ClientConnectionError
 from async_timeout import timeout
-from intellifire4py import IntellifireAsync, IntellifirePollData
+from intellifire4py import (
+    IntellifireAsync,
+    IntellifireControlAsync,
+    IntellifirePollData,
+)
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -17,7 +21,12 @@ from .const import DOMAIN, LOGGER
 class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntellifirePollData]):
     """Class to manage the polling of the fireplace API."""
 
-    def __init__(self, hass: HomeAssistant, api: IntellifireAsync) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        read_api: IntellifireAsync,
+        control_api: IntellifireControlAsync,
+    ) -> None:
         """Initialize the Coordinator."""
         super().__init__(
             hass,
@@ -25,21 +34,22 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntellifirePollData
             name=DOMAIN,
             update_interval=timedelta(seconds=15),
         )
-        self._api = api
+        self._read_api = read_api
+        self.control_api = control_api
 
     async def _async_update_data(self) -> IntellifirePollData:
         LOGGER.debug("Calling update loop on IntelliFire")
         async with timeout(100):
             try:
-                await self._api.poll()
+                await self._read_api.poll()
             except (ConnectionError, ClientConnectionError) as exception:
                 raise UpdateFailed from exception
-        return self._api.data
+        return self._read_api.data
 
     @property
     def api(self) -> IntellifireAsync:
         """Return the API pointer."""
-        return self._api
+        return self._read_api
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -50,4 +60,5 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntellifirePollData
             name="IntelliFire Fireplace",
             identifiers={("IntelliFire", f"{self.api.data.serial}]")},
             sw_version=self.api.data.fw_ver_str,
+            configuration_url=f"http://{self.api.ip}/poll",
         )

--- a/homeassistant/components/intellifire/manifest.json
+++ b/homeassistant/components/intellifire/manifest.json
@@ -3,7 +3,7 @@
   "name": "IntelliFire",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/intellifire",
-  "requirements": ["intellifire4py==0.6"],
+  "requirements": ["intellifire4py==0.9.7"],
   "dependencies": [],
   "codeowners": ["@jeeftor"],
   "iot_class": "local_polling",

--- a/homeassistant/components/intellifire/strings.json
+++ b/homeassistant/components/intellifire/strings.json
@@ -2,13 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+        "title": "IntelliFire Config",
+          "description": "Username and password are the same information used in your IntelliFire Android/iOS application.",        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "ssl": "[%key:common::config_flow::data::ssl%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "api_error": "api_error",
+      "iftapi_connect": "iftapi_connect"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/intellifire/switch.py
+++ b/homeassistant/components/intellifire/switch.py
@@ -1,0 +1,104 @@
+"""Switch definition."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from intellifire4py import IntellifireControlAsync, IntellifirePollData
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import IntellifireDataUpdateCoordinator
+from .entity import IntellifireEntity
+
+
+@dataclass()
+class IntellifireSwitchRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    on_fn: Callable[[IntellifireControlAsync], Awaitable]
+    off_fn: Callable[[IntellifireControlAsync], Awaitable]
+    value_fn: Callable[[IntellifirePollData], bool]
+    data_field: str
+
+
+@dataclass
+class IntellifireSwitchEntityDescription(
+    SwitchEntityDescription, IntellifireSwitchRequiredKeysMixin
+):
+    """Describes a switch entity."""
+
+
+INTELLIFIRE_SWITCHES: tuple[IntellifireSwitchEntityDescription, ...] = (
+    IntellifireSwitchEntityDescription(
+        key="on_off",
+        name="Flame",
+        on_fn=lambda control_api: control_api.flame_on(
+            fireplace=control_api.default_fireplace
+        ),
+        off_fn=lambda control_api: control_api.flame_off(
+            fireplace=control_api.default_fireplace
+        ),
+        value_fn=lambda data: data.is_on,
+        data_field="is_on",
+    ),
+    IntellifireSwitchEntityDescription(
+        key="pilot",
+        name="Pilot Light",
+        icon="mdi:fire-alert",
+        on_fn=lambda control_api: control_api.pilot_on(
+            fireplace=control_api.default_fireplace
+        ),
+        off_fn=lambda control_api: control_api.pilot_off(
+            fireplace=control_api.default_fireplace
+        ),
+        value_fn=lambda data: data.pilot_on,
+        data_field="pilot_on",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Configure switch entities."""
+    coordinator: IntellifireDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        IntellifireSwitch(coordinator=coordinator, description=description)
+        for description in INTELLIFIRE_SWITCHES
+    )
+
+
+class IntellifireSwitch(IntellifireEntity, SwitchEntity):
+    """Define an Intellifire Switch."""
+
+    entity_description: IntellifireSwitchEntityDescription
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch."""
+        await self.entity_description.on_fn(self.coordinator.control_api)
+        setattr(self.coordinator.api.data, self.entity_description.data_field, 1)
+        await self.async_update_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the switch."""
+        await self.entity_description.off_fn(self.coordinator.control_api)
+        setattr(self.coordinator.api.data, self.entity_description.data_field, 0)
+        await self.async_update_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the on state."""
+        return self.entity_description.value_fn(self.coordinator.api.data)
+
+    async def async_update(self) -> None:
+        """Tell coordinator to update."""
+        await self.coordinator.api.poll()

--- a/homeassistant/components/intellifire/translations/en.json
+++ b/homeassistant/components/intellifire/translations/en.json
@@ -4,14 +4,21 @@
             "already_configured": "Device is already configured"
         },
         "error": {
-            "cannot_connect": "Failed to connect",
-            "unknown": "Unexpected error"
+            "cannot_connect": "Failed to connect to intellifire on local network - check host and try agian.",
+            "api_error": "API Error",
+            "iftapi_connect": "IFTAPI Connection Error. Perhaps try insecure (http) mode."
         },
         "step": {
             "user": {
                 "data": {
-                    "host": "Host"
-                }
+                    "host": "Host",
+                    "password": "Password",
+                    "username": "Username (email)",
+                    "ssl": "Uncheck to enable HTTP communications with IFTAPI. In some cases such as SSL Inspection or perhaps behind a corporate proxy you may need to do this.",
+                    "verify_ssl": "Uncheck to disable client certificate verification SSL (https) mode"
+                },
+                "description": "Username and password are the same information used in your IntelliFire Android/iOS application.",
+                "title": "IntelliFire Config"
             }
         }
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -914,7 +914,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.6
+intellifire4py==0.9.7
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -592,7 +592,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.6
+intellifire4py==0.9.7
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -2,6 +2,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+from aiohttp.client_reqrep import ConnectionKey
 import pytest
 
 
@@ -26,4 +27,44 @@ def mock_intellifire_config_flow() -> Generator[None, MagicMock, None]:
     ) as intellifire_mock:
         intellifire = intellifire_mock.return_value
         intellifire.data = data_mock
+
         yield intellifire
+
+
+@pytest.fixture
+def mock_intellifire_config_flow_with_local_error() -> Generator[None, MagicMock, None]:
+    """Return a mocked IntelliFire client."""
+    data_mock = Mock()
+    data_mock.serial = "12345"
+
+    with patch(
+        "homeassistant.components.intellifire.config_flow.IntellifireAsync",
+        autospec=True,
+    ) as intellifire_mock:
+        intellifire_mock.side_effect = ConnectionError()
+        yield ConnectionError()
+
+
+@pytest.fixture
+def mock_intellifire_config_flow_with_api_error() -> Generator[None, MagicMock, None]:
+    """Return a mocked IntelliFire client."""
+    data_mock = Mock()
+    data_mock.serial = "12345"
+
+    with patch(
+        "homeassistant.components.intellifire.config_flow.IntellifireControlAsync",
+        autospec=True,
+    ), patch(
+        "homeassistant.components.intellifire.config_flow.IntellifireAsync",
+        autospec=True,
+    ) as intellifire_mock:
+        intellifire = intellifire_mock.return_value
+        intellifire.data = data_mock
+        yield intellifire
+
+
+def mock_api_connection_error() -> ConnectionError:
+    """Return a fake a ConnectionError for iftapi.net."""
+    ret = ConnectionError()
+    ret.args = [ConnectionKey("iftapi.net", 443, False, None, None, None, None)]
+    return ret

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -1,18 +1,28 @@
 """Test the IntelliFire config flow."""
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from intellifire4py.control import LoginException
 
 from homeassistant import config_entries
 from homeassistant.components.intellifire.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
 
+from tests.components.intellifire.conftest import mock_api_connection_error
 
+
+@patch.multiple(
+    "homeassistant.components.intellifire.config_flow.IntellifireControlAsync",
+    login=AsyncMock(),
+    get_username=AsyncMock(return_value="intellifire"),
+)
 async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_intellifire_config_flow: MagicMock,
 ) -> None:
     """Test we get the form."""
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -23,22 +33,23 @@ async def test_form(
         result["flow_id"],
         {
             "host": "1.1.1.1",
+            "username": "intelli",
+            "password": "fire",
+            "ssl": True,
+            "verify_ssl": True,
         },
     )
     await hass.async_block_till_done()
-
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "Fireplace"
-    assert result2["data"] == {"host": "1.1.1.1"}
-
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_cannot_connect(
-    hass: HomeAssistant, mock_intellifire_config_flow: MagicMock
+async def test_form_cannot_connect_local(
+    hass: HomeAssistant, mock_intellifire_config_flow_with_local_error: MagicMock
 ) -> None:
     """Test we handle cannot connect error."""
-    mock_intellifire_config_flow.poll.side_effect = ConnectionError
+    # mock_intellifire_config_flow_with_local_error.poll.side_effect = ConnectionError()
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -48,8 +59,79 @@ async def test_form_cannot_connect(
         result["flow_id"],
         {
             "host": "1.1.1.1",
+            "username": "intelli",
+            "password": "fire",
+            "ssl": True,
+            "verify_ssl": True,
         },
     )
 
     assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+@patch.multiple(
+    "homeassistant.components.intellifire.config_flow.IntellifireControlAsync",
+    login=AsyncMock(side_effect=mock_api_connection_error()),
+    get_username=AsyncMock(
+        return_value="intellifire",
+    ),
+)
+async def test_form_api_connect_error(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_intellifire_config_flow: MagicMock,
+) -> None:
+    """Test we get the form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "host": "1.1.1.1",
+            "username": "intelli",
+            "password": "fire",
+            "ssl": True,
+            "verify_ssl": True,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "iftapi_connect"}
+
+
+@patch.multiple(
+    "homeassistant.components.intellifire.config_flow.IntellifireControlAsync",
+    login=AsyncMock(side_effect=LoginException()),
+)
+async def test_form_api_login_error(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_intellifire_config_flow: MagicMock,
+) -> None:
+    """Test we get the form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "host": "1.1.1.1",
+            "username": "intelli",
+            "password": "fire",
+            "ssl": True,
+            "verify_ssl": True,
+        },
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "api_error"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

A variety of new config fields are being added. I do not know if this qualifies as a breaking change - but the integration (I believe) will likely stop working without a reconfiguration. 

After this change it will look like this.
<img width="574" alt="image" src="https://user-images.githubusercontent.com/6491743/153776209-a6c6d1ea-e13e-47a6-bced-3204c6bff611.png">


I'm hoping there is a **reconfigure dialog** or something that I'm unaware of -> because now it looks as if you need to delete and re-add the integration.

New config screen looks as follows:

<img width="517" alt="image" src="https://user-images.githubusercontent.com/6491743/153776234-2e848881-8e65-4486-9942-e782cc6b4d2e.png">


## Proposed change


This PR adds both Two new Switch entities, an updated config flow and support for controlling the fireplace. This will be bigger than subsequent PRs because the new control interface required an updated config_flow. 

- Update to intellifire4py library to version 0.9.7: [CHANGELOG](https://raw.githubusercontent.com/jeeftor/intellifire4py/master/CHANGELOG)
- Added two switches for controlling the Main and Pilot flames.
- Updated Config options for both accessing IFTAPI.net as well as SSL options.

The general way the control logic works for the unit is that there is a Cloud-accessed API Token that is retreived by the client. Once the token is obtained then a request is made to a `/challenge` endpoint on the unit. A combination of the `apiKey` + `challenge` + `command-to-send` go through a hasing process and a command is sent to the `/post` endpoint. 

There is also a cloud accessible endpoint that will likely be exposed in a future PR.

**Notes:**
- I think the tests could probably be a little cleaner
- I was unsure exactly how the config-migraiton works so I just made the function return `False` as new fields need to be added


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21635

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

https://github.com/home-assistant/home-assistant.io/pull/21635

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
