### PR TITLE
Bump Advantage Air 0.3.0

### DIFF
--- a/homeassistant/components/advantage_air/manifest.json
+++ b/homeassistant/components/advantage_air/manifest.json
@@ -7,7 +7,7 @@
     "@Bre77"
   ],
   "requirements": [
-    "advantage_air==0.2.6"
+    "advantage_air==0.2.7"
   ],
   "quality_scale": "platinum",
   "iot_class": "local_polling",

--- a/homeassistant/components/advantage_air/manifest.json
+++ b/homeassistant/components/advantage_air/manifest.json
@@ -7,7 +7,7 @@
     "@Bre77"
   ],
   "requirements": [
-    "advantage_air==0.2.7"
+    "advantage_air==0.3.0"
   ],
   "quality_scale": "platinum",
   "iot_class": "local_polling",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ adext==0.4.2
 adguardhome==0.5.1
 
 # homeassistant.components.advantage_air
-advantage_air==0.2.7
+advantage_air==0.3.0
 
 # homeassistant.components.frontier_silicon
 afsapi==0.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ adext==0.4.2
 adguardhome==0.5.1
 
 # homeassistant.components.advantage_air
-advantage_air==0.2.6
+advantage_air==0.2.7
 
 # homeassistant.components.frontier_silicon
 afsapi==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -70,7 +70,7 @@ adext==0.4.2
 adguardhome==0.5.1
 
 # homeassistant.components.advantage_air
-advantage_air==0.2.6
+advantage_air==0.2.7
 
 # homeassistant.components.agent_dvr
 agent-py==0.0.23

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -70,7 +70,7 @@ adext==0.4.2
 adguardhome==0.5.1
 
 # homeassistant.components.advantage_air
-advantage_air==0.2.7
+advantage_air==0.3.0
 
 # homeassistant.components.agent_dvr
 agent-py==0.0.23


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have identified that the fix to #62362 was incorrect, so I need to bump Adavantage Air again to correctly address the issue.
(https://github.com/home-assistant/core/pull/65849)

Changes:
https://github.com/Bre77/advantage_air/commit/eeb2daeb255a3bc0c1190952526a5adde43cf0f9
https://github.com/Bre77/advantage_air/commit/64d955b31cb6540417ee543e90da54de387eda92

https://github.com/Bre77/advantage_air/compare/d0e0265e31eab7ea6ed54b5336fbb4bd7365be30...64d955b31cb6540417ee543e90da54de387eda92

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #62362 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
