### PR TITLE
Add webhook trigger allowed_methods/local_only options

### DIFF
--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -135,7 +135,11 @@ async def async_handle_webhook(
             method_name,
             received_from,
         )
-        return Response(status=HTTPStatus.OK)
+        if method_name == METH_HEAD:
+            # Allow websites to verify that the URL exists.
+            # See https://github.com/home-assistant/core/pull/26299
+            return Response(status=HTTPStatus.OK)
+        return Response(status=HTTPStatus.METHOD_NOT_ALLOWED)
 
     if webhook["local_only"] and not isinstance(request, MockRequest):
         if TYPE_CHECKING:

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -220,6 +220,7 @@ def websocket_list(
             "domain": info["domain"],
             "name": info["name"],
             "local_only": info["local_only"],
+            "allowed_methods": sorted(info["allowed_methods"]),
         }
         for webhook_id, info in handlers.items()
     ]
@@ -231,7 +232,7 @@ def websocket_list(
     {
         vol.Required("type"): "webhook/handle",
         vol.Required("webhook_id"): str,
-        vol.Required("method"): vol.In(["GET", "POST", "PUT"]),
+        vol.Required("method"): vol.In(SUPPORTED_METHODS),
         vol.Optional("body", default=""): str,
         vol.Optional("headers", default={}): {str: str},
         vol.Optional("query", default=""): str,

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -51,7 +51,7 @@ def async_register(
 
     if allowed_methods is None:
         allowed_methods = DEFAULT_METHODS
-    allowed_methods = frozenset(method.upper() for method in allowed_methods)
+    allowed_methods = frozenset(method for method in allowed_methods)
 
     if not allowed_methods.issubset(SUPPORTED_METHODS):
         raise ValueError(

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -154,13 +154,15 @@ async def async_handle_webhook(
             _LOGGER.warning("Received remote request for local webhook %s", webhook_id)
             if webhook["local_only"]:
                 return Response(status=HTTPStatus.OK)
-            _LOGGER.warning(
-                "Deprecation warning: "
-                "Webhook '%s' does not provide a value for local_only. "
-                "This webhook will be blocked after the 2023.7.0 release. "
-                "Use `local_only: false` to keep this webhook operating as-is",
-                webhook_id,
-            )
+            if not webhook.get("warned_about_deprecation"):
+                webhook["warned_about_deprecation"] = True
+                _LOGGER.warning(
+                    "Deprecation warning: "
+                    "Webhook '%s' does not provide a value for local_only. "
+                    "This webhook will be blocked after the 2023.7.0 release. "
+                    "Use `local_only: false` to keep this webhook operating as-is",
+                    webhook_id,
+                )
 
     try:
         response = await webhook["handler"](hass, webhook_id, request)

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -158,7 +158,7 @@ async def async_handle_webhook(
             _LOGGER.warning(
                 "Deprecation warning: "
                 "Webhook '%s' does not provide a value for local_only. "
-                "This webhook will be blocked after the 2022.8.0 release. "
+                "This webhook will be blocked after the 2023.1.0 release. "
                 "Use `local_only: false` to keep this webhook operating as-is",
                 webhook_id,
             )

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -51,7 +51,7 @@ def async_register(
 
     if allowed_methods is None:
         allowed_methods = DEFAULT_METHODS
-    allowed_methods = frozenset(method for method in allowed_methods)
+    allowed_methods = frozenset(allowed_methods)
 
     if not allowed_methods.issubset(SUPPORTED_METHODS):
         raise ValueError(
@@ -139,9 +139,6 @@ async def async_handle_webhook(
             method_name,
             received_from,
         )
-        if method_name == METH_HEAD:
-            # Allow websites to verify that the URL exists.
-            return Response(status=HTTPStatus.OK)
         return Response(status=HTTPStatus.METHOD_NOT_ALLOWED)
 
     if webhook["local_only"] in (True, None) and not isinstance(request, MockRequest):

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -194,10 +194,10 @@ class WebhookView(HomeAssistantView):
         hass = request.app["hass"]
         return await async_handle_webhook(hass, webhook_id, request)
 
-
-for method in SUPPORTED_METHODS:
-    # pylint: disable=protected-access
-    setattr(WebhookView, method.lower(), WebhookView._handle)
+    get = _handle
+    head = _handle
+    post = _handle
+    put = _handle
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -158,7 +158,7 @@ async def async_handle_webhook(
             _LOGGER.warning(
                 "Deprecation warning: "
                 "Webhook '%s' does not provide a value for local_only. "
-                "This webhook will be blocked after the 2023.4.0 release. "
+                "This webhook will be blocked after the 2023.7.0 release. "
                 "Use `local_only: false` to keep this webhook operating as-is",
                 webhook_id,
             )

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -128,6 +128,10 @@ async def async_handle_webhook(
         return Response(status=HTTPStatus.OK)
 
     if method_name not in webhook["allowed_methods"]:
+        if method_name == METH_HEAD:
+            # Allow websites to verify that the URL exists.
+            return Response(status=HTTPStatus.OK)
+
         _LOGGER.warning(
             "Webhook %s only supports %s methods but %s was received from %s",
             webhook_id,

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -137,7 +137,6 @@ async def async_handle_webhook(
         )
         if method_name == METH_HEAD:
             # Allow websites to verify that the URL exists.
-            # See https://github.com/home-assistant/core/pull/26299
             return Response(status=HTTPStatus.OK)
         return Response(status=HTTPStatus.METHOD_NOT_ALLOWED)
 

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -159,7 +159,7 @@ async def async_handle_webhook(
                 "Deprecation warning: "
                 "Webhook '%s' does not provide a value for local_only. "
                 "This webhook will be blocked after the 2022.8.0 release. "
-                "Use `local_only: true` to keep this webhook operating as-is",
+                "Use `local_only: false` to keep this webhook operating as-is",
                 webhook_id,
             )
 

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -26,8 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "webhook"
 
-ALLOWED_METHODS = (METH_GET, METH_HEAD, METH_POST, METH_PUT)
 DEFAULT_METHODS = (METH_POST, METH_PUT)
+SUPPORTED_METHODS = (METH_GET, METH_HEAD, METH_POST, METH_PUT)
 URL_WEBHOOK_PATH = "/api/webhook/{webhook_id}"
 
 
@@ -53,9 +53,9 @@ def async_register(
         allowed_methods = DEFAULT_METHODS
     allowed_methods = frozenset(method.upper() for method in allowed_methods)
 
-    if not allowed_methods.issubset(ALLOWED_METHODS):
+    if not allowed_methods.issubset(SUPPORTED_METHODS):
         raise ValueError(
-            f"Unexpected method: {allowed_methods.difference(ALLOWED_METHODS)}"
+            f"Unexpected method: {allowed_methods.difference(SUPPORTED_METHODS)}"
         )
 
     handlers[webhook_id] = {
@@ -184,7 +184,7 @@ class WebhookView(HomeAssistantView):
         return await async_handle_webhook(hass, webhook_id, request)
 
 
-for method in ALLOWED_METHODS:
+for method in SUPPORTED_METHODS:
     # pylint: disable=protected-access
     setattr(WebhookView, method.lower(), WebhookView._handle)
 

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -158,7 +158,7 @@ async def async_handle_webhook(
             _LOGGER.warning(
                 "Deprecation warning: "
                 "Webhook '%s' does not provide a value for local_only. "
-                "This webhook will be blocked after the 2023.1.0 release. "
+                "This webhook will be blocked after the 2023.4.0 release. "
                 "Use `local_only: false` to keep this webhook operating as-is",
                 webhook_id,
             )

--- a/homeassistant/components/webhook/strings.json
+++ b/homeassistant/components/webhook/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "trigger_missing_local_only": {
+      "title": "Update webhook trigger: {webhook_id}",
+      "description": "A choice needs to be made about whether the {webhook_id} webhook automation trigger is accessible from the internet. Edit the {automation_name} automation, and click the gear icon beside the Webhook ID to choose a value for 'Only accessible from the local network'"
+    }
+  }
+}

--- a/homeassistant/components/webhook/strings.json
+++ b/homeassistant/components/webhook/strings.json
@@ -2,7 +2,7 @@
   "issues": {
     "trigger_missing_local_only": {
       "title": "Update webhook trigger: {webhook_id}",
-      "description": "A choice needs to be made about whether the {webhook_id} webhook automation trigger is accessible from the internet. Edit the {automation_name} automation, and click the gear icon beside the Webhook ID to choose a value for 'Only accessible from the local network'"
+      "description": "A choice needs to be made about whether the {webhook_id} webhook automation trigger is accessible from the internet. [Edit the automation]({edit}) \"{automation_name}\", (`{entity_id}`) and click the gear icon beside the Webhook ID to choose a value for 'Only accessible from the local network'"
     }
   }
 }

--- a/homeassistant/components/webhook/translations/en.json
+++ b/homeassistant/components/webhook/translations/en.json
@@ -1,0 +1,8 @@
+{
+    "issues": {
+        "trigger_missing_local_only": {
+            "description": "A choice needs to be made about whether the {webhook_id} webhook automation trigger is accessible from the internet. Edit the {automation_name} automation, and click the gear icon beside the Webhook ID to choose a value for 'Only accessible from the local network'",
+            "title": "Update webhook trigger: {webhook_id}"
+        }
+    }
+}

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -91,7 +91,7 @@ async def async_attach_trigger(
             hass,
             DOMAIN,
             issue_id,
-            breaks_in_ha_version="2023.1.0",
+            breaks_in_ha_version="2023.4.0",
             is_fixable=False,
             learn_more_url="https://github.com/home-assistant/core/pull/66494",
             severity=IssueSeverity.WARNING,
@@ -104,7 +104,7 @@ async def async_attach_trigger(
         _LOGGER.warning(
             "Deprecation warning: "
             "Webhook '%s' does not provide a value for local_only. "
-            "The default value will be 'true' in the 2023.1.0 release",
+            "The default value will be 'true' in the 2023.4.0 release",
             webhook_id,
         )
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -83,7 +83,7 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Trigger based on incoming webhooks."""
     webhook_id: str = config[CONF_WEBHOOK_ID]
-    local_only = config.get(CONF_LOCAL_ONLY, None)
+    local_only = config.get(CONF_LOCAL_ONLY)
     issue_id: str | None = None
     if local_only is None:
         issue_id = f"trigger_missing_local_only_{webhook_id}"

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -91,7 +91,7 @@ async def async_attach_trigger(
             hass,
             DOMAIN,
             issue_id,
-            breaks_in_ha_version="2023.4.0",
+            breaks_in_ha_version="2023.7.0",
             is_fixable=False,
             learn_more_url="https://github.com/home-assistant/core/pull/66494",
             severity=IssueSeverity.WARNING,

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -38,7 +38,7 @@ TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
         vol.Required(CONF_PLATFORM): "webhook",
         vol.Required(CONF_WEBHOOK_ID): cv.string,
         vol.Optional(CONF_ALLOWED_METHODS): vol.All(
-            cv.ensure_list, [vol.In(SUPPORTED_METHODS)], vol.Unique()
+            cv.ensure_list, [vol.All(vol.Upper, vol.In(SUPPORTED_METHODS))], vol.Unique()
         ),
         vol.Optional(CONF_LOCAL_ONLY): bool,
     }

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -89,6 +89,11 @@ async def async_attach_trigger(
     issue_id: str | None = None
     if local_only is None:
         issue_id = f"trigger_missing_local_only_{webhook_id}"
+        variables = trigger_info["variables"] or {}
+        automation_info = variables.get("this", {})
+        automation_id = automation_info.get("attributes", {}).get("id")
+        automation_entity_id = automation_info.get("entity_id")
+        automation_name = trigger_info.get("name") or automation_entity_id
         async_create_issue(
             hass,
             DOMAIN,
@@ -96,10 +101,13 @@ async def async_attach_trigger(
             breaks_in_ha_version="2023.7.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
+            learn_more_url="https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger",
             translation_key="trigger_missing_local_only",
             translation_placeholders={
                 "webhook_id": webhook_id,
-                "automation_name": trigger_info.get("name", "[unknown]"),
+                "automation_name": automation_name,
+                "entity_id": automation_entity_id,
+                "edit": f"/config/automation/edit/{automation_id}",
             },
         )
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 
 from aiohttp import hdrs
 import voluptuous as vol
@@ -19,6 +20,8 @@ from . import (
     async_register,
     async_unregister,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ("webhook",)
 
@@ -75,7 +78,14 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Trigger based on incoming webhooks."""
     webhook_id: str = config[CONF_WEBHOOK_ID]
-    local_only = config.get(CONF_LOCAL_ONLY, True)
+    local_only = config.get(CONF_LOCAL_ONLY, None)
+    if local_only is None:
+        _LOGGER.warning(
+            "Deprecation warning: "
+            "Webhook '%s' does not provide a value for local_only. "
+            "The default value will be 'true' in the 2022.8.0 release",
+            webhook_id,
+        )
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)
     job = HassJob(action)
 

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -12,21 +12,27 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
-from . import ALLOWED_METHODS, DEFAULT_METHODS, DOMAIN, async_register, async_unregister
+from . import (
+    DEFAULT_METHODS,
+    DOMAIN,
+    SUPPORTED_METHODS,
+    async_register,
+    async_unregister,
+)
 
 DEPENDENCIES = ("webhook",)
 
-CONF_ALLOW_INTERNET = "allow_internet"
-CONF_ALLOW_METHODS = "allow_methods"
+CONF_ALLOWED_METHODS = "allowed_methods"
+CONF_LOCAL_ONLY = "local_only"
 
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): "webhook",
         vol.Required(CONF_WEBHOOK_ID): cv.string,
-        vol.Optional(CONF_ALLOW_INTERNET): bool,
-        vol.Optional(CONF_ALLOW_METHODS): vol.All(
-            cv.ensure_list, [vol.In(ALLOWED_METHODS)], vol.Unique()
+        vol.Optional(CONF_ALLOWED_METHODS): vol.All(
+            cv.ensure_list, [vol.In(SUPPORTED_METHODS)], vol.Unique()
         ),
+        vol.Optional(CONF_LOCAL_ONLY): bool,
     }
 )
 
@@ -69,8 +75,8 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Trigger based on incoming webhooks."""
     webhook_id: str = config[CONF_WEBHOOK_ID]
-    local_only = not config.get(CONF_ALLOW_INTERNET, False)
-    allowed_methods = config.get(CONF_ALLOW_METHODS, DEFAULT_METHODS)
+    local_only = config.get(CONF_LOCAL_ONLY, True)
+    allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)
     job = HassJob(action)
 
     triggers: dict[str, list[TriggerInstance]] = hass.data.setdefault(

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -38,7 +38,9 @@ TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
         vol.Required(CONF_PLATFORM): "webhook",
         vol.Required(CONF_WEBHOOK_ID): cv.string,
         vol.Optional(CONF_ALLOWED_METHODS): vol.All(
-            cv.ensure_list, [vol.All(vol.Upper, vol.In(SUPPORTED_METHODS))], vol.Unique()
+            cv.ensure_list,
+            [vol.All(vol.Upper, vol.In(SUPPORTED_METHODS))],
+            vol.Unique(),
         ),
         vol.Optional(CONF_LOCAL_ONLY): bool,
     }

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -83,7 +83,7 @@ async def async_attach_trigger(
         _LOGGER.warning(
             "Deprecation warning: "
             "Webhook '%s' does not provide a value for local_only. "
-            "The default value will be 'true' in the 2022.8.0 release",
+            "The default value will be 'true' in the 2023.1.0 release",
             webhook_id,
         )
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -102,12 +102,6 @@ async def async_attach_trigger(
                 "automation_name": trigger_info.get("name", "[unknown]"),
             },
         )
-        _LOGGER.warning(
-            "Deprecation warning: "
-            "Webhook '%s' does not provide a value for local_only. "
-            "The default value will be 'true' in the 2023.7.0 release",
-            webhook_id,
-        )
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)
     job = HassJob(action)
 

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -95,7 +95,6 @@ async def async_attach_trigger(
             issue_id,
             breaks_in_ha_version="2023.7.0",
             is_fixable=False,
-            learn_more_url="https://github.com/home-assistant/core/pull/66494",
             severity=IssueSeverity.WARNING,
             translation_key="trigger_missing_local_only",
             translation_placeholders={

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -104,7 +104,7 @@ async def async_attach_trigger(
         _LOGGER.warning(
             "Deprecation warning: "
             "Webhook '%s' does not provide a value for local_only. "
-            "The default value will be 'true' in the 2023.4.0 release",
+            "The default value will be 'true' in the 2023.7.0 release",
             webhook_id,
         )
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)

--- a/tests/components/netatmo/common.py
+++ b/tests/components/netatmo/common.py
@@ -81,6 +81,7 @@ async def fake_post_request_no_data(*args, **kwargs):
 async def simulate_webhook(hass, webhook_id, response):
     """Simulate a webhook event."""
     request = MockRequest(
+        method="POST",
         content=bytes(json.dumps({**COMMON_RESPONSE, **response}), "utf-8"),
         mock_source="test",
     )

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -246,7 +246,15 @@ async def test_listing_webhook(
     client = await hass_ws_client(hass, hass_access_token)
 
     webhook.async_register(hass, "test", "Test hook", "my-id", None)
-    webhook.async_register(hass, "test", "Test hook", "my-2", None, local_only=True)
+    webhook.async_register(
+        hass,
+        "test",
+        "Test hook",
+        "my-2",
+        None,
+        local_only=True,
+        allowed_methods=["GET"],
+    )
 
     await client.send_json({"id": 5, "type": "webhook/list"})
 
@@ -259,12 +267,14 @@ async def test_listing_webhook(
             "domain": "test",
             "name": "Test hook",
             "local_only": False,
+            "allowed_methods": ["POST", "PUT"],
         },
         {
             "webhook_id": "my-2",
             "domain": "test",
             "name": "Test hook",
             "local_only": True,
+            "allowed_methods": ["GET"],
         },
     ]
 

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -187,7 +187,7 @@ async def test_webhook_get(hass, mock_client):
         hass, "test", "Test hook", webhook_id, handle, allowed_methods=["PUT"]
     )
     resp = await mock_client.get(f"/api/webhook/{webhook_id}")
-    assert resp.status == HTTPStatus.OK
+    assert resp.status == HTTPStatus.METHOD_NOT_ALLOWED
     assert len(hooks) == 1  # Should not have been called
 
 

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -181,7 +181,7 @@ async def test_webhook_get(hass, mock_client):
     assert hooks[0][1] == webhook_id
     assert hooks[0][2].method == "GET"
 
-    # Test that status is HTTPStatus.OK even when GET is not allowed.
+    # Test that status is HTTPStatus.METHOD_NOT_ALLOWED even when GET is not allowed.
     webhook.async_unregister(hass, webhook_id)
     webhook.async_register(
         hass, "test", "Test hook", webhook_id, handle, allowed_methods=["PUT"]

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -140,7 +140,9 @@ async def test_webhook_head(hass: HomeAssistant, mock_client) -> None:
         """Handle webhook."""
         hooks.append(args)
 
-    webhook.async_register(hass, "test", "Test hook", webhook_id, handle)
+    webhook.async_register(
+        hass, "test", "Test hook", webhook_id, handle, allowed_methods=["HEAD"]
+    )
 
     resp = await mock_client.head(f"/api/webhook/{webhook_id}")
     assert resp.status == HTTPStatus.OK
@@ -148,6 +150,58 @@ async def test_webhook_head(hass: HomeAssistant, mock_client) -> None:
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
     assert hooks[0][2].method == "HEAD"
+
+    # Test that status is HTTPStatus.OK even when HEAD is not allowed.
+    webhook.async_unregister(hass, webhook_id)
+    webhook.async_register(
+        hass, "test", "Test hook", webhook_id, handle, allowed_methods=["PUT"]
+    )
+    resp = await mock_client.head(f"/api/webhook/{webhook_id}")
+    assert resp.status == HTTPStatus.OK
+    assert len(hooks) == 1  # Should not have been called
+
+
+async def test_webhook_get(hass, mock_client):
+    """Test sending a get request to a webhook."""
+    hooks = []
+    webhook_id = webhook.async_generate_id()
+
+    async def handle(*args):
+        """Handle webhook."""
+        hooks.append(args)
+
+    webhook.async_register(
+        hass, "test", "Test hook", webhook_id, handle, allowed_methods=["GET"]
+    )
+
+    resp = await mock_client.get(f"/api/webhook/{webhook_id}")
+    assert resp.status == HTTPStatus.OK
+    assert len(hooks) == 1
+    assert hooks[0][0] is hass
+    assert hooks[0][1] == webhook_id
+    assert hooks[0][2].method == "GET"
+
+    # Test that status is HTTPStatus.OK even when GET is not allowed.
+    webhook.async_unregister(hass, webhook_id)
+    webhook.async_register(
+        hass, "test", "Test hook", webhook_id, handle, allowed_methods=["PUT"]
+    )
+    resp = await mock_client.get(f"/api/webhook/{webhook_id}")
+    assert resp.status == HTTPStatus.OK
+    assert len(hooks) == 1  # Should not have been called
+
+
+async def test_webhook_not_allowed_method(hass):
+    """Test that an exception is raised if an unsupported method is used."""
+    webhook_id = webhook.async_generate_id()
+
+    async def handle(*args):
+        pass
+
+    with pytest.raises(ValueError):
+        webhook.async_register(
+            hass, "test", "Test hook", webhook_id, handle, allowed_methods=["PATCH"]
+        )
 
 
 async def test_webhook_local_only(hass: HomeAssistant, mock_client) -> None:

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -117,7 +117,7 @@ async def test_webhook_allowed_methods_internet(hass, hass_client_no_auth):
 
     @callback
     def store_event(event):
-        """Helepr to store events."""
+        """Help store events."""
         events.append(event)
 
     hass.bus.async_listen("test_success", store_event)

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -131,7 +131,7 @@ async def test_webhook_allowed_methods_internet(hass, hass_client_no_auth):
                     "platform": "webhook",
                     "webhook_id": "post_webhook",
                     "allowed_methods": "PUT",
-                    # Enable after 2023.1.0: "local_only": False,
+                    # Enable after 2023.4.0: "local_only": False,
                 },
                 "action": {
                     "event": "test_success",

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -107,8 +107,8 @@ async def test_webhook_post(
     assert len(events) == 1
 
 
-async def test_webhook_allow_methods_internet(hass, hass_client_no_auth):
-    """Test the webhook obeys allow_methods and allow_internet options."""
+async def test_webhook_allowed_methods_internet(hass, hass_client_no_auth):
+    """Test the webhook obeys allowed_methods and local_only options."""
     events = []
 
     @callback
@@ -126,8 +126,8 @@ async def test_webhook_allow_methods_internet(hass, hass_client_no_auth):
                 "trigger": {
                     "platform": "webhook",
                     "webhook_id": "post_webhook",
-                    "allow_methods": "PUT",
-                    "allow_internet": True,
+                    "allowed_methods": "PUT",
+                    "local_only": False,
                 },
                 "action": {
                     "event": "test_success",

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -78,7 +78,11 @@ async def test_webhook_post(
         "automation",
         {
             "automation": {
-                "trigger": {"platform": "webhook", "webhook_id": "post_webhook"},
+                "trigger": {
+                    "platform": "webhook",
+                    "webhook_id": "post_webhook",
+                    "local_only": True,
+                },
                 "action": {
                     "event": "test_success",
                     "event_data_template": {"hello": "yo {{ trigger.data.hello }}"},

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -131,7 +131,7 @@ async def test_webhook_allowed_methods_internet(hass, hass_client_no_auth):
                     "platform": "webhook",
                     "webhook_id": "post_webhook",
                     "allowed_methods": "PUT",
-                    "local_only": False,
+                    # Enable after 2023.1.0: "local_only": False,
                 },
                 "action": {
                     "event": "test_success",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Two new Webhook trigger options have been added that limit how a webhook can be used to trigger an automation. A new _allowed_methods_ option can be used to control which HTTP request methods can activate the trigger (GET, HEAD, POST, PUT).  And the _local_only_ option is used allow devices outside your local network to activate the trigger.

Previously all webhook triggers could be activated by HEAD, POST, and PUT methods from any device (local or on the internet). With the new options, only POST and PUT are enabled by default. 

**In Home Assistant version 2023.7.0 any webhook trigger that does not set _local_only_ to false can only be activated by devices on the same network as Home Assistant.**

To update your webhook triggers, click the gear/cog icon beside the Webhook ID. Then select an appropriate value for _Only accessible from the local network_. It is necessary to deselect the option for the 'Save' button to appear. Then reselect the option if it should be enabled. This will make the repair warning go away.

![Screenshot 2022-09-14 10 19 56 AM](https://user-images.githubusercontent.com/289218/190221194-c18f9ec8-5847-4358-aa69-eaf81f5518d1.png)

See the [webhook trigger documentation](https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger) for a description of the new options. And please review the new the [Webhook Security](https://www.home-assistant.io/docs/automation/trigger/#webhook-security) section for best practices when using webhook triggers.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds two new options for webhook triggers:
1. __allowed_methods__: Controls which methods can be used with a webhook trigger. Allowed methods include GET, HEAD, POST, and PUT. By default only POST and PUT are enabled. Methods that are not enabled will return 200 OK to the caller, but will not trigger the webhook; they will cause a log message to be generated though.
2. __local_only__: Controls whether the webhook trigger can be accessed by devices on the internet. A log message will be generated for access attempts from the internet when this option is enabled. This option is ignored for webhook triggers that are activated via Nabu Casa Cloud or via the websocket API.

See #56446 & #65928 for a discussion on the security implications of this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
automation:
  trigger:
    - platform: webhook
      webhook_id: "some_hook_id"
      allowed_methods:
        - POST
        - PUT
      local_only: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65348
- This PR is related to issue: #56446
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21637
- Link to the frontend pull request: https://github.com/home-assistant/frontend/pull/11680

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
