### PR TITLE
Improve raised exception consistency for media source

### DIFF
--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -102,7 +102,10 @@ async def async_browse_media(
     if DOMAIN not in hass.data:
         raise BrowseError("Media Source not loaded")
 
-    item = await _get_media_item(hass, media_content_id).async_browse()
+    try:
+        item = await _get_media_item(hass, media_content_id).async_browse()
+    except ValueError as err:
+        raise BrowseError("Not a media source item") from err
 
     if content_filter is None or item.children is None:
         return item
@@ -118,7 +121,13 @@ async def async_resolve_media(hass: HomeAssistant, media_content_id: str) -> Pla
     """Get info to play media."""
     if DOMAIN not in hass.data:
         raise Unresolvable("Media Source not loaded")
-    return await _get_media_item(hass, media_content_id).async_resolve()
+
+    try:
+        item = _get_media_item(hass, media_content_id)
+    except ValueError as err:
+        raise Unresolvable("Not a media source item") from err
+
+    return await item.async_resolve()
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -276,7 +276,7 @@ class UploadMediaView(HomeAssistantView):
 
         uploaded_file: FileField = data["file"]
 
-        if not uploaded_file.content_type.startswith(("image/", "video/")):
+        if not uploaded_file.content_type.startswith(("image/", "video/", "audio/")):
             LOGGER.error("Content type not allowed")
             raise vol.Invalid("Only images and video are allowed")
 

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -60,7 +60,7 @@ async def test_async_browse_media(hass):
     media.children[0].title = "Epic Sax Guy 10 Hours"
 
     # Test invalid media content
-    with pytest.raises(ValueError):
+    with pytest.raises(BrowseError):
         await media_source.async_browse_media(hass, "invalid")
 
     # Test base URI returns all domains
@@ -80,6 +80,8 @@ async def test_async_resolve_media(hass):
         media_source.generate_media_source_id(media_source.DOMAIN, "local/test.mp3"),
     )
     assert isinstance(media, media_source.models.PlayMedia)
+    assert media.url == "/media/local/test.mp3"
+    assert media.mime_type == "audio/mpeg"
 
 
 async def test_async_unresolve_media(hass):
@@ -90,6 +92,10 @@ async def test_async_unresolve_media(hass):
     # Test no media content
     with pytest.raises(media_source.Unresolvable):
         await media_source.async_resolve_media(hass, "")
+
+    # Test invalid media content
+    with pytest.raises(media_source.Unresolvable):
+        await media_source.async_resolve_media(hass, "invalid")
 
 
 async def test_websocket_browse_media(hass, hass_ws_client):

--- a/tests/components/netatmo/test_media_source.py
+++ b/tests/components/netatmo/test_media_source.py
@@ -52,9 +52,9 @@ async def test_async_browse_media(hass):
     assert str(excinfo.value) == "Unknown source directory."
 
     # Test invalid base
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(media_source.BrowseError) as excinfo:
         await media_source.async_browse_media(hass, f"{const.URI_SCHEME}{DOMAIN}/")
-    assert str(excinfo.value) == "Invalid media source URI"
+    assert str(excinfo.value) == "Not a media source item"
 
     # Test successful listing
     media = await media_source.async_browse_media(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wrap ValueError with the expected exception type when browsing/resolving media.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
