### PR TITLE
Add support for MJPEG cameras to camera media source

### DIFF
--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -47,8 +47,18 @@ class CameraMediaSource(MediaSource):
         if not camera:
             raise Unresolvable(f"Could not resolve media item: {item.identifier}")
 
+        stream_type = camera.frontend_stream_type
+
+        if stream_type is None:
+            return PlayMedia(
+                f"/api/camera_proxy_stream/{camera.entity_id}", camera.content_type
+            )
+
         if camera.frontend_stream_type != STREAM_TYPE_HLS:
-            raise Unresolvable("Camera does not support HLS streaming.")
+            raise Unresolvable("Camera does not support MJPEG or HLS streaming.")
+
+        if "stream" not in self.hass.config.components:
+            raise Unresolvable("Stream integration not loaded")
 
         try:
             url = await _async_stream_endpoint_url(self.hass, camera, HLS_PROVIDER)
@@ -65,16 +75,19 @@ class CameraMediaSource(MediaSource):
         if item.identifier:
             raise BrowseError("Unknown item")
 
-        if "stream" not in self.hass.config.components:
-            raise BrowseError("Stream integration is not loaded")
+        supported_stream_types: list[str | None] = [None]
+
+        if "stream" in self.hass.config.components:
+            supported_stream_types.append(STREAM_TYPE_HLS)
 
         # Root. List cameras.
         component: EntityComponent = self.hass.data[DOMAIN]
         children = []
         for camera in component.entities:
             camera = cast(Camera, camera)
+            stream_type = camera.frontend_stream_type
 
-            if camera.frontend_stream_type != STREAM_TYPE_HLS:
+            if stream_type not in supported_stream_types:
                 continue
 
             children.append(

--- a/tests/components/camera/test_media_source.py
+++ b/tests/components/camera/test_media_source.py
@@ -15,17 +15,17 @@ async def setup_media_source(hass):
     assert await async_setup_component(hass, "media_source", {})
 
 
-@pytest.fixture(autouse=True)
-async def mock_stream(hass):
-    """Mock stream."""
-    hass.config.components.add("stream")
-
-
 async def test_browsing(hass, mock_camera_hls):
     """Test browsing camera media source."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
     assert item is not None
     assert item.title == "Camera"
+    assert len(item.children) == 0
+
+    # Adding stream enables HLS camera
+    hass.config.components.add("stream")
+
+    item = await media_source.async_browse_media(hass, "media-source://camera")
     assert len(item.children) == 2
 
 
@@ -39,6 +39,9 @@ async def test_browsing_filter_non_hls(hass, mock_camera_web_rtc):
 
 async def test_resolving(hass, mock_camera_hls):
     """Test resolving."""
+    # Adding stream enables HLS camera
+    hass.config.components.add("stream")
+
     with patch(
         "homeassistant.components.camera.media_source._async_stream_endpoint_url",
         return_value="http://example.com/stream",
@@ -53,20 +56,34 @@ async def test_resolving(hass, mock_camera_hls):
 
 async def test_resolving_errors(hass, mock_camera_hls):
     """Test resolving."""
-    with pytest.raises(media_source.Unresolvable):
+
+    with pytest.raises(media_source.Unresolvable) as exc_info:
+        await media_source.async_resolve_media(
+            hass, "media-source://camera/camera.demo_camera"
+        )
+    assert str(exc_info.value) == "Stream integration not loaded"
+
+    hass.config.components.add("stream")
+
+    with pytest.raises(media_source.Unresolvable) as exc_info:
         await media_source.async_resolve_media(
             hass, "media-source://camera/camera.non_existing"
         )
+    assert str(exc_info.value) == "Could not resolve media item: camera.non_existing"
 
-    with pytest.raises(media_source.Unresolvable), patch(
+    with pytest.raises(media_source.Unresolvable) as exc_info, patch(
         "homeassistant.components.camera.Camera.frontend_stream_type",
         new_callable=PropertyMock(return_value=STREAM_TYPE_WEB_RTC),
     ):
         await media_source.async_resolve_media(
             hass, "media-source://camera/camera.demo_camera"
         )
+    assert str(exc_info.value) == "Camera does not support MJPEG or HLS streaming."
 
-    with pytest.raises(media_source.Unresolvable):
+    with pytest.raises(media_source.Unresolvable) as exc_info:
         await media_source.async_resolve_media(
             hass, "media-source://camera/camera.demo_camera"
         )
+    assert (
+        str(exc_info.value) == "camera.demo_camera does not support play stream service"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for cameras with MJPEG streams to the camera media source

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
