### PR TITLE
Improve setup_time typing

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 import logging.handlers
 import os
@@ -450,7 +450,7 @@ async def _async_set_up_integrations(
 ) -> None:
     """Set up all the integrations."""
     hass.data[DATA_SETUP_STARTED] = {}
-    setup_time = hass.data[DATA_SETUP_TIME] = {}
+    setup_time: dict[str, timedelta] = hass.data.setdefault(DATA_SETUP_TIME, {})
 
     watch_task = asyncio.create_task(_async_watch_pending_setups(hass))
 
@@ -459,9 +459,9 @@ async def _async_set_up_integrations(
     # Resolve all dependencies so we know all integrations
     # that will have to be loaded and start rightaway
     integration_cache: dict[str, loader.Integration] = {}
-    to_resolve = domains_to_setup
+    to_resolve: set[str] = domains_to_setup
     while to_resolve:
-        old_to_resolve = to_resolve
+        old_to_resolve: set[str] = to_resolve
         to_resolve = set()
 
         integrations_to_process = [
@@ -508,11 +508,11 @@ async def _async_set_up_integrations(
         await async_setup_multi_components(hass, debuggers, config)
 
     # calculate what components to setup in what stage
-    stage_1_domains = set()
+    stage_1_domains: set[str] = set()
 
     # Find all dependencies of any dependency of any stage 1 integration that
     # we plan on loading and promote them to stage 1
-    deps_promotion = STAGE_1_INTEGRATIONS
+    deps_promotion: set[str] = STAGE_1_INTEGRATIONS
     while deps_promotion:
         old_deps_promotion = deps_promotion
         deps_promotion = set()
@@ -577,7 +577,7 @@ async def _async_set_up_integrations(
         {
             integration: timedelta.total_seconds()
             for integration, timedelta in sorted(
-                setup_time.items(), key=lambda item: item[1].total_seconds()  # type: ignore
+                setup_time.items(), key=lambda item: item[1].total_seconds()
             )
         },
     )

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+import datetime as dt
 import json
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 
@@ -305,7 +306,9 @@ async def handle_integration_setup_info(
         msg["id"],
         [
             {"domain": integration, "seconds": timedelta.total_seconds()}
-            for integration, timedelta in hass.data[DATA_SETUP_TIME].items()
+            for integration, timedelta in cast(
+                dict[str, dt.timedelta], hass.data[DATA_SETUP_TIME]
+            ).items()
         ],
     )
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Generator, Iterable
 import contextlib
+from datetime import timedelta
 import logging.handlers
 from timeit import default_timer as timer
 from types import ModuleType
@@ -436,7 +437,7 @@ def async_start_setup(
     """Keep track of when setup starts and finishes."""
     setup_started = hass.data.setdefault(DATA_SETUP_STARTED, {})
     started = dt_util.utcnow()
-    unique_components = {}
+    unique_components: dict[str, str] = {}
     for domain in components:
         unique = ensure_unique_string(domain, setup_started)
         unique_components[unique] = domain
@@ -444,7 +445,7 @@ def async_start_setup(
 
     yield
 
-    setup_time = hass.data.setdefault(DATA_SETUP_TIME, {})
+    setup_time: dict[str, timedelta] = hass.data.setdefault(DATA_SETUP_TIME, {})
     time_taken = dt_util.utcnow() - started
     for unique, domain in unique_components.items():
         del setup_started[unique]


### PR DESCRIPTION
## Proposed change
Add type hints for `setup_time` -> `dict[str, timedelta]`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
