### PR TITLE
Improve `util.async_` typing

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -20,6 +20,7 @@ homeassistant.helpers.entity_values
 homeassistant.helpers.reload
 homeassistant.helpers.script_variables
 homeassistant.helpers.translation
+homeassistant.util.async_
 homeassistant.util.color
 homeassistant.util.process
 homeassistant.util.unit_system

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -11,14 +11,20 @@ import threading
 from traceback import extract_stack
 from typing import Any, TypeVar
 
+from typing_extensions import ParamSpec
+
 _LOGGER = logging.getLogger(__name__)
 
 _SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_shutdown_run_callback_threadsafe"
 
-T = TypeVar("T")
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
-def fire_coroutine_threadsafe(coro: Coroutine, loop: AbstractEventLoop) -> None:
+def fire_coroutine_threadsafe(
+    coro: Coroutine[Any, Any, Any], loop: AbstractEventLoop
+) -> None:
     """Submit a coroutine object to a given event loop.
 
     This method does not provide a way to retrieve the result and
@@ -40,8 +46,8 @@ def fire_coroutine_threadsafe(coro: Coroutine, loop: AbstractEventLoop) -> None:
 
 
 def run_callback_threadsafe(
-    loop: AbstractEventLoop, callback: Callable[..., T], *args: Any
-) -> concurrent.futures.Future[T]:
+    loop: AbstractEventLoop, callback: Callable[..., _T], *args: Any
+) -> concurrent.futures.Future[_T]:
     """Submit a callback object to a given event loop.
 
     Return a concurrent.futures.Future to access the result.
@@ -50,7 +56,7 @@ def run_callback_threadsafe(
     if ident is not None and ident == threading.get_ident():
         raise RuntimeError("Cannot be called from within the event loop")
 
-    future: concurrent.futures.Future = concurrent.futures.Future()
+    future: concurrent.futures.Future[_T] = concurrent.futures.Future()
 
     def run_callback() -> None:
         """Run callback and store result."""
@@ -88,7 +94,7 @@ def run_callback_threadsafe(
     return future
 
 
-def check_loop(func: Callable, strict: bool = True) -> None:
+def check_loop(func: Callable[..., Any], strict: bool = True) -> None:
     """Warn if called inside the event loop. Raise if `strict` is True."""
     try:
         get_running_loop()
@@ -159,11 +165,11 @@ def check_loop(func: Callable, strict: bool = True) -> None:
         )
 
 
-def protect_loop(func: Callable, strict: bool = True) -> Callable:
+def protect_loop(func: Callable[_P, _R], strict: bool = True) -> Callable[_P, _R]:
     """Protect function from running in event loop."""
 
     @functools.wraps(func)
-    def protected_loop_func(*args, **kwargs):  # type: ignore
+    def protected_loop_func(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         check_loop(func, strict=strict)
         return func(*args, **kwargs)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -70,6 +70,9 @@ disallow_any_generics = true
 [mypy-homeassistant.helpers.translation]
 disallow_any_generics = true
 
+[mypy-homeassistant.util.async_]
+disallow_any_generics = true
+
 [mypy-homeassistant.util.color]
 disallow_any_generics = true
 


### PR DESCRIPTION
## Proposed change
Improve typing of the `util.async_` module.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
