### PR TITLE
Update pylint plugin to validate `_async_has_devices`

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -102,7 +102,7 @@ components: &components
 # Testing related files that affect the whole test/linting suite
 tests: &tests
   - codecov.yaml
-  - pylint/*
+  - pylint/**
   - requirements_test_pre_commit.txt
   - requirements_test.txt
   - tests/auth/**

--- a/homeassistant/components/fjaraskupan/config_flow.py
+++ b/homeassistant/components/fjaraskupan/config_flow.py
@@ -9,6 +9,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from fjaraskupan import UUID_SERVICE, device_filter
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_flow import register_discovery_flow
 
 from .const import DOMAIN
@@ -16,7 +17,7 @@ from .const import DOMAIN
 CONST_WAIT_TIME = 5.0
 
 
-async def _async_has_devices(hass) -> bool:
+async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
 
     event = asyncio.Event()

--- a/homeassistant/components/gree/config_flow.py
+++ b/homeassistant/components/gree/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for Gree."""
 from greeclimate.discovery import Discovery
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
 from .const import DISCOVERY_TIMEOUT, DOMAIN
 
 
-async def _async_has_devices(hass) -> bool:
+async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
     gree_discovery = Discovery(DISCOVERY_TIMEOUT)
     devices = await gree_discovery.scan(wait_for=DISCOVERY_TIMEOUT)

--- a/homeassistant/components/hisense_aehw4a1/config_flow.py
+++ b/homeassistant/components/hisense_aehw4a1/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for Hisense AEH-W4A1 integration."""
 from pyaehw4a1.aehw4a1 import AehW4a1
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
 
 
-async def _async_has_devices(hass):
+async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
     aehw4a1_ip_addresses = await AehW4a1().discovery()
     return len(aehw4a1_ip_addresses) > 0

--- a/homeassistant/components/ios/config_flow.py
+++ b/homeassistant/components/ios/config_flow.py
@@ -3,4 +3,6 @@ from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
 
-config_entry_flow.register_discovery_flow(DOMAIN, "Home Assistant iOS", lambda *_: True)
+config_entry_flow.register_discovery_flow(
+    DOMAIN, "Home Assistant iOS", lambda hass: True
+)

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -6,7 +6,7 @@ import logging
 
 from async_timeout import timeout
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_flow
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -16,7 +16,7 @@ from .discovery import async_start_discovery_service, async_stop_discovery_servi
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _async_has_devices(hass):
+async def _async_has_devices(hass: HomeAssistant) -> bool:
 
     controller_ready = asyncio.Event()
 

--- a/homeassistant/components/kulersky/config_flow.py
+++ b/homeassistant/components/kulersky/config_flow.py
@@ -3,6 +3,7 @@ import logging
 
 import pykulersky
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
@@ -10,7 +11,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _async_has_devices(hass) -> bool:
+async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
     # Check if there are any devices that can be discovered in the network.
     try:

--- a/homeassistant/components/lifx/config_flow.py
+++ b/homeassistant/components/lifx/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow flow LIFX."""
 import aiolifx
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
 
 
-async def _async_has_devices(hass):
+async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
     lifx_ip_addresses = await aiolifx.LifxScan(hass.loop).scan()
     return len(lifx_ip_addresses) > 0

--- a/homeassistant/components/zerproc/config_flow.py
+++ b/homeassistant/components/zerproc/config_flow.py
@@ -3,6 +3,7 @@ import logging
 
 import pyzerproc
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
 from .const import DOMAIN
@@ -10,7 +11,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _async_has_devices(hass) -> bool:
+async def _async_has_devices(hass: HomeAssistant) -> bool:
     """Return if there are devices that can be discovered."""
     try:
         devices = await pyzerproc.discover()

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -44,6 +44,8 @@ _MODULE_FILTERS: dict[str, re.Pattern] = {
     "device_tracker": re.compile(r"^homeassistant\.components\.\w+\.(device_tracker)$"),
     # diagnostics matches only in the package root (diagnostics.py)
     "diagnostics": re.compile(r"^homeassistant\.components\.\w+\.(diagnostics)$"),
+    # config_flow matches only in the package root (config_flow.py)
+    "config_flow": re.compile(r"^homeassistant\.components\.\w+\.(config_flow)$")
 }
 
 _METHOD_MATCH: list[TypeHintMatch] = [
@@ -191,6 +193,14 @@ _METHOD_MATCH: list[TypeHintMatch] = [
             2: "DeviceEntry",
         },
         return_type=UNDEFINED,
+    ),
+    TypeHintMatch(
+        module_filter=_MODULE_FILTERS["config_flow"],
+        function_name="_async_has_devices",
+        arg_types={
+            0: "HomeAssistant",
+        },
+        return_type="bool",
     ),
 ]
 


### PR DESCRIPTION
## Proposed change
Add `_async_has_devices` to pylint plugin `hass_enforce_type_hints.py`. Although not technically limited to it, all existing uses inside `config_flow.py` are for the call to `config_entry_flow.register_discovery_flow`. More specifically `_async_has_devices` is exclusively used as function name for the `discovery_function`. Thus I think it's safe to add a rule for it inside the pylint plugin.

https://github.com/home-assistant/core/blob/db73ce92faa1f89abe83577287cda4aec9fcbf4d/homeassistant/helpers/config_entry_flow.py#L153-L158

https://github.com/home-assistant/core/blob/db73ce92faa1f89abe83577287cda4aec9fcbf4d/homeassistant/helpers/config_entry_flow.py#L18


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
