### PR TITLE
Fix ImportError when discovery deps change

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -69,16 +69,14 @@ LOGGING_INTEGRATIONS = {
     # To record data
     "recorder",
 }
-
+DISCOVERY_INTEGRATIONS = ("dhcp", "ssdp", "usb", "zeroconf")
 STAGE_1_INTEGRATIONS = {
     # We need to make sure discovery integrations
-    # update their deps or they could have an import error
-    # as allow them to be imported without being added as a dep
-    # to manifest.json
-    "dhcp",
-    "ssdp",
-    "usb",
-    "zeroconf"
+    # update their deps before stage 2 integrations
+    # load them inadvertently before their deps have
+    # been updated which leads to using an old version
+    # of the dep, or worse (import errors).
+    *DISCOVERY_INTEGRATIONS,
     # To make sure we forward data to other instances
     "mqtt_eventstream",
     # To provide account link implementations

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -59,7 +59,7 @@ COOLDOWN_TIME = 60
 MAX_LOAD_CONCURRENTLY = 6
 
 DEBUGGER_INTEGRATIONS = {"debugpy"}
-CORE_INTEGRATIONS = ("homeassistant", "persistent_notification")
+CORE_INTEGRATIONS = {"homeassistant", "persistent_notification"}
 LOGGING_INTEGRATIONS = {
     # Set log levels
     "logger",
@@ -69,6 +69,11 @@ LOGGING_INTEGRATIONS = {
     # To record data
     "recorder",
 }
+# We need to make sure discovery integrations
+# update their deps or they could have an import error
+# as allow them to be imported without being added as a dep
+# to manifest.json
+DISCOVERY_INTEGRATIONS = {"dhcp", "ssdp", "usb", "zeroconf"}
 STAGE_1_INTEGRATIONS = {
     # To make sure we forward data to other instances
     "mqtt_eventstream",
@@ -507,6 +512,15 @@ async def _async_set_up_integrations(
         _LOGGER.debug("Setting up debuggers: %s", debuggers)
         await async_setup_multi_components(hass, debuggers, config)
 
+    # Set up discovery integrations.
+    # Make sure we do these first since integrations
+    # are allowed to import them without adding them to their
+    # manifest.json, and we want to make sure their deps are up
+    # to date before integrations get a shot at importing them
+    if discovery := domains_to_setup & DISCOVERY_INTEGRATIONS:
+        _LOGGER.debug("Setting up discovery integrations: %s", discovery)
+        await async_setup_multi_components(hass, discovery, config)
+
     # calculate what components to setup in what stage
     stage_1_domains = set()
 
@@ -528,7 +542,9 @@ async def _async_set_up_integrations(
 
             deps_promotion.update(dep_itg.all_dependencies)
 
-    stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
+    stage_2_domains = (
+        domains_to_setup - logging_domains - debuggers - discovery - stage_1_domains
+    )
 
     # Load the registries
     await asyncio.gather(

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -69,12 +69,16 @@ LOGGING_INTEGRATIONS = {
     # To record data
     "recorder",
 }
-# We need to make sure discovery integrations
-# update their deps or they could have an import error
-# as allow them to be imported without being added as a dep
-# to manifest.json
-DISCOVERY_INTEGRATIONS = {"dhcp", "ssdp", "usb", "zeroconf"}
+
 STAGE_1_INTEGRATIONS = {
+    # We need to make sure discovery integrations
+    # update their deps or they could have an import error
+    # as allow them to be imported without being added as a dep
+    # to manifest.json
+    "dhcp",
+    "ssdp",
+    "usb",
+    "zeroconf"
     # To make sure we forward data to other instances
     "mqtt_eventstream",
     # To provide account link implementations
@@ -512,15 +516,6 @@ async def _async_set_up_integrations(
         _LOGGER.debug("Setting up debuggers: %s", debuggers)
         await async_setup_multi_components(hass, debuggers, config)
 
-    # Set up discovery integrations.
-    # Make sure we do these first since integrations
-    # are allowed to import them without adding them to their
-    # manifest.json, and we want to make sure their deps are up
-    # to date before integrations get a shot at importing them
-    if discovery := domains_to_setup & DISCOVERY_INTEGRATIONS:
-        _LOGGER.debug("Setting up discovery integrations: %s", discovery)
-        await async_setup_multi_components(hass, discovery, config)
-
     # calculate what components to setup in what stage
     stage_1_domains = set()
 
@@ -542,9 +537,7 @@ async def _async_set_up_integrations(
 
             deps_promotion.update(dep_itg.all_dependencies)
 
-    stage_2_domains = (
-        domains_to_setup - logging_domains - debuggers - discovery - stage_1_domains
-    )
+    stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
     # Load the registries
     await asyncio.gather(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See
https://github.com/home-assistant/core/pull/66414#issuecomment-1039186515
https://github.com/home-assistant/core/pull/66414#issuecomment-1039192233


Make sure we do discovery integrations before stage2 since integrations
are allowed to import them without adding them to their
`manifest.json`, and we want to make sure their deps are up
to date before integrations get a shot at importing them
to avoid ImportError at startup when a discovery integration
dep changes.

This also explains why users had to report restarting 2x for
zeroconf changes to be effective when doing a venv install

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
