### PR TITLE
Allow integrations to request dhcp discovery flows for registered devices

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -80,10 +80,10 @@ def async_register_mac(
     registered which allows discovery flows to still be
     created to update the ip address when it changes.
 
-    It is recommended to wrap this call in entry.async_on_unload
+    It is recommended to wrap this call in entry.async_on_remove
 
     Example:
-    entry.async_on_unload(dhcp.async_register_mac(hass, "50147903852c", 'integration'))
+    entry.async_on_remove(dhcp.async_register_mac(hass, "50147903852c", 'integration'))
     """
     registrations: dict[str, set[str]] = hass.data.setdefault(DHCP_REGISTRATONS, {})
     formatted_mac = _format_mac(mac).upper()

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -429,7 +429,7 @@ def _decode_dhcp_option(dhcp_options, key):
             return None
 
 
-def _format_mac(mac_address: str) -> str:
+def _format_mac(mac_address):
     """Format a mac address for matching."""
     return format_mac(mac_address).replace(":", "")
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -86,10 +86,7 @@ def async_enable_device_flows(hass: HomeAssistant) -> None:
     cannot change once its been loaded (async_step_dhcp does
     not go away)
 
-    Devices that are bound to config entries for the integration
-    with a matching mac address will matched for discovery flows.
-
-    by enabling device flows, when the mac address bound to a device
+    By enabling device flows, when the mac address bound to a DeviceEntry
     that references an integration that has enabled device flow, a dhcp
     discovery flow will created for the discovered device.
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -188,13 +188,18 @@ class WatcherBase:
         )
 
         matched_domains = set()
+        device_domains = set()
+
         dev_reg: DeviceRegistry = async_get(self.hass)
-        device = dev_reg.async_get_device(
+        if device := dev_reg.async_get_device(
             identifiers=set(), connections={(CONNECTION_NETWORK_MAC, uppercase_mac)}
-        )
+        ):
+            for entry_id in device.config_entries:
+                if entry := self.hass.config_entries.async_get_entry(entry_id):
+                    device_domains.add(entry.domain)
 
         for entry in self._integration_matchers:
-            if entry.get(REGISTERED_DEVICES) and not device:
+            if entry.get(REGISTERED_DEVICES) and not entry["domain"] in device_domains:
                 continue
 
             if MAC_ADDRESS in entry and not fnmatch.fnmatch(

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -69,11 +69,6 @@ DHCP_ENABLED_DEVICE_FLOWS = "dhcp_enabled_device_flows"
 _LOGGER = logging.getLogger(__name__)
 
 
-def _format_mac(mac_address: str) -> str:
-    """Format a mac address for matching."""
-    return format_mac(mac_address).replace(":", "")
-
-
 @callback
 def async_enable_device_flows(hass: HomeAssistant) -> None:
     """Request to get discovery flows for devices with mac addresses.
@@ -466,6 +461,11 @@ def _decode_dhcp_option(dhcp_options, key):
             return value.decode()
         except (AttributeError, UnicodeDecodeError):
             return None
+
+
+def _format_mac(mac_address: str) -> str:
+    """Format a mac address for matching."""
+    return format_mac(mac_address).replace(":", "")
 
 
 def _verify_l2socket_setup(cap_filter):

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -7,635 +7,148 @@ from __future__ import annotations
 # fmt: off
 
 DHCP: list[dict[str, str | bool]] = [
-    {
-        "domain": "august",
-        "hostname": "connect",
-        "macaddress": "D86162*"
-    },
-    {
-        "domain": "august",
-        "hostname": "connect",
-        "macaddress": "B8B7F1*"
-    },
-    {
-        "domain": "august",
-        "hostname": "connect",
-        "macaddress": "2C9FFB*"
-    },
-    {
-        "domain": "august",
-        "hostname": "august*",
-        "macaddress": "E076D0*"
-    },
-    {
-        "domain": "axis",
-        "hostname": "axis-00408c*",
-        "macaddress": "00408C*"
-    },
-    {
-        "domain": "axis",
-        "hostname": "axis-accc8e*",
-        "macaddress": "ACCC8E*"
-    },
-    {
-        "domain": "axis",
-        "hostname": "axis-b8a44f*",
-        "macaddress": "B8A44F*"
-    },
-    {
-        "domain": "blink",
-        "hostname": "blink*",
-        "macaddress": "B85F98*"
-    },
-    {
-        "domain": "blink",
-        "hostname": "blink*",
-        "macaddress": "00037F*"
-    },
-    {
-        "domain": "blink",
-        "hostname": "blink*",
-        "macaddress": "20A171*"
-    },
-    {
-        "domain": "broadlink",
-        "macaddress": "34EA34*"
-    },
-    {
-        "domain": "broadlink",
-        "macaddress": "24DFA7*"
-    },
-    {
-        "domain": "broadlink",
-        "macaddress": "A043B0*"
-    },
-    {
-        "domain": "broadlink",
-        "macaddress": "B4430D*"
-    },
-    {
-        "domain": "elkm1",
-        "macaddress": "00409D*"
-    },
-    {
-        "domain": "emonitor",
-        "hostname": "emonitor*",
-        "macaddress": "0090C2*"
-    },
-    {
-        "domain": "flume",
-        "hostname": "flume-gw-*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "18B905*",
-        "hostname": "[ba][lk]*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "249494*",
-        "hostname": "[ba][lk]*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "7CB94C*",
-        "hostname": "[ba][lk]*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "ACCF23*",
-        "hostname": "[hba][flk]*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "B4E842*",
-        "hostname": "[ba][lk]*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "F0FE6B*",
-        "hostname": "[hba][flk]*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "8CCE4E*",
-        "hostname": "lwip*"
-    },
-    {
-        "domain": "flux_led",
-        "hostname": "zengge_[0-9a-f][0-9a-f]_*"
-    },
-    {
-        "domain": "flux_led",
-        "macaddress": "C82E47*",
-        "hostname": "sta*"
-    },
-    {
-        "domain": "fronius",
-        "macaddress": "0003AC*"
-    },
-    {
-        "domain": "goalzero",
-        "hostname": "yeti*"
-    },
-    {
-        "domain": "gogogate2",
-        "hostname": "ismartgate*"
-    },
-    {
-        "domain": "guardian",
-        "hostname": "gvc*",
-        "macaddress": "30AEA4*"
-    },
-    {
-        "domain": "guardian",
-        "hostname": "gvc*",
-        "macaddress": "B4E62D*"
-    },
-    {
-        "domain": "guardian",
-        "hostname": "guardian*",
-        "macaddress": "30AEA4*"
-    },
-    {
-        "domain": "hunterdouglas_powerview",
-        "hostname": "hunter*",
-        "macaddress": "002674*"
-    },
-    {
-        "domain": "isy994",
-        "hostname": "isy*",
-        "macaddress": "0021B9*"
-    },
-    {
-        "domain": "lyric",
-        "hostname": "lyric-*",
-        "macaddress": "48A2E6*"
-    },
-    {
-        "domain": "lyric",
-        "hostname": "lyric-*",
-        "macaddress": "B82CA0*"
-    },
-    {
-        "domain": "lyric",
-        "hostname": "lyric-*",
-        "macaddress": "00D02D*"
-    },
-    {
-        "domain": "myq",
-        "macaddress": "645299*"
-    },
-    {
-        "domain": "nest",
-        "macaddress": "18B430*"
-    },
-    {
-        "domain": "nest",
-        "macaddress": "641666*"
-    },
-    {
-        "domain": "nest",
-        "macaddress": "D8EB46*"
-    },
-    {
-        "domain": "nest",
-        "macaddress": "1C53F9*"
-    },
-    {
-        "domain": "nexia",
-        "hostname": "xl857-*",
-        "macaddress": "000231*"
-    },
-    {
-        "domain": "nuheat",
-        "hostname": "nuheat",
-        "macaddress": "002338*"
-    },
-    {
-        "domain": "nuki",
-        "hostname": "nuki_bridge_*"
-    },
-    {
-        "domain": "oncue",
-        "hostname": "kohlergen*",
-        "macaddress": "00146F*"
-    },
-    {
-        "domain": "overkiz",
-        "hostname": "gateway*",
-        "macaddress": "F8811A*"
-    },
-    {
-        "domain": "powerwall",
-        "hostname": "1118431-*"
-    },
-    {
-        "domain": "rachio",
-        "hostname": "rachio-*",
-        "macaddress": "009D6B*"
-    },
-    {
-        "domain": "rachio",
-        "hostname": "rachio-*",
-        "macaddress": "F0038C*"
-    },
-    {
-        "domain": "rachio",
-        "hostname": "rachio-*",
-        "macaddress": "74C63B*"
-    },
-    {
-        "domain": "rainforest_eagle",
-        "macaddress": "D8D5B9*"
-    },
-    {
-        "domain": "ring",
-        "hostname": "ring*",
-        "macaddress": "0CAE7D*"
-    },
-    {
-        "domain": "roomba",
-        "hostname": "irobot-*",
-        "macaddress": "501479*"
-    },
-    {
-        "domain": "roomba",
-        "hostname": "roomba-*",
-        "macaddress": "80A589*"
-    },
-    {
-        "domain": "roomba",
-        "hostname": "roomba-*",
-        "macaddress": "DCF505*"
-    },
-    {
-        "domain": "samsungtv",
-        "hostname": "tizen*"
-    },
-    {
-        "domain": "samsungtv",
-        "macaddress": "8CC8CD*"
-    },
-    {
-        "domain": "samsungtv",
-        "macaddress": "606BBD*"
-    },
-    {
-        "domain": "samsungtv",
-        "macaddress": "F47B5E*"
-    },
-    {
-        "domain": "samsungtv",
-        "macaddress": "4844F7*"
-    },
-    {
-        "domain": "screenlogic",
-        "hostname": "pentair: *",
-        "macaddress": "00C033*"
-    },
-    {
-        "domain": "sense",
-        "hostname": "sense-*",
-        "macaddress": "009D6B*"
-    },
-    {
-        "domain": "sense",
-        "hostname": "sense-*",
-        "macaddress": "DCEFCA*"
-    },
-    {
-        "domain": "sense",
-        "hostname": "sense-*",
-        "macaddress": "A4D578*"
-    },
-    {
-        "domain": "senseme",
-        "macaddress": "20F85E*"
-    },
-    {
-        "domain": "sensibo",
-        "hostname": "sensibo*"
-    },
-    {
-        "domain": "simplisafe",
-        "hostname": "simplisafe*",
-        "macaddress": "30AEA4*"
-    },
-    {
-        "domain": "smartthings",
-        "hostname": "st*",
-        "macaddress": "24FD5B*"
-    },
-    {
-        "domain": "smartthings",
-        "hostname": "smartthings*",
-        "macaddress": "24FD5B*"
-    },
-    {
-        "domain": "smartthings",
-        "hostname": "hub*",
-        "macaddress": "24FD5B*"
-    },
-    {
-        "domain": "smartthings",
-        "hostname": "hub*",
-        "macaddress": "D052A8*"
-    },
-    {
-        "domain": "smartthings",
-        "hostname": "hub*",
-        "macaddress": "286D97*"
-    },
-    {
-        "domain": "solaredge",
-        "hostname": "target",
-        "macaddress": "002702*"
-    },
-    {
-        "domain": "somfy_mylink",
-        "hostname": "somfy_*",
-        "macaddress": "B8B7F1*"
-    },
-    {
-        "domain": "squeezebox",
-        "hostname": "squeezebox*",
-        "macaddress": "000420*"
-    },
-    {
-        "domain": "steamist",
-        "macaddress": "001E0C*",
-        "hostname": "my[45]50*"
-    },
-    {
-        "domain": "tado",
-        "hostname": "tado*"
-    },
-    {
-        "domain": "tesla_wall_connector",
-        "hostname": "teslawallconnector_*",
-        "macaddress": "DC44271*"
-    },
-    {
-        "domain": "tesla_wall_connector",
-        "hostname": "teslawallconnector_*",
-        "macaddress": "98ED5C*"
-    },
-    {
-        "domain": "tesla_wall_connector",
-        "hostname": "teslawallconnector_*",
-        "macaddress": "4CFCAA*"
-    },
-    {
-        "domain": "tolo",
-        "hostname": "usr-tcp232-ed2"
-    },
-    {
-        "domain": "toon",
-        "hostname": "eneco-*",
-        "macaddress": "74C63B*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "60A4B7*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "005F67*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "1027F5*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "403F8C*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "C0C9E3*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "ep*",
-        "macaddress": "E848B8*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "E848B8*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "909A4A*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "hs*",
-        "macaddress": "1C3BF3*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "hs*",
-        "macaddress": "50C7BF*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "hs*",
-        "macaddress": "68FF7B*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "hs*",
-        "macaddress": "98DAC4*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "hs*",
-        "macaddress": "B09575*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "hs*",
-        "macaddress": "C006C3*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "ep*",
-        "macaddress": "003192*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "003192*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "1C3BF3*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "50C7BF*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "68FF7B*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "98DAC4*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "B09575*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "k[lp]*",
-        "macaddress": "C006C3*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "lb*",
-        "macaddress": "1C3BF3*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "lb*",
-        "macaddress": "50C7BF*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "lb*",
-        "macaddress": "68FF7B*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "lb*",
-        "macaddress": "98DAC4*"
-    },
-    {
-        "domain": "tplink",
-        "hostname": "lb*",
-        "macaddress": "B09575*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "105A17*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "10D561*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "1869D8*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "381F8D*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "508A06*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "68572D*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "708976*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "7CF666*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "84E342*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "D4A651*"
-    },
-    {
-        "domain": "tuya",
-        "macaddress": "D81F12*"
-    },
-    {
-        "domain": "twinkly",
-        "hostname": "twinkly_*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "B4FBE4*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "802AA8*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "F09FC2*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "68D79A*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "18E829*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "245A4C*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "784558*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "E063DA*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "265A4C*"
-    },
-    {
-        "domain": "unifiprotect",
-        "macaddress": "74ACB9*"
-    },
-    {
-        "domain": "verisure",
-        "macaddress": "0023C1*"
-    },
-    {
-        "domain": "vicare",
-        "macaddress": "B87424*"
-    },
-    {
-        "domain": "wiz",
-        "macaddress": "A8BB50*"
-    },
-    {
-        "domain": "wiz",
-        "hostname": "wiz_*"
-    },
-    {
-        "domain": "yeelight",
-        "hostname": "yeelink-*"
-    }
-]
+    {'domain': 'august', 'hostname': 'connect', 'macaddress': 'D86162*'},
+    {'domain': 'august', 'hostname': 'connect', 'macaddress': 'B8B7F1*'},
+    {'domain': 'august', 'hostname': 'connect', 'macaddress': '2C9FFB*'},
+    {'domain': 'august', 'hostname': 'august*', 'macaddress': 'E076D0*'},
+    {'domain': 'axis', 'hostname': 'axis-00408c*', 'macaddress': '00408C*'},
+    {'domain': 'axis', 'hostname': 'axis-accc8e*', 'macaddress': 'ACCC8E*'},
+    {'domain': 'axis', 'hostname': 'axis-b8a44f*', 'macaddress': 'B8A44F*'},
+    {'domain': 'blink', 'hostname': 'blink*', 'macaddress': 'B85F98*'},
+    {'domain': 'blink', 'hostname': 'blink*', 'macaddress': '00037F*'},
+    {'domain': 'blink', 'hostname': 'blink*', 'macaddress': '20A171*'},
+    {'domain': 'broadlink', 'macaddress': '34EA34*'},
+    {'domain': 'broadlink', 'macaddress': '24DFA7*'},
+    {'domain': 'broadlink', 'macaddress': 'A043B0*'},
+    {'domain': 'broadlink', 'macaddress': 'B4430D*'},
+    {'domain': 'elkm1', 'macaddress': '00409D*'},
+    {'domain': 'emonitor', 'hostname': 'emonitor*', 'macaddress': '0090C2*'},
+    {'domain': 'flume', 'hostname': 'flume-gw-*'},
+    {'domain': 'flux_led', 'hostname': '[ba][lk]*', 'macaddress': '18B905*'},
+    {'domain': 'flux_led', 'hostname': '[ba][lk]*', 'macaddress': '249494*'},
+    {'domain': 'flux_led', 'hostname': '[ba][lk]*', 'macaddress': '7CB94C*'},
+    {'domain': 'flux_led', 'hostname': '[hba][flk]*', 'macaddress': 'ACCF23*'},
+    {'domain': 'flux_led', 'hostname': '[ba][lk]*', 'macaddress': 'B4E842*'},
+    {'domain': 'flux_led', 'hostname': '[hba][flk]*', 'macaddress': 'F0FE6B*'},
+    {'domain': 'flux_led', 'hostname': 'lwip*', 'macaddress': '8CCE4E*'},
+    {'domain': 'flux_led', 'hostname': 'zengge_[0-9a-f][0-9a-f]_*'},
+    {'domain': 'flux_led', 'hostname': 'sta*', 'macaddress': 'C82E47*'},
+    {'domain': 'fronius', 'macaddress': '0003AC*'},
+    {'domain': 'goalzero', 'hostname': 'yeti*'},
+    {'domain': 'gogogate2', 'hostname': 'ismartgate*'},
+    {'domain': 'guardian', 'hostname': 'gvc*', 'macaddress': '30AEA4*'},
+    {'domain': 'guardian', 'hostname': 'gvc*', 'macaddress': 'B4E62D*'},
+    {'domain': 'guardian', 'hostname': 'guardian*', 'macaddress': '30AEA4*'},
+    {'domain': 'hunterdouglas_powerview',
+     'hostname': 'hunter*',
+     'macaddress': '002674*'},
+    {'domain': 'isy994', 'hostname': 'isy*', 'macaddress': '0021B9*'},
+    {'domain': 'lyric', 'hostname': 'lyric-*', 'macaddress': '48A2E6*'},
+    {'domain': 'lyric', 'hostname': 'lyric-*', 'macaddress': 'B82CA0*'},
+    {'domain': 'lyric', 'hostname': 'lyric-*', 'macaddress': '00D02D*'},
+    {'domain': 'myq', 'macaddress': '645299*'},
+    {'domain': 'nest', 'macaddress': '18B430*'},
+    {'domain': 'nest', 'macaddress': '641666*'},
+    {'domain': 'nest', 'macaddress': 'D8EB46*'},
+    {'domain': 'nest', 'macaddress': '1C53F9*'},
+    {'domain': 'nexia', 'hostname': 'xl857-*', 'macaddress': '000231*'},
+    {'domain': 'nuheat', 'hostname': 'nuheat', 'macaddress': '002338*'},
+    {'domain': 'nuki', 'hostname': 'nuki_bridge_*'},
+    {'domain': 'oncue', 'hostname': 'kohlergen*', 'macaddress': '00146F*'},
+    {'domain': 'overkiz', 'hostname': 'gateway*', 'macaddress': 'F8811A*'},
+    {'domain': 'powerwall', 'hostname': '1118431-*'},
+    {'domain': 'rachio', 'hostname': 'rachio-*', 'macaddress': '009D6B*'},
+    {'domain': 'rachio', 'hostname': 'rachio-*', 'macaddress': 'F0038C*'},
+    {'domain': 'rachio', 'hostname': 'rachio-*', 'macaddress': '74C63B*'},
+    {'domain': 'rainforest_eagle', 'macaddress': 'D8D5B9*'},
+    {'domain': 'ring', 'hostname': 'ring*', 'macaddress': '0CAE7D*'},
+    {'domain': 'roomba', 'hostname': 'irobot-*', 'macaddress': '501479*'},
+    {'domain': 'roomba', 'hostname': 'roomba-*', 'macaddress': '80A589*'},
+    {'domain': 'roomba', 'hostname': 'roomba-*', 'macaddress': 'DCF505*'},
+    {'domain': 'samsungtv', 'hostname': 'tizen*'},
+    {'domain': 'samsungtv', 'macaddress': '8CC8CD*'},
+    {'domain': 'samsungtv', 'macaddress': '606BBD*'},
+    {'domain': 'samsungtv', 'macaddress': 'F47B5E*'},
+    {'domain': 'samsungtv', 'macaddress': '4844F7*'},
+    {'domain': 'screenlogic', 'hostname': 'pentair: *', 'macaddress': '00C033*'},
+    {'domain': 'sense', 'hostname': 'sense-*', 'macaddress': '009D6B*'},
+    {'domain': 'sense', 'hostname': 'sense-*', 'macaddress': 'DCEFCA*'},
+    {'domain': 'sense', 'hostname': 'sense-*', 'macaddress': 'A4D578*'},
+    {'domain': 'senseme', 'macaddress': '20F85E*'},
+    {'domain': 'sensibo', 'hostname': 'sensibo*'},
+    {'domain': 'simplisafe', 'hostname': 'simplisafe*', 'macaddress': '30AEA4*'},
+    {'domain': 'smartthings', 'hostname': 'st*', 'macaddress': '24FD5B*'},
+    {'domain': 'smartthings', 'hostname': 'smartthings*', 'macaddress': '24FD5B*'},
+    {'domain': 'smartthings', 'hostname': 'hub*', 'macaddress': '24FD5B*'},
+    {'domain': 'smartthings', 'hostname': 'hub*', 'macaddress': 'D052A8*'},
+    {'domain': 'smartthings', 'hostname': 'hub*', 'macaddress': '286D97*'},
+    {'domain': 'solaredge', 'hostname': 'target', 'macaddress': '002702*'},
+    {'domain': 'somfy_mylink', 'hostname': 'somfy_*', 'macaddress': 'B8B7F1*'},
+    {'domain': 'squeezebox', 'hostname': 'squeezebox*', 'macaddress': '000420*'},
+    {'domain': 'steamist', 'hostname': 'my[45]50*', 'macaddress': '001E0C*'},
+    {'domain': 'tado', 'hostname': 'tado*'},
+    {'domain': 'tesla_wall_connector',
+     'hostname': 'teslawallconnector_*',
+     'macaddress': 'DC44271*'},
+    {'domain': 'tesla_wall_connector',
+     'hostname': 'teslawallconnector_*',
+     'macaddress': '98ED5C*'},
+    {'domain': 'tesla_wall_connector',
+     'hostname': 'teslawallconnector_*',
+     'macaddress': '4CFCAA*'},
+    {'domain': 'tolo', 'hostname': 'usr-tcp232-ed2'},
+    {'domain': 'toon', 'hostname': 'eneco-*', 'macaddress': '74C63B*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '60A4B7*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '005F67*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '1027F5*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '403F8C*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': 'C0C9E3*'},
+    {'domain': 'tplink', 'hostname': 'ep*', 'macaddress': 'E848B8*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': 'E848B8*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '909A4A*'},
+    {'domain': 'tplink', 'hostname': 'hs*', 'macaddress': '1C3BF3*'},
+    {'domain': 'tplink', 'hostname': 'hs*', 'macaddress': '50C7BF*'},
+    {'domain': 'tplink', 'hostname': 'hs*', 'macaddress': '68FF7B*'},
+    {'domain': 'tplink', 'hostname': 'hs*', 'macaddress': '98DAC4*'},
+    {'domain': 'tplink', 'hostname': 'hs*', 'macaddress': 'B09575*'},
+    {'domain': 'tplink', 'hostname': 'hs*', 'macaddress': 'C006C3*'},
+    {'domain': 'tplink', 'hostname': 'ep*', 'macaddress': '003192*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '003192*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '1C3BF3*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '50C7BF*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '68FF7B*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': '98DAC4*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': 'B09575*'},
+    {'domain': 'tplink', 'hostname': 'k[lp]*', 'macaddress': 'C006C3*'},
+    {'domain': 'tplink', 'hostname': 'lb*', 'macaddress': '1C3BF3*'},
+    {'domain': 'tplink', 'hostname': 'lb*', 'macaddress': '50C7BF*'},
+    {'domain': 'tplink', 'hostname': 'lb*', 'macaddress': '68FF7B*'},
+    {'domain': 'tplink', 'hostname': 'lb*', 'macaddress': '98DAC4*'},
+    {'domain': 'tplink', 'hostname': 'lb*', 'macaddress': 'B09575*'},
+    {'domain': 'tuya', 'macaddress': '105A17*'},
+    {'domain': 'tuya', 'macaddress': '10D561*'},
+    {'domain': 'tuya', 'macaddress': '1869D8*'},
+    {'domain': 'tuya', 'macaddress': '381F8D*'},
+    {'domain': 'tuya', 'macaddress': '508A06*'},
+    {'domain': 'tuya', 'macaddress': '68572D*'},
+    {'domain': 'tuya', 'macaddress': '708976*'},
+    {'domain': 'tuya', 'macaddress': '7CF666*'},
+    {'domain': 'tuya', 'macaddress': '84E342*'},
+    {'domain': 'tuya', 'macaddress': 'D4A651*'},
+    {'domain': 'tuya', 'macaddress': 'D81F12*'},
+    {'domain': 'twinkly', 'hostname': 'twinkly_*'},
+    {'domain': 'unifiprotect', 'macaddress': 'B4FBE4*'},
+    {'domain': 'unifiprotect', 'macaddress': '802AA8*'},
+    {'domain': 'unifiprotect', 'macaddress': 'F09FC2*'},
+    {'domain': 'unifiprotect', 'macaddress': '68D79A*'},
+    {'domain': 'unifiprotect', 'macaddress': '18E829*'},
+    {'domain': 'unifiprotect', 'macaddress': '245A4C*'},
+    {'domain': 'unifiprotect', 'macaddress': '784558*'},
+    {'domain': 'unifiprotect', 'macaddress': 'E063DA*'},
+    {'domain': 'unifiprotect', 'macaddress': '265A4C*'},
+    {'domain': 'unifiprotect', 'macaddress': '74ACB9*'},
+    {'domain': 'verisure', 'macaddress': '0023C1*'},
+    {'domain': 'vicare', 'macaddress': 'B87424*'},
+    {'domain': 'wiz', 'macaddress': 'A8BB50*'},
+    {'domain': 'wiz', 'hostname': 'wiz_*'},
+    {'domain': 'yeelight', 'hostname': 'yeelink-*'}]

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -2,10 +2,11 @@
 
 To update, run python3 -m script.hassfest
 """
+from __future__ import annotations
 
 # fmt: off
 
-DHCP = [
+DHCP: list[dict[str, str | bool]] = [
     {
         "domain": "august",
         "hostname": "connect",

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -82,7 +82,7 @@ class Manifest(TypedDict, total=False):
     mqtt: list[str]
     ssdp: list[dict[str, str]]
     zeroconf: list[str | dict[str, str]]
-    dhcp: list[dict[str, str]]
+    dhcp: list[dict[str, bool | str]]
     usb: list[dict[str, str]]
     homekit: dict[str, list[str]]
     is_built_in: bool
@@ -228,9 +228,9 @@ async def async_get_zeroconf(
     return zeroconf
 
 
-async def async_get_dhcp(hass: HomeAssistant) -> list[dict[str, str]]:
+async def async_get_dhcp(hass: HomeAssistant) -> list[dict[str, str | bool]]:
     """Return cached list of dhcp types."""
-    dhcp: list[dict[str, str]] = DHCP.copy()
+    dhcp: list[dict[str, str | bool]] = DHCP.copy()
 
     integrations = await async_get_custom_components(hass)
     for integration in integrations.values():
@@ -474,7 +474,7 @@ class Integration:
         return self.manifest.get("zeroconf")
 
     @property
-    def dhcp(self) -> list[dict[str, str]] | None:
+    def dhcp(self) -> list[dict[str, str | bool]] | None:
         """Return Integration dhcp entries."""
         return self.manifest.get("dhcp")
 

--- a/script/hassfest/dhcp.py
+++ b/script/hassfest/dhcp.py
@@ -10,10 +10,11 @@ BASE = """
 
 To update, run python3 -m script.hassfest
 \"\"\"
+from __future__ import annotations
 
 # fmt: off
 
-DHCP = {}
+DHCP: list[dict[str, str | bool]] = {}
 """.strip()
 
 

--- a/script/hassfest/dhcp.py
+++ b/script/hassfest/dhcp.py
@@ -1,7 +1,8 @@
 """Generate dhcp file."""
 from __future__ import annotations
 
-import json
+import pprint
+import re
 
 from .model import Config, Integration
 
@@ -36,7 +37,14 @@ def generate_and_validate(integrations: list[dict[str, str]]):
         for entry in match_types:
             match_list.append({"domain": domain, **entry})
 
-    return BASE.format(json.dumps(match_list, indent=4))
+    # JSON will format `True` as `true`
+    # re.sub for flake8 E128
+    formatted = pprint.pformat(match_list)
+    formatted_aligned_continuation = re.sub(r"^\[\{", "[\n {", formatted)
+    formatted_align_indent = re.sub(
+        r"(?m)^ ", "    ", formatted_aligned_continuation, flags=re.MULTILINE, count=0
+    )
+    return BASE.format(formatted_align_indent)
 
 
 def validate(integrations: dict[str, Integration], config: Config):

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -218,7 +218,7 @@ MANIFEST_SCHEMA = vol.Schema(
                         str, verify_uppercase, verify_wildcard
                     ),
                     vol.Optional("hostname"): vol.All(str, verify_lowercase),
-                    vol.Optional("registered_devices"): bool,
+                    vol.Optional("registered_devices"): cv.boolean,
                 }
             )
         ],

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -218,6 +218,7 @@ MANIFEST_SCHEMA = vol.Schema(
                         str, verify_uppercase, verify_wildcard
                     ),
                     vol.Optional("hostname"): vol.All(str, verify_lowercase),
+                    vol.Optional("registered_devices"): bool,
                 }
             )
         ],

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -213,6 +213,11 @@ async def test_registering_mac_address(hass):
 
     packet = Ether(RAW_DHCP_RENEWAL)
 
+    # Make sure we can register multiple times since
+    # this is usually wrapped in entry.async_on_remove
+    # which may run many times as config retry happens
+    cancel = dhcp.async_register_mac(hass, "50147903852c", "mock-domain")
+    cancel = dhcp.async_register_mac(hass, "50147903852c", "mock-domain")
     cancel = dhcp.async_register_mac(hass, "50147903852c", "mock-domain")
 
     async_handle_dhcp_packet = await _async_get_handle_dhcp_packet(

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -208,8 +208,8 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
     )
 
 
-async def test_registering_mac_address(hass):
-    """Test discovery callbacks happen when registering a mac address."""
+async def test_registered_devices(hass):
+    """Test discovery flows are created for registered devices."""
     integration_matchers = [{"domain": "mock-domain", "registered_devices": True}]
 
     packet = Ether(RAW_DHCP_RENEWAL)

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -210,7 +210,10 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
 
 async def test_registered_devices(hass):
     """Test discovery flows are created for registered devices."""
-    integration_matchers = [{"domain": "mock-domain", "registered_devices": True}]
+    integration_matchers = [
+        {"domain": "not-matching", "registered_devices": True},
+        {"domain": "mock-domain", "registered_devices": True},
+    ]
 
     packet = Ether(RAW_DHCP_RENEWAL)
 
@@ -223,7 +226,7 @@ async def test_registered_devices(hass):
         name="name",
     )
     # Not enabled should not get flows
-    config_entry2 = MockConfigEntry(domain="mock-domain", data={})
+    config_entry2 = MockConfigEntry(domain="mock-domain-2", data={})
     config_entry2.add_to_hass(hass)
     registry.async_get_or_create(
         config_entry_id=config_entry2.entry_id,

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -210,15 +210,12 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
 
 async def test_registering_mac_address(hass):
     """Test discovery callbacks happen when registering a mac address."""
-    integration_matchers = []
+    integration_matchers = [{"domain": "mock-domain", "registered_devices": True}]
 
     packet = Ether(RAW_DHCP_RENEWAL)
 
     registry = dr.async_get(hass)
     config_entry = MockConfigEntry(domain="mock-domain", data={})
-    config_entries.current_entry.set(config_entry)
-    dhcp.async_enable_device_flows(hass)
-
     config_entry.add_to_hass(hass)
     registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -203,6 +203,7 @@ def test_integration_properties(hass):
                 {"hostname": "tesla_*", "macaddress": "4CFCAA*"},
                 {"hostname": "tesla_*", "macaddress": "044EAF*"},
                 {"hostname": "tesla_*", "macaddress": "98ED5C*"},
+                {"registered_devices": True},
             ],
             "usb": [
                 {"vid": "10C4", "pid": "EA60"},
@@ -233,6 +234,7 @@ def test_integration_properties(hass):
         {"hostname": "tesla_*", "macaddress": "4CFCAA*"},
         {"hostname": "tesla_*", "macaddress": "044EAF*"},
         {"hostname": "tesla_*", "macaddress": "98ED5C*"},
+        {"registered_devices": True},
     ]
     assert integration.usb == [
         {"vid": "10C4", "pid": "EA60"},


### PR DESCRIPTION
This change is much smaller than it appears because the generated `dhcp.py` file
had to be reformatted since it was using json to output which formats `True` as `true`
and breaks python syntax.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many integrations use ESP chips or other broad use OUIs which
prevent them from listing the OUI in their `manifest.json` which
means that they do not get discovery flows if the ip address of
the device changes even though Home Assistant knows the new
IP address of the device.

When the integration knows the mac address of a device and
has added it to the device registry it can
can register its interest in receiving dhcp discovery flows for
the device by adding the following to their `manifest.json`

```json
  "dhcp": [{"registered_devices": true}]
```

These can co-existing with existing dhcp discovery entries.

```json
  "dhcp": [
     {"registered_devices": true},
     {"hostname": "awesomeintegration*"},
   ]
```

The following integrations can use this with no code changes (except for elkm1): 

- `axis` https://github.com/home-assistant/core/pull/66581
- `broadlink` https://github.com/home-assistant/core/pull/66582
- `elkm1` https://github.com/home-assistant/core/pull/66583 
- `emonitor` https://github.com/home-assistant/core/pull/66584
- `flux_led` https://github.com/home-assistant/core/pull/66585
-  `goalzero` https://github.com/home-assistant/core/pull/66586
-  `gogogate2` -- needs additional investigate as we might have mismatched unique ids
-  `hunterdouglas_powerview` https://github.com/home-assistant/core/pull/66587
-  `isy994` https://github.com/home-assistant/core/pull/66588
-  `powerwall` awaits https://github.com/home-assistant/core/pull/65577
- `samsungtv` https://github.com/home-assistant/core/pull/66589
-  `screenlogic` https://github.com/home-assistant/core/pull/66591
-  `senseme` https://github.com/home-assistant/core/pull/66590
-  `steamist` https://github.com/home-assistant/core/pull/66593
-  `tplink` https://github.com/home-assistant/core/pull/66592
-  `twinkly` -- missing mac in device info (https://xled-docs.readthedocs.io/en/latest/rest_api.html#device-details)
- `wiz` https://github.com/home-assistant/core/pull/66595


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1212

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
