### PR TITLE
Fix wifi switches name for Fritz

### DIFF
--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -64,3 +64,5 @@ FRITZ_EXCEPTIONS = (
     FritzServiceError,
     FritzLookUpError,
 )
+
+WIFI_STANDARD = {1: "2.4Ghz", 2: "5Ghz", 3: "5Ghz", 4: "Guest"}

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -31,6 +31,7 @@ from .const import (
     SWITCH_TYPE_DEFLECTION,
     SWITCH_TYPE_PORTFORWARD,
     SWITCH_TYPE_WIFINETWORK,
+    WIFI_STANDARD,
     MeshRoles,
 )
 
@@ -141,31 +142,43 @@ def wifi_entities_list(
 ) -> list[FritzBoxWifiSwitch]:
     """Get list of wifi entities."""
     _LOGGER.debug("Setting up %s switches", SWITCH_TYPE_WIFINETWORK)
-    std_table = {"ax": "Wifi6", "ac": "5Ghz", "n": "2.4Ghz"}
-    if avm_wrapper.model == "FRITZ!Box 7390":
-        std_table = {"n": "5Ghz"}
 
+    #
+    # https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/wlanconfigSCPD.pdf
+    #
+    wifi_count = len(
+        [
+            s
+            for s in avm_wrapper.connection.services
+            if s.startswith("WLANConfiguration")
+        ]
+    )
+    _LOGGER.debug("WiFi networks count: %s", wifi_count)
     networks: dict = {}
-    for i in range(4):
-        if not ("WLANConfiguration" + str(i)) in avm_wrapper.connection.services:
-            continue
+    for i in range(1, wifi_count + 1):
+        network_info = avm_wrapper.connection.call_action(
+            f"WLANConfiguration{i}", "GetInfo"
+        )
+        # Devices with 4 WLAN services, use the 2nd for internal communications
+        if not (wifi_count == 4 and i == 2):
+            networks[i] = {
+                "ssid": network_info["NewSSID"],
+                "bssid": network_info["NewBSSID"],
+                "standard": network_info["NewStandard"],
+                "enabled": network_info["NewEnable"],
+                "status": network_info["NewStatus"],
+            }
+    for i, network in networks.copy().items():
+        networks[i]["switch_name"] = network["ssid"]
+        if len([j for j, n in networks.items() if n["ssid"] == network["ssid"]]) > 1:
+            networks[i]["switch_name"] += f" ({WIFI_STANDARD[i]})"
 
-        network_info = avm_wrapper.get_wlan_configuration(i)
-        if network_info:
-            ssid = network_info["NewSSID"]
-            _LOGGER.debug("SSID from device: <%s>", ssid)
-            if slugify(
-                ssid,
-            ) in [slugify(v) for v in networks.values()]:
-                _LOGGER.debug("SSID duplicated, adding suffix")
-                networks[i] = f'{ssid} {std_table[network_info["NewStandard"]]}'
-            else:
-                networks[i] = ssid
-            _LOGGER.debug("SSID normalized: <%s>", networks[i])
-
+    _LOGGER.debug("WiFi networks list: %s", networks)
     return [
-        FritzBoxWifiSwitch(avm_wrapper, device_friendly_name, net, network_name)
-        for net, network_name in networks.items()
+        FritzBoxWifiSwitch(
+            avm_wrapper, device_friendly_name, index, data["switch_name"]
+        )
+        for index, data in networks.items()
     ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After analyzing `wlanconfigSCPD.pdf` API document with @mib1185 , we came up with this PR that will add the correct suffix to WIFI switches in case of duplicate name.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65921
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
