### PR TITLE
Add binary_sensor to Version integration

### DIFF
--- a/homeassistant/components/version/binary_sensor.py
+++ b/homeassistant/components/version/binary_sensor.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up version binary_sensors."""
     coordinator: VersionDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    if (source := config_entry.data.get(CONF_SOURCE)) == "local":
+    if (source := config_entry.data[CONF_SOURCE]) == "local":
         return
 
     if (entity_name := config_entry.data[CONF_NAME]) == DEFAULT_NAME:

--- a/homeassistant/components/version/binary_sensor.py
+++ b/homeassistant/components/version/binary_sensor.py
@@ -1,0 +1,61 @@
+"""Binary sensor platform for Version."""
+from __future__ import annotations
+
+from awesomeversion import AwesomeVersion
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, __version__ as HA_VERSION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_SOURCE, DEFAULT_NAME, DOMAIN
+from .coordinator import VersionDataUpdateCoordinator
+from .entity import VersionEntity
+
+HA_VERSION_OBJECT = AwesomeVersion(HA_VERSION)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up version binary_sensors."""
+    coordinator: VersionDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    if (source := config_entry.data.get(CONF_SOURCE)) == "local":
+        return
+
+    if (entity_name := config_entry.data[CONF_NAME]) == DEFAULT_NAME:
+        entity_name = config_entry.title
+
+    entities: list[VersionBinarySensor] = [
+        VersionBinarySensor(
+            coordinator=coordinator,
+            entity_description=BinarySensorEntityDescription(
+                key=str(source),
+                name=f"{entity_name} Update Available",
+                device_class=BinarySensorDeviceClass.UPDATE,
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+        )
+    ]
+
+    async_add_entities(entities)
+
+
+class VersionBinarySensor(VersionEntity, BinarySensorEntity):
+    """Binary sensor for version entities."""
+
+    entity_description: BinarySensorEntityDescription
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the binary sensor is on."""
+        version = self.coordinator.version
+        return version is not None and (version > HA_VERSION_OBJECT)

--- a/homeassistant/components/version/const.py
+++ b/homeassistant/components/version/const.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_NAME, Platform
 
 DOMAIN: Final = "version"
 LOGGER: Final[Logger] = getLogger(__package__)
-PLATFORMS: Final[list[Platform]] = [Platform.SENSOR]
+PLATFORMS: Final[list[Platform]] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 UPDATE_COORDINATOR_UPDATE_INTERVAL: Final[timedelta] = timedelta(minutes=5)
 
 ENTRY_TYPE_SERVICE: Final = "service"

--- a/homeassistant/components/version/entity.py
+++ b/homeassistant/components/version/entity.py
@@ -1,0 +1,34 @@
+"""Common entity class for Version integration."""
+
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo, EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, HOME_ASSISTANT
+from .coordinator import VersionDataUpdateCoordinator
+
+
+class VersionEntity(CoordinatorEntity):
+    """Common entity class for Version integration."""
+
+    _attr_icon = "mdi:package-up"
+    _attr_device_info = DeviceInfo(
+        name=f"{HOME_ASSISTANT} {DOMAIN.title()}",
+        identifiers={(HOME_ASSISTANT, DOMAIN)},
+        manufacturer=HOME_ASSISTANT,
+        entry_type=DeviceEntryType.SERVICE,
+    )
+
+    coordinator: VersionDataUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: VersionDataUpdateCoordinator,
+        entity_description: EntityDescription,
+    ) -> None:
+        """Initialize version entities."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{entity_description.key}"
+        )

--- a/homeassistant/components/version/entity.py
+++ b/homeassistant/components/version/entity.py
@@ -11,7 +11,6 @@ from .coordinator import VersionDataUpdateCoordinator
 class VersionEntity(CoordinatorEntity):
     """Common entity class for Version integration."""
 
-    _attr_icon = "mdi:package-up"
     _attr_device_info = DeviceInfo(
         name=f"{HOME_ASSISTANT} {DOMAIN.title()}",
         identifiers={(HOME_ASSISTANT, DOMAIN)},

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -15,11 +15,8 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_SOURCE,
@@ -31,12 +28,12 @@ from .const import (
     DEFAULT_NAME,
     DEFAULT_SOURCE,
     DOMAIN,
-    HOME_ASSISTANT,
     LOGGER,
     VALID_IMAGES,
     VALID_SOURCES,
 )
 from .coordinator import VersionDataUpdateCoordinator
+from .entity import VersionEntity
 
 PLATFORM_SCHEMA: Final[Schema] = SENSOR_PLATFORM_SCHEMA.extend(
     {
@@ -91,30 +88,8 @@ async def async_setup_entry(
     async_add_entities(version_sensor_entities)
 
 
-class VersionSensorEntity(CoordinatorEntity, SensorEntity):
+class VersionSensorEntity(VersionEntity, SensorEntity):
     """Version sensor entity class."""
-
-    _attr_icon = "mdi:package-up"
-    _attr_device_info = DeviceInfo(
-        name=f"{HOME_ASSISTANT} {DOMAIN.title()}",
-        identifiers={(HOME_ASSISTANT, DOMAIN)},
-        manufacturer=HOME_ASSISTANT,
-        entry_type=DeviceEntryType.SERVICE,
-    )
-
-    coordinator: VersionDataUpdateCoordinator
-
-    def __init__(
-        self,
-        coordinator: VersionDataUpdateCoordinator,
-        entity_description: SensorEntityDescription,
-    ) -> None:
-        """Initialize version sensor entities."""
-        super().__init__(coordinator)
-        self.entity_description = entity_description
-        self._attr_unique_id = (
-            f"{coordinator.config_entry.entry_id}_{entity_description.key}"
-        )
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -91,6 +91,8 @@ async def async_setup_entry(
 class VersionSensorEntity(VersionEntity, SensorEntity):
     """Version sensor entity class."""
 
+    _attr_icon = "mdi:package-up"
+
     @property
     def native_value(self) -> StateType:
         """Return the native value of this sensor."""

--- a/tests/components/version/common.py
+++ b/tests/components/version/common.py
@@ -52,9 +52,17 @@ async def mock_get_version_update(
         await hass.async_block_till_done()
 
 
-async def setup_version_integration(hass: HomeAssistant) -> MockConfigEntry:
+async def setup_version_integration(
+    hass: HomeAssistant,
+    entry_data: dict[str, Any] | None = None,
+) -> MockConfigEntry:
     """Set up the Version integration."""
-    mock_entry = MockConfigEntry(**MOCK_VERSION_CONFIG_ENTRY_DATA)
+    mock_entry = MockConfigEntry(
+        **{
+            **MOCK_VERSION_CONFIG_ENTRY_DATA,
+            "data": entry_data or MOCK_VERSION_CONFIG_ENTRY_DATA["data"],
+        }
+    )
     mock_entry.add_to_hass(hass)
 
     with patch(
@@ -65,7 +73,6 @@ async def setup_version_integration(hass: HomeAssistant) -> MockConfigEntry:
         assert await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.local_installation").state == MOCK_VERSION
     assert mock_entry.state == config_entries.ConfigEntryState.LOADED
 
     return mock_entry

--- a/tests/components/version/test_binary_sensor.py
+++ b/tests/components/version/test_binary_sensor.py
@@ -7,11 +7,17 @@ from homeassistant.core import HomeAssistant
 from .common import setup_version_integration
 
 
+async def test_version_binary_sensor_local_source(hass: HomeAssistant):
+    """Test the Version binary sensor with local source."""
+    await setup_version_integration(hass)
+
+    state = hass.states.get("binary_sensor.local_installation_update_available")
+    assert not state
+
+
 async def test_version_binary_sensor(hass: HomeAssistant):
     """Test the Version binary sensor."""
-    await setup_version_integration(
-        hass, {**DEFAULT_CONFIGURATION, "source": "pypi", "name": "PyPi"}
-    )
+    await setup_version_integration(hass, {**DEFAULT_CONFIGURATION, "source": "pypi"})
 
-    state = hass.states.get("binary_sensor.pypi_update_available")
-    assert state.state == "off"
+    state = hass.states.get("binary_sensor.local_installation_update_available")
+    assert state

--- a/tests/components/version/test_binary_sensor.py
+++ b/tests/components/version/test_binary_sensor.py
@@ -1,0 +1,17 @@
+"""The test for the version binary sensor platform."""
+from __future__ import annotations
+
+from homeassistant.components.version.const import DEFAULT_CONFIGURATION
+from homeassistant.core import HomeAssistant
+
+from .common import setup_version_integration
+
+
+async def test_version_binary_sensor(hass: HomeAssistant):
+    """Test the Version binary sensor."""
+    await setup_version_integration(
+        hass, {**DEFAULT_CONFIGURATION, "source": "pypi", "name": "PyPi"}
+    )
+
+    state = hass.states.get("binary_sensor.pypi_update_available")
+    assert state.state == "off"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a binary sensor to the Version integration for all but the local source to indicate that there is an update available.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21650

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
