### PR TITLE
Replace discord.py with nextcord

### DIFF
--- a/homeassistant/components/discord/manifest.json
+++ b/homeassistant/components/discord/manifest.json
@@ -2,7 +2,7 @@
   "domain": "discord",
   "name": "Discord",
   "documentation": "https://www.home-assistant.io/integrations/discord",
-  "requirements": ["discord.py==1.7.3"],
+  "requirements": ["nextcord==2.0.0a8"],
   "codeowners": [],
   "iot_class": "cloud_push",
   "loggers": ["discord"]

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -1,8 +1,10 @@
 """Discord platform for notify component."""
+from __future__ import annotations
+
 import logging
 import os.path
 
-import discord
+import nextcord
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -48,8 +50,8 @@ class DiscordNotificationService(BaseNotificationService):
 
     async def async_send_message(self, message, **kwargs):
         """Login to Discord, send message to channel(s) and log out."""
-        discord.VoiceClient.warn_nacl = False
-        discord_bot = discord.Client()
+        nextcord.VoiceClient.warn_nacl = False
+        discord_bot = nextcord.Client()
         images = None
         embedding = None
 
@@ -59,13 +61,13 @@ class DiscordNotificationService(BaseNotificationService):
 
         data = kwargs.get(ATTR_DATA) or {}
 
-        embed = None
+        embeds: list[nextcord.Embed] | nextcord.Embed = []
         if ATTR_EMBED in data:
             embedding = data[ATTR_EMBED]
             fields = embedding.get(ATTR_EMBED_FIELDS) or []
 
             if embedding:
-                embed = discord.Embed(**embedding)
+                embed = nextcord.Embed(**embedding)
                 for field in fields:
                     embed.add_field(**field)
                 if ATTR_EMBED_FOOTER in embedding:
@@ -74,11 +76,12 @@ class DiscordNotificationService(BaseNotificationService):
                     embed.set_author(**embedding[ATTR_EMBED_AUTHOR])
                 if ATTR_EMBED_THUMBNAIL in embedding:
                     embed.set_thumbnail(**embedding[ATTR_EMBED_THUMBNAIL])
+                embeds.append(embed)
 
         if ATTR_IMAGES in data:
             images = []
 
-            for image in data.get(ATTR_IMAGES):
+            for image in data.get(ATTR_IMAGES, []):
                 image_exists = await self.hass.async_add_executor_job(
                     self.file_exists, image
                 )
@@ -95,15 +98,15 @@ class DiscordNotificationService(BaseNotificationService):
                 channelid = int(channelid)
                 try:
                     channel = await discord_bot.fetch_channel(channelid)
-                except discord.NotFound:
+                except nextcord.NotFound:
                     try:
                         channel = await discord_bot.fetch_user(channelid)
-                    except discord.NotFound:
+                    except nextcord.NotFound:
                         _LOGGER.warning("Channel not found for ID: %s", channelid)
                         continue
                 # Must create new instances of File for each channel.
-                files = [discord.File(image) for image in images] if images else None
-                await channel.send(message, files=files, embed=embed)
-        except (discord.HTTPException, discord.NotFound) as error:
+                files = [nextcord.File(image) for image in images] if images else []
+                await channel.send(message, files=files, embeds=embeds)
+        except (nextcord.HTTPException, nextcord.NotFound) as error:
             _LOGGER.warning("Communication error: %s", error)
         await discord_bot.close()

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -61,7 +61,7 @@ class DiscordNotificationService(BaseNotificationService):
 
         data = kwargs.get(ATTR_DATA) or {}
 
-        embeds: list[nextcord.Embed] | nextcord.Embed = []
+        embeds: list[nextcord.Embed] = []
         if ATTR_EMBED in data:
             embedding = data[ATTR_EMBED]
             fields = embedding.get(ATTR_EMBED_FIELDS) or []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -565,9 +565,6 @@ directv==0.4.0
 # homeassistant.components.discogs
 discogs_client==2.3.0
 
-# homeassistant.components.discord
-discord.py==1.7.3
-
 # homeassistant.components.steamist
 discovery30303==0.2.1
 
@@ -1098,6 +1095,9 @@ nexia==0.9.13
 
 # homeassistant.components.nextcloud
 nextcloudmonitor==1.1.0
+
+# homeassistant.components.discord
+nextcord==2.0.0a8
 
 # homeassistant.components.niko_home_control
 niko-home-control==0.2.1

--- a/script/pip_check
+++ b/script/pip_check
@@ -3,7 +3,7 @@ PIP_CACHE=$1
 
 # Number of existing dependency conflicts
 # Update if a PR resolve one!
-DEPENDENCY_CONFLICTS=10
+DEPENDENCY_CONFLICTS=9
 
 PIP_CHECK=$(pip check --cache-dir=$PIP_CACHE)
 LINE_COUNT=$(echo "$PIP_CHECK" | wc -l)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`discord.py` has been archived, for more information see: <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>

Meanwhile, we have a dependency conflict:

`discord-py 1.7.3 has requirement aiohttp<3.8.0,>=3.6.0, but you have aiohttp 3.8.1`

This PR replaces `discord.py` with `nextcord`, which is a fork that has picked up development and gained quite a traction:

<https://github.com/nextcord/nextcord/>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
