### PR TITLE
Cleanup samsungtv tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1006,7 +1006,6 @@ omit =
     homeassistant/components/russound_rnet/media_player.py
     homeassistant/components/sabnzbd/*
     homeassistant/components/saj/sensor.py
-    homeassistant/components/samsungtv/bridge.py
     homeassistant/components/satel_integra/*
     homeassistant/components/schluter/*
     homeassistant/components/screenlogic/__init__.py

--- a/tests/components/samsungtv/__init__.py
+++ b/tests/components/samsungtv/__init__.py
@@ -1,14 +1,1 @@
 """Tests for the samsungtv component."""
-from homeassistant.components.samsungtv.const import DOMAIN as SAMSUNGTV_DOMAIN
-from homeassistant.core import HomeAssistant
-
-from tests.common import MockConfigEntry
-
-
-async def setup_samsungtv(hass: HomeAssistant, config: dict):
-    """Set up mock Samsung TV."""
-
-    entry = MockConfigEntry(domain=SAMSUNGTV_DOMAIN, data=config)
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -7,15 +7,20 @@ import pytest
 import homeassistant.util.dt as dt_util
 
 
-@pytest.fixture(name="remote")
-def remote_fixture() -> Mock:
-    """Patch the samsungctl Remote."""
+@pytest.fixture(autouse=True)
+def fake_host_fixture() -> None:
+    """Patch gethostbyname."""
     with patch(
-        "homeassistant.components.samsungtv.bridge.Remote"
-    ) as remote_class, patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
         return_value="fake_host",
     ):
+        yield
+
+
+@pytest.fixture(name="remote")
+def remote_fixture() -> Mock:
+    """Patch the samsungctl Remote."""
+    with patch("homeassistant.components.samsungtv.bridge.Remote") as remote_class:
         remote = Mock()
         remote.__enter__ = Mock()
         remote.__exit__ = Mock()
@@ -29,10 +34,7 @@ def remotews_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class, patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    ) as remotews_class:
         remotews = Mock()
         remotews.__enter__ = Mock()
         remotews.__exit__ = Mock()
@@ -57,10 +59,7 @@ def remotews_no_device_info_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class, patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    ) as remotews_class:
         remotews = Mock()
         remotews.__enter__ = Mock()
         remotews.__exit__ = Mock()
@@ -75,10 +74,7 @@ def remotews_soundbar_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class, patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    ) as remotews_class:
         remotews = Mock()
         remotews.__enter__ = Mock()
         remotews.__exit__ = Mock()

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -1,16 +1,14 @@
 """Fixtures for Samsung TV."""
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
 
 import homeassistant.util.dt as dt_util
 
-RESULT_ALREADY_CONFIGURED = "already_configured"
-RESULT_ALREADY_IN_PROGRESS = "already_in_progress"
-
 
 @pytest.fixture(name="remote")
-def remote_fixture():
+def remote_fixture() -> Mock:
     """Patch the samsungctl Remote."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote"
@@ -27,7 +25,7 @@ def remote_fixture():
 
 
 @pytest.fixture(name="remotews")
-def remotews_fixture():
+def remotews_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -55,7 +53,7 @@ def remotews_fixture():
 
 
 @pytest.fixture(name="remotews_no_device_info")
-def remotews_no_device_info_fixture():
+def remotews_no_device_info_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -73,7 +71,7 @@ def remotews_no_device_info_fixture():
 
 
 @pytest.fixture(name="remotews_soundbar")
-def remotews_soundbar_fixture():
+def remotews_soundbar_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -100,7 +98,7 @@ def remotews_soundbar_fixture():
 
 
 @pytest.fixture(name="delay")
-def delay_fixture():
+def delay_fixture() -> Mock:
     """Patch the delay script function."""
     with patch(
         "homeassistant.components.samsungtv.media_player.Script.async_run"
@@ -109,13 +107,13 @@ def delay_fixture():
 
 
 @pytest.fixture
-def mock_now():
+def mock_now() -> datetime:
     """Fixture for dtutil.now."""
     return dt_util.utcnow()
 
 
 @pytest.fixture(name="no_mac_address")
-def mac_address_fixture():
+def mac_address_fixture() -> Mock:
     """Patch getmac.get_mac_address."""
     with patch("getmac.get_mac_address", return_value=None) as mac:
         yield mac

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -1,5 +1,4 @@
 """Fixtures for Samsung TV."""
-from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
@@ -18,7 +17,7 @@ def fake_host_fixture() -> None:
 
 
 @pytest.fixture(name="remote")
-def remote_fixture() -> Mock:
+def remote_fixture():
     """Patch the samsungctl Remote."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote_class:
         remote = Mock()
@@ -30,7 +29,7 @@ def remote_fixture() -> Mock:
 
 
 @pytest.fixture(name="remotews")
-def remotews_fixture() -> Mock:
+def remotews_fixture():
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -55,7 +54,7 @@ def remotews_fixture() -> Mock:
 
 
 @pytest.fixture(name="remotews_no_device_info")
-def remotews_no_device_info_fixture() -> Mock:
+def remotews_no_device_info_fixture():
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -70,7 +69,7 @@ def remotews_no_device_info_fixture() -> Mock:
 
 
 @pytest.fixture(name="remotews_soundbar")
-def remotews_soundbar_fixture() -> Mock:
+def remotews_soundbar_fixture():
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -94,7 +93,7 @@ def remotews_soundbar_fixture() -> Mock:
 
 
 @pytest.fixture(name="delay")
-def delay_fixture() -> Mock:
+def delay_fixture():
     """Patch the delay script function."""
     with patch(
         "homeassistant.components.samsungtv.media_player.Script.async_run"
@@ -103,13 +102,13 @@ def delay_fixture() -> Mock:
 
 
 @pytest.fixture
-def mock_now() -> datetime:
+def mock_now():
     """Fixture for dtutil.now."""
     return dt_util.utcnow()
 
 
 @pytest.fixture(name="no_mac_address")
-def mac_address_fixture() -> Mock:
+def mac_address_fixture():
     """Patch getmac.get_mac_address."""
     with patch("getmac.get_mac_address", return_value=None) as mac:
         yield mac

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -235,7 +235,7 @@ async def test_user_websocket(hass: HomeAssistant) -> None:
         assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remote", "remotews")
+@pytest.mark.usefixtures("remotews")
 async def test_user_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow by user with authentication."""
     with patch(
@@ -250,7 +250,6 @@ async def test_user_legacy_missing_auth(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_AUTH_MISSING
 
 
-@pytest.mark.usefixtures("remote")
 async def test_user_legacy_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow by user for not supported device."""
     with patch(
@@ -382,7 +381,7 @@ async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
             assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
 
 
-@pytest.mark.usefixtures("remote", "remotews")
+@pytest.mark.usefixtures("remotews")
 async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery with authentication."""
     with patch(
@@ -457,7 +456,6 @@ async def test_ssdp_websocket_success_populates_mac_address(
     assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remote")
 async def test_ssdp_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery for not supported device."""
     with patch(
@@ -489,7 +487,7 @@ async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remote", "no_mac_address")
+@pytest.mark.usefixtures("no_mac_address")
 async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
@@ -518,7 +516,7 @@ async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-@pytest.mark.usefixtures("remote", "no_mac_address")
+@pytest.mark.usefixtures("no_mac_address")
 async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
@@ -612,15 +610,11 @@ async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test importing from yaml with hostname."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
-    with patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_IMPORT_DATA,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=MOCK_IMPORT_DATA,
+    )
     await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["title"] == "fake"
@@ -638,15 +632,11 @@ async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
 @pytest.mark.usefixtures("remote", "remotews_no_device_info", "no_mac_address")
 async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
     """Test importing from yaml without a name."""
-    with patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_IMPORT_DATA_WITHOUT_NAME,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=MOCK_IMPORT_DATA_WITHOUT_NAME,
+    )
     await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["title"] == "fake_host"
@@ -663,15 +653,11 @@ async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("remotews")
 async def test_import_websocket(hass: HomeAssistant):
     """Test importing from yaml with hostname."""
-    with patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_IMPORT_WSDATA,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=MOCK_IMPORT_WSDATA,
+    )
     await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["title"] == "fake"
@@ -686,15 +672,11 @@ async def test_import_websocket(hass: HomeAssistant):
 @pytest.mark.usefixtures("remotews")
 async def test_import_websocket_without_port(hass: HomeAssistant):
     """Test importing from yaml with hostname by no port."""
-    with patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=MOCK_IMPORT_WSDATA,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=MOCK_IMPORT_WSDATA,
+    )
     await hass.async_block_till_done()
     assert result["type"] == "create_entry"
     assert result["title"] == "fake"
@@ -827,19 +809,12 @@ async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant) -> None:
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_autodetect_websocket(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-) -> None:
+async def test_autodetect_websocket(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
-    ), patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews:
+    ), patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remotews:
         enter = Mock()
         type(enter).token = PropertyMock(return_value="123456789")
         remote = Mock()
@@ -877,16 +852,11 @@ async def test_autodetect_websocket(
     assert entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_websocket_no_mac(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-) -> None:
+async def test_websocket_no_mac(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
-    ), patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews, patch(
@@ -928,16 +898,12 @@ async def test_websocket_no_mac(
     assert entries[0].data[CONF_MAC] == "gg:hh:ii:ll:mm:nn"
 
 
-@pytest.mark.usefixtures("remote")
-async def test_autodetect_auth_missing(hass: HomeAssistant, remote: Mock) -> None:
+async def test_autodetect_auth_missing(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=[AccessDenied("Boom")],
-    ) as remote, patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    ) as remote:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
         )
@@ -947,16 +913,12 @@ async def test_autodetect_auth_missing(hass: HomeAssistant, remote: Mock) -> Non
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-@pytest.mark.usefixtures("remote")
-async def test_autodetect_not_supported(hass: HomeAssistant, remote: Mock) -> None:
+async def test_autodetect_not_supported(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=[UnhandledResponse("Boom")],
-    ) as remote, patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    ) as remote:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
         )
@@ -979,9 +941,7 @@ async def test_autodetect_legacy(hass: HomeAssistant) -> None:
     assert result["data"][CONF_PORT] == LEGACY_PORT
 
 
-async def test_autodetect_none(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-) -> None:
+async def test_autodetect_none(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -989,10 +949,7 @@ async def test_autodetect_none(
     ) as remote, patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=OSError("Boom"),
-    ) as remotews, patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    ) as remotews:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
         )
@@ -1010,7 +967,7 @@ async def test_autodetect_none(
 
 
 @pytest.mark.usefixtures("remotews")
-async def test_update_old_entry(hass: HomeAssistant, remote: Mock) -> None:
+async def test_update_old_entry(hass: HomeAssistant) -> None:
     """Test update of old entry."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         remote().rest_device_info.return_value = {
@@ -1303,9 +1260,6 @@ async def test_form_reauth_websocket_cannot_connect(hass: HomeAssistant) -> None
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=ConnectionFailure,
-    ), patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1342,9 +1296,6 @@ async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=WebSocketException,
-    ), patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -424,7 +424,9 @@ async def test_ssdp_legacy_not_supported(
 
 
 async def test_ssdp_websocket_success_populates_mac_address(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
+    hass: HomeAssistant,
+    remote: Mock,
+    remotews: Mock,
 ):
     """Test starting a flow from ssdp for a supported device populates the mac."""
     result = await hass.config_entries.flow.async_init(
@@ -988,10 +990,7 @@ async def test_update_old_entry(hass: HomeAssistant, remotews: Mock):
         assert entry2.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_missing_mac_unique_id_added_from_dhcp(
-    hass: HomeAssistant,
-    remotews: Mock,
-):
+async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock):
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1017,10 +1016,7 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_update_missing_mac_unique_id_added_from_zeroconf(
-    hass: HomeAssistant,
-    remotews: Mock,
-):
+async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: Mock):
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1045,10 +1041,7 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_update_missing_mac_unique_id_added_from_ssdp(
-    hass: HomeAssistant,
-    remotews: Mock,
-):
+async def test_update_missing_mac_unique_id_added_from_ssdp(hass, remotews: Mock):
     """Test missing mac and unique id added via ssdp."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1075,8 +1068,7 @@ async def test_update_missing_mac_unique_id_added_from_ssdp(
 
 
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
-    hass: HomeAssistant,
-    remotews: Mock,
+    hass, remotews: Mock
 ):
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(
@@ -1106,7 +1098,7 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant, remote: Mock):
+async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
     """Test missing mac added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1137,10 +1129,7 @@ async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant, remote: 
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
-    hass: HomeAssistant,
-    remote: Mock,
-):
+async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mock):
     """Test missing mac added when there is no unique id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1176,7 +1165,7 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
     assert entry.unique_id is None
 
 
-async def test_form_reauth_legacy(hass: HomeAssistant, remote: Mock):
+async def test_form_reauth_legacy(hass, remote: Mock):
     """Test reauthenticate legacy."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
     entry.add_to_hass(hass)
@@ -1197,7 +1186,7 @@ async def test_form_reauth_legacy(hass: HomeAssistant, remote: Mock):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket(hass: HomeAssistant, remotews: Mock):
+async def test_form_reauth_websocket(hass, remotews: Mock):
     """Test reauthenticate websocket."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1221,9 +1210,7 @@ async def test_form_reauth_websocket(hass: HomeAssistant, remotews: Mock):
     assert entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_form_reauth_websocket_cannot_connect(
-    hass: HomeAssistant, remotews: Mock
-):
+async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
     """Test reauthenticate websocket when we cannot connect on the first attempt."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1258,7 +1245,7 @@ async def test_form_reauth_websocket_cannot_connect(
     assert result3["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket_not_supported(hass: HomeAssistant):
+async def test_form_reauth_websocket_not_supported(hass):
     """Test reauthenticate websocket when the device is not supported."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -264,7 +264,6 @@ async def test_user_legacy_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_user_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow by user for not supported device."""
     with patch(
@@ -282,7 +281,6 @@ async def test_user_websocket_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_user_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection found."""
     with patch(
@@ -299,7 +297,6 @@ async def test_user_not_successful(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_user_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection found."""
     with patch(
@@ -1280,7 +1277,6 @@ async def test_form_reauth_websocket_cannot_connect(hass: HomeAssistant) -> None
     assert result3["reason"] == "reauth_successful"
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when the device is not supported."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -2,6 +2,7 @@
 import socket
 from unittest.mock import Mock, PropertyMock, call, patch
 
+import pytest
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from websocket import WebSocketException, WebSocketProtocolException
@@ -43,10 +44,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
-from tests.components.samsungtv.conftest import (
-    RESULT_ALREADY_CONFIGURED,
-    RESULT_ALREADY_IN_PROGRESS,
-)
+
+RESULT_ALREADY_CONFIGURED = "already_configured"
+RESULT_ALREADY_IN_PROGRESS = "already_in_progress"
 
 MOCK_IMPORT_DATA = {
     CONF_HOST: "fake_host",
@@ -182,7 +182,8 @@ DEVICEINFO_WEBSOCKET_SSL = {
 }
 
 
-async def test_user_legacy(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_user_legacy(hass: HomeAssistant) -> None:
     """Test starting a flow by user."""
     # show form
     result = await hass.config_entries.flow.async_init(
@@ -206,7 +207,8 @@ async def test_user_legacy(hass: HomeAssistant, remote: Mock):
     assert result["result"].unique_id is None
 
 
-async def test_user_websocket(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_user_websocket(hass: HomeAssistant) -> None:
     """Test starting a flow by user."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError("Boom")
@@ -233,9 +235,8 @@ async def test_user_websocket(hass: HomeAssistant, remotews: Mock):
         assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_user_legacy_missing_auth(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_user_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow by user with authentication."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -249,7 +250,8 @@ async def test_user_legacy_missing_auth(
         assert result["reason"] == RESULT_AUTH_MISSING
 
 
-async def test_user_legacy_not_supported(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_user_legacy_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow by user for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -263,7 +265,8 @@ async def test_user_legacy_not_supported(hass: HomeAssistant, remote: Mock):
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_user_websocket_not_supported(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_user_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow by user for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -280,7 +283,8 @@ async def test_user_websocket_not_supported(hass: HomeAssistant, remotews: Mock)
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_user_not_successful(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_user_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -296,7 +300,8 @@ async def test_user_not_successful(hass: HomeAssistant, remotews: Mock):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_user_not_successful_2(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_user_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -312,7 +317,8 @@ async def test_user_not_successful_2(hass: HomeAssistant, remotews: Mock):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_ssdp(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test starting a flow from discovery."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -340,7 +346,8 @@ async def test_ssdp(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
         assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test starting a flow from discovery without prefixes."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -375,9 +382,8 @@ async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock, no_mac_address: 
             assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
 
 
-async def test_ssdp_legacy_missing_auth(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery with authentication."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -404,9 +410,8 @@ async def test_ssdp_legacy_missing_auth(
             assert result["reason"] == RESULT_AUTH_MISSING
 
 
-async def test_ssdp_legacy_not_supported(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery for not supported device."""
 
     # confirm to add the entry
@@ -428,11 +433,10 @@ async def test_ssdp_legacy_not_supported(
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
+@pytest.mark.usefixtures("remote", "remotews")
 async def test_ssdp_websocket_success_populates_mac_address(
     hass: HomeAssistant,
-    remote: Mock,
-    remotews: Mock,
-):
+) -> None:
     """Test starting a flow from ssdp for a supported device populates the mac."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -453,7 +457,8 @@ async def test_ssdp_websocket_success_populates_mac_address(
     assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_ssdp_websocket_not_supported(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -470,7 +475,8 @@ async def test_ssdp_websocket_not_supported(hass: HomeAssistant, remote: Mock):
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_ssdp_model_not_supported(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery."""
 
     # confirm to add the entry
@@ -483,9 +489,8 @@ async def test_ssdp_model_not_supported(hass: HomeAssistant, remote: Mock):
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_ssdp_not_successful(
-    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
-):
+@pytest.mark.usefixtures("remote", "no_mac_address")
+async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -513,9 +518,8 @@ async def test_ssdp_not_successful(
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_ssdp_not_successful_2(
-    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
-):
+@pytest.mark.usefixtures("remote", "no_mac_address")
+async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -543,9 +547,10 @@ async def test_ssdp_not_successful_2(
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
+@pytest.mark.usefixtures("remote")
 async def test_ssdp_already_in_progress(
-    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
-):
+    hass: HomeAssistant, no_mac_address: Mock
+) -> None:
     """Test starting a flow from discovery twice."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -569,9 +574,10 @@ async def test_ssdp_already_in_progress(
         assert result["reason"] == RESULT_ALREADY_IN_PROGRESS
 
 
+@pytest.mark.usefixtures("remote")
 async def test_ssdp_already_configured(
-    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
-):
+    hass: HomeAssistant, no_mac_address: Mock
+) -> None:
     """Test starting a flow from discovery when already configured."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -601,7 +607,8 @@ async def test_ssdp_already_configured(
         assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_import_legacy(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test importing from yaml with hostname."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -628,12 +635,8 @@ async def test_import_legacy(hass: HomeAssistant, remote: Mock, no_mac_address: 
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-async def test_import_legacy_without_name(
-    hass: HomeAssistant,
-    remote: Mock,
-    remotews_no_device_info: Mock,
-    no_mac_address: Mock,
-):
+@pytest.mark.usefixtures("remote", "remotews_no_device_info", "no_mac_address")
+async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
     """Test importing from yaml without a name."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -657,7 +660,8 @@ async def test_import_legacy_without_name(
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-async def test_import_websocket(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_import_websocket(hass: HomeAssistant):
     """Test importing from yaml with hostname."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -679,7 +683,8 @@ async def test_import_websocket(hass: HomeAssistant, remotews: Mock):
     assert result["result"].unique_id is None
 
 
-async def test_import_websocket_without_port(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_import_websocket_without_port(hass: HomeAssistant):
     """Test importing from yaml with hostname by no port."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -704,7 +709,8 @@ async def test_import_websocket_without_port(hass: HomeAssistant, remotews: Mock
     assert entries[0].data[CONF_PORT] == 8002
 
 
-async def test_import_unknown_host(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_import_unknown_host(hass: HomeAssistant):
     """Test importing from yaml with hostname that does not resolve."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -720,7 +726,8 @@ async def test_import_unknown_host(hass: HomeAssistant, remotews: Mock):
     assert result["reason"] == RESULT_UNKNOWN_HOST
 
 
-async def test_dhcp(hass: HomeAssistant, remote: Mock, remotews: Mock):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_dhcp(hass: HomeAssistant) -> None:
     """Test starting a flow from dhcp."""
     # confirm to add the entry
     result = await hass.config_entries.flow.async_init(
@@ -746,7 +753,8 @@ async def test_dhcp(hass: HomeAssistant, remote: Mock, remotews: Mock):
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_zeroconf(hass: HomeAssistant, remote: Mock, remotews: Mock):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -771,7 +779,8 @@ async def test_zeroconf(hass: HomeAssistant, remote: Mock, remotews: Mock):
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, remotews_soundbar: Mock):
+@pytest.mark.usefixtures("remotews_soundbar")
+async def test_zeroconf_ignores_soundbar(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf where the device is actually a soundbar."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -783,9 +792,8 @@ async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, remotews_soundbar:
     assert result["reason"] == "not_supported"
 
 
-async def test_zeroconf_no_device_info(
-    hass: HomeAssistant, remote: Mock, remotews_no_device_info: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews_no_device_info")
+async def test_zeroconf_no_device_info(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf where device_info returns None."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -797,7 +805,8 @@ async def test_zeroconf_no_device_info(
     assert result["reason"] == "not_supported"
 
 
-async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf and dhcp."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -818,7 +827,9 @@ async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant, remotews: Mock):
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_autodetect_websocket(hass: HomeAssistant, remote: Mock, remotews: Mock):
+async def test_autodetect_websocket(
+    hass: HomeAssistant, remote: Mock, remotews: Mock
+) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -866,7 +877,9 @@ async def test_autodetect_websocket(hass: HomeAssistant, remote: Mock, remotews:
     assert entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_websocket_no_mac(hass: HomeAssistant, remote: Mock, remotews: Mock):
+async def test_websocket_no_mac(
+    hass: HomeAssistant, remote: Mock, remotews: Mock
+) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -915,7 +928,8 @@ async def test_websocket_no_mac(hass: HomeAssistant, remote: Mock, remotews: Moc
     assert entries[0].data[CONF_MAC] == "gg:hh:ii:ll:mm:nn"
 
 
-async def test_autodetect_auth_missing(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_autodetect_auth_missing(hass: HomeAssistant, remote: Mock) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -933,7 +947,8 @@ async def test_autodetect_auth_missing(hass: HomeAssistant, remote: Mock):
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-async def test_autodetect_not_supported(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_autodetect_not_supported(hass: HomeAssistant, remote: Mock) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -951,7 +966,8 @@ async def test_autodetect_not_supported(hass: HomeAssistant, remote: Mock):
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-async def test_autodetect_legacy(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_autodetect_legacy(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
@@ -963,7 +979,9 @@ async def test_autodetect_legacy(hass: HomeAssistant, remote: Mock):
     assert result["data"][CONF_PORT] == LEGACY_PORT
 
 
-async def test_autodetect_none(hass: HomeAssistant, remote: Mock, remotews: Mock):
+async def test_autodetect_none(
+    hass: HomeAssistant, remote: Mock, remotews: Mock
+) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -991,7 +1009,8 @@ async def test_autodetect_none(hass: HomeAssistant, remote: Mock, remotews: Mock
         ]
 
 
-async def test_update_old_entry(hass: HomeAssistant, remote: Mock, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_old_entry(hass: HomeAssistant, remote: Mock) -> None:
     """Test update of old entry."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         remote().rest_device_info.return_value = {
@@ -1032,7 +1051,10 @@ async def test_update_old_entry(hass: HomeAssistant, remote: Mock, remotews: Moc
         assert entry2.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_missing_mac_unique_id_added_from_dhcp(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1058,7 +1080,10 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_missing_mac_unique_id_added_from_zeroconf(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1083,7 +1108,10 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: 
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_update_missing_mac_unique_id_added_from_ssdp(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_missing_mac_unique_id_added_from_ssdp(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added via ssdp."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1109,9 +1137,10 @@ async def test_update_missing_mac_unique_id_added_from_ssdp(hass, remotews: Mock
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
+@pytest.mark.usefixtures("remotews")
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
-    hass, remotews: Mock
-):
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1140,7 +1169,8 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
     """Test missing mac added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1171,7 +1201,10 @@ async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac added when there is no unique id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1207,7 +1240,8 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mo
     assert entry.unique_id is None
 
 
-async def test_form_reauth_legacy(hass, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_form_reauth_legacy(hass: HomeAssistant) -> None:
     """Test reauthenticate legacy."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
     entry.add_to_hass(hass)
@@ -1228,7 +1262,8 @@ async def test_form_reauth_legacy(hass, remote: Mock):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1252,7 +1287,8 @@ async def test_form_reauth_websocket(hass, remotews: Mock):
     assert entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_form_reauth_websocket_cannot_connect(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when we cannot connect on the first attempt."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1290,7 +1326,8 @@ async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
     assert result3["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket_not_supported(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when the device is not supported."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -2,7 +2,6 @@
 import socket
 from unittest.mock import Mock, PropertyMock, call, patch
 
-import pytest
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from websocket import WebSocketException, WebSocketProtocolException
@@ -182,8 +181,7 @@ DEVICEINFO_WEBSOCKET_SSL = {
 }
 
 
-@pytest.mark.usefixtures("remote")
-async def test_user_legacy(hass: HomeAssistant) -> None:
+async def test_user_legacy(hass: HomeAssistant, remote: Mock):
     """Test starting a flow by user."""
     # show form
     result = await hass.config_entries.flow.async_init(
@@ -207,8 +205,7 @@ async def test_user_legacy(hass: HomeAssistant) -> None:
     assert result["result"].unique_id is None
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_user_websocket(hass: HomeAssistant) -> None:
+async def test_user_websocket(hass: HomeAssistant, remotews: Mock):
     """Test starting a flow by user."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError("Boom")
@@ -235,8 +232,7 @@ async def test_user_websocket(hass: HomeAssistant) -> None:
         assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_user_legacy_missing_auth(hass: HomeAssistant) -> None:
+async def test_user_legacy_missing_auth(hass: HomeAssistant, remotews: Mock):
     """Test starting a flow by user with authentication."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -250,7 +246,7 @@ async def test_user_legacy_missing_auth(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_AUTH_MISSING
 
 
-async def test_user_legacy_not_supported(hass: HomeAssistant) -> None:
+async def test_user_legacy_not_supported(hass: HomeAssistant):
     """Test starting a flow by user for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -264,7 +260,7 @@ async def test_user_legacy_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_user_websocket_not_supported(hass: HomeAssistant) -> None:
+async def test_user_websocket_not_supported(hass: HomeAssistant):
     """Test starting a flow by user for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -281,7 +277,7 @@ async def test_user_websocket_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_user_not_successful(hass: HomeAssistant) -> None:
+async def test_user_not_successful(hass: HomeAssistant):
     """Test starting a flow by user but no connection found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -297,7 +293,7 @@ async def test_user_not_successful(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_user_not_successful_2(hass: HomeAssistant) -> None:
+async def test_user_not_successful_2(hass: HomeAssistant):
     """Test starting a flow by user but no connection found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -313,8 +309,7 @@ async def test_user_not_successful_2(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-@pytest.mark.usefixtures("remote")
-async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
+async def test_ssdp(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
     """Test starting a flow from discovery."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -342,8 +337,7 @@ async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
         assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remote")
-async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
+async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
     """Test starting a flow from discovery without prefixes."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -378,8 +372,7 @@ async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
             assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
+async def test_ssdp_legacy_missing_auth(hass: HomeAssistant, remotews: Mock):
     """Test starting a flow from discovery with authentication."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -406,8 +399,9 @@ async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
             assert result["reason"] == RESULT_AUTH_MISSING
 
 
-@pytest.mark.usefixtures("remote", "remotews")
-async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
+async def test_ssdp_legacy_not_supported(
+    hass: HomeAssistant, remote: Mock, remotews: Mock
+):
     """Test starting a flow from discovery for not supported device."""
 
     # confirm to add the entry
@@ -429,10 +423,9 @@ async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remote", "remotews")
 async def test_ssdp_websocket_success_populates_mac_address(
-    hass: HomeAssistant,
-) -> None:
+    hass: HomeAssistant, remote: Mock, remotews: Mock
+):
     """Test starting a flow from ssdp for a supported device populates the mac."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -453,7 +446,7 @@ async def test_ssdp_websocket_success_populates_mac_address(
     assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_ssdp_websocket_not_supported(hass: HomeAssistant) -> None:
+async def test_ssdp_websocket_not_supported(hass: HomeAssistant):
     """Test starting a flow from discovery for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -470,8 +463,7 @@ async def test_ssdp_websocket_not_supported(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("remote")
-async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
+async def test_ssdp_model_not_supported(hass: HomeAssistant, remote: Mock):
     """Test starting a flow from discovery."""
 
     # confirm to add the entry
@@ -484,8 +476,7 @@ async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("no_mac_address")
-async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
+async def test_ssdp_not_successful(hass: HomeAssistant, no_mac_address: Mock):
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -513,8 +504,7 @@ async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-@pytest.mark.usefixtures("no_mac_address")
-async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
+async def test_ssdp_not_successful_2(hass: HomeAssistant, no_mac_address: Mock):
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -542,10 +532,9 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-@pytest.mark.usefixtures("remote")
 async def test_ssdp_already_in_progress(
-    hass: HomeAssistant, no_mac_address: Mock
-) -> None:
+    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
+):
     """Test starting a flow from discovery twice."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -569,10 +558,9 @@ async def test_ssdp_already_in_progress(
         assert result["reason"] == RESULT_ALREADY_IN_PROGRESS
 
 
-@pytest.mark.usefixtures("remote")
 async def test_ssdp_already_configured(
-    hass: HomeAssistant, no_mac_address: Mock
-) -> None:
+    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
+):
     """Test starting a flow from discovery when already configured."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -602,8 +590,7 @@ async def test_ssdp_already_configured(
         assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remote")
-async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
+async def test_import_legacy(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
     """Test importing from yaml with hostname."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -626,8 +613,12 @@ async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-@pytest.mark.usefixtures("remote", "remotews_no_device_info", "no_mac_address")
-async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
+async def test_import_legacy_without_name(
+    hass: HomeAssistant,
+    remote: Mock,
+    remotews_no_device_info: Mock,
+    no_mac_address: Mock,
+):
     """Test importing from yaml without a name."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -647,8 +638,7 @@ async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_import_websocket(hass: HomeAssistant):
+async def test_import_websocket(hass: HomeAssistant, remotews: Mock):
     """Test importing from yaml with hostname."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -666,8 +656,7 @@ async def test_import_websocket(hass: HomeAssistant):
     assert result["result"].unique_id is None
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_import_websocket_without_port(hass: HomeAssistant):
+async def test_import_websocket_without_port(hass: HomeAssistant, remotews: Mock):
     """Test importing from yaml with hostname by no port."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -688,8 +677,7 @@ async def test_import_websocket_without_port(hass: HomeAssistant):
     assert entries[0].data[CONF_PORT] == 8002
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_import_unknown_host(hass: HomeAssistant):
+async def test_import_unknown_host(hass: HomeAssistant, remotews: Mock):
     """Test importing from yaml with hostname that does not resolve."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -705,8 +693,7 @@ async def test_import_unknown_host(hass: HomeAssistant):
     assert result["reason"] == RESULT_UNKNOWN_HOST
 
 
-@pytest.mark.usefixtures("remote", "remotews")
-async def test_dhcp(hass: HomeAssistant) -> None:
+async def test_dhcp(hass: HomeAssistant, remote: Mock, remotews: Mock):
     """Test starting a flow from dhcp."""
     # confirm to add the entry
     result = await hass.config_entries.flow.async_init(
@@ -732,8 +719,7 @@ async def test_dhcp(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remote", "remotews")
-async def test_zeroconf(hass: HomeAssistant) -> None:
+async def test_zeroconf(hass: HomeAssistant, remote: Mock, remotews: Mock):
     """Test starting a flow from zeroconf."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -758,8 +744,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews_soundbar")
-async def test_zeroconf_ignores_soundbar(hass: HomeAssistant) -> None:
+async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, remotews_soundbar: Mock):
     """Test starting a flow from zeroconf where the device is actually a soundbar."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -771,8 +756,9 @@ async def test_zeroconf_ignores_soundbar(hass: HomeAssistant) -> None:
     assert result["reason"] == "not_supported"
 
 
-@pytest.mark.usefixtures("remote", "remotews_no_device_info")
-async def test_zeroconf_no_device_info(hass: HomeAssistant) -> None:
+async def test_zeroconf_no_device_info(
+    hass: HomeAssistant, remote: Mock, remotews_no_device_info: Mock
+):
     """Test starting a flow from zeroconf where device_info returns None."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -784,8 +770,7 @@ async def test_zeroconf_no_device_info(hass: HomeAssistant) -> None:
     assert result["reason"] == "not_supported"
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant) -> None:
+async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant, remotews: Mock):
     """Test starting a flow from zeroconf and dhcp."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -806,7 +791,7 @@ async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant) -> None:
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_autodetect_websocket(hass: HomeAssistant) -> None:
+async def test_autodetect_websocket(hass: HomeAssistant):
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -849,7 +834,7 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
     assert entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_websocket_no_mac(hass: HomeAssistant) -> None:
+async def test_websocket_no_mac(hass: HomeAssistant):
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -895,7 +880,7 @@ async def test_websocket_no_mac(hass: HomeAssistant) -> None:
     assert entries[0].data[CONF_MAC] == "gg:hh:ii:ll:mm:nn"
 
 
-async def test_autodetect_auth_missing(hass: HomeAssistant) -> None:
+async def test_autodetect_auth_missing(hass: HomeAssistant):
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -910,7 +895,7 @@ async def test_autodetect_auth_missing(hass: HomeAssistant) -> None:
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-async def test_autodetect_not_supported(hass: HomeAssistant) -> None:
+async def test_autodetect_not_supported(hass: HomeAssistant):
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -925,8 +910,7 @@ async def test_autodetect_not_supported(hass: HomeAssistant) -> None:
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-@pytest.mark.usefixtures("remote")
-async def test_autodetect_legacy(hass: HomeAssistant) -> None:
+async def test_autodetect_legacy(hass: HomeAssistant, remote: Mock):
     """Test for send key with autodetection of protocol."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
@@ -938,7 +922,7 @@ async def test_autodetect_legacy(hass: HomeAssistant) -> None:
     assert result["data"][CONF_PORT] == LEGACY_PORT
 
 
-async def test_autodetect_none(hass: HomeAssistant) -> None:
+async def test_autodetect_none(hass: HomeAssistant):
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -963,8 +947,7 @@ async def test_autodetect_none(hass: HomeAssistant) -> None:
         ]
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_update_old_entry(hass: HomeAssistant) -> None:
+async def test_update_old_entry(hass: HomeAssistant, remotews: Mock):
     """Test update of old entry."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         remote().rest_device_info.return_value = {
@@ -1005,10 +988,10 @@ async def test_update_old_entry(hass: HomeAssistant) -> None:
         assert entry2.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_update_missing_mac_unique_id_added_from_dhcp(
     hass: HomeAssistant,
-) -> None:
+    remotews: Mock,
+):
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1034,10 +1017,10 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_update_missing_mac_unique_id_added_from_zeroconf(
     hass: HomeAssistant,
-) -> None:
+    remotews: Mock,
+):
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1062,10 +1045,10 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_update_missing_mac_unique_id_added_from_ssdp(
     hass: HomeAssistant,
-) -> None:
+    remotews: Mock,
+):
     """Test missing mac and unique id added via ssdp."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1091,10 +1074,10 @@ async def test_update_missing_mac_unique_id_added_from_ssdp(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remotews")
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     hass: HomeAssistant,
-) -> None:
+    remotews: Mock,
+):
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1123,8 +1106,7 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remote")
-async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
+async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant, remote: Mock):
     """Test missing mac added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1155,10 +1137,10 @@ async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-@pytest.mark.usefixtures("remote")
 async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
     hass: HomeAssistant,
-) -> None:
+    remote: Mock,
+):
     """Test missing mac added when there is no unique id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1194,8 +1176,7 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
     assert entry.unique_id is None
 
 
-@pytest.mark.usefixtures("remote")
-async def test_form_reauth_legacy(hass: HomeAssistant) -> None:
+async def test_form_reauth_legacy(hass: HomeAssistant, remote: Mock):
     """Test reauthenticate legacy."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
     entry.add_to_hass(hass)
@@ -1216,8 +1197,7 @@ async def test_form_reauth_legacy(hass: HomeAssistant) -> None:
     assert result2["reason"] == "reauth_successful"
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
+async def test_form_reauth_websocket(hass: HomeAssistant, remotews: Mock):
     """Test reauthenticate websocket."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1241,8 +1221,9 @@ async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     assert entry.state == config_entries.ConfigEntryState.LOADED
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_form_reauth_websocket_cannot_connect(hass: HomeAssistant) -> None:
+async def test_form_reauth_websocket_cannot_connect(
+    hass: HomeAssistant, remotews: Mock
+):
     """Test reauthenticate websocket when we cannot connect on the first attempt."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1277,7 +1258,7 @@ async def test_form_reauth_websocket_cannot_connect(hass: HomeAssistant) -> None
     assert result3["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
+async def test_form_reauth_websocket_not_supported(hass: HomeAssistant):
     """Test reauthenticate websocket when the device is not supported."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)

--- a/tests/components/samsungtv/test_diagnostics.py
+++ b/tests/components/samsungtv/test_diagnostics.py
@@ -7,9 +7,10 @@ from homeassistant.components.samsungtv import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .test_media_player import MOCK_ENTRY_WS_WITH_MAC
+
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
-from tests.components.samsungtv.test_media_player import MOCK_ENTRY_WS_WITH_MAC
 
 
 @pytest.fixture(name="config_entry")

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -58,27 +58,21 @@ REMOTE_CALL = {
 @pytest.mark.usefixtures("remotews", "no_mac_address")
 async def test_setup(hass: HomeAssistant) -> None:
     """Test Samsung TV integration is setup."""
-    with patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
+    await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY_ID)
 
-        await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
-        await hass.async_block_till_done()
-        state = hass.states.get(ENTITY_ID)
+    # test name and turn_on
+    assert state
+    assert state.name == "fake_name"
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
+    )
 
-        # test name and turn_on
-        assert state
-        assert state.name == "fake_name"
-        assert (
-            state.attributes[ATTR_SUPPORTED_FEATURES]
-            == SUPPORT_SAMSUNGTV | SUPPORT_TURN_ON
-        )
-
-        # test host and port
-        assert await hass.services.async_call(
-            DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
-        )
+    # test host and port
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
 
 
 async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) -> None:
@@ -91,9 +85,6 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) 
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
         return_value=None,
-    ), patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
     ):
         await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
         await hass.async_block_till_done()
@@ -106,12 +97,8 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) 
 @pytest.mark.usefixtures("remotews")
 async def test_setup_from_yaml_without_port_device_online(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is online."""
-    with patch(
-        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
-        return_value="fake_host",
-    ):
-        await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
-        await hass.async_block_till_done()
+    await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
+    await hass.async_block_till_done()
 
     config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
     assert len(config_entries_domain) == 1

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -1,7 +1,5 @@
 """Tests for the Samsung TV Integration."""
-from unittest.mock import patch
-
-import pytest
+from unittest.mock import Mock, patch
 
 from homeassistant.components.media_player.const import DOMAIN, SUPPORT_TURN_ON
 from homeassistant.components.samsungtv.const import (
@@ -55,8 +53,7 @@ REMOTE_CALL = {
 }
 
 
-@pytest.mark.usefixtures("remotews", "no_mac_address")
-async def test_setup(hass: HomeAssistant) -> None:
+async def test_setup(hass: HomeAssistant, remotews: Mock, no_mac_address: Mock):
     """Test Samsung TV integration is setup."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -75,7 +72,7 @@ async def test_setup(hass: HomeAssistant) -> None:
     )
 
 
-async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) -> None:
+async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
     """Test import from yaml when the device is offline."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError
@@ -94,8 +91,9 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) 
     assert config_entries_domain[0].state == ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.usefixtures("remotews")
-async def test_setup_from_yaml_without_port_device_online(hass: HomeAssistant) -> None:
+async def test_setup_from_yaml_without_port_device_online(
+    hass: HomeAssistant, remotews: Mock
+):
     """Test import from yaml when the device is online."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -105,10 +103,7 @@ async def test_setup_from_yaml_without_port_device_online(hass: HomeAssistant) -
     assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-@pytest.mark.usefixtures("remote")
-async def test_setup_duplicate_config(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog):
     """Test duplicate setup of platform."""
     duplicate = {
         SAMSUNGTV_DOMAIN: [
@@ -123,8 +118,9 @@ async def test_setup_duplicate_config(
     assert "duplicate host entries found" in caplog.text
 
 
-@pytest.mark.usefixtures("remote", "remotews", "no_mac_address")
-async def test_setup_duplicate_entries(hass: HomeAssistant) -> None:
+async def test_setup_duplicate_entries(
+    hass: HomeAssistant, remote: Mock, remotews: Mock, no_mac_address: Mock
+):
     """Test duplicate setup of platform."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -1,5 +1,7 @@
 """Tests for the Samsung TV Integration."""
-from unittest.mock import Mock, patch
+from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components.media_player.const import DOMAIN, SUPPORT_TURN_ON
 from homeassistant.components.samsungtv.const import (
@@ -53,7 +55,8 @@ REMOTE_CALL = {
 }
 
 
-async def test_setup(hass: HomeAssistant, remotews: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remotews", "no_mac_address")
+async def test_setup(hass: HomeAssistant) -> None:
     """Test Samsung TV integration is setup."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -78,7 +81,7 @@ async def test_setup(hass: HomeAssistant, remotews: Mock, no_mac_address: Mock):
         )
 
 
-async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
+async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is offline."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError
@@ -100,9 +103,8 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
     assert config_entries_domain[0].state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_from_yaml_without_port_device_online(
-    hass: HomeAssistant, remotews: Mock
-):
+@pytest.mark.usefixtures("remotews")
+async def test_setup_from_yaml_without_port_device_online(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is online."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -116,7 +118,10 @@ async def test_setup_from_yaml_without_port_device_online(
     assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog):
+@pytest.mark.usefixtures("remote")
+async def test_setup_duplicate_config(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test duplicate setup of platform."""
     DUPLICATE = {
         SAMSUNGTV_DOMAIN: [
@@ -131,9 +136,8 @@ async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog)
     assert "duplicate host entries found" in caplog.text
 
 
-async def test_setup_duplicate_entries(
-    hass: HomeAssistant, remote: Mock, remotews: Mock, no_mac_address: Mock, caplog
-):
+@pytest.mark.usefixtures("remote", "remotews", "no_mac_address")
+async def test_setup_duplicate_entries(hass: HomeAssistant) -> None:
     """Test duplicate setup of platform."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -123,13 +123,13 @@ async def test_setup_duplicate_config(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test duplicate setup of platform."""
-    DUPLICATE = {
+    duplicate = {
         SAMSUNGTV_DOMAIN: [
             MOCK_CONFIG[SAMSUNGTV_DOMAIN][0],
             MOCK_CONFIG[SAMSUNGTV_DOMAIN][0],
         ]
     }
-    await async_setup_component(hass, SAMSUNGTV_DOMAIN, DUPLICATE)
+    await async_setup_component(hass, SAMSUNGTV_DOMAIN, duplicate)
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID) is None
     assert len(hass.states.async_all("media_player")) == 0

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1,11 +1,19 @@
 """Tests for samsungtv component."""
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
-from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
+from unittest.mock import (
+    DEFAULT as DEFAULT_MOCK,
+    MagicMock,
+    Mock,
+    PropertyMock,
+    call,
+    patch,
+)
 
 import pytest
-from samsungctl import exceptions
+from samsungctl import Remote, exceptions
+from samsungtvws import SamsungTVWS
 from samsungtvws.exceptions import ConnectionFailure
 from websocket import WebSocketException
 
@@ -55,6 +63,8 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -117,6 +127,9 @@ MOCK_CONFIG_NOTURNON = {
     ]
 }
 
+# Fake mac address in all mediaplayer tests.
+pytestmark = pytest.mark.usefixtures("no_mac_address")
+
 
 @pytest.fixture(name="delay")
 def delay_fixture():
@@ -127,30 +140,27 @@ def delay_fixture():
         yield delay
 
 
-@pytest.fixture(autouse=True)
-def mock_no_mac_address(no_mac_address):
-    """Fake mac address in all mediaplayer tests."""
-
-
-async def setup_samsungtv(hass, config):
+async def setup_samsungtv(hass: HomeAssistant, config: ConfigType) -> None:
     """Set up mock Samsung TV."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, config)
     await hass.async_block_till_done()
 
 
-async def test_setup_with_turnon(hass, remote):
+async def test_setup_with_turnon(hass: HomeAssistant, remote: Remote) -> None:
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert hass.states.get(ENTITY_ID)
 
 
-async def test_setup_without_turnon(hass, remote):
+async def test_setup_without_turnon(hass: HomeAssistant, remote: Remote) -> None:
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert hass.states.get(ENTITY_ID_NOTURNON)
 
 
-async def test_setup_websocket(hass, remotews, mock_now):
+async def test_setup_websocket(
+    hass: HomeAssistant, remotews: SamsungTVWS, mock_now: datetime
+) -> None:
     """Test setup of platform."""
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
         enter = Mock()
@@ -186,7 +196,7 @@ async def test_setup_websocket(hass, remotews, mock_now):
         assert config_entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_setup_websocket_2(hass, mock_now):
+async def test_setup_websocket_2(hass: HomeAssistant, mock_now: datetime) -> None:
     """Test setup of platform from config entry."""
     entity_id = f"{DOMAIN}.fake"
 
@@ -234,7 +244,9 @@ async def test_setup_websocket_2(hass, mock_now):
     assert remote_class.call_args_list[0] == call(**MOCK_CALLS_WS)
 
 
-async def test_update_on(hass, remote, mock_now):
+async def test_update_on(
+    hass: HomeAssistant, remote: Remote, mock_now: datetime
+) -> None:
     """Testing update tv on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -247,7 +259,9 @@ async def test_update_on(hass, remote, mock_now):
     assert state.state == STATE_ON
 
 
-async def test_update_off(hass, remote, mock_now):
+async def test_update_off(
+    hass: HomeAssistant, remote: Remote, mock_now: datetime
+) -> None:
     """Testing update tv off."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -265,7 +279,9 @@ async def test_update_off(hass, remote, mock_now):
         assert state.state == STATE_OFF
 
 
-async def test_update_access_denied(hass, remote, mock_now):
+async def test_update_access_denied(
+    hass: HomeAssistant, remote: Remote, mock_now: datetime
+) -> None:
     """Testing update tv access denied exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -291,7 +307,9 @@ async def test_update_access_denied(hass, remote, mock_now):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update_connection_failure(hass, remotews, mock_now):
+async def test_update_connection_failure(
+    hass: HomeAssistant, remotews: SamsungTVWS, mock_now: datetime
+) -> None:
     """Testing update tv connection failure exception."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -321,7 +339,9 @@ async def test_update_connection_failure(hass, remotews, mock_now):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update_unhandled_response(hass, remote, mock_now):
+async def test_update_unhandled_response(
+    hass: HomeAssistant, remote: Remote, mock_now: datetime
+) -> None:
     """Testing update tv unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -339,7 +359,9 @@ async def test_update_unhandled_response(hass, remote, mock_now):
         assert state.state == STATE_ON
 
 
-async def test_connection_closed_during_update_can_recover(hass, remote, mock_now):
+async def test_connection_closed_during_update_can_recover(
+    hass: HomeAssistant, remote: Remote, mock_now: datetime
+) -> None:
     """Testing update tv connection closed exception can recover."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -365,7 +387,7 @@ async def test_connection_closed_during_update_can_recover(hass, remote, mock_no
         assert state.state == STATE_ON
 
 
-async def test_send_key(hass, remote):
+async def test_send_key(hass: HomeAssistant, remote: Remote) -> None:
     """Test for send key."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -380,7 +402,7 @@ async def test_send_key(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_broken_pipe(hass, remote):
+async def test_send_key_broken_pipe(hass: HomeAssistant, remote: Remote) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=BrokenPipeError("Boom"))
@@ -391,7 +413,9 @@ async def test_send_key_broken_pipe(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_connection_closed_retry_succeed(hass, remote):
+async def test_send_key_connection_closed_retry_succeed(
+    hass: HomeAssistant, remote: Remote
+) -> None:
     """Test retry on connection closed."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(
@@ -412,7 +436,7 @@ async def test_send_key_connection_closed_retry_succeed(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_unhandled_response(hass, remote):
+async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Remote) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=exceptions.UnhandledResponse("Boom"))
@@ -423,7 +447,7 @@ async def test_send_key_unhandled_response(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_websocketexception(hass, remote):
+async def test_send_key_websocketexception(hass: HomeAssistant, remote: Remote) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=WebSocketException("Boom"))
@@ -434,7 +458,7 @@ async def test_send_key_websocketexception(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_os_error(hass, remote):
+async def test_send_key_os_error(hass: HomeAssistant, remote: Remote) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=OSError("Boom"))
@@ -445,14 +469,16 @@ async def test_send_key_os_error(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_name(hass, remote):
+async def test_name(hass: HomeAssistant, remote: Remote) -> None:
     """Test for name property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake"
 
 
-async def test_state_with_turnon(hass, remote, delay):
+async def test_state_with_turnon(
+    hass: HomeAssistant, remote: Remote, delay: MagicMock
+) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -469,7 +495,7 @@ async def test_state_with_turnon(hass, remote, delay):
     assert state.state == STATE_OFF
 
 
-async def test_state_without_turnon(hass, remote):
+async def test_state_without_turnon(hass: HomeAssistant, remote: Remote) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -497,7 +523,9 @@ async def test_state_without_turnon(hass, remote):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_supported_features_with_turnon(hass, remote):
+async def test_supported_features_with_turnon(
+    hass: HomeAssistant, remote: Remote
+) -> None:
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
@@ -506,21 +534,23 @@ async def test_supported_features_with_turnon(hass, remote):
     )
 
 
-async def test_supported_features_without_turnon(hass, remote):
+async def test_supported_features_without_turnon(
+    hass: HomeAssistant, remote: Remote
+) -> None:
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     state = hass.states.get(ENTITY_ID_NOTURNON)
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV
 
 
-async def test_device_class(hass, remote):
+async def test_device_class(hass: HomeAssistant, remote: Remote) -> None:
     """Test for device_class property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_DEVICE_CLASS] is MediaPlayerDeviceClass.TV.value
 
 
-async def test_turn_off_websocket(hass, remotews):
+async def test_turn_off_websocket(hass: HomeAssistant, remotews: SamsungTVWS) -> None:
     """Test for turn_off."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -535,7 +565,7 @@ async def test_turn_off_websocket(hass, remotews):
         assert remotews.send_key.call_args_list == [call("KEY_POWER")]
 
 
-async def test_turn_off_legacy(hass, remote):
+async def test_turn_off_legacy(hass: HomeAssistant, remote: Remote) -> None:
     """Test for turn_off."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -546,7 +576,9 @@ async def test_turn_off_legacy(hass, remote):
     assert remote.control.call_args_list == [call("KEY_POWEROFF")]
 
 
-async def test_turn_off_os_error(hass, remote, caplog):
+async def test_turn_off_os_error(
+    hass: HomeAssistant, remote: Remote, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for turn_off with OSError."""
     caplog.set_level(logging.DEBUG)
     await setup_samsungtv(hass, MOCK_CONFIG)
@@ -557,7 +589,7 @@ async def test_turn_off_os_error(hass, remote, caplog):
     assert "Could not establish connection" in caplog.text
 
 
-async def test_volume_up(hass, remote):
+async def test_volume_up(hass: HomeAssistant, remote: Remote) -> None:
     """Test for volume_up."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -570,7 +602,7 @@ async def test_volume_up(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_volume_down(hass, remote):
+async def test_volume_down(hass: HomeAssistant, remote: Remote) -> None:
     """Test for volume_down."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -583,7 +615,7 @@ async def test_volume_down(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_mute_volume(hass, remote):
+async def test_mute_volume(hass: HomeAssistant, remote: Remote) -> None:
     """Test for mute_volume."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -599,7 +631,7 @@ async def test_mute_volume(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_media_play(hass, remote):
+async def test_media_play(hass: HomeAssistant, remote: Remote) -> None:
     """Test for media_play."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -621,7 +653,7 @@ async def test_media_play(hass, remote):
     assert remote.close.call_args_list == [call(), call()]
 
 
-async def test_media_pause(hass, remote):
+async def test_media_pause(hass: HomeAssistant, remote: Remote) -> None:
     """Test for media_pause."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -643,7 +675,7 @@ async def test_media_pause(hass, remote):
     assert remote.close.call_args_list == [call(), call()]
 
 
-async def test_media_next_track(hass, remote):
+async def test_media_next_track(hass: HomeAssistant, remote: Remote) -> None:
     """Test for media_next_track."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -656,7 +688,7 @@ async def test_media_next_track(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_media_previous_track(hass, remote):
+async def test_media_previous_track(hass: HomeAssistant, remote: Remote) -> None:
     """Test for media_previous_track."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -669,7 +701,9 @@ async def test_media_previous_track(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_turn_on_with_turnon(hass, remote, delay):
+async def test_turn_on_with_turnon(
+    hass: HomeAssistant, remote: Remote, delay: MagicMock
+) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -678,7 +712,7 @@ async def test_turn_on_with_turnon(hass, remote, delay):
     assert delay.call_count == 1
 
 
-async def test_turn_on_wol(hass, remotews):
+async def test_turn_on_wol(hass: HomeAssistant, remotews: SamsungTVWS) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
         domain=SAMSUNGTV_DOMAIN,
@@ -698,7 +732,7 @@ async def test_turn_on_wol(hass, remotews):
     assert mock_send_magic_packet.called
 
 
-async def test_turn_on_without_turnon(hass, remote):
+async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Remote) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -708,7 +742,7 @@ async def test_turn_on_without_turnon(hass, remote):
     assert remote.control.call_count == 0
 
 
-async def test_play_media(hass, remote):
+async def test_play_media(hass: HomeAssistant, remote: Remote) -> None:
     """Test for play_media."""
     asyncio_sleep = asyncio.sleep
     sleeps = []
@@ -742,7 +776,7 @@ async def test_play_media(hass, remote):
         assert len(sleeps) == 3
 
 
-async def test_play_media_invalid_type(hass, remote):
+async def test_play_media_invalid_type(hass: HomeAssistant, remote: Remote) -> None:
     """Test for play_media with invalid media type."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -764,7 +798,9 @@ async def test_play_media_invalid_type(hass, remote):
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_string(hass, remote):
+async def test_play_media_channel_as_string(
+    hass: HomeAssistant, remote: Remote
+) -> None:
     """Test for play_media with invalid channel as string."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -786,7 +822,9 @@ async def test_play_media_channel_as_string(hass, remote):
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_non_positive(hass, remote):
+async def test_play_media_channel_as_non_positive(
+    hass: HomeAssistant, remote: Remote
+) -> None:
     """Test for play_media with invalid channel as non positive integer."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)
@@ -807,7 +845,7 @@ async def test_play_media_channel_as_non_positive(hass, remote):
         assert remote.call_count == 1
 
 
-async def test_select_source(hass, remote):
+async def test_select_source(hass: HomeAssistant, remote: Remote) -> None:
     """Test for select_source."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -823,7 +861,9 @@ async def test_select_source(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_select_source_invalid_source(hass, remote):
+async def test_select_source_invalid_source(
+    hass: HomeAssistant, remote: Remote
+) -> None:
     """Test for select_source with invalid source."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -146,21 +146,22 @@ async def setup_samsungtv(hass: HomeAssistant, config: ConfigType) -> None:
     await hass.async_block_till_done()
 
 
-async def test_setup_with_turnon(hass: HomeAssistant, remote: Remote) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_setup_with_turnon(hass: HomeAssistant) -> None:
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert hass.states.get(ENTITY_ID)
 
 
-async def test_setup_without_turnon(hass: HomeAssistant, remote: Remote) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_setup_without_turnon(hass: HomeAssistant) -> None:
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert hass.states.get(ENTITY_ID_NOTURNON)
 
 
-async def test_setup_websocket(
-    hass: HomeAssistant, remotews: SamsungTVWS, mock_now: datetime
-) -> None:
+@pytest.mark.usefixtures("remotews")
+async def test_setup_websocket(hass: HomeAssistant) -> None:
     """Test setup of platform."""
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
         enter = Mock()
@@ -244,9 +245,8 @@ async def test_setup_websocket_2(hass: HomeAssistant, mock_now: datetime) -> Non
     assert remote_class.call_args_list[0] == call(**MOCK_CALLS_WS)
 
 
-async def test_update_on(
-    hass: HomeAssistant, remote: Remote, mock_now: datetime
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_update_on(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -259,9 +259,8 @@ async def test_update_on(
     assert state.state == STATE_ON
 
 
-async def test_update_off(
-    hass: HomeAssistant, remote: Remote, mock_now: datetime
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_update_off(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv off."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -279,9 +278,8 @@ async def test_update_off(
         assert state.state == STATE_OFF
 
 
-async def test_update_access_denied(
-    hass: HomeAssistant, remote: Remote, mock_now: datetime
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_update_access_denied(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv access denied exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -307,8 +305,9 @@ async def test_update_access_denied(
     assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("remotews")
 async def test_update_connection_failure(
-    hass: HomeAssistant, remotews: SamsungTVWS, mock_now: datetime
+    hass: HomeAssistant, mock_now: datetime
 ) -> None:
     """Testing update tv connection failure exception."""
     with patch(
@@ -339,8 +338,9 @@ async def test_update_connection_failure(
     assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("remote")
 async def test_update_unhandled_response(
-    hass: HomeAssistant, remote: Remote, mock_now: datetime
+    hass: HomeAssistant, mock_now: datetime
 ) -> None:
     """Testing update tv unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
@@ -359,8 +359,9 @@ async def test_update_unhandled_response(
         assert state.state == STATE_ON
 
 
+@pytest.mark.usefixtures("remote")
 async def test_connection_closed_during_update_can_recover(
-    hass: HomeAssistant, remote: Remote, mock_now: datetime
+    hass: HomeAssistant, mock_now: datetime
 ) -> None:
     """Testing update tv connection closed exception can recover."""
     await setup_samsungtv(hass, MOCK_CONFIG)
@@ -469,16 +470,16 @@ async def test_send_key_os_error(hass: HomeAssistant, remote: Remote) -> None:
     assert state.state == STATE_ON
 
 
-async def test_name(hass: HomeAssistant, remote: Remote) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_name(hass: HomeAssistant) -> None:
     """Test for name property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake"
 
 
-async def test_state_with_turnon(
-    hass: HomeAssistant, remote: Remote, delay: MagicMock
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_state_with_turnon(hass: HomeAssistant, delay: MagicMock) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -495,7 +496,8 @@ async def test_state_with_turnon(
     assert state.state == STATE_OFF
 
 
-async def test_state_without_turnon(hass: HomeAssistant, remote: Remote) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_state_without_turnon(hass: HomeAssistant) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -523,9 +525,8 @@ async def test_state_without_turnon(hass: HomeAssistant, remote: Remote) -> None
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_supported_features_with_turnon(
-    hass: HomeAssistant, remote: Remote
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_supported_features_with_turnon(hass: HomeAssistant) -> None:
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
@@ -534,16 +535,16 @@ async def test_supported_features_with_turnon(
     )
 
 
-async def test_supported_features_without_turnon(
-    hass: HomeAssistant, remote: Remote
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_supported_features_without_turnon(hass: HomeAssistant) -> None:
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     state = hass.states.get(ENTITY_ID_NOTURNON)
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV
 
 
-async def test_device_class(hass: HomeAssistant, remote: Remote) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_device_class(hass: HomeAssistant) -> None:
     """Test for device_class property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
@@ -701,9 +702,8 @@ async def test_media_previous_track(hass: HomeAssistant, remote: Remote) -> None
     assert remote.close.call_args_list == [call()]
 
 
-async def test_turn_on_with_turnon(
-    hass: HomeAssistant, remote: Remote, delay: MagicMock
-) -> None:
+@pytest.mark.usefixtures("remote")
+async def test_turn_on_with_turnon(hass: HomeAssistant, delay: MagicMock) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -712,7 +712,8 @@ async def test_turn_on_with_turnon(
     assert delay.call_count == 1
 
 
-async def test_turn_on_wol(hass: HomeAssistant, remotews: SamsungTVWS) -> None:
+@pytest.mark.usefixtures("remotews")
+async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
         domain=SAMSUNGTV_DOMAIN,

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -769,7 +769,7 @@ async def test_play_media(hass: HomeAssistant, remote: Mock) -> None:
         assert len(sleeps) == 3
 
 
-async def test_play_media_invalid_type(hass: HomeAssistant, remote: Mock) -> None:
+async def test_play_media_invalid_type(hass: HomeAssistant) -> None:
     """Test for play_media with invalid media type."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -791,7 +791,7 @@ async def test_play_media_invalid_type(hass: HomeAssistant, remote: Mock) -> Non
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_string(hass: HomeAssistant, remote: Mock) -> None:
+async def test_play_media_channel_as_string(hass: HomeAssistant) -> None:
     """Test for play_media with invalid channel as string."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -813,9 +813,7 @@ async def test_play_media_channel_as_string(hass: HomeAssistant, remote: Mock) -
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_non_positive(
-    hass: HomeAssistant, remote: Mock
-) -> None:
+async def test_play_media_channel_as_non_positive(hass: HomeAssistant) -> None:
     """Test for play_media with invalid channel as non positive integer."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)
@@ -852,7 +850,7 @@ async def test_select_source(hass: HomeAssistant, remote: Mock) -> None:
     assert remote.close.call_args_list == [call()]
 
 
-async def test_select_source_invalid_source(hass: HomeAssistant, remote: Mock) -> None:
+async def test_select_source_invalid_source(hass: HomeAssistant) -> None:
     """Test for select_source with invalid source."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -2,18 +2,10 @@
 import asyncio
 from datetime import datetime, timedelta
 import logging
-from unittest.mock import (
-    DEFAULT as DEFAULT_MOCK,
-    MagicMock,
-    Mock,
-    PropertyMock,
-    call,
-    patch,
-)
+from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
 
 import pytest
-from samsungctl import Remote, exceptions
-from samsungtvws import SamsungTVWS
+from samsungctl import exceptions
 from samsungtvws.exceptions import ConnectionFailure
 from websocket import WebSocketException
 
@@ -388,7 +380,7 @@ async def test_connection_closed_during_update_can_recover(
         assert state.state == STATE_ON
 
 
-async def test_send_key(hass: HomeAssistant, remote: Remote) -> None:
+async def test_send_key(hass: HomeAssistant, remote: Mock) -> None:
     """Test for send key."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -403,7 +395,7 @@ async def test_send_key(hass: HomeAssistant, remote: Remote) -> None:
     assert state.state == STATE_ON
 
 
-async def test_send_key_broken_pipe(hass: HomeAssistant, remote: Remote) -> None:
+async def test_send_key_broken_pipe(hass: HomeAssistant, remote: Mock) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=BrokenPipeError("Boom"))
@@ -415,7 +407,7 @@ async def test_send_key_broken_pipe(hass: HomeAssistant, remote: Remote) -> None
 
 
 async def test_send_key_connection_closed_retry_succeed(
-    hass: HomeAssistant, remote: Remote
+    hass: HomeAssistant, remote: Mock
 ) -> None:
     """Test retry on connection closed."""
     await setup_samsungtv(hass, MOCK_CONFIG)
@@ -437,7 +429,7 @@ async def test_send_key_connection_closed_retry_succeed(
     assert state.state == STATE_ON
 
 
-async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Remote) -> None:
+async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Mock) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=exceptions.UnhandledResponse("Boom"))
@@ -448,7 +440,7 @@ async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Remote) 
     assert state.state == STATE_ON
 
 
-async def test_send_key_websocketexception(hass: HomeAssistant, remote: Remote) -> None:
+async def test_send_key_websocketexception(hass: HomeAssistant, remote: Mock) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=WebSocketException("Boom"))
@@ -459,7 +451,7 @@ async def test_send_key_websocketexception(hass: HomeAssistant, remote: Remote) 
     assert state.state == STATE_ON
 
 
-async def test_send_key_os_error(hass: HomeAssistant, remote: Remote) -> None:
+async def test_send_key_os_error(hass: HomeAssistant, remote: Mock) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=OSError("Boom"))
@@ -479,7 +471,7 @@ async def test_name(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_state_with_turnon(hass: HomeAssistant, delay: MagicMock) -> None:
+async def test_state_with_turnon(hass: HomeAssistant, delay: Mock) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -551,7 +543,7 @@ async def test_device_class(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] is MediaPlayerDeviceClass.TV.value
 
 
-async def test_turn_off_websocket(hass: HomeAssistant, remotews: SamsungTVWS) -> None:
+async def test_turn_off_websocket(hass: HomeAssistant, remotews: Mock) -> None:
     """Test for turn_off."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -566,7 +558,7 @@ async def test_turn_off_websocket(hass: HomeAssistant, remotews: SamsungTVWS) ->
         assert remotews.send_key.call_args_list == [call("KEY_POWER")]
 
 
-async def test_turn_off_legacy(hass: HomeAssistant, remote: Remote) -> None:
+async def test_turn_off_legacy(hass: HomeAssistant, remote: Mock) -> None:
     """Test for turn_off."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -578,7 +570,7 @@ async def test_turn_off_legacy(hass: HomeAssistant, remote: Remote) -> None:
 
 
 async def test_turn_off_os_error(
-    hass: HomeAssistant, remote: Remote, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, remote: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test for turn_off with OSError."""
     caplog.set_level(logging.DEBUG)
@@ -590,7 +582,7 @@ async def test_turn_off_os_error(
     assert "Could not establish connection" in caplog.text
 
 
-async def test_volume_up(hass: HomeAssistant, remote: Remote) -> None:
+async def test_volume_up(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_up."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -603,7 +595,7 @@ async def test_volume_up(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call()]
 
 
-async def test_volume_down(hass: HomeAssistant, remote: Remote) -> None:
+async def test_volume_down(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_down."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -616,7 +608,7 @@ async def test_volume_down(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call()]
 
 
-async def test_mute_volume(hass: HomeAssistant, remote: Remote) -> None:
+async def test_mute_volume(hass: HomeAssistant, remote: Mock) -> None:
     """Test for mute_volume."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -632,7 +624,7 @@ async def test_mute_volume(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call()]
 
 
-async def test_media_play(hass: HomeAssistant, remote: Remote) -> None:
+async def test_media_play(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_play."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -654,7 +646,7 @@ async def test_media_play(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call(), call()]
 
 
-async def test_media_pause(hass: HomeAssistant, remote: Remote) -> None:
+async def test_media_pause(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_pause."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -676,7 +668,7 @@ async def test_media_pause(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call(), call()]
 
 
-async def test_media_next_track(hass: HomeAssistant, remote: Remote) -> None:
+async def test_media_next_track(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_next_track."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -689,7 +681,7 @@ async def test_media_next_track(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call()]
 
 
-async def test_media_previous_track(hass: HomeAssistant, remote: Remote) -> None:
+async def test_media_previous_track(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_previous_track."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -703,7 +695,7 @@ async def test_media_previous_track(hass: HomeAssistant, remote: Remote) -> None
 
 
 @pytest.mark.usefixtures("remote")
-async def test_turn_on_with_turnon(hass: HomeAssistant, delay: MagicMock) -> None:
+async def test_turn_on_with_turnon(hass: HomeAssistant, delay: Mock) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -733,7 +725,7 @@ async def test_turn_on_wol(hass: HomeAssistant) -> None:
     assert mock_send_magic_packet.called
 
 
-async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Remote) -> None:
+async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Mock) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -743,7 +735,7 @@ async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Remote) -> No
     assert remote.control.call_count == 0
 
 
-async def test_play_media(hass: HomeAssistant, remote: Remote) -> None:
+async def test_play_media(hass: HomeAssistant, remote: Mock) -> None:
     """Test for play_media."""
     asyncio_sleep = asyncio.sleep
     sleeps = []
@@ -777,7 +769,7 @@ async def test_play_media(hass: HomeAssistant, remote: Remote) -> None:
         assert len(sleeps) == 3
 
 
-async def test_play_media_invalid_type(hass: HomeAssistant, remote: Remote) -> None:
+async def test_play_media_invalid_type(hass: HomeAssistant, remote: Mock) -> None:
     """Test for play_media with invalid media type."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -799,9 +791,7 @@ async def test_play_media_invalid_type(hass: HomeAssistant, remote: Remote) -> N
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_string(
-    hass: HomeAssistant, remote: Remote
-) -> None:
+async def test_play_media_channel_as_string(hass: HomeAssistant, remote: Mock) -> None:
     """Test for play_media with invalid channel as string."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -824,7 +814,7 @@ async def test_play_media_channel_as_string(
 
 
 async def test_play_media_channel_as_non_positive(
-    hass: HomeAssistant, remote: Remote
+    hass: HomeAssistant, remote: Mock
 ) -> None:
     """Test for play_media with invalid channel as non positive integer."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
@@ -846,7 +836,7 @@ async def test_play_media_channel_as_non_positive(
         assert remote.call_count == 1
 
 
-async def test_select_source(hass: HomeAssistant, remote: Remote) -> None:
+async def test_select_source(hass: HomeAssistant, remote: Mock) -> None:
     """Test for select_source."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -862,9 +852,7 @@ async def test_select_source(hass: HomeAssistant, remote: Remote) -> None:
     assert remote.close.call_args_list == [call()]
 
 
-async def test_select_source_invalid_source(
-    hass: HomeAssistant, remote: Remote
-) -> None:
+async def test_select_source_invalid_source(hass: HomeAssistant, remote: Mock) -> None:
     """Test for select_source with invalid source."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints, drop unused functions and adjust fixtures for samsungtv

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
