### PR TITLE
Bump holidays to 0.13

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -96,16 +96,14 @@ def setup_platform(
     obj_holidays = getattr(holidays, country)(years=year)
 
     if province:
-        # 'state' and 'prov' are not interchangeable, so need to make
-        # sure we use the right one
-        if hasattr(obj_holidays, "PROVINCES") and province in obj_holidays.PROVINCES:
-            obj_holidays = getattr(holidays, country)(prov=province, years=year)
-        elif hasattr(obj_holidays, "STATES") and province in obj_holidays.STATES:
-            obj_holidays = getattr(holidays, country)(state=province, years=year)
+        # 'state' and 'prov' were replaced by `subdiv`, we use province for both - great!
+        if (
+            hasattr(obj_holidays, "subdivisions")
+            and province in obj_holidays.subdivisions
+        ):
+            obj_holidays = getattr(holidays, country)(subdiv=province, years=year)
         else:
-            _LOGGER.error(
-                "There is no province/state %s in country %s", province, country
-            )
+            _LOGGER.error("There is no subdivision %s in country %s", province, country)
             return
 
     # Add custom holidays

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -96,7 +96,6 @@ def setup_platform(
     obj_holidays = getattr(holidays, country)(years=year)
 
     if province:
-        # 'state' and 'prov' were replaced by `subdiv`, we use province for both - great!
         if (
             hasattr(obj_holidays, "subdivisions")
             and province in obj_holidays.subdivisions

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -2,7 +2,7 @@
   "domain": "workday",
   "name": "Workday",
   "documentation": "https://www.home-assistant.io/integrations/workday",
-  "requirements": ["holidays==0.12"],
+  "requirements": ["holidays==0.13"],
   "codeowners": ["@fabaff"],
   "quality_scale": "internal",
   "iot_class": "local_polling",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -836,7 +836,7 @@ hlk-sw16==0.0.9
 hole==0.7.0
 
 # homeassistant.components.workday
-holidays==0.12
+holidays==0.13
 
 # homeassistant.components.frontend
 home-assistant-frontend==20220214.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -546,7 +546,7 @@ hlk-sw16==0.0.9
 hole==0.7.0
 
 # homeassistant.components.workday
-holidays==0.12
+holidays==0.13
 
 # homeassistant.components.frontend
 home-assistant-frontend==20220214.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumping the holidays library to 0.13. It includes fixes for a number of countries: https://github.com/dr-prodigy/python-holidays/releases
The integration has a **static dependency on version 0.12**, that is preventing me from making a release of a custom integration that has a dependency on >= 0.13. So I appreciate the quick response.

It also marks the `state` and `province` attributes obsolete, as well as the `CountryHolidays` class. So in the future, we should look at migrating from these to the new `subdiv` attribute, and using the `country_holidays` function instead. But this would be more long-term objective. They also added a function 'list_supported_countries', which returns a dict with the supported countries and subdivs. So I'd like to discuss with @fabaff to take this as an opportunity to move this to config_flow.
And I'd also like to beg to add features so that I can get rid of the Holidays custom integration. I am looking forward for the discussion. For now, I'd just bump the version, please. Thanks!

https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.13


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed: N/A

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools: No

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->
Just bumped version and tested, did not alter the code
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
