### PR TITLE
Allow integrations to provide custom actions

### DIFF
--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -56,7 +56,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_CONDITION): _CONDITION_SCHEMA,
             vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
             vol.Optional(CONF_TRIGGER_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
-            vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA_WITH_DYNAMIC,
         },
         script.SCRIPT_MODE_SINGLE,
     ),

--- a/homeassistant/components/media_player/action.py
+++ b/homeassistant/components/media_player/action.py
@@ -1,0 +1,66 @@
+"""Media player actions."""
+
+from typing import cast
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, script
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_CONTENT_TYPE,
+    DOMAIN,
+    SERVICE_PLAY_MEDIA,
+)
+
+PLAY_MEDIA_SCHEMA = vol.Schema(
+    {
+        vol.Required("media_player.play_media"): vol.Schema(
+            {
+                "entity_id": cv.entity_domain(DOMAIN),
+                "media_content_id": str,
+                "media_content_type": str,
+            }
+        )
+    }
+)
+
+PLATFORM_SCHEMA = cv.single_key_schemas(
+    {
+        "media_player.play_media": PLAY_MEDIA_SCHEMA,
+    }
+)
+
+
+async def async_validate_action_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    return cast(ConfigType, PLATFORM_SCHEMA(config))
+
+
+async def async_run_action(
+    hass: HomeAssistant, config: ConfigType, info: script.ScriptInfo
+) -> None:
+    """Run action."""
+    action_key, action_conf = next(c for c in config.items())
+    action = action_key.partition(".")[2]
+
+    if action == "play_media":
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: action_conf[ATTR_ENTITY_ID],
+                ATTR_MEDIA_CONTENT_TYPE: action_conf[ATTR_MEDIA_CONTENT_TYPE],
+                ATTR_MEDIA_CONTENT_ID: action_conf[ATTR_MEDIA_CONTENT_ID],
+            },
+            context=info.context,
+            blocking=True,
+        )
+        return
+
+    raise ValueError(f"Unknown action {action_key} specified")

--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -45,7 +45,7 @@ SCRIPT_ENTITY_SCHEMA = make_script_schema(
         vol.Optional(CONF_ALIAS): cv.string,
         vol.Optional(CONF_TRACE, default={}): TRACE_CONFIG_SCHEMA,
         vol.Optional(CONF_ICON): cv.icon,
-        vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
+        vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA_WITH_DYNAMIC,
         vol.Optional(CONF_DESCRIPTION, default=""): cv.string,
         vol.Optional(CONF_VARIABLES): cv.SCRIPT_VARIABLES_SCHEMA,
         vol.Optional(CONF_FIELDS, default={}): {

--- a/tests/components/media_player/test_action.py
+++ b/tests/components/media_player/test_action.py
@@ -1,0 +1,60 @@
+"""Test media player actions."""
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.core import Context
+from homeassistant.helpers.script import Script, async_validate_actions_config
+
+from tests.common import async_mock_service
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "media_player.not_supported": {},
+        },
+        {
+            "media_player.play_media": {
+                "entity_id": "not_media_player.not_supported",
+                "media_content_id": "youtube:video:123",
+                "media_content_type": "movie",
+            },
+        },
+    ],
+)
+async def test_play_media_validate_action(hass, config):
+    """Test validate play media config."""
+    with pytest.raises(vol.Invalid):
+        await async_validate_actions_config(
+            hass,
+            [config],
+        )
+
+
+async def test_play_media_run_action(hass):
+    """Test run play media action."""
+    calls = async_mock_service(hass, "media_player", "play_media")
+    config = await async_validate_actions_config(
+        hass,
+        [
+            {
+                "media_player.play_media": {
+                    "entity_id": "media_player.test",
+                    "media_content_id": "youtube:video:123",
+                    "media_content_type": "movie",
+                }
+            }
+        ],
+    )
+    script = Script(hass, config, "Test Script", "test")
+    context = Context()
+    await script.async_run(context=context)
+    assert len(calls) == 1
+    assert calls[0].data == {
+        "entity_id": "media_player.test",
+        "media_content_id": "youtube:video:123",
+        "media_content_type": "movie",
+    }
+    assert calls[0].context is context


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Marked as draft because of the fair feedback that this is too confusing with services.**

Allow integrations to provide custom actions by integrating `action.py` platforms. This is similar to what we support for triggers, albeit a bit more extensive and strict.

Action platforms will be called whenever an action step contains a dynamic action. Dynamic actions contain of a single string key `<domain>.<action>` with as value the configuration of that action.

As an example I've implemented a new `media_player.play_media` action:

```yaml
action:
- media_player.play_media:
    entity_id: media_player.living_room
    media_content_id: https://example.com/bla.mp3
    media_content_type: audio/mpeg
```

Any place that provides scripts need to switch to config validation using the config platform and calling `homeassistant.helpers.script.async_validate_actions_config`. I've added this to the Script and Automation integration. Grepping for `cv.SCRIPT_SCHEMA` will show many other spots that also do this.

Action platforms are required to implement 5 methods:

```python
class ActionPlatform(Protocol):
    """Type for the action platform."""

    async def async_validate_action_config(
        self, hass: HomeAssistant, config: ConfigType
    ) -> ConfigType:
        """Validate config."""
        ...

    async def async_run_action(
        self, hass: HomeAssistant, config: ConfigType, info: ScriptInfo
    ) -> None:
        """Run an action."""
        ...

    @callback
    def async_find_referenced_entities(
        self, referenced: set[str], config: ConfigType
    ) -> None:
        """Find referenced entities."""
        ...

    @callback
    def async_find_referenced_devices(
        self, referenced: set[str], config: ConfigType
    ) -> None:
        """Find referenced devices."""
        ...

    @callback
    def async_find_referenced_areas(
        self, referenced: set[str], config: ConfigType
    ) -> None:
        """Find referenced areas."""
        ...
```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
