### PR TITLE
Add type hints in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Samsung TV."""
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
@@ -17,7 +18,7 @@ def fake_host_fixture() -> None:
 
 
 @pytest.fixture(name="remote")
-def remote_fixture():
+def remote_fixture() -> Mock:
     """Patch the samsungctl Remote."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote_class:
         remote = Mock()
@@ -29,7 +30,7 @@ def remote_fixture():
 
 
 @pytest.fixture(name="remotews")
-def remotews_fixture():
+def remotews_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -54,7 +55,7 @@ def remotews_fixture():
 
 
 @pytest.fixture(name="remotews_no_device_info")
-def remotews_no_device_info_fixture():
+def remotews_no_device_info_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -69,7 +70,7 @@ def remotews_no_device_info_fixture():
 
 
 @pytest.fixture(name="remotews_soundbar")
-def remotews_soundbar_fixture():
+def remotews_soundbar_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
@@ -93,7 +94,7 @@ def remotews_soundbar_fixture():
 
 
 @pytest.fixture(name="delay")
-def delay_fixture():
+def delay_fixture() -> Mock:
     """Patch the delay script function."""
     with patch(
         "homeassistant.components.samsungtv.media_player.Script.async_run"
@@ -102,13 +103,13 @@ def delay_fixture():
 
 
 @pytest.fixture
-def mock_now():
+def mock_now() -> datetime:
     """Fixture for dtutil.now."""
     return dt_util.utcnow()
 
 
 @pytest.fixture(name="no_mac_address")
-def mac_address_fixture():
+def mac_address_fixture() -> Mock:
     """Patch getmac.get_mac_address."""
     with patch("getmac.get_mac_address", return_value=None) as mac:
         yield mac

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -2,6 +2,7 @@
 import socket
 from unittest.mock import Mock, PropertyMock, call, patch
 
+import pytest
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from websocket import WebSocketException, WebSocketProtocolException
@@ -181,7 +182,8 @@ DEVICEINFO_WEBSOCKET_SSL = {
 }
 
 
-async def test_user_legacy(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_user_legacy(hass: HomeAssistant) -> None:
     """Test starting a flow by user."""
     # show form
     result = await hass.config_entries.flow.async_init(
@@ -205,7 +207,8 @@ async def test_user_legacy(hass: HomeAssistant, remote: Mock):
     assert result["result"].unique_id is None
 
 
-async def test_user_websocket(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_user_websocket(hass: HomeAssistant) -> None:
     """Test starting a flow by user."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError("Boom")
@@ -232,7 +235,8 @@ async def test_user_websocket(hass: HomeAssistant, remotews: Mock):
         assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_user_legacy_missing_auth(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_user_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow by user with authentication."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -246,7 +250,7 @@ async def test_user_legacy_missing_auth(hass: HomeAssistant, remotews: Mock):
         assert result["reason"] == RESULT_AUTH_MISSING
 
 
-async def test_user_legacy_not_supported(hass: HomeAssistant):
+async def test_user_legacy_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow by user for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -260,7 +264,7 @@ async def test_user_legacy_not_supported(hass: HomeAssistant):
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_user_websocket_not_supported(hass: HomeAssistant):
+async def test_user_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow by user for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -277,7 +281,7 @@ async def test_user_websocket_not_supported(hass: HomeAssistant):
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_user_not_successful(hass: HomeAssistant):
+async def test_user_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -293,7 +297,7 @@ async def test_user_not_successful(hass: HomeAssistant):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_user_not_successful_2(hass: HomeAssistant):
+async def test_user_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow by user but no connection found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -309,7 +313,8 @@ async def test_user_not_successful_2(hass: HomeAssistant):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_ssdp(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test starting a flow from discovery."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -337,7 +342,8 @@ async def test_ssdp(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
         assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test starting a flow from discovery without prefixes."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -372,7 +378,8 @@ async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock, no_mac_address: 
             assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
 
 
-async def test_ssdp_legacy_missing_auth(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery with authentication."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -399,9 +406,8 @@ async def test_ssdp_legacy_missing_auth(hass: HomeAssistant, remotews: Mock):
             assert result["reason"] == RESULT_AUTH_MISSING
 
 
-async def test_ssdp_legacy_not_supported(
-    hass: HomeAssistant, remote: Mock, remotews: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery for not supported device."""
 
     # confirm to add the entry
@@ -423,11 +429,10 @@ async def test_ssdp_legacy_not_supported(
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
+@pytest.mark.usefixtures("remote", "remotews")
 async def test_ssdp_websocket_success_populates_mac_address(
     hass: HomeAssistant,
-    remote: Mock,
-    remotews: Mock,
-):
+) -> None:
     """Test starting a flow from ssdp for a supported device populates the mac."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -448,7 +453,7 @@ async def test_ssdp_websocket_success_populates_mac_address(
     assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_ssdp_websocket_not_supported(hass: HomeAssistant):
+async def test_ssdp_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery for not supported device."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -465,7 +470,8 @@ async def test_ssdp_websocket_not_supported(hass: HomeAssistant):
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_ssdp_model_not_supported(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery."""
 
     # confirm to add the entry
@@ -478,7 +484,8 @@ async def test_ssdp_model_not_supported(hass: HomeAssistant, remote: Mock):
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_ssdp_not_successful(hass: HomeAssistant, no_mac_address: Mock):
+@pytest.mark.usefixtures("no_mac_address")
+async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -506,7 +513,8 @@ async def test_ssdp_not_successful(hass: HomeAssistant, no_mac_address: Mock):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_ssdp_not_successful_2(hass: HomeAssistant, no_mac_address: Mock):
+@pytest.mark.usefixtures("no_mac_address")
+async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -534,9 +542,10 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant, no_mac_address: Mock):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
+@pytest.mark.usefixtures("remote")
 async def test_ssdp_already_in_progress(
-    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
-):
+    hass: HomeAssistant, no_mac_address: Mock
+) -> None:
     """Test starting a flow from discovery twice."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -560,9 +569,10 @@ async def test_ssdp_already_in_progress(
         assert result["reason"] == RESULT_ALREADY_IN_PROGRESS
 
 
+@pytest.mark.usefixtures("remote")
 async def test_ssdp_already_configured(
-    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
-):
+    hass: HomeAssistant, no_mac_address: Mock
+) -> None:
     """Test starting a flow from discovery when already configured."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -592,7 +602,8 @@ async def test_ssdp_already_configured(
         assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_import_legacy(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
     """Test importing from yaml with hostname."""
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
@@ -615,12 +626,8 @@ async def test_import_legacy(hass: HomeAssistant, remote: Mock, no_mac_address: 
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-async def test_import_legacy_without_name(
-    hass: HomeAssistant,
-    remote: Mock,
-    remotews_no_device_info: Mock,
-    no_mac_address: Mock,
-):
+@pytest.mark.usefixtures("remote", "remotews_no_device_info", "no_mac_address")
+async def test_import_legacy_without_name(hass: HomeAssistant) -> None:
     """Test importing from yaml without a name."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -640,7 +647,8 @@ async def test_import_legacy_without_name(
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-async def test_import_websocket(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_import_websocket(hass: HomeAssistant):
     """Test importing from yaml with hostname."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -658,7 +666,8 @@ async def test_import_websocket(hass: HomeAssistant, remotews: Mock):
     assert result["result"].unique_id is None
 
 
-async def test_import_websocket_without_port(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_import_websocket_without_port(hass: HomeAssistant):
     """Test importing from yaml with hostname by no port."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -679,7 +688,8 @@ async def test_import_websocket_without_port(hass: HomeAssistant, remotews: Mock
     assert entries[0].data[CONF_PORT] == 8002
 
 
-async def test_import_unknown_host(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_import_unknown_host(hass: HomeAssistant):
     """Test importing from yaml with hostname that does not resolve."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -695,7 +705,8 @@ async def test_import_unknown_host(hass: HomeAssistant, remotews: Mock):
     assert result["reason"] == RESULT_UNKNOWN_HOST
 
 
-async def test_dhcp(hass: HomeAssistant, remote: Mock, remotews: Mock):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_dhcp(hass: HomeAssistant) -> None:
     """Test starting a flow from dhcp."""
     # confirm to add the entry
     result = await hass.config_entries.flow.async_init(
@@ -721,7 +732,8 @@ async def test_dhcp(hass: HomeAssistant, remote: Mock, remotews: Mock):
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_zeroconf(hass: HomeAssistant, remote: Mock, remotews: Mock):
+@pytest.mark.usefixtures("remote", "remotews")
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -746,7 +758,8 @@ async def test_zeroconf(hass: HomeAssistant, remote: Mock, remotews: Mock):
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, remotews_soundbar: Mock):
+@pytest.mark.usefixtures("remotews_soundbar")
+async def test_zeroconf_ignores_soundbar(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf where the device is actually a soundbar."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -758,9 +771,8 @@ async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, remotews_soundbar:
     assert result["reason"] == "not_supported"
 
 
-async def test_zeroconf_no_device_info(
-    hass: HomeAssistant, remote: Mock, remotews_no_device_info: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews_no_device_info")
+async def test_zeroconf_no_device_info(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf where device_info returns None."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -772,7 +784,8 @@ async def test_zeroconf_no_device_info(
     assert result["reason"] == "not_supported"
 
 
-async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant) -> None:
     """Test starting a flow from zeroconf and dhcp."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -793,7 +806,7 @@ async def test_zeroconf_and_dhcp_same_time(hass: HomeAssistant, remotews: Mock):
     assert result2["reason"] == "already_in_progress"
 
 
-async def test_autodetect_websocket(hass: HomeAssistant):
+async def test_autodetect_websocket(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -836,7 +849,7 @@ async def test_autodetect_websocket(hass: HomeAssistant):
     assert entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_websocket_no_mac(hass: HomeAssistant):
+async def test_websocket_no_mac(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -882,7 +895,7 @@ async def test_websocket_no_mac(hass: HomeAssistant):
     assert entries[0].data[CONF_MAC] == "gg:hh:ii:ll:mm:nn"
 
 
-async def test_autodetect_auth_missing(hass: HomeAssistant):
+async def test_autodetect_auth_missing(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -897,7 +910,7 @@ async def test_autodetect_auth_missing(hass: HomeAssistant):
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-async def test_autodetect_not_supported(hass: HomeAssistant):
+async def test_autodetect_not_supported(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -912,7 +925,8 @@ async def test_autodetect_not_supported(hass: HomeAssistant):
         assert remote.call_args_list == [call(AUTODETECT_LEGACY)]
 
 
-async def test_autodetect_legacy(hass: HomeAssistant, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_autodetect_legacy(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA
@@ -924,7 +938,7 @@ async def test_autodetect_legacy(hass: HomeAssistant, remote: Mock):
     assert result["data"][CONF_PORT] == LEGACY_PORT
 
 
-async def test_autodetect_none(hass: HomeAssistant):
+async def test_autodetect_none(hass: HomeAssistant) -> None:
     """Test for send key with autodetection of protocol."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -949,7 +963,8 @@ async def test_autodetect_none(hass: HomeAssistant):
         ]
 
 
-async def test_update_old_entry(hass: HomeAssistant, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_old_entry(hass: HomeAssistant) -> None:
     """Test update of old entry."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         remote().rest_device_info.return_value = {
@@ -990,7 +1005,10 @@ async def test_update_old_entry(hass: HomeAssistant, remotews: Mock):
         assert entry2.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_missing_mac_unique_id_added_from_dhcp(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1016,7 +1034,10 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_missing_mac_unique_id_added_from_zeroconf(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1041,7 +1062,10 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: 
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_update_missing_mac_unique_id_added_from_ssdp(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_update_missing_mac_unique_id_added_from_ssdp(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added via ssdp."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
@@ -1067,9 +1091,10 @@ async def test_update_missing_mac_unique_id_added_from_ssdp(hass, remotews: Mock
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
+@pytest.mark.usefixtures("remotews")
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
-    hass, remotews: Mock
-):
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1098,7 +1123,8 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_update_legacy_missing_mac_from_dhcp(hass: HomeAssistant) -> None:
     """Test missing mac added."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1129,7 +1155,10 @@ async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
-async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(
+    hass: HomeAssistant,
+) -> None:
     """Test missing mac added when there is no unique id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1165,7 +1194,8 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mo
     assert entry.unique_id is None
 
 
-async def test_form_reauth_legacy(hass, remote: Mock):
+@pytest.mark.usefixtures("remote")
+async def test_form_reauth_legacy(hass: HomeAssistant) -> None:
     """Test reauthenticate legacy."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
     entry.add_to_hass(hass)
@@ -1186,7 +1216,8 @@ async def test_form_reauth_legacy(hass, remote: Mock):
     assert result2["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1210,7 +1241,8 @@ async def test_form_reauth_websocket(hass, remotews: Mock):
     assert entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
+@pytest.mark.usefixtures("remotews")
+async def test_form_reauth_websocket_cannot_connect(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when we cannot connect on the first attempt."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)
@@ -1245,7 +1277,7 @@ async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
     assert result3["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_websocket_not_supported(hass):
+async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when the device is not supported."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_WS_ENTRY)
     entry.add_to_hass(hass)

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -1,5 +1,7 @@
 """Tests for the Samsung TV Integration."""
-from unittest.mock import Mock, patch
+from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components.media_player.const import DOMAIN, SUPPORT_TURN_ON
 from homeassistant.components.samsungtv.const import (
@@ -53,7 +55,8 @@ REMOTE_CALL = {
 }
 
 
-async def test_setup(hass: HomeAssistant, remotews: Mock, no_mac_address: Mock):
+@pytest.mark.usefixtures("remotews", "no_mac_address")
+async def test_setup(hass: HomeAssistant) -> None:
     """Test Samsung TV integration is setup."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -72,7 +75,7 @@ async def test_setup(hass: HomeAssistant, remotews: Mock, no_mac_address: Mock):
     )
 
 
-async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
+async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is offline."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError
@@ -91,9 +94,8 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
     assert config_entries_domain[0].state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_from_yaml_without_port_device_online(
-    hass: HomeAssistant, remotews: Mock
-):
+@pytest.mark.usefixtures("remotews")
+async def test_setup_from_yaml_without_port_device_online(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is online."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -103,7 +105,10 @@ async def test_setup_from_yaml_without_port_device_online(
     assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog):
+@pytest.mark.usefixtures("remote")
+async def test_setup_duplicate_config(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test duplicate setup of platform."""
     duplicate = {
         SAMSUNGTV_DOMAIN: [
@@ -118,9 +123,8 @@ async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog)
     assert "duplicate host entries found" in caplog.text
 
 
-async def test_setup_duplicate_entries(
-    hass: HomeAssistant, remote: Mock, remotews: Mock, no_mac_address: Mock
-):
+@pytest.mark.usefixtures("remote", "remotews", "no_mac_address")
+async def test_setup_duplicate_entries(hass: HomeAssistant) -> None:
     """Test duplicate setup of platform."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1,6 +1,6 @@
 """Tests for samsungtv component."""
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
 
@@ -55,6 +55,8 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -130,25 +132,28 @@ def delay_fixture():
         yield delay
 
 
-async def setup_samsungtv(hass, config):
+async def setup_samsungtv(hass: HomeAssistant, config: ConfigType) -> None:
     """Set up mock Samsung TV."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, config)
     await hass.async_block_till_done()
 
 
-async def test_setup_with_turnon(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_setup_with_turnon(hass: HomeAssistant) -> None:
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert hass.states.get(ENTITY_ID)
 
 
-async def test_setup_without_turnon(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_setup_without_turnon(hass: HomeAssistant) -> None:
     """Test setup of platform."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert hass.states.get(ENTITY_ID_NOTURNON)
 
 
-async def test_setup_websocket(hass, remotews):
+@pytest.mark.usefixtures("remotews")
+async def test_setup_websocket(hass: HomeAssistant) -> None:
     """Test setup of platform."""
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
         enter = Mock()
@@ -184,7 +189,7 @@ async def test_setup_websocket(hass, remotews):
         assert config_entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_setup_websocket_2(hass, mock_now):
+async def test_setup_websocket_2(hass: HomeAssistant, mock_now: datetime) -> None:
     """Test setup of platform from config entry."""
     entity_id = f"{DOMAIN}.fake"
 
@@ -232,7 +237,8 @@ async def test_setup_websocket_2(hass, mock_now):
     assert remote_class.call_args_list[0] == call(**MOCK_CALLS_WS)
 
 
-async def test_update_on(hass, remote, mock_now):
+@pytest.mark.usefixtures("remote")
+async def test_update_on(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -245,7 +251,8 @@ async def test_update_on(hass, remote, mock_now):
     assert state.state == STATE_ON
 
 
-async def test_update_off(hass, remote, mock_now):
+@pytest.mark.usefixtures("remote")
+async def test_update_off(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv off."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -263,7 +270,8 @@ async def test_update_off(hass, remote, mock_now):
         assert state.state == STATE_OFF
 
 
-async def test_update_access_denied(hass, remote, mock_now):
+@pytest.mark.usefixtures("remote")
+async def test_update_access_denied(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv access denied exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -289,7 +297,10 @@ async def test_update_access_denied(hass, remote, mock_now):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update_connection_failure(hass, remotews, mock_now):
+@pytest.mark.usefixtures("remotews")
+async def test_update_connection_failure(
+    hass: HomeAssistant, mock_now: datetime
+) -> None:
     """Testing update tv connection failure exception."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -319,7 +330,10 @@ async def test_update_connection_failure(hass, remotews, mock_now):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update_unhandled_response(hass, remote, mock_now):
+@pytest.mark.usefixtures("remote")
+async def test_update_unhandled_response(
+    hass: HomeAssistant, mock_now: datetime
+) -> None:
     """Testing update tv unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -337,7 +351,10 @@ async def test_update_unhandled_response(hass, remote, mock_now):
         assert state.state == STATE_ON
 
 
-async def test_connection_closed_during_update_can_recover(hass, remote, mock_now):
+@pytest.mark.usefixtures("remote")
+async def test_connection_closed_during_update_can_recover(
+    hass: HomeAssistant, mock_now: datetime
+) -> None:
     """Testing update tv connection closed exception can recover."""
     await setup_samsungtv(hass, MOCK_CONFIG)
 
@@ -363,7 +380,7 @@ async def test_connection_closed_during_update_can_recover(hass, remote, mock_no
         assert state.state == STATE_ON
 
 
-async def test_send_key(hass, remote):
+async def test_send_key(hass: HomeAssistant, remote: Mock) -> None:
     """Test for send key."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -378,7 +395,7 @@ async def test_send_key(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_broken_pipe(hass, remote):
+async def test_send_key_broken_pipe(hass: HomeAssistant, remote: Mock) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=BrokenPipeError("Boom"))
@@ -389,7 +406,9 @@ async def test_send_key_broken_pipe(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_connection_closed_retry_succeed(hass, remote):
+async def test_send_key_connection_closed_retry_succeed(
+    hass: HomeAssistant, remote: Mock
+) -> None:
     """Test retry on connection closed."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(
@@ -410,7 +429,7 @@ async def test_send_key_connection_closed_retry_succeed(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_unhandled_response(hass, remote):
+async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Mock) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=exceptions.UnhandledResponse("Boom"))
@@ -421,7 +440,7 @@ async def test_send_key_unhandled_response(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_websocketexception(hass, remote):
+async def test_send_key_websocketexception(hass: HomeAssistant, remote: Mock) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=WebSocketException("Boom"))
@@ -432,7 +451,7 @@ async def test_send_key_websocketexception(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_send_key_os_error(hass, remote):
+async def test_send_key_os_error(hass: HomeAssistant, remote: Mock) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=OSError("Boom"))
@@ -443,14 +462,16 @@ async def test_send_key_os_error(hass, remote):
     assert state.state == STATE_ON
 
 
-async def test_name(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_name(hass: HomeAssistant) -> None:
     """Test for name property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake"
 
 
-async def test_state_with_turnon(hass, remote, delay):
+@pytest.mark.usefixtures("remote")
+async def test_state_with_turnon(hass: HomeAssistant, delay: Mock) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -467,7 +488,8 @@ async def test_state_with_turnon(hass, remote, delay):
     assert state.state == STATE_OFF
 
 
-async def test_state_without_turnon(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_state_without_turnon(hass: HomeAssistant) -> None:
     """Test for state property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -495,7 +517,8 @@ async def test_state_without_turnon(hass, remote):
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_supported_features_with_turnon(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_supported_features_with_turnon(hass: HomeAssistant) -> None:
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
@@ -504,21 +527,23 @@ async def test_supported_features_with_turnon(hass, remote):
     )
 
 
-async def test_supported_features_without_turnon(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_supported_features_without_turnon(hass: HomeAssistant) -> None:
     """Test for supported_features property."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     state = hass.states.get(ENTITY_ID_NOTURNON)
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_SAMSUNGTV
 
 
-async def test_device_class(hass, remote):
+@pytest.mark.usefixtures("remote")
+async def test_device_class(hass: HomeAssistant) -> None:
     """Test for device_class property."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state.attributes[ATTR_DEVICE_CLASS] is MediaPlayerDeviceClass.TV.value
 
 
-async def test_turn_off_websocket(hass, remotews):
+async def test_turn_off_websocket(hass: HomeAssistant, remotews: Mock) -> None:
     """Test for turn_off."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -533,7 +558,7 @@ async def test_turn_off_websocket(hass, remotews):
         assert remotews.send_key.call_args_list == [call("KEY_POWER")]
 
 
-async def test_turn_off_legacy(hass, remote):
+async def test_turn_off_legacy(hass: HomeAssistant, remote: Mock) -> None:
     """Test for turn_off."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -544,7 +569,9 @@ async def test_turn_off_legacy(hass, remote):
     assert remote.control.call_args_list == [call("KEY_POWEROFF")]
 
 
-async def test_turn_off_os_error(hass, remote, caplog):
+async def test_turn_off_os_error(
+    hass: HomeAssistant, remote: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for turn_off with OSError."""
     caplog.set_level(logging.DEBUG)
     await setup_samsungtv(hass, MOCK_CONFIG)
@@ -555,7 +582,7 @@ async def test_turn_off_os_error(hass, remote, caplog):
     assert "Could not establish connection" in caplog.text
 
 
-async def test_volume_up(hass, remote):
+async def test_volume_up(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_up."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -568,7 +595,7 @@ async def test_volume_up(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_volume_down(hass, remote):
+async def test_volume_down(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_down."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -581,7 +608,7 @@ async def test_volume_down(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_mute_volume(hass, remote):
+async def test_mute_volume(hass: HomeAssistant, remote: Mock) -> None:
     """Test for mute_volume."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -597,7 +624,7 @@ async def test_mute_volume(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_media_play(hass, remote):
+async def test_media_play(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_play."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -619,7 +646,7 @@ async def test_media_play(hass, remote):
     assert remote.close.call_args_list == [call(), call()]
 
 
-async def test_media_pause(hass, remote):
+async def test_media_pause(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_pause."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -641,7 +668,7 @@ async def test_media_pause(hass, remote):
     assert remote.close.call_args_list == [call(), call()]
 
 
-async def test_media_next_track(hass, remote):
+async def test_media_next_track(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_next_track."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -654,7 +681,7 @@ async def test_media_next_track(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_media_previous_track(hass, remote):
+async def test_media_previous_track(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_previous_track."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -667,7 +694,8 @@ async def test_media_previous_track(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_turn_on_with_turnon(hass, remote, delay):
+@pytest.mark.usefixtures("remote")
+async def test_turn_on_with_turnon(hass: HomeAssistant, delay: Mock) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -676,7 +704,8 @@ async def test_turn_on_with_turnon(hass, remote, delay):
     assert delay.call_count == 1
 
 
-async def test_turn_on_wol(hass, remotews):
+@pytest.mark.usefixtures("remotews")
+async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
         domain=SAMSUNGTV_DOMAIN,
@@ -696,7 +725,7 @@ async def test_turn_on_wol(hass, remotews):
     assert mock_send_magic_packet.called
 
 
-async def test_turn_on_without_turnon(hass, remote):
+async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Mock) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
     assert await hass.services.async_call(
@@ -706,7 +735,7 @@ async def test_turn_on_without_turnon(hass, remote):
     assert remote.control.call_count == 0
 
 
-async def test_play_media(hass, remote):
+async def test_play_media(hass: HomeAssistant, remote: Mock) -> None:
     """Test for play_media."""
     asyncio_sleep = asyncio.sleep
     sleeps = []
@@ -740,7 +769,7 @@ async def test_play_media(hass, remote):
         assert len(sleeps) == 3
 
 
-async def test_play_media_invalid_type(hass):
+async def test_play_media_invalid_type(hass: HomeAssistant) -> None:
     """Test for play_media with invalid media type."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -762,7 +791,7 @@ async def test_play_media_invalid_type(hass):
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_string(hass):
+async def test_play_media_channel_as_string(hass: HomeAssistant) -> None:
     """Test for play_media with invalid channel as string."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         url = "https://example.com"
@@ -784,7 +813,7 @@ async def test_play_media_channel_as_string(hass):
         assert remote.call_count == 1
 
 
-async def test_play_media_channel_as_non_positive(hass):
+async def test_play_media_channel_as_non_positive(hass: HomeAssistant) -> None:
     """Test for play_media with invalid channel as non positive integer."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)
@@ -805,7 +834,7 @@ async def test_play_media_channel_as_non_positive(hass):
         assert remote.call_count == 1
 
 
-async def test_select_source(hass, remote):
+async def test_select_source(hass: HomeAssistant, remote: Mock) -> None:
     """Test for select_source."""
     await setup_samsungtv(hass, MOCK_CONFIG)
     assert await hass.services.async_call(
@@ -821,7 +850,7 @@ async def test_select_source(hass, remote):
     assert remote.close.call_args_list == [call()]
 
 
-async def test_select_source_invalid_source(hass):
+async def test_select_source_invalid_source(hass: HomeAssistant) -> None:
     """Test for select_source with invalid source."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote:
         await setup_samsungtv(hass, MOCK_CONFIG)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints in samsungtv tests, and implement usefixtures decorator

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
