### PR TITLE
Include changes in EVENT_DEVICE_REGISTRY_UPDATED

### DIFF
--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -96,8 +96,12 @@ async def test_get_or_create_returns_same_entry(
     assert len(update_events) == 2
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry.id
+    assert update_events[1]["changes"] == {
+        "connections": {("mac", "12:34:56:ab:cd:ef")}
+    }
 
 
 async def test_requirement_for_identifier_or_connection(registry):
@@ -518,14 +522,19 @@ async def test_removing_config_entries(hass, registry, update_events):
     assert len(update_events) == 5
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry2.id
+    assert update_events[1]["changes"] == {"config_entries": {"123"}}
     assert update_events[2]["action"] == "create"
     assert update_events[2]["device_id"] == entry3.id
+    assert "changes" not in update_events[2]
     assert update_events[3]["action"] == "update"
     assert update_events[3]["device_id"] == entry.id
+    assert update_events[3]["changes"] == {"config_entries": {"456", "123"}}
     assert update_events[4]["action"] == "remove"
     assert update_events[4]["device_id"] == entry3.id
+    assert "changes" not in update_events[4]
 
 
 async def test_deleted_device_removing_config_entries(hass, registry, update_events):
@@ -568,14 +577,19 @@ async def test_deleted_device_removing_config_entries(hass, registry, update_eve
     assert len(update_events) == 5
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry2.id
+    assert update_events[1]["changes"] == {"config_entries": {"123"}}
     assert update_events[2]["action"] == "create"
     assert update_events[2]["device_id"] == entry3.id
+    assert "changes" not in update_events[2]["device_id"]
     assert update_events[3]["action"] == "remove"
     assert update_events[3]["device_id"] == entry.id
+    assert "changes" not in update_events[3]
     assert update_events[4]["action"] == "remove"
     assert update_events[4]["device_id"] == entry3.id
+    assert "changes" not in update_events[4]
 
     registry.async_clear_config_entry("123")
     assert len(registry.devices) == 0
@@ -892,7 +906,7 @@ async def test_format_mac(registry):
         assert list(invalid_mac_entry.connections)[0][1] == invalid
 
 
-async def test_update(registry):
+async def test_update(hass, registry, update_events):
     """Verify that we can update some attributes of a device."""
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -939,6 +953,24 @@ async def test_update(registry):
     )
 
     assert registry.async_get(updated_entry.id) is not None
+
+    await hass.async_block_till_done()
+
+    assert len(update_events) == 2
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry.id
+    assert update_events[1]["changes"] == {
+        "area_id": None,
+        "disabled_by": None,
+        "identifiers": {("bla", "123"), ("hue", "456")},
+        "manufacturer": None,
+        "model": None,
+        "name_by_user": None,
+        "via_device_id": None,
+    }
 
 
 async def test_update_remove_config_entries(hass, registry, update_events):
@@ -989,17 +1021,22 @@ async def test_update_remove_config_entries(hass, registry, update_events):
     assert len(update_events) == 5
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry2.id
+    assert update_events[1]["changes"] == {"config_entries": {"123"}}
     assert update_events[2]["action"] == "create"
     assert update_events[2]["device_id"] == entry3.id
+    assert "changes" not in update_events[2]
     assert update_events[3]["action"] == "update"
     assert update_events[3]["device_id"] == entry.id
+    assert update_events[3]["changes"] == {"config_entries": {"456", "123"}}
     assert update_events[4]["action"] == "remove"
     assert update_events[4]["device_id"] == entry3.id
+    assert "changes" not in update_events[4]
 
 
-async def test_update_sw_version(registry):
+async def test_update_sw_version(hass, registry, update_events):
     """Verify that we can update software version of a device."""
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -1016,8 +1053,18 @@ async def test_update_sw_version(registry):
     assert updated_entry != entry
     assert updated_entry.sw_version == sw_version
 
+    await hass.async_block_till_done()
 
-async def test_update_hw_version(registry):
+    assert len(update_events) == 2
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry.id
+    assert update_events[1]["changes"] == {"sw_version": None}
+
+
+async def test_update_hw_version(hass, registry, update_events):
     """Verify that we can update hardware version of a device."""
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -1034,8 +1081,18 @@ async def test_update_hw_version(registry):
     assert updated_entry != entry
     assert updated_entry.hw_version == hw_version
 
+    await hass.async_block_till_done()
 
-async def test_update_suggested_area(registry, area_registry):
+    assert len(update_events) == 2
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry.id
+    assert update_events[1]["changes"] == {"hw_version": None}
+
+
+async def test_update_suggested_area(hass, registry, area_registry, update_events):
     """Verify that we can update the suggested area version of a device."""
     entry = registry.async_get_or_create(
         config_entry_id="1234",
@@ -1060,6 +1117,16 @@ async def test_update_suggested_area(registry, area_registry):
     assert pool_area is not None
     assert updated_entry.area_id == pool_area.id
     assert len(area_registry.areas) == 1
+
+    await hass.async_block_till_done()
+
+    assert len(update_events) == 2
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry.id
+    assert update_events[1]["changes"] == {"area_id": None, "suggested_area": None}
 
 
 async def test_cleanup_device_registry(hass, registry):
@@ -1221,12 +1288,16 @@ async def test_restore_device(hass, registry, update_events):
     assert len(update_events) == 4
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "remove"
     assert update_events[1]["device_id"] == entry.id
+    assert "changes" not in update_events[1]
     assert update_events[2]["action"] == "create"
     assert update_events[2]["device_id"] == entry2.id
+    assert "changes" not in update_events[2]
     assert update_events[3]["action"] == "create"
     assert update_events[3]["device_id"] == entry3.id
+    assert "changes" not in update_events[3]
 
 
 async def test_restore_simple_device(hass, registry, update_events):
@@ -1266,12 +1337,16 @@ async def test_restore_simple_device(hass, registry, update_events):
     assert len(update_events) == 4
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "remove"
     assert update_events[1]["device_id"] == entry.id
+    assert "changes" not in update_events[1]
     assert update_events[2]["action"] == "create"
     assert update_events[2]["device_id"] == entry2.id
+    assert "changes" not in update_events[2]
     assert update_events[3]["action"] == "create"
     assert update_events[3]["device_id"] == entry3.id
+    assert "changes" not in update_events[3]
 
 
 async def test_restore_shared_device(hass, registry, update_events):
@@ -1358,18 +1433,31 @@ async def test_restore_shared_device(hass, registry, update_events):
     assert len(update_events) == 7
     assert update_events[0]["action"] == "create"
     assert update_events[0]["device_id"] == entry.id
+    assert "changes" not in update_events[0]
     assert update_events[1]["action"] == "update"
     assert update_events[1]["device_id"] == entry.id
+    assert update_events[1]["changes"] == {
+        "config_entries": {"123"},
+        "identifiers": {("entry_123", "0123")},
+    }
     assert update_events[2]["action"] == "remove"
     assert update_events[2]["device_id"] == entry.id
+    assert "changes" not in update_events[2]
     assert update_events[3]["action"] == "create"
     assert update_events[3]["device_id"] == entry.id
+    assert "changes" not in update_events[3]
     assert update_events[4]["action"] == "remove"
     assert update_events[4]["device_id"] == entry.id
+    assert "changes" not in update_events[4]
     assert update_events[5]["action"] == "create"
     assert update_events[5]["device_id"] == entry.id
-    assert update_events[1]["action"] == "update"
-    assert update_events[1]["device_id"] == entry.id
+    assert "changes" not in update_events[5]
+    assert update_events[6]["action"] == "update"
+    assert update_events[6]["device_id"] == entry.id
+    assert update_events[6]["changes"] == {
+        "config_entries": {"234"},
+        "identifiers": {("entry_234", "2345")},
+    }
 
 
 async def test_get_or_create_empty_then_set_default_values(hass, registry):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include changes in `EVENT_DEVICE_REGISTRY_UPDATED`, in the same way as for `EVENT_ENTITY_REGISTRY_UPDATED`.

The changes are included as key value pairs in `event.data["changes"]`. The values in the event are the old values, before the update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
