### PR TITLE
Fix SamsungTVWS mocking in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -35,7 +35,7 @@ def remotews_fixture():
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews_class:
         remotews = Mock()
-        remotews.__enter__ = Mock()
+        remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
         remotews.port.return_value = 8002
         remotews.rest_device_info.return_value = {
@@ -60,7 +60,7 @@ def remotews_no_device_info_fixture():
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews_class:
         remotews = Mock()
-        remotews.__enter__ = Mock()
+        remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
         remotews.rest_device_info.return_value = None
         remotews_class.return_value = remotews
@@ -75,7 +75,7 @@ def remotews_soundbar_fixture():
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews_class:
         remotews = Mock()
-        remotews.__enter__ = Mock()
+        remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
         remotews.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from samsungtvws import SamsungTVWS
 
 import homeassistant.util.dt as dt_util
 
@@ -34,10 +35,9 @@ def remotews_fixture():
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews_class:
-        remotews = Mock()
+        remotews = Mock(SamsungTVWS)
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
-        remotews.port.return_value = 8002
         remotews.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
             "device": {
@@ -59,7 +59,7 @@ def remotews_no_device_info_fixture():
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews_class:
-        remotews = Mock()
+        remotews = Mock(SamsungTVWS)
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
         remotews.rest_device_info.return_value = None
@@ -74,7 +74,7 @@ def remotews_soundbar_fixture():
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
     ) as remotews_class:
-        remotews = Mock()
+        remotews = Mock(SamsungTVWS)
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
         remotews.rest_device_info.return_value = {

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -48,8 +48,8 @@ def remotews_fixture():
                 "networkType": "wireless",
             },
         }
+        remotews.token = "FAKE_TOKEN"
         remotews_class.return_value = remotews
-        remotews_class().__enter__().token = "FAKE_TOKEN"
         yield remotews
 
 
@@ -63,8 +63,8 @@ def remotews_no_device_info_fixture():
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
         remotews.rest_device_info.return_value = None
+        remotews.token = "FAKE_TOKEN"
         remotews_class.return_value = remotews
-        remotews_class().__enter__().token = "FAKE_TOKEN"
         yield remotews
 
 
@@ -87,8 +87,8 @@ def remotews_soundbar_fixture():
                 "type": "Samsung SoundBar",
             },
         }
+        remotews.token = "FAKE_TOKEN"
         remotews_class.return_value = remotews
-        remotews_class().__enter__().token = "FAKE_TOKEN"
         yield remotews
 
 

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from samsungctl import Remote
 from samsungtvws import SamsungTVWS
 
 import homeassistant.util.dt as dt_util
@@ -21,10 +22,9 @@ def fake_host_fixture() -> None:
 def remote_fixture():
     """Patch the samsungctl Remote."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote_class:
-        remote = Mock()
+        remote = Mock(Remote)
         remote.__enter__ = Mock()
         remote.__exit__ = Mock()
-        remote.port.return_value = 55000
         remote_class.return_value = remote
         yield remote
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for Samsung TV config flow."""
 import socket
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, PropertyMock, call, patch
 
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
@@ -814,7 +814,7 @@ async def test_autodetect_websocket(hass: HomeAssistant):
                 "type": "Samsung SmartTV",
             },
         }
-        remote.token = "123456789"
+        remote.token = PropertyMock(return_value="123456789")
         remotews.return_value = remote
 
         result = await hass.config_entries.flow.async_init(
@@ -858,7 +858,7 @@ async def test_websocket_no_mac(hass: HomeAssistant):
                 "type": "Samsung SmartTV",
             },
         }
-        remote.token = "123456789"
+        remote.token = PropertyMock(return_value="123456789")
         remotews.return_value = remote
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1222,10 +1222,7 @@ async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
-        side_effect=ConnectionFailure,
-    ):
+    with patch.object(remotews, "open", side_effect=ConnectionFailure):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for Samsung TV config flow."""
 import socket
-from unittest.mock import Mock, PropertyMock, call, patch
+from unittest.mock import Mock, call, patch
 
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
@@ -799,10 +799,8 @@ async def test_autodetect_websocket(hass: HomeAssistant):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remotews:
-        enter = Mock()
-        type(enter).token = PropertyMock(return_value="123456789")
         remote = Mock()
-        remote.__enter__ = Mock(return_value=enter)
+        remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock(return_value=False)
         remote.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -816,6 +814,7 @@ async def test_autodetect_websocket(hass: HomeAssistant):
                 "type": "Samsung SmartTV",
             },
         }
+        remote.token = "123456789"
         remotews.return_value = remote
 
         result = await hass.config_entries.flow.async_init(
@@ -846,10 +845,8 @@ async def test_websocket_no_mac(hass: HomeAssistant):
     ) as remotews, patch(
         "getmac.get_mac_address", return_value="gg:hh:ii:ll:mm:nn"
     ):
-        enter = Mock()
-        type(enter).token = PropertyMock(return_value="123456789")
         remote = Mock()
-        remote.__enter__ = Mock(return_value=enter)
+        remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock(return_value=False)
         remote.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -861,6 +858,7 @@ async def test_websocket_no_mac(hass: HomeAssistant):
                 "type": "Samsung SmartTV",
             },
         }
+        remote.token = "123456789"
         remotews.return_value = remote
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1222,7 +1222,10 @@ async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch.object(remotews, "open", side_effect=ConnectionFailure):
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        side_effect=ConnectionFailure,
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for Samsung TV config flow."""
 import socket
-from unittest.mock import Mock, PropertyMock, call, patch
+from unittest.mock import Mock, call, patch
 
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
@@ -814,7 +814,7 @@ async def test_autodetect_websocket(hass: HomeAssistant):
                 "type": "Samsung SmartTV",
             },
         }
-        remote.token = PropertyMock(return_value="123456789")
+        remote.token = "123456789"
         remotews.return_value = remote
 
         result = await hass.config_entries.flow.async_init(
@@ -858,7 +858,7 @@ async def test_websocket_no_mac(hass: HomeAssistant):
                 "type": "Samsung SmartTV",
             },
         }
-        remote.token = PropertyMock(return_value="123456789")
+        remote.token = "123456789"
         remotews.return_value = remote
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -3,6 +3,7 @@ import socket
 from unittest.mock import Mock, call, patch
 
 from samsungctl.exceptions import AccessDenied, UnhandledResponse
+from samsungtvws import SamsungTVWS
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from websocket import WebSocketException, WebSocketProtocolException
 
@@ -799,7 +800,7 @@ async def test_autodetect_websocket(hass: HomeAssistant):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remotews:
-        remote = Mock()
+        remote = Mock(SamsungTVWS)
         remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock(return_value=False)
         remote.rest_device_info.return_value = {
@@ -845,7 +846,7 @@ async def test_websocket_no_mac(hass: HomeAssistant):
     ) as remotews, patch(
         "getmac.get_mac_address", return_value="gg:hh:ii:ll:mm:nn"
     ):
-        remote = Mock()
+        remote = Mock(SamsungTVWS)
         remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock(return_value=False)
         remote.rest_device_info.return_value = {

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
+from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, call, patch
 
 import pytest
 from samsungctl import exceptions
@@ -151,10 +151,8 @@ async def test_setup_without_turnon(hass, remote):
 async def test_setup_websocket(hass, remotews):
     """Test setup of platform."""
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
-        enter = Mock()
-        type(enter).token = PropertyMock(return_value="987654321")
         remote = Mock()
-        remote.__enter__ = Mock(return_value=enter)
+        remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock()
         remote.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -166,6 +164,7 @@ async def test_setup_websocket(hass, remotews):
                 "networkType": "wireless",
             },
         }
+        remote.token = "987654321"
         remote_class.return_value = remote
 
         await setup_samsungtv(hass, MOCK_CONFIGWS)
@@ -200,10 +199,8 @@ async def test_setup_websocket_2(hass, mock_now):
     assert entry is config_entries[0]
 
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
-        enter = Mock()
-        type(enter).token = PropertyMock(return_value="987654321")
         remote = Mock()
-        remote.__enter__ = Mock(return_value=enter)
+        remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock()
         remote.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -215,6 +212,7 @@ async def test_setup_websocket_2(hass, mock_now):
                 "networkType": "wireless",
             },
         }
+        remote.token = "987654321"
         remote_class.return_value = remote
         assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
         await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
+from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, call, patch
 
 import pytest
 from samsungctl import exceptions
@@ -164,7 +164,7 @@ async def test_setup_websocket(hass, remotews):
                 "networkType": "wireless",
             },
         }
-        remote.token = PropertyMock(return_value="987654321")
+        remote.token = "987654321"
         remote_class.return_value = remote
 
         await setup_samsungtv(hass, MOCK_CONFIGWS)
@@ -212,7 +212,7 @@ async def test_setup_websocket_2(hass, mock_now):
                 "networkType": "wireless",
             },
         }
-        remote.token = PropertyMock(return_value="987654321")
+        remote.token = "987654321"
         remote_class.return_value = remote
         assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
         await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, call, patch
+from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, PropertyMock, call, patch
 
 import pytest
 from samsungctl import exceptions
@@ -164,7 +164,7 @@ async def test_setup_websocket(hass, remotews):
                 "networkType": "wireless",
             },
         }
-        remote.token = "987654321"
+        remote.token = PropertyMock(return_value="987654321")
         remote_class.return_value = remote
 
         await setup_samsungtv(hass, MOCK_CONFIGWS)
@@ -212,7 +212,7 @@ async def test_setup_websocket_2(hass, mock_now):
                 "networkType": "wireless",
             },
         }
-        remote.token = "987654321"
+        remote.token = PropertyMock(return_value="987654321")
         remote_class.return_value = remote
         assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
         await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -297,10 +297,7 @@ async def test_update_connection_failure(hass, remotews, mock_now):
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-        with patch(
-            "homeassistant.components.samsungtv.bridge.SamsungTVWS",
-            side_effect=ConnectionFailure("Boom"),
-        ):
+        with patch.object(remotews, "open", side_effect=ConnectionFailure("Boom")):
             next_update = mock_now + timedelta(minutes=5)
             with patch("homeassistant.util.dt.utcnow", return_value=next_update):
                 async_fire_time_changed(hass, next_update)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -297,7 +297,10 @@ async def test_update_connection_failure(hass, remotews, mock_now):
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-        with patch.object(remotews, "open", side_effect=ConnectionFailure("Boom")):
+        with patch(
+            "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+            side_effect=ConnectionFailure("Boom"),
+        ):
             next_update = mock_now + timedelta(minutes=5)
             with patch("homeassistant.util.dt.utcnow", return_value=next_update):
                 async_fire_time_changed(hass, next_update)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -6,6 +6,7 @@ from unittest.mock import DEFAULT as DEFAULT_MOCK, Mock, call, patch
 
 import pytest
 from samsungctl import exceptions
+from samsungtvws import SamsungTVWS
 from samsungtvws.exceptions import ConnectionFailure
 from websocket import WebSocketException
 
@@ -151,7 +152,7 @@ async def test_setup_without_turnon(hass, remote):
 async def test_setup_websocket(hass, remotews):
     """Test setup of platform."""
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
-        remote = Mock()
+        remote = Mock(SamsungTVWS)
         remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock()
         remote.rest_device_info.return_value = {
@@ -199,7 +200,7 @@ async def test_setup_websocket_2(hass, mock_now):
     assert entry is config_entries[0]
 
     with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
-        remote = Mock()
+        remote = Mock(SamsungTVWS)
         remote.__enter__ = Mock(return_value=remote)
         remote.__exit__ = Mock()
         remote.rest_device_info.return_value = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure the `__enter__`  method mock returns the correct object, so that we can apply further patching outside of the fixture.

As per https://github.com/xchwarze/samsung-tv-ws-api/blob/d539372cb7dc93e7b94bb3fdf5cc57f585b69e45/samsungtvws/remote.py#L36
```python
class SamsungTVWS:
    ...

    def __enter__(self):
        return self
```
Needed for #66651

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
