### PR TITLE
Fix side_effect patching in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -925,12 +925,17 @@ async def test_autodetect_legacy(hass: HomeAssistant, remote: Mock):
 
 async def test_autodetect_none(hass: HomeAssistant):
     """Test for send key with autodetection of protocol."""
+    mock_remotews = Mock()
+    mock_remotews.__enter__ = Mock(return_value=mock_remotews)
+    mock_remotews.__exit__ = Mock()
+    mock_remotews.open = Mock(side_effect=OSError("Boom"))
+
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ) as remote, patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
-        side_effect=OSError("Boom"),
+        return_value=mock_remotews,
     ) as remotews:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}, data=MOCK_USER_DATA

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1226,10 +1226,7 @@ async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
-        side_effect=ConnectionFailure,
-    ):
+    with patch.object(remotews, "open", side_effect=ConnectionFailure):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -267,7 +267,7 @@ async def test_user_websocket_not_supported(hass: HomeAssistant):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=WebSocketProtocolException("Boom"),
     ):
         # websocket device not supported
@@ -284,7 +284,7 @@ async def test_user_not_successful(hass: HomeAssistant):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=OSError("Boom"),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -300,7 +300,7 @@ async def test_user_not_successful_2(hass: HomeAssistant):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=ConnectionFailure("Boom"),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -455,7 +455,7 @@ async def test_ssdp_websocket_not_supported(hass: HomeAssistant):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=WebSocketProtocolException("Boom"),
     ):
         # device not supported
@@ -485,7 +485,7 @@ async def test_ssdp_not_successful(hass: HomeAssistant, no_mac_address: Mock):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=OSError("Boom"),
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
@@ -513,7 +513,7 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant, no_mac_address: Mock):
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=ConnectionFailure("Boom"),
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
@@ -1257,7 +1257,7 @@ async def test_form_reauth_websocket_not_supported(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=WebSocketException,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -296,10 +296,7 @@ async def test_update_connection_failure(hass, remotews, mock_now):
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-        with patch(
-            "homeassistant.components.samsungtv.bridge.SamsungTVWS",
-            side_effect=ConnectionFailure("Boom"),
-        ):
+        with patch.object(remotews, "open", side_effect=ConnectionFailure("Boom")):
             next_update = mock_now + timedelta(minutes=5)
             with patch("homeassistant.util.dt.utcnow", return_value=next_update):
                 async_fire_time_changed(hass, next_update)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This moves the side_effect to the correct location, as the constructor cannot raise an exception, only some of the method calls.
Needs: #66650

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
