### PR TITLE
Remove deprecated way of setting fan preset in Vallox

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -29,7 +29,6 @@ from .const import (
     METRIC_KEY_PROFILE_FAN_SPEED_BOOST,
     METRIC_KEY_PROFILE_FAN_SPEED_HOME,
     STATE_SCAN_INTERVAL,
-    STR_TO_VALLOX_PROFILE_SETTABLE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,16 +54,7 @@ PLATFORMS: list[str] = [
     Platform.BINARY_SENSOR,
 ]
 
-ATTR_PROFILE = "profile"
 ATTR_PROFILE_FAN_SPEED = "fan_speed"
-
-SERVICE_SCHEMA_SET_PROFILE = vol.Schema(
-    {
-        vol.Required(ATTR_PROFILE): vol.All(
-            cv.string, vol.In(STR_TO_VALLOX_PROFILE_SETTABLE)
-        )
-    }
-)
 
 SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED = vol.Schema(
     {
@@ -82,16 +72,11 @@ class ServiceMethodDetails(NamedTuple):
     schema: vol.Schema
 
 
-SERVICE_SET_PROFILE = "set_profile"
 SERVICE_SET_PROFILE_FAN_SPEED_HOME = "set_profile_fan_speed_home"
 SERVICE_SET_PROFILE_FAN_SPEED_AWAY = "set_profile_fan_speed_away"
 SERVICE_SET_PROFILE_FAN_SPEED_BOOST = "set_profile_fan_speed_boost"
 
 SERVICE_TO_METHOD = {
-    SERVICE_SET_PROFILE: ServiceMethodDetails(
-        method="async_set_profile",
-        schema=SERVICE_SCHEMA_SET_PROFILE,
-    ),
     SERVICE_SET_PROFILE_FAN_SPEED_HOME: ServiceMethodDetails(
         method="async_set_profile_fan_speed_home",
         schema=SERVICE_SCHEMA_SET_PROFILE_FAN_SPEED,
@@ -228,24 +213,6 @@ class ValloxServiceHandler:
         """Initialize the proxy."""
         self._client = client
         self._coordinator = coordinator
-
-    async def async_set_profile(self, profile: str = "Home") -> bool:
-        """Set the ventilation profile."""
-        _LOGGER.debug("Setting ventilation profile to: %s", profile)
-
-        _LOGGER.warning(
-            "Attention: The service 'vallox.set_profile' is superseded by the "
-            "'fan.set_preset_mode' service. It will be removed in the future, please migrate to "
-            "'fan.set_preset_mode' to prevent breakage"
-        )
-
-        try:
-            await self._client.set_profile(STR_TO_VALLOX_PROFILE_SETTABLE[profile])
-            return True
-
-        except (OSError, ValloxApiException) as err:
-            _LOGGER.error("Error setting ventilation profile: %s", err)
-            return False
 
     async def async_set_profile_fan_speed_home(
         self, fan_speed: int = DEFAULT_FAN_SPEED_HOME

--- a/homeassistant/components/vallox/services.yaml
+++ b/homeassistant/components/vallox/services.yaml
@@ -1,19 +1,3 @@
-set_profile:
-  name: Set profile
-  description: Set the ventilation profile.
-  fields:
-    profile:
-      name: Profile
-      description: "Set profile."
-      required: true
-      selector:
-        select:
-          options:
-            - 'Away'
-            - 'Boost'
-            - 'Fireplace'
-            - 'Home'
-
 set_profile_fan_speed_home:
   name: Set profile fan speed home
   description: Set the fan speed of the Home profile.


### PR DESCRIPTION
It has been some months now since we switched Vallox to the new fan
platform, which brings inherent support for switching the fan profile.

It's time to remove the old and deprecated way now.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21671

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
