### PR TITLE
Add Classic200S and Dual200S support for vesync integration

### DIFF
--- a/homeassistant/components/vesync/manifest.json
+++ b/homeassistant/components/vesync/manifest.json
@@ -3,7 +3,7 @@
   "name": "VeSync",
   "documentation": "https://www.home-assistant.io/integrations/vesync",
   "codeowners": ["@markperdue", "@webdjoe", "@thegardenmonkey"],
-  "requirements": ["pyvesync==1.4.2"],
+  "requirements": ["pyvesync==1.4.3"],
   "config_flow": true,
   "iot_class": "cloud_polling",
   "loggers": ["pyvesync"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR implements support for the Levoit Classic 200S and Dual 200S humidifiers in the VeSync core integration.  The following PR was recently merged into pyvesync master branch and version released, which now makes HA support possible:
- https://github.com/webdjoe/pyvesync/pull/104
- https://pypi.org/project/pyvesync/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/61417
- This PR is related to issue: 
- Link to documentation pull request: 

I have both the Classic 200S and Dual 200S humidifiers and was able to implement support in Home Assistant and test against my humidifers.

1. Adding support for Classic200S and Dual200S
As of pyvesync v1.4.3, fans and humidifiers don't have all of the same implemented methods and variables.  The pyvesync core developers may consider fans and humidifiers as different device types which is why implementing the same functions across both types may not be the best solution.  To address unimplemented humidifier logic, I've implemented the following alternative logic:
- Humidifiers use `set_mist_level()` in place of `change_fan_speed()`
- Humidifiers use `automatic_stop_on` in place of `auto_mode()`

2. Adding support for different fan speeds based on device type
- Classic200S has 9 fan speeds
- Dual200S has 2 fan speeds
- Existing fans retain 3 fan speeds (logic unchanged)

3. Implemented `turn_off()` method with `device_status = 'off'`
4. Fixed `turn_on()` method by implementing `device_status = 'on'`.  Various wrapper functions around the entity's status ultimately key off of the fan's `device_status` variable.
5. Bumped pyvesync version requirements to 1.4.3 to address dependency on Classic200S and Dual200S implementation

Known issues:
- Preset mode 'auto' doesn't currently work with the Classic200S and Dual200S humidifiers as `device_type` isn't being set within pyvesync.
- There are also a number of other variables that are not properly being set.  Rather than code additional workaround logic here, I believe the best place to implement this will be in pyvesync directly.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.
- https://github.com/home-assistant/core/pull/51563#pullrequestreview-854743655
- https://github.com/home-assistant/core/pull/62907#pullrequestreview-885312717

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
