### PR TITLE
Proxy Plex thumbnail images in media browser

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -920,6 +920,7 @@ omit =
     homeassistant/components/plaato/entity.py
     homeassistant/components/plaato/sensor.py
     homeassistant/components/plex/media_player.py
+    homeassistant/components/plex/view.py
     homeassistant/components/plum_lightpad/light.py
     homeassistant/components/pocketcasts/sensor.py
     homeassistant/components/point/__init__.py

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -999,7 +999,7 @@ class MediaPlayerEntity(Entity):
 
     async def _async_fetch_image(self, url: str) -> tuple[bytes | None, str | None]:
         """Retrieve an image."""
-        return await async_fetch_image(self.hass, url)
+        return await async_fetch_image(_LOGGER, self.hass, url)
 
     def get_browse_image_url(
         self,
@@ -1190,7 +1190,7 @@ async def websocket_browse_media(hass, connection, msg):
 
 
 async def async_fetch_image(
-    hass: HomeAssistant, url: str
+    logger: logging.Logger, hass: HomeAssistant, url: str
 ) -> tuple[bytes | None, str | None]:
     """Retrieve an image."""
     content, content_type = (None, None)
@@ -1209,6 +1209,6 @@ async def async_fetch_image(
         if url_parts.password is not None:
             url_parts = url_parts.with_password("xxxxxxxx")
         url = str(url_parts)
-        _LOGGER.warning("Error retrieving proxied image from %s", url)
+        logger.warning("Error retrieving proxied image from %s", url)
 
     return content, content_type

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -999,25 +999,7 @@ class MediaPlayerEntity(Entity):
 
     async def _async_fetch_image(self, url: str) -> tuple[bytes | None, str | None]:
         """Retrieve an image."""
-        content, content_type = (None, None)
-        websession = async_get_clientsession(self.hass)
-        with suppress(asyncio.TimeoutError), async_timeout.timeout(10):
-            response = await websession.get(url)
-            if response.status == HTTPStatus.OK:
-                content = await response.read()
-                if content_type := response.headers.get(CONTENT_TYPE):
-                    content_type = content_type.split(";")[0]
-
-        if content is None:
-            url_parts = URL(url)
-            if url_parts.user is not None:
-                url_parts = url_parts.with_user("xxxx")
-            if url_parts.password is not None:
-                url_parts = url_parts.with_password("xxxxxxxx")
-            url = str(url_parts)
-            _LOGGER.warning("Error retrieving proxied image from %s", url)
-
-        return content, content_type
+        return await async_fetch_image(self.hass, url)
 
     def get_browse_image_url(
         self,
@@ -1205,3 +1187,28 @@ async def websocket_browse_media(hass, connection, msg):
         _LOGGER.warning("Browse Media should use new BrowseMedia class")
 
     connection.send_result(msg["id"], payload)
+
+
+async def async_fetch_image(
+    hass: HomeAssistant, url: str
+) -> tuple[bytes | None, str | None]:
+    """Retrieve an image."""
+    content, content_type = (None, None)
+    websession = async_get_clientsession(hass)
+    with suppress(asyncio.TimeoutError), async_timeout.timeout(10):
+        response = await websession.get(url)
+        if response.status == HTTPStatus.OK:
+            content = await response.read()
+            if content_type := response.headers.get(CONTENT_TYPE):
+                content_type = content_type.split(";")[0]
+
+    if content is None:
+        url_parts = URL(url)
+        if url_parts.user is not None:
+            url_parts = url_parts.with_user("xxxx")
+        if url_parts.password is not None:
+            url_parts = url_parts.with_password("xxxxxxxx")
+        url = str(url_parts)
+        _LOGGER.warning("Error retrieving proxied image from %s", url)
+
+    return content, content_type

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -85,7 +85,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     await async_setup_services(hass)
 
-    hass.http.register_view(PlexImageView(hass))
+    hass.http.register_view(PlexImageView())
 
     gdm = hass.data[PLEX_DOMAIN][GDM_SCANNER] = GDM()
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -85,6 +85,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     await async_setup_services(hass)
 
+    hass.http.register_view(PlexImageView(hass))
+
     gdm = hass.data[PLEX_DOMAIN][GDM_SCANNER] = GDM()
 
     def gdm_scan():
@@ -163,8 +165,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     server_id = plex_server.machine_identifier
     hass.data[PLEX_DOMAIN][SERVERS][server_id] = plex_server
     hass.data[PLEX_DOMAIN][PLATFORMS_COMPLETED][server_id] = set()
-
-    hass.http.register_view(PlexImageView(hass, server_id))
 
     entry.add_update_listener(async_options_updated)
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -48,6 +48,7 @@ from .errors import ShouldUpdateConfigEntry
 from .media_browser import browse_media
 from .server import PlexServer
 from .services import async_setup_services
+from .view import PlexImageView
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -162,6 +163,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     server_id = plex_server.machine_identifier
     hass.data[PLEX_DOMAIN][SERVERS][server_id] = plex_server
     hass.data[PLEX_DOMAIN][PLATFORMS_COMPLETED][server_id] = set()
+
+    hass.http.register_view(PlexImageView(hass, server_id))
 
     entry.add_update_listener(async_options_updated)
 

--- a/homeassistant/components/plex/media_browser.py
+++ b/homeassistant/components/plex/media_browser.py
@@ -1,5 +1,9 @@
 """Support to interface with the Plex API."""
+from __future__ import annotations
+
 import logging
+
+import yarl
 
 from homeassistant.components.media_player import BrowseMedia
 from homeassistant.components.media_player.const import (
@@ -73,7 +77,15 @@ def browse_media(  # noqa: C901
             "can_expand": item.type in EXPANDABLES,
         }
         if hasattr(item, "thumbUrl"):
-            payload["thumbnail"] = item.thumbUrl
+            plex_server.thumbnail_cache.setdefault(str(item.ratingKey), item.thumbUrl)
+            if is_internal:
+                thumbnail = item.thumbUrl
+            else:
+                thumbnail = get_proxy_image_url(
+                    plex_server.machine_identifier,
+                    item.ratingKey,
+                )
+            payload["thumbnail"] = thumbnail
 
         return BrowseMedia(**payload)
 
@@ -321,3 +333,12 @@ def station_payload(station):
         can_play=True,
         can_expand=False,
     )
+
+
+def get_proxy_image_url(
+    server_id: str,
+    media_content_id: str,
+) -> str:
+    """Generate an url for a Plex media browser image."""
+    url_path = f"/api/plex_image_proxy/{server_id}/{media_content_id}"
+    return str(yarl.URL(url_path))

--- a/homeassistant/components/plex/media_browser.py
+++ b/homeassistant/components/plex/media_browser.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import logging
 
-import yarl
-
 from homeassistant.components.media_player import BrowseMedia
 from homeassistant.components.media_player.const import (
     MEDIA_CLASS_ALBUM,
@@ -340,5 +338,4 @@ def get_proxy_image_url(
     media_content_id: str,
 ) -> str:
     """Generate an url for a Plex media browser image."""
-    url_path = f"/api/plex_image_proxy/{server_id}/{media_content_id}"
-    return str(yarl.URL(url_path))
+    return f"/api/plex_image_proxy/{server_id}/{media_content_id}"

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -585,17 +585,3 @@ class PlexMediaPlayer(MediaPlayerEntity):
             media_content_type,
             media_content_id,
         )
-
-    async def async_get_browse_image(
-        self,
-        media_content_type: str,
-        media_content_id: str,
-        media_image_id: str | None = None,
-    ) -> tuple[bytes | None, str | None]:
-        """Get media image from Plex server."""
-        image_url = self.plex_server.thumbnail_cache.get(media_content_id)
-        if image_url:
-            result = await self._async_fetch_image(image_url)
-            return result
-
-        return (None, None)

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -25,8 +25,8 @@ class PlexImageView(HomeAssistantView):
     async def get(  # pylint: disable=no-self-use
         self,
         request: web.Request,
+        media_content_id: str,
         server_id: str | None = None,
-        media_content_id: str | None = None,
     ) -> web.Response:
         """Start a get request."""
         if not request[KEY_AUTHENTICATED]:
@@ -37,13 +37,10 @@ class PlexImageView(HomeAssistantView):
             _LOGGER.error("Plex server_id %s not known", server_id)
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
-        if media_content_id:
-            if (image_url := server.thumbnail_cache.get(media_content_id)) is None:
-                _LOGGER.debug(
-                    "Thumbnail URL for %s not found in cache", media_content_id
-                )
-                return web.Response(status=HTTPStatus.NOT_FOUND)
-            data, content_type = await async_fetch_image(_LOGGER, hass, image_url)
+        if (image_url := server.thumbnail_cache.get(media_content_id)) is None:
+            _LOGGER.debug("Thumbnail URL for %s not found in cache", media_content_id)
+            return web.Response(status=HTTPStatus.NOT_FOUND)
+        data, content_type = await async_fetch_image(_LOGGER, hass, image_url)
 
         if data is None:
             return web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -1,20 +1,16 @@
 """Implement a view to provide proxied Plex thumbnails to the media browser."""
 from __future__ import annotations
 
-import asyncio
-from contextlib import suppress
 from http import HTTPStatus
 import logging
 
 from aiohttp import web
-from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
+from aiohttp.hdrs import CACHE_CONTROL
 from aiohttp.typedefs import LooseHeaders
-import async_timeout
-from yarl import URL
 
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
+from homeassistant.components.media_player import async_fetch_image
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN as PLEX_DOMAIN, SERVERS
 
@@ -48,32 +44,10 @@ class PlexImageView(HomeAssistantView):
         server = self.hass.data[PLEX_DOMAIN][SERVERS][self.server_id]
         if media_content_id:
             image_url = server.thumbnail_cache.get(media_content_id)
-            data, content_type = await self._async_fetch_image(image_url)
+            data, content_type = await async_fetch_image(self.hass, image_url)
 
         if data is None:
             return web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         headers: LooseHeaders = {CACHE_CONTROL: "max-age=3600"}
         return web.Response(body=data, content_type=content_type, headers=headers)
-
-    async def _async_fetch_image(self, url: str) -> tuple[bytes | None, str | None]:
-        """Retrieve an image."""
-        content, content_type = (None, None)
-        websession = async_get_clientsession(self.hass)
-        with suppress(asyncio.TimeoutError), async_timeout.timeout(10):
-            response = await websession.get(url)
-            if response.status == HTTPStatus.OK:
-                content = await response.read()
-                if content_type := response.headers.get(CONTENT_TYPE):
-                    content_type = content_type.split(";")[0]
-
-        if content is None:
-            url_parts = URL(url)
-            if url_parts.user is not None:
-                url_parts = url_parts.with_user("xxxx")
-            if url_parts.password is not None:
-                url_parts = url_parts.with_password("xxxxxxxx")
-            url = str(url_parts)
-            _LOGGER.warning("Error retrieving proxied image from %s", url)
-
-        return content, content_type

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -25,8 +25,8 @@ class PlexImageView(HomeAssistantView):
     async def get(  # pylint: disable=no-self-use
         self,
         request: web.Request,
+        server_id: str,
         media_content_id: str,
-        server_id: str | None = None,
     ) -> web.Response:
         """Start a get request."""
         if not request[KEY_AUTHENTICATED]:

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -34,16 +34,15 @@ class PlexImageView(HomeAssistantView):
 
         hass = request.app["hass"]
         if (server := hass.data[PLEX_DOMAIN][SERVERS].get(server_id)) is None:
-            _LOGGER.error("Plex server_id %s not known", server_id)
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
         if (image_url := server.thumbnail_cache.get(media_content_id)) is None:
-            _LOGGER.debug("Thumbnail URL for %s not found in cache", media_content_id)
             return web.Response(status=HTTPStatus.NOT_FOUND)
+
         data, content_type = await async_fetch_image(_LOGGER, hass, image_url)
 
         if data is None:
-            return web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return web.Response(status=HTTPStatus.SERVICE_UNAVAILABLE)
 
         headers: LooseHeaders = {CACHE_CONTROL: "max-age=3600"}
         return web.Response(body=data, content_type=content_type, headers=headers)

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 class PlexImageView(HomeAssistantView):
     """Media player view to serve a Plex image."""
 
-    requires_auth = False
     name = "api:plex:image"
     url = "/api/plex_image_proxy/{server_id}/{media_content_id}"
 
@@ -39,7 +38,7 @@ class PlexImageView(HomeAssistantView):
             return web.Response(status=HTTPStatus.UNAUTHORIZED)
 
         if (server := self.hass.data[PLEX_DOMAIN][SERVERS].get(server_id)) is None:
-            return web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return web.Response(status=HTTPStatus.NOT_FOUND)
 
         if media_content_id:
             image_url = server.thumbnail_cache.get(media_content_id)

--- a/homeassistant/components/plex/view.py
+++ b/homeassistant/components/plex/view.py
@@ -1,0 +1,79 @@
+"""Implement a view to provide proxied Plex thumbnails to the media browser."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from http import HTTPStatus
+import logging
+
+from aiohttp import web
+from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
+from aiohttp.typedefs import LooseHeaders
+import async_timeout
+from yarl import URL
+
+from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN as PLEX_DOMAIN, SERVERS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PlexImageView(HomeAssistantView):
+    """Media player view to serve a Plex image."""
+
+    requires_auth = False
+    name = "api:plex:image"
+
+    def __init__(self, hass: HomeAssistant, server_id: str) -> None:
+        """Initialize a media player view."""
+        self.hass = hass
+        self.server_id = server_id
+        self.url = f"/api/plex_image_proxy/{server_id}"
+        self.extra_urls = [
+            self.url + "/{media_content_id}",
+        ]
+
+    async def get(
+        self,
+        request: web.Request,
+        media_content_id: str | None = None,
+    ) -> web.Response:
+        """Start a get request."""
+        if not request[KEY_AUTHENTICATED]:
+            return web.Response(status=HTTPStatus.UNAUTHORIZED)
+
+        server = self.hass.data[PLEX_DOMAIN][SERVERS][self.server_id]
+        if media_content_id:
+            image_url = server.thumbnail_cache.get(media_content_id)
+            data, content_type = await self._async_fetch_image(image_url)
+
+        if data is None:
+            return web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        headers: LooseHeaders = {CACHE_CONTROL: "max-age=3600"}
+        return web.Response(body=data, content_type=content_type, headers=headers)
+
+    async def _async_fetch_image(self, url: str) -> tuple[bytes | None, str | None]:
+        """Retrieve an image."""
+        content, content_type = (None, None)
+        websession = async_get_clientsession(self.hass)
+        with suppress(asyncio.TimeoutError), async_timeout.timeout(10):
+            response = await websession.get(url)
+            if response.status == HTTPStatus.OK:
+                content = await response.read()
+                if content_type := response.headers.get(CONTENT_TYPE):
+                    content_type = content_type.split(";")[0]
+
+        if content is None:
+            url_parts = URL(url)
+            if url_parts.user is not None:
+                url_parts = url_parts.with_user("xxxx")
+            if url_parts.password is not None:
+                url_parts = url_parts.with_password("xxxxxxxx")
+            url = str(url_parts)
+            _LOGGER.warning("Error retrieving proxied image from %s", url)
+
+        return content, content_type


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change proxies Plex media browser thumbnail images through the backend when the frontend is connecting remotely. Local frontends will still query the Plex server directly for images.

This functionality was previously temporarily removed in #64951.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
