### PR TITLE
Startup with an emergency self signed cert if the ssl certificate cannot be loaded

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -158,8 +158,11 @@ async def async_setup_hass(
 
         safe_mode = True
         old_config = hass.config
+        old_logging = hass.data.get(DATA_LOGGING)
 
         hass = core.HomeAssistant()
+        if old_logging:
+            hass.data[DATA_LOGGING] = old_logging
         hass.config.skip_pip = old_config.skip_pip
         hass.config.internal_url = old_config.internal_url
         hass.config.external_url = old_config.external_url

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -421,7 +421,7 @@ class HomeAssistantHTTP:
 
     async def start(self) -> None:
         """Start the aiohttp server."""
-        context: ssl.SSLContext | None
+        context: ssl.SSLContext | None = None
         if self.ssl_certificate:
             context = await self.hass.async_add_executor_job(self._create_ssl_context)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -22,6 +22,7 @@ from yarl import URL
 from homeassistant.components.network import async_get_source_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, SERVER_PORT
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import storage
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.network import NoURLAvailableError, get_url
@@ -362,10 +363,14 @@ class HomeAssistantHTTP:
                     "Could not create an emergency self signed ssl certificate: %s",
                     error,
                 )
-                return None
+                context = None
 
-        assert context is not None
         if self.ssl_peer_certificate:
+            if context is None:
+                raise HomeAssistantError(
+                    "Failed to create ssl context, no fallback available because a peer certificate is required."
+                )
+
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_verify_locations(self.ssl_peer_certificate)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -1,22 +1,30 @@
 """Support to serve the Home Assistant API as WSGI application."""
 from __future__ import annotations
 
+import datetime
 from ipaddress import IPv4Network, IPv6Network, ip_network
 import logging
 import os
 import ssl
+from tempfile import NamedTemporaryFile
 from typing import Any, Final, Optional, TypedDict, Union, cast
 
 from aiohttp import web
 from aiohttp.typedefs import StrOrURL
 from aiohttp.web_exceptions import HTTPMovedPermanently, HTTPRedirection
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.components.network import async_get_source_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, SERVER_PORT
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import storage
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_start_setup, async_when_setup_or_start
@@ -329,34 +337,93 @@ class HomeAssistantHTTP:
             self.app.router.add_route("GET", url_path, serve_file)
         )
 
+    def _create_ssl_context(self) -> ssl.SSLContext | None:
+        context: ssl.SSLContext | None = None
+        assert self.ssl_certificate is not None
+        try:
+            if self.ssl_profile == SSL_INTERMEDIATE:
+                context = ssl_util.server_context_intermediate()
+            else:
+                context = ssl_util.server_context_modern()
+            context.load_cert_chain(self.ssl_certificate, self.ssl_key)
+        except OSError as error:
+            _LOGGER.error(
+                "Could not read SSL certificate from %s: %s",
+                self.ssl_certificate,
+                error,
+            )
+            _LOGGER.warning(
+                "The server will start up with an emergency self signed ssl certificate"
+            )
+            try:
+                return self._create_emergency_ssl_context()
+            except OSError as error:
+                _LOGGER.error(
+                    "Could not create an emergency self signed ssl certificate: %s",
+                    error,
+                )
+                return None
+
+        assert context is not None
+        if self.ssl_peer_certificate:
+            context.verify_mode = ssl.CERT_REQUIRED
+            context.load_verify_locations(self.ssl_peer_certificate)
+
+        return context
+
+    def _create_emergency_ssl_context(self) -> ssl.SSLContext | None:
+        """Create an emergency ssl certificate so we can still startup."""
+        context = ssl_util.server_context_modern()
+        host: str
+        try:
+            host = cast(str, URL(get_url(self.hass, prefer_external=True)).host)
+        except NoURLAvailableError:
+            host = "homeassistant.local"
+        key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+        )
+        subject = issuer = x509.Name(
+            [
+                x509.NameAttribute(
+                    NameOID.ORGANIZATION_NAME, "Home Assistant Emergency Certificate"
+                ),
+                x509.NameAttribute(NameOID.COMMON_NAME, host),
+            ]
+        )
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow())
+            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=30))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(host)]),
+                critical=False,
+            )
+            .sign(key, hashes.SHA256())
+        )
+        with NamedTemporaryFile() as cert_pem, NamedTemporaryFile() as key_pem:
+            cert_pem.write(cert.public_bytes(serialization.Encoding.PEM))
+            key_pem.write(
+                key.private_bytes(
+                    serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=serialization.NoEncryption(),
+                )
+            )
+            cert_pem.flush()
+            key_pem.flush()
+            context.load_cert_chain(cert_pem.name, key_pem.name)
+        return context
+
     async def start(self) -> None:
         """Start the aiohttp server."""
         context: ssl.SSLContext | None
         if self.ssl_certificate:
-            try:
-                if self.ssl_profile == SSL_INTERMEDIATE:
-                    context = ssl_util.server_context_intermediate()
-                else:
-                    context = ssl_util.server_context_modern()
-                await self.hass.async_add_executor_job(
-                    context.load_cert_chain, self.ssl_certificate, self.ssl_key
-                )
-            except OSError as error:
-                _LOGGER.error(
-                    "Could not read SSL certificate from %s: %s",
-                    self.ssl_certificate,
-                    error,
-                )
-                return
-
-            if self.ssl_peer_certificate:
-                context.verify_mode = ssl.CERT_REQUIRED
-                await self.hass.async_add_executor_job(
-                    context.load_verify_locations, self.ssl_peer_certificate
-                )
-
-        else:
-            context = None
+            context = await self.hass.async_add_executor_job(self._create_ssl_context)
 
         # Aiohttp freezes apps after start so that no changes can be made.
         # However in Home Assistant components can be discovered after boot.

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -225,7 +225,7 @@ async def test_emergency_ssl_certificate_when_invalid(hass, tmpdir, caplog):
     await hass.async_start()
     await hass.async_block_till_done()
     assert (
-        "The server will start up with an emergency self signed ssl certificate"
+        "Home Assistant is running in safe mode with an emergency self signed ssl certificate because the configured SSL certificate was not usable"
         in caplog.text
     )
 
@@ -258,7 +258,7 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
 
     assert len(mock_get_url.mock_calls) == 1
     assert (
-        "The server will start up with an emergency self signed ssl certificate"
+        "Home Assistant is running in safe mode with an emergency self signed ssl certificate because the configured SSL certificate was not usable"
         in caplog.text
     )
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -268,12 +268,12 @@ async def test_emergency_ssl_certificate_when_invalid(hass, tmpdir, caplog):
         _setup_broken_ssl_pem_files, tmpdir
     )
 
+    hass.config.safe_mode = True
     assert (
         await async_setup_component(
             hass,
             "http",
             {
-                "safe_mode": {},
                 "http": {"ssl_certificate": cert_path, "ssl_key": key_path},
             },
         )
@@ -317,6 +317,7 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
     cert_path, key_path = await hass.async_add_executor_job(
         _setup_broken_ssl_pem_files, tmpdir
     )
+    hass.config.safe_mode = True
 
     with patch(
         "homeassistant.components.http.get_url", side_effect=NoURLAvailableError
@@ -326,7 +327,6 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
                 hass,
                 "http",
                 {
-                    "safe_mode": {},
                     "http": {"ssl_certificate": cert_path, "ssl_key": key_path},
                 },
             )
@@ -350,6 +350,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert(hass, tmpdir, caplog
     cert_path, key_path = await hass.async_add_executor_job(
         _setup_broken_ssl_pem_files, tmpdir
     )
+    hass.config.safe_mode = True
 
     with patch(
         "homeassistant.components.http.x509.CertificateBuilder", side_effect=OSError
@@ -359,7 +360,6 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert(hass, tmpdir, caplog
                 hass,
                 "http",
                 {
-                    "safe_mode": {},
                     "http": {"ssl_certificate": cert_path, "ssl_key": key_path},
                 },
             )
@@ -387,6 +387,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
     cert_path, key_path = await hass.async_add_executor_job(
         _setup_broken_ssl_pem_files, tmpdir
     )
+    hass.config.safe_mode = True
 
     with patch(
         "homeassistant.components.http.x509.CertificateBuilder", side_effect=OSError
@@ -396,7 +397,6 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
                 hass,
                 "http",
                 {
-                    "safe_mode": {},
                     "http": {
                         "ssl_certificate": cert_path,
                         "ssl_key": key_path,

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -17,6 +17,15 @@ from homeassistant.util.ssl import server_context_intermediate, server_context_m
 from tests.common import async_fire_time_changed
 
 
+def _setup_broken_ssl_pem_files(tmpdir):
+    test_dir = tmpdir.mkdir("test_broken_ssl")
+    cert_path = pathlib.Path(test_dir) / "cert.pem"
+    cert_path.write_text("garbage")
+    key_path = pathlib.Path(test_dir) / "key.pem"
+    key_path.write_text("garbage")
+    return cert_path, key_path
+
+
 @pytest.fixture
 def mock_stack():
     """Mock extract stack."""
@@ -179,19 +188,9 @@ async def test_ssl_profile_change_modern(hass):
 async def test_emergency_ssl_certificate_when_invalid(hass, tmpdir, caplog):
     """Test http can startup with an emergency self signed cert when the current one is broken."""
 
-    cert_path = None
-    key_path = None
-
-    def _setup_test_files():
-        nonlocal cert_path
-        nonlocal key_path
-        test_dir = tmpdir.mkdir("test_broken_ssl")
-        cert_path = pathlib.Path(test_dir) / "cert.pem"
-        cert_path.write_text("garbage")
-        key_path = pathlib.Path(test_dir) / "key.pem"
-        key_path.write_text("garbage")
-
-    await hass.async_add_executor_job(_setup_test_files)
+    cert_path, key_path = await hass.async_add_executor_job(
+        _setup_broken_ssl_pem_files, tmpdir
+    )
 
     assert (
         await async_setup_component(
@@ -218,20 +217,9 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
 
     Ensure we can still start of we cannot determine the external url as well.
     """
-
-    cert_path = None
-    key_path = None
-
-    def _setup_test_files():
-        nonlocal cert_path
-        nonlocal key_path
-        test_dir = tmpdir.mkdir("test_broken_ssl")
-        cert_path = pathlib.Path(test_dir) / "cert.pem"
-        cert_path.write_text("garbage")
-        key_path = pathlib.Path(test_dir) / "key.pem"
-        key_path.write_text("garbage")
-
-    await hass.async_add_executor_job(_setup_test_files)
+    cert_path, key_path = await hass.async_add_executor_job(
+        _setup_broken_ssl_pem_files, tmpdir
+    )
 
     assert (
         await async_setup_component(
@@ -260,19 +248,9 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
 async def test_invalid_ssl_and_cannot_create_emergency_cert(hass, tmpdir, caplog):
     """Test http falls back to no ssl when an emergency cert cannot be created when the configured one is broken."""
 
-    cert_path = None
-    key_path = None
-
-    def _setup_test_files():
-        nonlocal cert_path
-        nonlocal key_path
-        test_dir = tmpdir.mkdir("test_broken_ssl")
-        cert_path = pathlib.Path(test_dir) / "cert.pem"
-        cert_path.write_text("garbage")
-        key_path = pathlib.Path(test_dir) / "key.pem"
-        key_path.write_text("garbage")
-
-    await hass.async_add_executor_job(_setup_test_files)
+    cert_path, key_path = await hass.async_add_executor_job(
+        _setup_broken_ssl_pem_files, tmpdir
+    )
 
     assert (
         await async_setup_component(

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -230,6 +230,7 @@ async def test_emergency_ssl_certificate_when_invalid(hass, tmpdir, caplog):
     )
 
     assert hass.http.site is not None
+    assert hass.config.safe_mode is True
 
 
 async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
@@ -263,6 +264,7 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
     )
 
     assert hass.http.site is not None
+    assert hass.config.safe_mode is True
 
 
 async def test_invalid_ssl_and_cannot_create_emergency_cert(hass, tmpdir, caplog):

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -3,11 +3,13 @@ from datetime import timedelta
 from http import HTTPStatus
 from ipaddress import ip_network
 import logging
+import pathlib
 from unittest.mock import Mock, patch
 
 import pytest
 
 import homeassistant.components.http as http
+from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.ssl import server_context_intermediate, server_context_modern
@@ -172,6 +174,123 @@ async def test_ssl_profile_change_modern(hass):
         await hass.async_block_till_done()
 
     assert len(mock_context.mock_calls) == 1
+
+
+async def test_emergency_ssl_certificate_when_invalid(hass, tmpdir, caplog):
+    """Test http can startup with an emergency self signed cert when the current one is broken."""
+
+    cert_path = None
+    key_path = None
+
+    def _setup_test_files():
+        nonlocal cert_path
+        nonlocal key_path
+        test_dir = tmpdir.mkdir("test_broken_ssl")
+        cert_path = pathlib.Path(test_dir) / "cert.pem"
+        cert_path.write_text("garbage")
+        key_path = pathlib.Path(test_dir) / "key.pem"
+        key_path.write_text("garbage")
+
+    await hass.async_add_executor_job(_setup_test_files)
+
+    assert (
+        await async_setup_component(
+            hass, "http", {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}}
+        )
+        is True
+    )
+
+    hass.http.ssl_certificate = "bla"
+    await hass.async_start()
+    await hass.async_block_till_done()
+    assert (
+        "The server will start up with an emergency self signed ssl certificate"
+        in caplog.text
+    )
+
+    assert hass.http.site is not None
+
+
+async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
+    hass, tmpdir, caplog
+):
+    """Test http falls back to no ssl when an emergency cert cannot be created when the configured one is broken.
+
+    Ensure we can still start of we cannot determine the external url as well.
+    """
+
+    cert_path = None
+    key_path = None
+
+    def _setup_test_files():
+        nonlocal cert_path
+        nonlocal key_path
+        test_dir = tmpdir.mkdir("test_broken_ssl")
+        cert_path = pathlib.Path(test_dir) / "cert.pem"
+        cert_path.write_text("garbage")
+        key_path = pathlib.Path(test_dir) / "key.pem"
+        key_path.write_text("garbage")
+
+    await hass.async_add_executor_job(_setup_test_files)
+
+    assert (
+        await async_setup_component(
+            hass, "http", {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}}
+        )
+        is True
+    )
+
+    hass.http.ssl_certificate = "bla"
+
+    with patch(
+        "homeassistant.components.http.get_url", side_effect=NoURLAvailableError
+    ) as mock_get_url:
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert len(mock_get_url.mock_calls) == 1
+    assert (
+        "The server will start up with an emergency self signed ssl certificate"
+        in caplog.text
+    )
+
+    assert hass.http.site is not None
+
+
+async def test_invalid_ssl_and_cannot_create_emergency_cert(hass, tmpdir, caplog):
+    """Test http falls back to no ssl when an emergency cert cannot be created when the configured one is broken."""
+
+    cert_path = None
+    key_path = None
+
+    def _setup_test_files():
+        nonlocal cert_path
+        nonlocal key_path
+        test_dir = tmpdir.mkdir("test_broken_ssl")
+        cert_path = pathlib.Path(test_dir) / "cert.pem"
+        cert_path.write_text("garbage")
+        key_path = pathlib.Path(test_dir) / "key.pem"
+        key_path.write_text("garbage")
+
+    await hass.async_add_executor_job(_setup_test_files)
+
+    assert (
+        await async_setup_component(
+            hass, "http", {"http": {"ssl_certificate": cert_path, "ssl_key": key_path}}
+        )
+        is True
+    )
+
+    hass.http.ssl_certificate = "bla"
+
+    with patch(
+        "homeassistant.components.http.x509.CertificateBuilder", side_effect=OSError
+    ):
+        await hass.async_start()
+        await hass.async_block_till_done()
+    assert "Could not create an emergency self signed ssl certificate" in caplog.text
+
+    assert hass.http.site is not None
 
 
 async def test_cors_defaults(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Startup with an emergency self signed cert if the ssl certificate cannot be loaded to facility recovery since otherwise the instance is not reachable remotely. 

The idea here is that they only need certificate for a few minutes to get in and replace it with a valid one when something goes wrong.

Its not intended to be used for production, only recovery since otherwise the webserver doesn't startup and they have no way to get back in and recover it remotely unless they have some type of side channel access setup. The goal is to avoid a restore from backup situation or having to insert a usb stick to get access to port 22222 if they don't already have something setup to get in.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66701
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
