### PR TITLE
Don't allow creating or updating input_select with duplicates

### DIFF
--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -47,13 +47,17 @@ STORAGE_VERSION_MINOR = 2
 
 CREATE_FIELDS = {
     vol.Required(CONF_NAME): vol.All(str, vol.Length(min=1)),
-    vol.Required(CONF_OPTIONS): vol.All(cv.ensure_list, vol.Length(min=1), [cv.string]),
+    vol.Required(CONF_OPTIONS): vol.All(
+        cv.ensure_list, vol.Length(min=1), vol.Unique(), [cv.string]
+    ),
     vol.Optional(CONF_INITIAL): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
 }
 UPDATE_FIELDS = {
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_OPTIONS): vol.All(cv.ensure_list, vol.Length(min=1), [cv.string]),
+    vol.Optional(CONF_OPTIONS): vol.All(
+        cv.ensure_list, vol.Length(min=1), vol.Unique(), [cv.string]
+    ),
     vol.Optional(CONF_INITIAL): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
 }

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -50,7 +50,7 @@ def _unique(options: Any) -> Any:
     try:
         return vol.Unique()(options)
     except vol.Invalid as exc:
-        raise HomeAssistantError("duplicate options") from exc
+        raise HomeAssistantError("Duplicate options are not allowed") from exc
 
 
 CREATE_FIELDS = {

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -45,10 +45,18 @@ STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
 STORAGE_VERSION_MINOR = 2
 
+
+def _unique(options: Any) -> Any:
+    try:
+        return vol.Unique()(options)
+    except vol.Invalid as exc:
+        raise HomeAssistantError("duplicate options") from exc
+
+
 CREATE_FIELDS = {
     vol.Required(CONF_NAME): vol.All(str, vol.Length(min=1)),
     vol.Required(CONF_OPTIONS): vol.All(
-        cv.ensure_list, vol.Length(min=1), vol.Unique(), [cv.string]
+        cv.ensure_list, vol.Length(min=1), _unique, [cv.string]
     ),
     vol.Optional(CONF_INITIAL): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
@@ -56,7 +64,7 @@ CREATE_FIELDS = {
 UPDATE_FIELDS = {
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_OPTIONS): vol.All(
-        cv.ensure_list, vol.Length(min=1), vol.Unique(), [cv.string]
+        cv.ensure_list, vol.Length(min=1), _unique, [cv.string]
     ),
     vol.Optional(CONF_INITIAL): cv.string,
     vol.Optional(CONF_ICON): cv.icon,

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -709,7 +709,7 @@ async def test_update_duplicates(hass, hass_ws_client, storage_setup, caplog):
     resp = await client.receive_json()
     assert not resp["success"]
     assert resp["error"]["code"] == "unknown_error"
-    assert resp["error"]["message"] == "duplicate options"
+    assert resp["error"]["message"] == "Duplicate options are not allowed"
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
@@ -772,7 +772,7 @@ async def test_ws_create_duplicates(hass, hass_ws_client, storage_setup, caplog)
     resp = await client.receive_json()
     assert not resp["success"]
     assert resp["error"]["code"] == "unknown_error"
-    assert resp["error"]["message"] == "duplicate options"
+    assert resp["error"]["message"] == "Duplicate options are not allowed"
 
     assert not hass.states.get(input_entity_id)
 

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -708,12 +708,8 @@ async def test_update_duplicates(hass, hass_ws_client, storage_setup, caplog):
     )
     resp = await client.receive_json()
     assert not resp["success"]
-    assert resp["error"]["code"] == "invalid_format"
-    assert resp["error"]["message"] == (
-        "contains duplicate items: ['newer option'] for "
-        "dictionary value @ data['options']. Got ['new option', "
-        "'newer option', 'newer option']"
-    )
+    assert resp["error"]["code"] == "unknown_error"
+    assert resp["error"]["message"] == "duplicate options"
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
@@ -775,12 +771,10 @@ async def test_ws_create_duplicates(hass, hass_ws_client, storage_setup, caplog)
     )
     resp = await client.receive_json()
     assert not resp["success"]
-    assert resp["error"]["code"] == "invalid_format"
-    assert resp["error"]["message"] == (
-        "contains duplicate items: ['even newer option'] for "
-        "dictionary value @ data['options']. Got ['new option', "
-        "'even newer option', 'even newer option']"
-    )
+    assert resp["error"]["code"] == "unknown_error"
+    assert resp["error"]["message"] == "duplicate options"
+
+    assert not hass.states.get(input_entity_id)
 
 
 async def test_setup_no_config(hass, hass_admin_user):

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -707,16 +707,16 @@ async def test_update_duplicates(hass, hass_ws_client, storage_setup, caplog):
         }
     )
     resp = await client.receive_json()
-    assert resp["success"]
-
-    assert (
-        "Input select 'from storage' with options "
-        "['new option', 'newer option', 'newer option'] "
-        "had duplicated options, the duplicates have been removed"
-    ) in caplog.text
+    assert not resp["success"]
+    assert resp["error"]["code"] == "invalid_format"
+    assert resp["error"]["message"] == (
+        "contains duplicate items: ['newer option'] for "
+        "dictionary value @ data['options']. Got ['new option', "
+        "'newer option', 'newer option']"
+    )
 
     state = hass.states.get(input_entity_id)
-    assert state.attributes[ATTR_OPTIONS] == ["new option", "newer option"]
+    assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
 
 
 async def test_ws_create(hass, hass_ws_client, storage_setup):
@@ -774,17 +774,13 @@ async def test_ws_create_duplicates(hass, hass_ws_client, storage_setup, caplog)
         }
     )
     resp = await client.receive_json()
-    assert resp["success"]
-
-    assert (
-        "Input select 'New Input' with options "
-        "['new option', 'even newer option', 'even newer option'] "
-        "had duplicated options, the duplicates have been removed"
-    ) in caplog.text
-
-    state = hass.states.get(input_entity_id)
-    assert state.state == "even newer option"
-    assert state.attributes[ATTR_OPTIONS] == ["new option", "even newer option"]
+    assert not resp["success"]
+    assert resp["error"]["code"] == "invalid_format"
+    assert resp["error"]["message"] == (
+        "contains duplicate items: ['even newer option'] for "
+        "dictionary value @ data['options']. Got ['new option', "
+        "'even newer option', 'even newer option']"
+    )
 
 
 async def test_setup_no_config(hass, hass_admin_user):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't allow creating or updating `input_select` with duplicates via websocket instead of silently dropping the duplicates

The error shown in frontend:
![image](https://user-images.githubusercontent.com/14281572/154468445-3d521ec1-5d82-4f07-a863-abc1db21638f.png)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #66680

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
