### PR TITLE
Ensure new samsungtv token is updated in the config_entry

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -117,6 +117,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Initialize bridge
     bridge = await _async_create_bridge_with_updated_data(hass, entry)
 
+    # Ensure new token gets saved against the config_entry
+    def new_token_callback() -> None:
+        """Stop SamsungTV bridge connection."""
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_TOKEN: bridge.token}
+        )
+
+    bridge.register_new_token_callback(new_token_callback)
+
     def stop_bridge(event: Event) -> None:
         """Stop SamsungTV bridge connection."""
         bridge.stop()

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -119,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Ensure new token gets saved against the config_entry
     def new_token_callback() -> None:
-        """Stop SamsungTV bridge connection."""
+        """Update config entry with the new token."""
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_TOKEN: bridge.token}
         )

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.async_ import run_callback_threadsafe
 
 from .bridge import (
     SamsungTVBridge,
@@ -118,11 +119,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     bridge = await _async_create_bridge_with_updated_data(hass, entry)
 
     # Ensure new token gets saved against the config_entry
-    def new_token_callback() -> None:
+    def _update_token() -> None:
         """Update config entry with the new token."""
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_TOKEN: bridge.token}
         )
+
+    def new_token_callback() -> None:
+        """Update config entry with the new token."""
+        run_callback_threadsafe(hass.loop, _update_token)
 
     bridge.register_new_token_callback(new_token_callback)
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -187,7 +187,7 @@ class SamsungTVBridge(ABC):
             self._reauth_callback()
 
     def _notify_new_token_callback(self) -> None:
-        """Notify access denied callback."""
+        """Notify new token callback."""
         if self._new_token_callback is not None:
             self._new_token_callback()
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -98,11 +98,16 @@ class SamsungTVBridge(ABC):
         self.host = host
         self.token: str | None = None
         self._remote: Remote | None = None
-        self._callback: CALLBACK_TYPE | None = None
+        self._reauth_callback: CALLBACK_TYPE | None = None
+        self._new_token_callback: CALLBACK_TYPE | None = None
 
     def register_reauth_callback(self, func: CALLBACK_TYPE) -> None:
         """Register a callback function."""
-        self._callback = func
+        self._reauth_callback = func
+
+    def register_new_token_callback(self, func: CALLBACK_TYPE) -> None:
+        """Register a callback function."""
+        self._new_token_callback = func
 
     @abstractmethod
     def try_connect(self) -> str | None:
@@ -176,10 +181,15 @@ class SamsungTVBridge(ABC):
         except OSError:
             LOGGER.debug("Could not establish connection")
 
-    def _notify_callback(self) -> None:
+    def _notify_reauth_callback(self) -> None:
         """Notify access denied callback."""
-        if self._callback is not None:
-            self._callback()
+        if self._reauth_callback is not None:
+            self._reauth_callback()
+
+    def _notify_new_token_callback(self) -> None:
+        """Notify access denied callback."""
+        if self._new_token_callback is not None:
+            self._new_token_callback()
 
 
 class SamsungTVLegacyBridge(SamsungTVBridge):
@@ -245,7 +255,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             # This is only happening when the auth was switched to DENY
             # A removed auth will lead to socket timeout because waiting for auth popup is just an open socket
             except AccessDenied:
-                self._notify_callback()
+                self._notify_reauth_callback()
                 raise
             except (ConnectionClosed, OSError):
                 pass
@@ -355,7 +365,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             # This is only happening when the auth was switched to DENY
             # A removed auth will lead to socket timeout because waiting for auth popup is just an open socket
             except ConnectionFailure:
-                self._notify_callback()
+                self._notify_reauth_callback()
             except (WebSocketException, OSError):
                 self._remote = None
             else:
@@ -365,6 +375,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                         self._remote.token,
                     )
                     self.token = self._remote.token
+                    self._notify_new_token_callback()
         return self._remote
 
     def stop(self) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#66533 fixed it for the current session - but didn't update the config entry so a restart of HA requested a new token.

I think it is worthy of the next milestone, but feel free to remove it if that is not the case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
