### PR TITLE
Update google-cloud-texttospeech to 2.10.0

### DIFF
--- a/homeassistant/components/google_cloud/manifest.json
+++ b/homeassistant/components/google_cloud/manifest.json
@@ -2,7 +2,7 @@
   "domain": "google_cloud",
   "name": "Google Cloud Platform",
   "documentation": "https://www.home-assistant.io/integrations/google_cloud",
-  "requirements": ["google-cloud-texttospeech==0.4.0"],
+  "requirements": ["google-cloud-texttospeech==2.10.0"],
   "codeowners": ["@lufton"],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/google_pubsub/__init__.py
+++ b/homeassistant/components/google_pubsub/__init__.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 
-from google.cloud import pubsub_v1
+from google.cloud.pubsub_v1 import PublisherClient
 import voluptuous as vol
 
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -52,9 +52,7 @@ def setup(hass: HomeAssistant, yaml_config: ConfigType) -> bool:
 
     entities_filter = config[CONF_FILTER]
 
-    publisher = pubsub_v1.PublisherClient.from_service_account_json(
-        service_principal_path
-    )
+    publisher = PublisherClient.from_service_account_json(service_principal_path)
 
     topic_path = publisher.topic_path(  # pylint: disable=no-member
         project_id, topic_name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -719,7 +719,7 @@ google-api-python-client==2.38.0
 google-cloud-pubsub==2.9.0
 
 # homeassistant.components.google_cloud
-google-cloud-texttospeech==0.4.0
+google-cloud-texttospeech==2.10.0
 
 # homeassistant.components.nest
 google-nest-sdm==1.7.1

--- a/script/pip_check
+++ b/script/pip_check
@@ -3,7 +3,7 @@ PIP_CACHE=$1
 
 # Number of existing dependency conflicts
 # Update if a PR resolve one!
-DEPENDENCY_CONFLICTS=6
+DEPENDENCY_CONFLICTS=5
 
 PIP_CHECK=$(pip check --cache-dir=$PIP_CACHE)
 LINE_COUNT=$(echo "$PIP_CHECK" | wc -l)

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -42,10 +42,9 @@ async def test_nested():
 @pytest.fixture(autouse=True, name="mock_client")
 def mock_client_fixture():
     """Mock the pubsub client."""
-    with mock.patch(f"{GOOGLE_PUBSUB_PATH}.pubsub_v1") as client:
-        client.PublisherClient = mock.MagicMock()
+    with mock.patch(f"{GOOGLE_PUBSUB_PATH}.PublisherClient") as client:
         setattr(
-            client.PublisherClient,
+            client,
             "from_service_account_json",
             mock.MagicMock(return_value=mock.MagicMock()),
         )
@@ -83,10 +82,10 @@ async def test_minimal_config(hass, mock_client):
     await hass.async_block_till_done()
     assert hass.bus.listen.called
     assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
-    assert mock_client.PublisherClient.from_service_account_json.call_count == 1
-    assert mock_client.PublisherClient.from_service_account_json.call_args[0][
-        0
-    ] == os.path.join(hass.config.config_dir, "creds")
+    assert mock_client.from_service_account_json.call_count == 1
+    assert mock_client.from_service_account_json.call_args[0][0] == os.path.join(
+        hass.config.config_dir, "creds"
+    )
 
 
 async def test_full_config(hass, mock_client):
@@ -110,10 +109,10 @@ async def test_full_config(hass, mock_client):
     await hass.async_block_till_done()
     assert hass.bus.listen.called
     assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
-    assert mock_client.PublisherClient.from_service_account_json.call_count == 1
-    assert mock_client.PublisherClient.from_service_account_json.call_args[0][
-        0
-    ] == os.path.join(hass.config.config_dir, "creds")
+    assert mock_client.from_service_account_json.call_count == 1
+    assert mock_client.from_service_account_json.call_args[0][0] == os.path.join(
+        hass.config.config_dir, "creds"
+    )
 
 
 def make_event(entity_id):
@@ -154,7 +153,7 @@ async def test_allowlist(hass, mock_client):
             "include_entities": ["binary_sensor.included"],
         },
     )
-    publish_client = mock_client.PublisherClient.from_service_account_json("path")
+    publish_client = mock_client.from_service_account_json("path")
 
     tests = [
         FilterTest("climate.excluded", False),
@@ -184,7 +183,7 @@ async def test_denylist(hass, mock_client):
             "exclude_entities": ["binary_sensor.excluded"],
         },
     )
-    publish_client = mock_client.PublisherClient.from_service_account_json("path")
+    publish_client = mock_client.from_service_account_json("path")
 
     tests = [
         FilterTest("climate.excluded", False),
@@ -216,7 +215,7 @@ async def test_filtered_allowlist(hass, mock_client):
             "exclude_entities": ["light.excluded"],
         },
     )
-    publish_client = mock_client.PublisherClient.from_service_account_json("path")
+    publish_client = mock_client.from_service_account_json("path")
 
     tests = [
         FilterTest("light.included", True),
@@ -246,7 +245,7 @@ async def test_filtered_denylist(hass, mock_client):
             "exclude_entities": ["light.excluded"],
         },
     )
-    publish_client = mock_client.PublisherClient.from_service_account_json("path")
+    publish_client = mock_client.from_service_account_json("path")
 
     tests = [
         FilterTest("climate.excluded", False),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a very major version bump, as it ran on version 0.4.0 from 2019 still...

Changelog: <https://github.com/googleapis/python-texttospeech/blob/main/CHANGELOG.md>

(Almost everything in the changelog applies...)

✅ I've set up an account and verified it still works as expected.

---

The second attempt, the first try was in #66726, which has been reverted.
I cannot reproduce the issue locally. I suspect this is caused by jumping from 1.x to 2.x of the Google Cloud libraries and reusing our venv in the tests.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
