### PR TITLE
Improve Vallox filter remaining time sensor

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date
 import ipaddress
 import logging
 from typing import Any, NamedTuple
@@ -9,7 +10,10 @@ from uuid import UUID
 
 from vallox_websocket_api import PROFILE as VALLOX_PROFILE, Vallox
 from vallox_websocket_api.exceptions import ValloxApiException
-from vallox_websocket_api.vallox import get_uuid as calculate_uuid
+from vallox_websocket_api.vallox import (
+    get_next_filter_change_date as calculate_next_filter_change_date,
+    get_uuid as calculate_uuid,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -131,6 +135,13 @@ class ValloxState:
         if not isinstance(uuid, UUID):
             raise ValueError
         return uuid
+
+    def get_next_filter_change_date(self) -> date | None:
+        """Return the next filter change date."""
+        next_filter_change_date = calculate_next_filter_change_date(self.metric_cache)
+        if not isinstance(next_filter_change_date, date):
+            raise ValueError
+        return next_filter_change_date
 
 
 class ValloxDataUpdateCoordinator(DataUpdateCoordinator):

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -140,7 +140,9 @@ class ValloxState:
         """Return the next filter change date."""
         next_filter_change_date = calculate_next_filter_change_date(self.metric_cache)
         if not isinstance(next_filter_change_date, date):
-            raise ValueError
+            raise ValueError(
+                f"Unexpected next filter change date type: {type(next_filter_change_date)}"
+            )
         return next_filter_change_date
 
 

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -139,10 +139,14 @@ class ValloxState:
     def get_next_filter_change_date(self) -> date | None:
         """Return the next filter change date."""
         next_filter_change_date = calculate_next_filter_change_date(self.metric_cache)
+
         if not isinstance(next_filter_change_date, date):
-            raise ValueError(
-                f"Unexpected next filter change date type: {type(next_filter_change_date)}"
+            _LOGGER.debug(
+                "Unexpected next filter change date type: %s",
+                type(next_filter_change_date),
             )
+            return None
+
         return next_filter_change_date
 
 

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -140,12 +140,10 @@ class ValloxState:
         """Return the next filter change date."""
         next_filter_change_date = calculate_next_filter_change_date(self.metric_cache)
 
-        if not isinstance(next_filter_change_date, date):
-            _LOGGER.debug(
-                "Unexpected next filter change date type: %s",
-                type(next_filter_change_date),
-            )
+        if next_filter_change_date is None:
             return None
+        if not isinstance(next_filter_change_date, date):
+            raise ValueError("Error fetching next filter change date")
 
         return next_filter_change_date
 

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -140,10 +140,8 @@ class ValloxState:
         """Return the next filter change date."""
         next_filter_change_date = calculate_next_filter_change_date(self.metric_cache)
 
-        if next_filter_change_date is None:
-            return None
         if not isinstance(next_filter_change_date, date):
-            raise ValueError("Error fetching next filter change date")
+            return None
 
         return next_filter_change_date
 

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vallox",
   "name": "Vallox",
   "documentation": "https://www.home-assistant.io/integrations/vallox",
-  "requirements": ["vallox-websocket-api==2.9.0"],
+  "requirements": ["vallox-websocket-api==2.11.0"],
   "codeowners": ["@andre-richter", "@slovdahl", "@viiru-"],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, time
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt
 
 from . import ValloxDataUpdateCoordinator
 from .const import (
@@ -95,18 +95,15 @@ class ValloxFilterRemainingSensor(ValloxSensor):
     @property
     def native_value(self) -> StateType | datetime:
         """Return the value reported by the sensor."""
-        super_native_value = super().native_value
+        next_filter_change_date = self.coordinator.data.get_next_filter_change_date()
 
-        if not isinstance(super_native_value, (int, float)):
+        if next_filter_change_date is None:
             return None
 
-        # Since only a delta of days is received from the device, fix the time so the timestamp does
-        # not change with every update.
-        days_remaining = float(super_native_value)
-        days_remaining_delta = timedelta(days=days_remaining)
-        now = datetime.utcnow().replace(hour=13, minute=0, second=0, microsecond=0)
-
-        return (now + days_remaining_delta).astimezone(dt_util.UTC)
+        return datetime.combine(
+            next_filter_change_date,
+            time(hour=13, minute=0, second=0, tzinfo=dt.DEFAULT_TIME_ZONE),
+        )
 
 
 class ValloxCellStateSensor(ValloxSensor):
@@ -150,7 +147,6 @@ SENSORS: tuple[ValloxSensorEntityDescription, ...] = (
     ValloxSensorEntityDescription(
         key="remaining_time_for_filter",
         name="Remaining Time For Filter",
-        metric_key="A_CYC_REMAINING_TIME_FOR_FILTER",
         device_class=SensorDeviceClass.TIMESTAMP,
         sensor_type=ValloxFilterRemainingSensor,
     ),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2418,7 +2418,7 @@ uscisstatus==0.1.1
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==2.9.0
+vallox-websocket-api==2.11.0
 
 # homeassistant.components.rdw
 vehicle==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1488,7 +1488,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==2.9.0
+vallox-websocket-api==2.11.0
 
 # homeassistant.components.rdw
 vehicle==0.3.1

--- a/tests/components/vallox/conftest.py
+++ b/tests/components/vallox/conftest.py
@@ -1,6 +1,5 @@
 """Common utilities for Vallox tests."""
 
-from datetime import datetime
 import random
 import string
 from typing import Any
@@ -30,14 +29,6 @@ def mock_entry(hass: HomeAssistant) -> MockConfigEntry:
     vallox_mock_entry.add_to_hass(hass)
 
     return vallox_mock_entry
-
-
-def patch_ha_now(mocked_datetime: datetime):
-    """Patch the current time."""
-    return patch(
-        "homeassistant.components.vallox.sensor.dt.now",
-        return_value=mocked_datetime,
-    )
 
 
 def patch_metrics(metrics: dict[str, Any]):

--- a/tests/components/vallox/conftest.py
+++ b/tests/components/vallox/conftest.py
@@ -1,0 +1,74 @@
+"""Common utilities for Vallox tests."""
+
+from datetime import datetime
+import random
+import string
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from vallox_websocket_api.vallox import PROFILE
+
+from homeassistant.components.vallox.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create mocked Vallox config entry."""
+    vallox_mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.100.50",
+            CONF_NAME: "Vallox",
+        },
+    )
+    vallox_mock_entry.add_to_hass(hass)
+
+    return vallox_mock_entry
+
+
+def patch_ha_now(mocked_datetime: datetime):
+    """Patch the current time."""
+    return patch(
+        "homeassistant.components.vallox.sensor.dt.now",
+        return_value=mocked_datetime,
+    )
+
+
+def patch_metrics(metrics: dict[str, Any]):
+    """Patch the Vallox metrics response."""
+    return patch(
+        "homeassistant.components.vallox.Vallox.fetch_metrics",
+        return_value=metrics,
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_profile_home():
+    """Patch the Vallox profile response."""
+    with patch(
+        "homeassistant.components.vallox.Vallox.get_profile",
+        return_value=PROFILE.HOME,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_uuid():
+    """Patch the Vallox entity UUID."""
+    with patch(
+        "homeassistant.components.vallox.calculate_uuid",
+        return_value=_random_uuid(),
+    ):
+        yield
+
+
+def _random_uuid():
+    """Generate a random UUID."""
+    uuid = "".join(random.choices(string.hexdigits, k=32))
+    return UUID(uuid)

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -77,10 +77,10 @@ async def test_remaining_filter_returns_timestamp(
     assert sensor.attributes["device_class"] == "timestamp"
 
 
-async def test_remaining_time_for_filter_nothing_returned_from_vallox(
+async def test_remaining_time_for_filter_none_returned_from_vallox(
     mock_entry: MockConfigEntry, hass: HomeAssistant
 ):
-    """Test that the remaining time for filter sensor returns 'unknown' when Vallox doesn't return anything."""
+    """Test that the remaining time for filter sensor returns 'unknown' when Vallox returns None."""
     # Act
     with patch(
         "homeassistant.components.vallox.calculate_next_filter_change_date",

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -91,7 +91,7 @@ async def test_remaining_time_for_filter_nothing_returned_from_vallox(
 
     # Assert
     sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
-    assert sensor is None
+    assert sensor.state == "unknown"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -1,0 +1,175 @@
+"""Tests for Vallox sensor platform."""
+
+from datetime import datetime, timedelta, tzinfo
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt
+
+from .conftest import patch_metrics
+
+from tests.common import MockConfigEntry
+
+ORIG_TZ = dt.DEFAULT_TIME_ZONE
+
+
+@pytest.fixture(autouse=True)
+def reset_tz():
+    """Restore the default TZ after test runs."""
+    yield
+    dt.DEFAULT_TIME_ZONE = ORIG_TZ
+
+
+@pytest.fixture
+def set_tz(request):
+    """Set the default TZ to the one requested."""
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def utc() -> tzinfo:
+    """Set the default TZ to UTC."""
+    tz = dt.get_time_zone("UTC")
+    dt.set_default_time_zone(tz)
+    return tz
+
+
+@pytest.fixture
+def helsinki() -> tzinfo:
+    """Set the default TZ to Europe/Helsinki."""
+    tz = dt.get_time_zone("Europe/Helsinki")
+    dt.set_default_time_zone(tz)
+    return tz
+
+
+@pytest.fixture
+def new_york() -> tzinfo:
+    """Set the default TZ to America/New_York."""
+    tz = dt.get_time_zone("America/New_York")
+    dt.set_default_time_zone(tz)
+    return tz
+
+
+def _sensor_to_datetime(sensor):
+    return datetime.fromisoformat(sensor.state)
+
+
+def _now_at_13():
+    return dt.now().timetz().replace(hour=13, minute=0, second=0, microsecond=0)
+
+
+async def test_remaining_filter_returns_timestamp(
+    mock_entry: MockConfigEntry, hass: HomeAssistant
+):
+    """Test that the remaining time for filter sensor returns a timestamp."""
+    # Act
+    with patch(
+        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        return_value=dt.now().date(),
+    ), patch_metrics(metrics={}):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Assert
+    sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
+    assert sensor.attributes["device_class"] == "timestamp"
+
+
+async def test_remaining_time_for_filter_nothing_returned_from_vallox(
+    mock_entry: MockConfigEntry, hass: HomeAssistant
+):
+    """Test that the remaining time for filter sensor returns 'unknown' when Vallox doesn't return anything."""
+    # Act
+    with patch(
+        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        return_value=None,
+    ), patch_metrics(metrics={}):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Assert
+    sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
+    assert sensor.state == "unknown"
+
+
+@pytest.mark.parametrize(
+    "set_tz",
+    [
+        "utc",
+        "helsinki",
+        "new_york",
+    ],
+    indirect=True,
+)
+async def test_remaining_time_for_filter_in_the_future(
+    mock_entry: MockConfigEntry, set_tz: tzinfo, hass: HomeAssistant
+):
+    """Test remaining time for filter when Vallox returns a date in the future."""
+    # Arrange
+    remaining_days = 112
+    mocked_filter_end_date = dt.now().date() + timedelta(days=remaining_days)
+
+    # Act
+    with patch(
+        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        return_value=mocked_filter_end_date,
+    ), patch_metrics(metrics={}):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Assert
+    sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
+    assert _sensor_to_datetime(sensor) == datetime.combine(
+        mocked_filter_end_date,
+        _now_at_13(),
+    )
+
+
+async def test_remaining_time_for_filter_today(
+    mock_entry: MockConfigEntry, hass: HomeAssistant
+):
+    """Test remaining time for filter when Vallox returns today."""
+    # Arrange
+    remaining_days = 0
+    mocked_filter_end_date = dt.now().date() + timedelta(days=remaining_days)
+
+    # Act
+    with patch(
+        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        return_value=mocked_filter_end_date,
+    ), patch_metrics(metrics={}):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Assert
+    sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
+    assert _sensor_to_datetime(sensor) == datetime.combine(
+        mocked_filter_end_date,
+        _now_at_13(),
+    )
+
+
+async def test_remaining_time_for_filter_in_the_past(
+    mock_entry: MockConfigEntry, hass: HomeAssistant
+):
+    """Test remaining time for filter when Vallox returns a date in the past."""
+    # Arrange
+    remaining_days = -3
+    mocked_filter_end_date = dt.now().date() + timedelta(days=remaining_days)
+
+    # Act
+    with patch(
+        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        return_value=mocked_filter_end_date,
+    ), patch_metrics(metrics={}):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Assert
+    sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
+    assert _sensor_to_datetime(sensor) == datetime.combine(
+        mocked_filter_end_date,
+        _now_at_13(),
+    )

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -91,7 +91,7 @@ async def test_remaining_time_for_filter_nothing_returned_from_vallox(
 
     # Assert
     sensor = hass.states.get("sensor.vallox_remaining_time_for_filter")
-    assert sensor.state == "unknown"
+    assert sensor is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

The value returned for the "remaining time for filter" Vallox metric is the number of days left. The counter is decremented at midnight according to the clock of the Vallox unit. The Vallox unit does not seem to synchronize its clock using NTP, which means that it will drift and get out of sync.

Until now, this meant that the "remaining time for filter" sensor would fluctuate around midnight, moving backwards or forwards for a while before returning to the correct date.

This is now fixed by updating the Vallox library to a version that calculates the remaining time itself based on the last filter change and the filter change interval.

This also means that the when the filter change date is passed, the same date will continue to be shown until the filter change is reset in the Vallox unit.

Changes for the updated `vallox_websocket_api` version: https://github.com/yozik04/vallox_websocket_api/compare/2.9.0...2.11.0

The first attempt of fixing this was done in #66443, but based on the feedback there, it was possible to solve it in a much better and cleaner way like this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
