### PR TITLE
Correctly handle missing mpd albumart

### DIFF
--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -120,7 +120,8 @@ class MpdDevice(MediaPlayerEntity):
         self._media_position_updated_at = None
         self._media_position = None
         self._media_image_hash = None
-        self._media_image_file = None  # used to track if the song changed so image doesn't have to be loaded every update
+        # Track if the song changed so image doesn't have to be loaded every update.
+        self._media_image_file = None
         self._commands = None
 
         # set up MPD client
@@ -278,7 +279,7 @@ class MpdDevice(MediaPlayerEntity):
         if not response:
             return None, None
 
-        image = bytes(response.get("binary"))
+        image = bytes(response["binary"])
         mime = response.get(
             "type", "image/png"
         )  # readpicture has type, albumart does not
@@ -300,7 +301,7 @@ class MpdDevice(MediaPlayerEntity):
             self._media_image_hash = None
         else:
             self._media_image_hash = hashlib.sha256(
-                bytes(response.get("binary"))
+                bytes(response["binary"])
             ).hexdigest()[:16]
 
         self._media_image_file = file

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -119,6 +119,8 @@ class MpdDevice(MediaPlayerEntity):
         self._muted_volume = None
         self._media_position_updated_at = None
         self._media_position = None
+        self._media_image_hash = None
+        self._media_image_file = None  # used to track if the song changed so image doesn't have to be loaded every update
         self._commands = None
 
         # set up MPD client
@@ -149,6 +151,7 @@ class MpdDevice(MediaPlayerEntity):
         """Fetch status from MPD."""
         self._status = await self._client.status()
         self._currentsong = await self._client.currentsong()
+        await self._async_update_media_image_hash()
 
         if (position := self._status.get("elapsed")) is None:
             position = self._status.get("time")
@@ -265,16 +268,44 @@ class MpdDevice(MediaPlayerEntity):
     @property
     def media_image_hash(self):
         """Hash value for media image."""
-        if file := self._currentsong.get("file"):
-            return hashlib.sha256(file.encode("utf-8")).hexdigest()[:16]
-
-        return None
+        return self._media_image_hash
 
     async def async_get_media_image(self):
         """Fetch media image of current playing track."""
         if not (file := self._currentsong.get("file")):
             return None, None
+        response = await self._async_get_file_image_response(file)
+        if not response:
+            return None, None
 
+        image = bytes(response.get("binary"))
+        mime = response.get(
+            "type", "image/png"
+        )  # readpicture has type, albumart does not
+        return (image, mime)
+
+    async def _async_update_media_image_hash(self):
+        """Update the hash value for the media image."""
+        file = self._currentsong.get("file")
+
+        if file == self._media_image_file:
+            return
+
+        response = await self._async_get_file_image_response(file)
+
+        if not response:
+            # If there is no image, this hash has to be None, else the media player component
+            # assumes there is an image and returns an error trying to load it and the
+            # frontend media control card breaks.
+            self._media_image_hash = None
+        else:
+            self._media_image_hash = hashlib.sha256(
+                bytes(response.get("binary"))
+            ).hexdigest()[:16]
+
+        self._media_image_file = file
+
+    async def _async_get_file_image_response(self, file):
         # not all MPD implementations and versions support the `albumart` and `fetchpicture` commands
         can_albumart = "albumart" in self._commands
         can_readpicture = "readpicture" in self._commands
@@ -303,14 +334,7 @@ class MpdDevice(MediaPlayerEntity):
                         error,
                     )
 
-        if not response:
-            return None, None
-
-        image = bytes(response.get("binary"))
-        mime = response.get(
-            "type", "image/png"
-        )  # readpicture has type, albumart does not
-        return (image, mime)
+        return response
 
     @property
     def volume_level(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set mpd media_player state's `entity_picture` (determined by `media_image_hash`) only when there is actually an image. Before, a hash was always provided, which caused the client to request an image, which caused an error 500, which in turn caused browser/JS errors  (see linked issue).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66751

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
