### PR TITLE
Add type ignore error codes [util]

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -137,7 +137,7 @@ class Throttle:
 
         else:
 
-            def throttled_value() -> None:  # type: ignore
+            def throttled_value() -> None:  # type: ignore[misc]
                 """Stand-in function for when real func is being throttled."""
                 return None
 
@@ -191,7 +191,7 @@ class Throttle:
                 if force or utcnow() - throttle[1] > self.min_time:
                     result = method(*args, **kwargs)
                     throttle[1] = utcnow()
-                    return result  # type: ignore
+                    return result  # type: ignore[no-any-return]
 
                 return throttled_value()
             finally:

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -30,7 +30,7 @@ def load_json(filename: str, default: list | dict | None = None) -> list | dict:
     """
     try:
         with open(filename, encoding="utf-8") as fdesc:
-            return json.loads(fdesc.read())  # type: ignore
+            return json.loads(fdesc.read())  # type: ignore[no-any-return]
     except FileNotFoundError:
         # This is not a fatal error
         _LOGGER.debug("JSON file not found: %s", filename)

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -50,7 +50,7 @@ def is_installed(package: str) -> bool:
         # was aborted while in progress see
         # https://github.com/home-assistant/core/issues/47699
         if installed_version is None:
-            _LOGGER.error("Installed version for %s resolved to None", req.project_name)  # type: ignore
+            _LOGGER.error("Installed version for %s resolved to None", req.project_name)  # type: ignore[unreachable]
             return False
         return installed_version in req
     except PackageNotFoundError:

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -134,7 +134,7 @@ class UnitSystem:
             raise TypeError(f"{length!s} is not a numeric value.")
 
         # type ignore: https://github.com/python/mypy/issues/7207
-        return distance_util.convert(  # type: ignore
+        return distance_util.convert(  # type: ignore[unreachable]
             length, from_unit, self.length_unit
         )
 
@@ -144,7 +144,7 @@ class UnitSystem:
             raise TypeError(f"{precip!s} is not a numeric value.")
 
         # type ignore: https://github.com/python/mypy/issues/7207
-        return distance_util.convert(  # type: ignore
+        return distance_util.convert(  # type: ignore[unreachable]
             precip, from_unit, self.accumulated_precipitation_unit
         )
 
@@ -154,7 +154,7 @@ class UnitSystem:
             raise TypeError(f"{pressure!s} is not a numeric value.")
 
         # type ignore: https://github.com/python/mypy/issues/7207
-        return pressure_util.convert(  # type: ignore
+        return pressure_util.convert(  # type: ignore[unreachable]
             pressure, from_unit, self.pressure_unit
         )
 
@@ -164,7 +164,7 @@ class UnitSystem:
             raise TypeError(f"{wind_speed!s} is not a numeric value.")
 
         # type ignore: https://github.com/python/mypy/issues/7207
-        return speed_util.convert(wind_speed, from_unit, self.wind_speed_unit)  # type: ignore
+        return speed_util.convert(wind_speed, from_unit, self.wind_speed_unit)  # type: ignore[unreachable]
 
     def volume(self, volume: float | None, from_unit: str) -> float:
         """Convert the given volume to this unit system."""
@@ -172,7 +172,7 @@ class UnitSystem:
             raise TypeError(f"{volume!s} is not a numeric value.")
 
         # type ignore: https://github.com/python/mypy/issues/7207
-        return volume_util.convert(volume, from_unit, self.volume_unit)  # type: ignore
+        return volume_util.convert(volume, from_unit, self.volume_unit)  # type: ignore[unreachable]
 
     def as_dict(self) -> dict[str, str]:
         """Convert the unit system to a dictionary."""

--- a/homeassistant/util/yaml/dumper.py
+++ b/homeassistant/util/yaml/dumper.py
@@ -24,7 +24,7 @@ def save_yaml(path: str, data: dict) -> None:
 
 
 # From: https://gist.github.com/miracle2k/3184458
-def represent_odict(  # type: ignore
+def represent_odict(  # type: ignore[no-untyped-def]
     dumper, tag, mapping, flow_style=None
 ) -> yaml.MappingNode:
     """Like BaseRepresenter.represent_mapping but does not issue the sort()."""

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -100,7 +100,7 @@ class SafeLineLoader(yaml.SafeLoader):
         """Annotate a node with the first line it was seen."""
         last_line: int = self.line
         node: yaml.nodes.Node = super().compose_node(parent, index)  # type: ignore[assignment]
-        node.__line__ = last_line + 1  # type: ignore
+        node.__line__ = last_line + 1  # type: ignore[attr-defined]
         return node
 
 
@@ -149,7 +149,7 @@ def _add_reference(
     ...
 
 
-def _add_reference(obj, loader: SafeLineLoader, node: yaml.nodes.Node):  # type: ignore
+def _add_reference(obj, loader: SafeLineLoader, node: yaml.nodes.Node):  # type: ignore[no-untyped-def]
     """Add file reference information to an object."""
     if isinstance(obj, list):
         obj = NodeListClass(obj)


### PR DESCRIPTION
## Proposed change
Followup to #66773. Add error codes to `type: ignore` comments.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
