### PR TITLE
Add type ignore error codes [other]

### DIFF
--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -12,7 +12,7 @@ T = TypeVar("T")
 
 
 @overload
-def async_redact_data(data: Mapping, to_redact: Iterable[Any]) -> dict:  # type: ignore
+def async_redact_data(data: Mapping, to_redact: Iterable[Any]) -> dict:  # type: ignore[misc]
     ...
 
 

--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -291,7 +291,7 @@ class EnergyManager:
             "device_consumption",
         ):
             if key in update:
-                data[key] = update[key]  # type: ignore
+                data[key] = update[key]  # type: ignore[misc]
 
         self.data = data
         self._store.async_delay_save(lambda: cast(dict, self.data), 60)

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -148,17 +148,17 @@ class SensorManager:
                     self._process_sensor_data(
                         adapter,
                         # Opting out of the type complexity because can't get it to work
-                        energy_source,  # type: ignore
+                        energy_source,  # type: ignore[arg-type]
                         to_add,
                         to_remove,
                     )
                     continue
 
-                for flow in energy_source[adapter.flow_type]:  # type: ignore
+                for flow in energy_source[adapter.flow_type]:  # type: ignore[typeddict-item]
                     self._process_sensor_data(
                         adapter,
                         # Opting out of the type complexity because can't get it to work
-                        flow,  # type: ignore
+                        flow,  # type: ignore[arg-type]
                         to_add,
                         to_remove,
                     )

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -123,7 +123,7 @@ class MediaGroup(MediaPlayerEntity):
         """Update supported features and state when a new state is received."""
         self.async_set_context(event.context)
         self.async_update_supported_features(
-            event.data.get("entity_id"), event.data.get("new_state")  # type: ignore
+            event.data.get("entity_id"), event.data.get("new_state")  # type: ignore[arg-type]
         )
         self.async_update_state()
 
@@ -361,14 +361,14 @@ class MediaGroup(MediaPlayerEntity):
     async def async_volume_up(self) -> None:
         """Turn volume up for media player(s)."""
         for entity in self._features[KEY_VOLUME]:
-            volume_level = self.hass.states.get(entity).attributes["volume_level"]  # type: ignore
+            volume_level = self.hass.states.get(entity).attributes["volume_level"]  # type: ignore[union-attr]
             if volume_level < 1:
                 await self.async_set_volume_level(min(1, volume_level + 0.1))
 
     async def async_volume_down(self) -> None:
         """Turn volume down for media player(s)."""
         for entity in self._features[KEY_VOLUME]:
-            volume_level = self.hass.states.get(entity).attributes["volume_level"]  # type: ignore
+            volume_level = self.hass.states.get(entity).attributes["volume_level"]  # type: ignore[union-attr]
             if volume_level > 0:
                 await self.async_set_volume_level(max(0, volume_level - 0.1))
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -355,7 +355,7 @@ class SensorEntity(Entity):
             hasattr(self, "_attr_unit_of_measurement")
             and self._attr_unit_of_measurement is not None
         ):
-            return self._attr_unit_of_measurement  # type: ignore
+            return self._attr_unit_of_measurement  # type: ignore[unreachable]
 
         native_unit_of_measurement = self.native_unit_of_measurement
 

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -418,7 +418,7 @@ def _compile_statistics(  # noqa: C901
     ]
     history_list = {}
     if entities_full_history:
-        history_list = history.get_significant_states_with_session(  # type: ignore
+        history_list = history.get_significant_states_with_session(  # type: ignore[no-untyped-call]
             hass,
             session,
             start - datetime.timedelta.resolution,
@@ -432,7 +432,7 @@ def _compile_statistics(  # noqa: C901
         if "sum" not in wanted_statistics[i.entity_id]
     ]
     if entities_significant_history:
-        _history_list = history.get_significant_states_with_session(  # type: ignore
+        _history_list = history.get_significant_states_with_session(  # type: ignore[no-untyped-call]
             hass,
             session,
             start - datetime.timedelta.resolution,

--- a/homeassistant/components/tts/media_source.py
+++ b/homeassistant/components/tts/media_source.py
@@ -56,7 +56,7 @@ class TTSMediaSource(MediaSource):
         manager: SpeechManager = self.hass.data[DOMAIN]
 
         try:
-            url = await manager.async_get_url_path(**kwargs)  # type: ignore
+            url = await manager.async_get_url_path(**kwargs)  # type: ignore[arg-type]
         except HomeAssistantError as err:
             raise Unresolvable(str(err)) from err
 

--- a/homeassistant/components/zeroconf/usage.py
+++ b/homeassistant/components/zeroconf/usage.py
@@ -23,5 +23,5 @@ def install_multiple_zeroconf_catcher(hass_zc: HaZeroconf) -> None:
     def new_zeroconf_init(self: zeroconf.Zeroconf, *k: Any, **kw: Any) -> None:
         return
 
-    zeroconf.Zeroconf.__new__ = new_zeroconf_new  # type: ignore
-    zeroconf.Zeroconf.__init__ = new_zeroconf_init  # type: ignore
+    zeroconf.Zeroconf.__new__ = new_zeroconf_new  # type: ignore[assignment]
+    zeroconf.Zeroconf.__init__ = new_zeroconf_init  # type: ignore[assignment]

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -122,7 +122,7 @@ def async_active_zone(
             continue
 
         within_zone = zone_dist - radius < zone.attributes[ATTR_RADIUS]
-        closer_zone = closest is None or zone_dist < min_dist  # type: ignore
+        closer_zone = closest is None or zone_dist < min_dist  # type: ignore[unreachable]
         smaller_zone = (
             zone_dist == min_dist
             and zone.attributes[ATTR_RADIUS]


### PR DESCRIPTION
## Proposed change
Followup to #66773. Add error codes to `type: ignore` comments.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
