### PR TITLE
Clean webostv notify

### DIFF
--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -46,7 +46,7 @@ class LgWebOSNotificationService(BaseNotificationService):
             if not self._client.is_connected():
                 await self._client.connect()
 
-            data = kwargs.get(ATTR_DATA)
+            data = kwargs[ATTR_DATA]
             icon_path = data.get(CONF_ICON) if data else None
             await self._client.send_message(message, icon_path=icon_path)
         except WebOsTvPairError:

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -7,7 +7,7 @@ from typing import Any
 from aiowebostv import WebOsClient, WebOsTvPairError
 
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
-from homeassistant.const import CONF_ICON
+from homeassistant.const import ATTR_ICON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -47,7 +47,7 @@ class LgWebOSNotificationService(BaseNotificationService):
                 await self._client.connect()
 
             data = kwargs[ATTR_DATA]
-            icon_path = data.get(CONF_ICON) if data else None
+            icon_path = data.get(ATTR_ICON) if data else None
             await self._client.send_message(message, icon_path=icon_path)
         except WebOsTvPairError:
             _LOGGER.error("Pairing with TV failed")

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock, call
 from aiowebostv import WebOsTvPairError
 import pytest
 
-from homeassistant.components.notify import ATTR_MESSAGE, DOMAIN as NOTIFY_DOMAIN
+from homeassistant.components.notify import (
+    ATTR_DATA,
+    ATTR_MESSAGE,
+    DOMAIN as NOTIFY_DOMAIN,
+)
 from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import ATTR_ICON
 from homeassistant.setup import async_setup_component
@@ -12,7 +16,6 @@ from homeassistant.setup import async_setup_component
 from . import setup_webostv
 from .const import TV_NAME
 
-ATTR_SERVICE_DATA = "data"
 ICON_PATH = "/some/path"
 MESSAGE = "one, two, testing, testing"
 
@@ -27,7 +30,7 @@ async def test_notify(hass, client):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            ATTR_SERVICE_DATA: {
+            ATTR_DATA: {
                 ATTR_ICON: ICON_PATH,
             },
         },
@@ -42,7 +45,7 @@ async def test_notify(hass, client):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            ATTR_SERVICE_DATA: {
+            ATTR_DATA: {
                 "OTHER_DATA": "not_used",
             },
         },
@@ -78,7 +81,7 @@ async def test_notify_not_connected(hass, client, monkeypatch):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            ATTR_SERVICE_DATA: {
+            ATTR_DATA: {
                 ATTR_ICON: ICON_PATH,
             },
         },
@@ -100,7 +103,7 @@ async def test_icon_not_found(hass, caplog, client, monkeypatch):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            ATTR_SERVICE_DATA: {
+            ATTR_DATA: {
                 ATTR_ICON: ICON_PATH,
             },
         },
@@ -131,7 +134,7 @@ async def test_connection_errors(hass, caplog, client, monkeypatch, side_effect,
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            ATTR_SERVICE_DATA: {
+            ATTR_DATA: {
                 ATTR_ICON: ICON_PATH,
             },
         },

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.notify import ATTR_MESSAGE, DOMAIN as NOTIFY_DOMAIN
 from homeassistant.components.webostv import DOMAIN
-from homeassistant.const import CONF_ICON
+from homeassistant.const import ATTR_ICON
 from homeassistant.setup import async_setup_component
 
 from . import setup_webostv
@@ -28,7 +28,7 @@ async def test_notify(hass, client):
         {
             ATTR_MESSAGE: MESSAGE,
             ATTR_SERVICE_DATA: {
-                CONF_ICON: ICON_PATH,
+                ATTR_ICON: ICON_PATH,
             },
         },
         blocking=True,
@@ -79,7 +79,7 @@ async def test_notify_not_connected(hass, client, monkeypatch):
         {
             ATTR_MESSAGE: MESSAGE,
             ATTR_SERVICE_DATA: {
-                CONF_ICON: ICON_PATH,
+                ATTR_ICON: ICON_PATH,
             },
         },
         blocking=True,
@@ -101,7 +101,7 @@ async def test_icon_not_found(hass, caplog, client, monkeypatch):
         {
             ATTR_MESSAGE: MESSAGE,
             ATTR_SERVICE_DATA: {
-                CONF_ICON: ICON_PATH,
+                ATTR_ICON: ICON_PATH,
             },
         },
         blocking=True,
@@ -132,7 +132,7 @@ async def test_connection_errors(hass, caplog, client, monkeypatch, side_effect,
         {
             ATTR_MESSAGE: MESSAGE,
             ATTR_SERVICE_DATA: {
-                CONF_ICON: ICON_PATH,
+                ATTR_ICON: ICON_PATH,
             },
         },
         blocking=True,

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -52,6 +52,20 @@ async def test_notify(hass, client):
     assert client.connect.call_count == 1
     client.send_message.assert_called_with(MESSAGE, icon_path=None)
 
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        TV_NAME,
+        {
+            ATTR_MESSAGE: "only message, no data",
+        },
+        blocking=True,
+    )
+
+    assert client.connect.call_count == 1
+    assert client.send_message.call_args == call(
+        "only message, no data", icon_path=None
+    )
+
 
 async def test_notify_not_connected(hass, client, monkeypatch):
     """Test sending a message when client is not connected."""

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -6,12 +6,13 @@ import pytest
 
 from homeassistant.components.notify import ATTR_MESSAGE, DOMAIN as NOTIFY_DOMAIN
 from homeassistant.components.webostv import DOMAIN
-from homeassistant.const import CONF_ICON, CONF_SERVICE_DATA
+from homeassistant.const import CONF_ICON
 from homeassistant.setup import async_setup_component
 
 from . import setup_webostv
 from .const import TV_NAME
 
+ATTR_SERVICE_DATA = "data"
 ICON_PATH = "/some/path"
 MESSAGE = "one, two, testing, testing"
 
@@ -26,7 +27,7 @@ async def test_notify(hass, client):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            CONF_SERVICE_DATA: {
+            ATTR_SERVICE_DATA: {
                 CONF_ICON: ICON_PATH,
             },
         },
@@ -41,7 +42,7 @@ async def test_notify(hass, client):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            CONF_SERVICE_DATA: {
+            ATTR_SERVICE_DATA: {
                 "OTHER_DATA": "not_used",
             },
         },
@@ -63,7 +64,7 @@ async def test_notify_not_connected(hass, client, monkeypatch):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            CONF_SERVICE_DATA: {
+            ATTR_SERVICE_DATA: {
                 CONF_ICON: ICON_PATH,
             },
         },
@@ -85,7 +86,7 @@ async def test_icon_not_found(hass, caplog, client, monkeypatch):
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            CONF_SERVICE_DATA: {
+            ATTR_SERVICE_DATA: {
                 CONF_ICON: ICON_PATH,
             },
         },
@@ -116,7 +117,7 @@ async def test_connection_errors(hass, caplog, client, monkeypatch, side_effect,
         TV_NAME,
         {
             ATTR_MESSAGE: MESSAGE,
-            CONF_SERVICE_DATA: {
+            ATTR_SERVICE_DATA: {
                 CONF_ICON: ICON_PATH,
             },
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Replace conf prefixed constants with attr prefixed constants in service calls.
- Avoid `dict.get` when accessing default parameters.
- Test notify service call without data in service parameters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
