### PR TITLE
Update srpenergy dependency to 1.3.6

### DIFF
--- a/homeassistant/components/srp_energy/manifest.json
+++ b/homeassistant/components/srp_energy/manifest.json
@@ -3,7 +3,7 @@
   "name": "SRP Energy",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/srp_energy",
-  "requirements": ["srpenergy==1.3.2"],
+  "requirements": ["srpenergy==1.3.6"],
   "codeowners": ["@briglx"],
   "iot_class": "cloud_polling",
   "loggers": ["srpenergy"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2266,7 +2266,7 @@ spotipy==2.19.0
 sqlalchemy==1.4.27
 
 # homeassistant.components.srp_energy
-srpenergy==1.3.2
+srpenergy==1.3.6
 
 # homeassistant.components.starline
 starline==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1402,7 +1402,7 @@ spotipy==2.19.0
 sqlalchemy==1.4.27
 
 # homeassistant.components.srp_energy
-srpenergy==1.3.2
+srpenergy==1.3.6
 
 # homeassistant.components.starline
 starline==0.1.5


### PR DESCRIPTION
This srpenergy package has been updated to support additional payment
plans. This should improve the usability of the srp_energy integration.

Dependency change log is available at https://github.com/lamoreauxlab/srpenergy-api-client-python/compare/1.3.5...1.3.6

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Upgrade srpenergy package to 1.3.6. The client interface has not changed but under the covers, the client now handles EZ-3 energy plans.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://pypi.org/project/srpenergy/1.3.6/

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
