### PR TITLE
Add functionality to play Spotify on Soundtouch integration

### DIFF
--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -6,5 +6,6 @@
   "after_dependencies": ["zeroconf"],
   "codeowners": [],
   "iot_class": "local_polling",
-  "loggers": ["libsoundtouch"]
+  "loggers": ["libsoundtouch"],
+  "version": "1.0.0"
 }

--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -6,6 +6,5 @@
   "after_dependencies": ["zeroconf"],
   "codeowners": [],
   "iot_class": "local_polling",
-  "loggers": ["libsoundtouch"],
-  "version": "1.0.0"
+  "loggers": ["libsoundtouch"]
 }

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -362,25 +362,37 @@ class SoundTouchDevice(MediaPlayerEntity):
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
-        _LOGGER.debug("Starting media with media_id: %s", media_id)
-        if re.match(r"http?://", str(media_id)):
-            # URL
-            _LOGGER.debug("Playing URL %s", str(media_id))
-            self._device.play_url(str(media_id))
-        else:
-            # Preset
-            presets = self._device.presets()
-            preset = next(
-                [
-                    preset for preset in presets if preset.preset_id == str(media_id)
-                ].__iter__(),
-                None,
+        if media_type == "spotify":
+            _LOGGER.debug(
+                "Starting spotify with spotify_media_uri: %s and user_id: %s",
+                media_id,
+                kwargs["extra"]["user_id"],
             )
-            if preset is not None:
-                _LOGGER.debug("Playing preset: %s", preset.name)
-                self._device.select_preset(preset)
+            self._device.play_media(
+                Source.SPOTIFY, media_id, kwargs["extra"]["user_id"]
+            )
+        else:
+            _LOGGER.debug("Starting media with media_id: %s", media_id)
+            if re.match(r"http?://", str(media_id)):
+                # URL
+                _LOGGER.debug("Playing URL %s", str(media_id))
+                self._device.play_url(str(media_id))
             else:
-                _LOGGER.warning("Unable to find preset with id %s", media_id)
+                # Preset
+                presets = self._device.presets()
+                preset = next(
+                    [
+                        preset
+                        for preset in presets
+                        if preset.preset_id == str(media_id)
+                    ].__iter__(),
+                    None,
+                )
+                if preset is not None:
+                    _LOGGER.debug("Playing preset: %s", preset.name)
+                    self._device.select_preset(preset)
+                else:
+                    _LOGGER.warning("Unable to find preset with id %s", media_id)
 
     def select_source(self, source):
         """Select input source."""

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -285,6 +285,21 @@ class MockStatusPlayingBluetooth(Status):
         self._station_name = None
 
 
+class MockStatusPlayingSpotify(Status):
+    """Mock status Spotify."""
+
+    def __init__(self):
+        """Init the class."""
+        self._source = "SPOTIFY"
+        self._play_status = "PLAY_STATE"
+        self._image = "image.url"
+        self._artist = "artist"
+        self._track = "track"
+        self._album = "album"
+        self._duration = 1
+        self._station_name = None
+
+
 async def test_ensure_setup_config(mocked_status, mocked_volume, hass, one_device):
     """Test setup OK with custom config."""
     await setup_soundtouch(
@@ -425,6 +440,24 @@ async def test_playing_bluetooth(mocked_status, mocked_volume, hass, one_device)
     assert entity_1_state.attributes["media_track"] == "track"
     assert entity_1_state.attributes["media_artist"] == "artist"
     assert entity_1_state.attributes["media_album_name"] == "album"
+
+
+async def test_playing_spotify(mocked_status, mocked_volume, hass, one_device):
+    """Test playing Bluetooth info."""
+    mocked_status.side_effect = MockStatusPlayingSpotify
+    await setup_soundtouch(hass, DEVICE_1_CONFIG)
+
+    assert one_device.call_count == 1
+    assert mocked_status.call_count == 2
+    assert mocked_volume.call_count == 2
+
+    entity_1_state = hass.states.get("media_player.soundtouch_1")
+    assert entity_1_state.state == STATE_PLAYING
+    assert entity_1_state.attributes["source"] == "SPOTIFY"
+    assert entity_1_state.attributes["media_track"] == "track"
+    assert entity_1_state.attributes["media_artist"] == "artist"
+    assert entity_1_state.attributes["media_album_name"] == "album"
+    assert entity_1_state.attributes["media_duration"] == 1
 
 
 async def test_get_volume_level(mocked_status, mocked_volume, hass, one_device):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds the functionality to play music from Spotify on the Bose SoundTouch integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21688

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
