### PR TITLE
Validate in split_entity_id

### DIFF
--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -71,7 +71,7 @@ GROUP_BY_MINUTES = 15
 EMPTY_JSON_OBJECT = "{}"
 UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
 
-HA_DOMAIN_ENTITY_ID = f"{HA_DOMAIN}."
+HA_DOMAIN_ENTITY_ID = f"{HA_DOMAIN}._"
 
 CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA}, extra=vol.ALLOW_EXTRA
@@ -598,7 +598,7 @@ def _keep_event(hass, event, entities_filter):
     if domain is None:
         return False
 
-    return entities_filter is None or entities_filter(f"{domain}.")
+    return entities_filter is None or entities_filter(f"{domain}._")
 
 
 def _augment_data_with_context(

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -141,9 +141,12 @@ TIMEOUT_EVENT_START = 15
 _LOGGER = logging.getLogger(__name__)
 
 
-def split_entity_id(entity_id: str) -> list[str]:
+def split_entity_id(entity_id: str) -> tuple[str, str]:
     """Split a state entity ID into domain and object ID."""
-    return entity_id.split(".", 1)
+    domain, _, object_id = entity_id.partition(".")
+    if not domain or not object_id:
+        raise ValueError("Invalid entity ID")
+    return domain, object_id
 
 
 VALID_ENTITY_ID = re.compile(r"^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$")

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -145,7 +145,7 @@ def split_entity_id(entity_id: str) -> tuple[str, str]:
     """Split a state entity ID into domain and object ID."""
     domain, _, object_id = entity_id.partition(".")
     if not domain or not object_id:
-        raise ValueError("Invalid entity ID")
+        raise ValueError(f"Invalid entity ID {entity_id}")
     return domain, object_id
 
 

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1220,9 +1220,9 @@ def test_entity_registry_items():
 async def test_deprecated_disabled_by_str(hass, registry, caplog):
     """Test deprecated str use of disabled_by converts to enum and logs a warning."""
     entry = registry.async_get_or_create(
-        "light",
-        "hue",
-        "5678",
+        domain="light.kitchen",
+        platform="hue",
+        unique_id="5678",
         disabled_by=er.RegistryEntryDisabler.USER.value,
     )
 
@@ -1233,9 +1233,9 @@ async def test_deprecated_disabled_by_str(hass, registry, caplog):
 async def test_deprecated_entity_category_str(hass, registry, caplog):
     """Test deprecated str use of entity_category converts to enum and logs a warning."""
     entry = er.RegistryEntry(
-        "light",
-        "hue",
-        "5678",
+        entity_id="light.kitchen",
+        unique_id="5678",
+        platform="hue",
         entity_category="diagnostic",
     )
 
@@ -1246,9 +1246,9 @@ async def test_deprecated_entity_category_str(hass, registry, caplog):
 async def test_invalid_entity_category_str(hass, registry, caplog):
     """Test use of invalid entity category."""
     entry = er.RegistryEntry(
-        "light",
-        "hue",
-        "5678",
+        entity_id="light.kitchen",
+        unique_id="5678",
+        platform="hue",
         entity_category="invalid",
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,7 +49,17 @@ PST = dt_util.get_time_zone("America/Los_Angeles")
 
 def test_split_entity_id():
     """Test split_entity_id."""
-    assert ha.split_entity_id("domain.object_id") == ["domain", "object_id"]
+    assert ha.split_entity_id("domain.object_id") == ("domain", "object_id")
+    with pytest.raises(ValueError):
+        ha.split_entity_id("")
+    with pytest.raises(ValueError):
+        ha.split_entity_id(".")
+    with pytest.raises(ValueError):
+        ha.split_entity_id("just_domain")
+    with pytest.raises(ValueError):
+        ha.split_entity_id("empty_object_id.")
+    with pytest.raises(ValueError):
+        ha.split_entity_id(".empty_domain")
 
 
 def test_async_add_hass_job_schedule_callback():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Custom component authors: `split_entity_id` will now raise a `ValueError` if the passed value does not follow the basic entity ID format (`<domain>.<object id>`). Previously it could return a list with a single item.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate it's a valid entity ID and not return data that violates the type signature.

I noticed that our validator would crash if the entity ID was invalid when I stumbled upon this commit: https://github.com/zachowj/node-red-contrib-home-assistant-websocket/commit/d085ef444f04d3f472180eae6e4e6f895c7a22eb#diff-ada8264180728098ca920091eca5641fd9a97221543fa087a9cec21b488c3de3R258-R267

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
