### PR TITLE
Log error when using zwave_js 'refresh_value' on ping button/node status sensor

### DIFF
--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_CLIENT, DOMAIN
+from .const import DATA_CLIENT, DOMAIN, LOGGER
 from .helpers import get_device_id, get_valueless_base_unique_id
 
 
@@ -61,7 +61,10 @@ class ZWaveNodePingButton(ButtonEntity):
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
         # pylint: disable=no-self-use
-        raise ValueError("There is no value to poll for this entity")
+        LOGGER.error(
+            "There is no value to refresh for this entity so the zwave_js.refresh_value "
+            "service won't work for it"
+        )
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""

--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -58,8 +58,21 @@ class ZWaveNodePingButton(ButtonEntity):
             identifiers={get_device_id(client, node)},
         )
 
+    async def async_poll_value(self, _: bool) -> None:
+        """Poll a value."""
+        # pylint: disable=no-self-use
+        raise ValueError("There is no value to poll for this entity")
+
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self.unique_id}_poll_value",
+                self.async_poll_value,
+            )
+        )
+
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -488,7 +488,10 @@ class ZWaveNodeStatusSensor(SensorEntity):
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
         # pylint: disable=no-self-use
-        raise ValueError("There is no value to poll for this entity")
+        LOGGER.error(
+            "There is no value to refresh for this entity so the zwave_js.refresh_value "
+            "service won't work for it"
+        )
 
     @callback
     def _status_changed(self, _: dict) -> None:

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -1,5 +1,6 @@
 """Test the Z-Wave JS button entities."""
 from homeassistant.components.button.const import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.zwave_js.const import DOMAIN, SERVICE_REFRESH_VALUE
 from homeassistant.const import ATTR_ENTITY_ID
 
 
@@ -8,6 +9,7 @@ async def test_ping_entity(
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
+    caplog,
 ):
     """Test ping entity."""
     client.async_send_command.return_value = {"responded": True}
@@ -31,3 +33,15 @@ async def test_ping_entity(
     )
 
     client.async_send_command.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_REFRESH_VALUE,
+        {
+            ATTR_ENTITY_ID: "button.z_wave_thermostat_ping",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert "ValueError" in caplog.text

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -8,6 +8,7 @@ async def test_ping_entity(
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
+    caplog,
 ):
     """Test ping entity."""
     client.async_send_command.return_value = {"responded": True}

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -42,6 +42,5 @@ async def test_ping_entity(
         },
         blocking=True,
     )
-    # await hass.async_block_till_done()
 
     assert "There is no value to refresh for this entity" in caplog.text

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -8,7 +8,6 @@ async def test_ping_entity(
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     integration,
-    caplog,
 ):
     """Test ping entity."""
     client.async_send_command.return_value = {"responded": True}

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -42,6 +42,6 @@ async def test_ping_entity(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
+    # await hass.async_block_till_done()
 
-    assert "ValueError" in caplog.text
+    assert "There is no value to refresh for this entity" in caplog.text

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.zwave_js.const import (
     ATTR_METER_TYPE_NAME,
     ATTR_VALUE,
     DOMAIN,
+    SERVICE_REFRESH_VALUE,
     SERVICE_RESET_METER,
 )
 from homeassistant.const import (
@@ -207,6 +208,7 @@ async def test_node_status_sensor_not_ready(
     lock_id_lock_as_id150_not_ready,
     lock_id_lock_as_id150_state,
     integration,
+    caplog,
 ):
     """Test node status sensor is created and available if node is not ready."""
     NODE_STATUS_ENTITY = "sensor.z_wave_module_for_id_lock_150_and_101_node_status"
@@ -233,6 +235,17 @@ async def test_node_status_sensor_not_ready(
     assert node.ready
     assert hass.states.get(NODE_STATUS_ENTITY)
     assert hass.states.get(NODE_STATUS_ENTITY).state == "alive"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_REFRESH_VALUE,
+        {
+            ATTR_ENTITY_ID: NODE_STATUS_ENTITY,
+        },
+        blocking=True,
+    )
+
+    assert "There is no value to refresh for this entity" in caplog.text
 
 
 async def test_reset_meter(


### PR DESCRIPTION
## Proposed change
Added logic to handle `zwave_js.refresh_value` call on a button and for both this and the node status sensor, instead of raising an exception we log an error since the exception is not handled by the frontend


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
