### PR TITLE
Create button entities for SleepIQ

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -22,7 +22,7 @@ from .coordinator import SleepIQDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.BUTTON]
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -33,9 +33,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -22,7 +22,7 @@ from .coordinator import SleepIQDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.BUTTON]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/sleepiq/button.py
+++ b/homeassistant/components/sleepiq/button.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from asyncsleepiq import SleepIQBed
 
@@ -20,7 +21,7 @@ from .entity import SleepIQEntity
 class SleepIQButtonEntityDescriptionMixin:
     """Describes a SleepIQ Button entity."""
 
-    press_action: Callable
+    press_action: Callable[[SleepIQBed], Any]
 
 
 @dataclass
@@ -38,7 +39,7 @@ ENTITY_DESCRIPTIONS = [
         icon="mdi:target",
     ),
     SleepIQButtonEntityDescription(
-        key="stoppump",
+        key="stop-pump",
         name="Stop Pump",
         press_action=lambda client: client.stop_pump(),
         icon="mdi:stop",
@@ -72,9 +73,7 @@ class SleepNumberButton(SleepIQEntity, ButtonEntity):
         """Initialize the Button."""
         super().__init__(bed)
         self._attr_name = f"SleepNumber {bed.name} {entity_description.name}"
-        if entity_description.name:
-            unique_name = entity_description.name.lower().replace(" ", "-")
-            self._attr_unique_id = f"{bed.id}-{unique_name}"
+        self._attr_unique_id = f"{bed.id}-{entity_description.key}"
         self.entity_description = entity_description
 
     async def async_press(self) -> None:

--- a/homeassistant/components/sleepiq/button.py
+++ b/homeassistant/components/sleepiq/button.py
@@ -1,0 +1,56 @@
+"""Support for SleepIQ buttons."""
+from __future__ import annotations
+
+from asyncsleepiq import SleepIQBed
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SleepIQDataUpdateCoordinator
+from .entity import SleepIQEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the sleep number buttons."""
+    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SleepIQEntity] = []
+    for bed in coordinator.client.beds.values():
+        entities.append(SleepNumberCalibrateButton(bed))
+        entities.append(SleepNumberStopPumpButton(bed))
+
+    async_add_entities(entities)
+
+
+class SleepNumberCalibrateButton(SleepIQEntity, ButtonEntity):
+    """Representation of an SleepIQ calibrate button."""
+
+    def __init__(self, bed: SleepIQBed) -> None:
+        """Initialize the Button."""
+        super().__init__(bed)
+        self._attr_name = f"SleepNumber {bed.name} Calibrate"
+        self._attr_unique_id = f"{bed.id}-calibrate"
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.bed.calibrate()
+
+
+class SleepNumberStopPumpButton(SleepIQEntity, ButtonEntity):
+    """Representation of an SleepIQ stop pump button."""
+
+    def __init__(self, bed: SleepIQBed) -> None:
+        """Initialize the Button."""
+        super().__init__(bed)
+        self._attr_name = f"SleepNumber {bed.name} Stop Pump"
+        self._attr_unique_id = f"{bed.id}-stop_pump"
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.bed.stop_pump()

--- a/homeassistant/components/sleepiq/entity.py
+++ b/homeassistant/components/sleepiq/entity.py
@@ -28,7 +28,7 @@ class SleepIQEntity(Entity):
         )
 
 
-class SleepIQSensor(CoordinatorEntity, SleepIQEntity):
+class SleepIQSensor(CoordinatorEntity):
     """Implementation of a SleepIQ sensor."""
 
     _attr_icon = ICON_OCCUPIED
@@ -42,12 +42,18 @@ class SleepIQSensor(CoordinatorEntity, SleepIQEntity):
     ) -> None:
         """Initialize the SleepIQ sensor entity."""
         super().__init__(coordinator)
-        SleepIQEntity.__init__(self, bed)
         self.sleeper = sleeper
-        self._async_update_attrs()
+        self.bed = bed
+        self._attr_device_info = DeviceInfo(
+            connections={(device_registry.CONNECTION_NETWORK_MAC, bed.mac_addr)},
+            manufacturer="SleepNumber",
+            name=bed.name,
+            model=bed.model,
+        )
 
         self._attr_name = f"SleepNumber {bed.name} {sleeper.name} {SENSOR_TYPES[name]}"
         self._attr_unique_id = f"{bed.id}_{sleeper.name}_{name}"
+        self._async_update_attrs()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -1,6 +1,7 @@
 """Common methods for SleepIQ."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import create_autospec, patch
 
+from asyncsleepiq import SleepIQBed, SleepIQSleeper
 import pytest
 
 from homeassistant.components.sleepiq import DOMAIN
@@ -24,15 +25,15 @@ def mock_asyncsleepiq():
     """Mock an AsyncSleepIQ object."""
     with patch("homeassistant.components.sleepiq.AsyncSleepIQ", autospec=True) as mock:
         client = mock.return_value
-        bed = MagicMock()
+        bed = create_autospec(SleepIQBed)
         client.beds = {BED_ID: bed}
         bed.name = BED_NAME
         bed.id = BED_ID
         bed.mac_addr = "12:34:56:78:AB:CD"
         bed.model = "C10"
         bed.paused = False
-        sleeper_l = MagicMock()
-        sleeper_r = MagicMock()
+        sleeper_l = create_autospec(SleepIQSleeper)
+        sleeper_r = create_autospec(SleepIQSleeper)
         bed.sleepers = [sleeper_l, sleeper_r]
 
         sleeper_l.side = "L"

--- a/tests/components/sleepiq/test_button.py
+++ b/tests/components/sleepiq/test_button.py
@@ -1,0 +1,61 @@
+"""The tests for SleepIQ binary sensor platform."""
+from homeassistant.components.button import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.helpers import entity_registry as er
+
+from tests.components.sleepiq.conftest import (
+    BED_ID,
+    BED_NAME,
+    BED_NAME_LOWER,
+    setup_platform,
+)
+
+
+async def test_button_calibrate(hass, mock_asyncsleepiq):
+    """Test the SleepIQ calibrate button."""
+    await setup_platform(hass, DOMAIN)
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get(f"button.sleepnumber_{BED_NAME_LOWER}_calibrate")
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME) == f"SleepNumber {BED_NAME} Calibrate"
+    )
+
+    entity = entity_registry.async_get(f"button.sleepnumber_{BED_NAME_LOWER}_calibrate")
+    assert entity
+    assert entity.unique_id == f"{BED_ID}-calibrate"
+
+    await hass.services.async_call(
+        DOMAIN,
+        "press",
+        {ATTR_ENTITY_ID: f"button.sleepnumber_{BED_NAME_LOWER}_calibrate"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_asyncsleepiq.beds[BED_ID].calibrate.assert_called_once()
+
+
+async def test_button_stop_pump(hass, mock_asyncsleepiq):
+    """Test the SleepIQ stop pump button."""
+    await setup_platform(hass, DOMAIN)
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get(f"button.sleepnumber_{BED_NAME_LOWER}_stop_pump")
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME) == f"SleepNumber {BED_NAME} Stop Pump"
+    )
+
+    entity = entity_registry.async_get(f"button.sleepnumber_{BED_NAME_LOWER}_stop_pump")
+    assert entity
+    assert entity.unique_id == f"{BED_ID}-stop_pump"
+
+    await hass.services.async_call(
+        DOMAIN,
+        "press",
+        {ATTR_ENTITY_ID: f"button.sleepnumber_{BED_NAME_LOWER}_stop_pump"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_asyncsleepiq.beds[BED_ID].stop_pump.assert_called_once()

--- a/tests/components/sleepiq/test_button.py
+++ b/tests/components/sleepiq/test_button.py
@@ -48,7 +48,7 @@ async def test_button_stop_pump(hass, mock_asyncsleepiq):
 
     entity = entity_registry.async_get(f"button.sleepnumber_{BED_NAME_LOWER}_stop_pump")
     assert entity
-    assert entity.unique_id == f"{BED_ID}-stop_pump"
+    assert entity.unique_id == f"{BED_ID}-stop-pump"
 
     await hass.services.async_call(
         DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added two new buttons, one for bed calibrate, one for "stop pump".  Separated the SleepIQ entity to a version that does not have the coordinator (as buttons don't need to sync state) and which is only for the bed, not including sleepers (buttons are for the whole bed, not one per side)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
