### PR TITLE
Add config_flow for openhome component

### DIFF
--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -1,1 +1,26 @@
 """The openhome component."""
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.MEDIA_PLAYER]
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up openhome from a config entry."""
+    _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
+
+    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    # Forward to the same platform as async_setup_entry did
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/openhome/config_flow.py
+++ b/homeassistant/components/openhome/config_flow.py
@@ -1,0 +1,49 @@
+"""Config flow for openhome."""
+
+import logging
+
+from homeassistant.components.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_HOST
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _is_complete_discovery(discovery_info: SsdpServiceInfo) -> bool:
+    """Test if discovery is complete and usable."""
+    return bool(ATTR_UPNP_UDN in discovery_info.upnp and discovery_info.ssdp_location)
+
+
+class OpenhomeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle an Openhome config flow."""
+
+    async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> FlowResult:
+        """Handle a flow initialized by discovery."""
+        _LOGGER.debug("async_step_ssdp: started")
+
+        if not _is_complete_discovery(discovery_info):
+            _LOGGER.debug("async_step_ssdp: Incomplete discovery, ignoring")
+            return self.async_abort(reason="incomplete_discovery")
+
+        _LOGGER.debug(
+            "async_step_ssdp: setting unique id %s", discovery_info.upnp[ATTR_UPNP_UDN]
+        )
+
+        await self.async_set_unique_id(discovery_info.upnp[ATTR_UPNP_UDN])
+        self._abort_if_unique_id_configured({CONF_HOST: discovery_info.ssdp_location})
+
+        _LOGGER.debug(
+            "async_step_ssdp: create entry %s", discovery_info.upnp[ATTR_UPNP_UDN]
+        )
+
+        return self.async_create_entry(
+            title=discovery_info.upnp[ATTR_UPNP_FRIENDLY_NAME],
+            data={CONF_HOST: discovery_info.ssdp_location},
+        )

--- a/homeassistant/components/openhome/const.py
+++ b/homeassistant/components/openhome/const.py
@@ -3,3 +3,5 @@ DOMAIN = "openhome"
 SERVICE_INVOKE_PIN = "invoke_pin"
 ATTR_PIN_INDEX = "pin"
 DATA_OPENHOME = "openhome"
+
+DOMAIN_DATA_ENTRIES = f"{DOMAIN}.entries"

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -1,8 +1,20 @@
 {
   "domain": "openhome",
   "name": "Linn / OpenHome",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/openhome",
   "requirements": ["openhomedevice==2.0.1"],
+  "ssdp": [
+    {
+      "deviceType": "urn:av-openhome-org:service:Product:1"
+    },
+    {
+      "deviceType": "urn:av-openhome-org:service:Product:2"
+    },
+    {
+      "deviceType": "urn:av-openhome-org:service:Product:3"
+    }
+  ],
   "codeowners": ["@bazwilliams"],
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client", "openhomedevice"]

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -234,6 +234,7 @@ FLOWS = [
     "onvif",
     "open_meteo",
     "opengarage",
+    "openhome",
     "opentherm_gw",
     "openuv",
     "openweathermap",

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -191,6 +191,17 @@ SSDP = {
             "manufacturer": "The OctoPrint Project"
         }
     ],
+    "openhome": [
+        {
+            "deviceType": "urn:av-openhome-org:service:Product:1"
+        },
+        {
+            "deviceType": "urn:av-openhome-org:service:Product:2"
+        },
+        {
+            "deviceType": "urn:av-openhome-org:service:Product:3"
+        }
+    ],
     "roku": [
         {
             "deviceType": "urn:roku-com:device:player:1-0",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Remove the following section from your media_player yaml configuration:

```
  - platform: openhome
```

## Proposed change

Migrate the openhome component away from yaml configuration and to config_flow. 
Documentation updates will be necessary. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21691

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
