### PR TITLE
Correct state restoring for Utility Meter sensors

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from decimal import Decimal, InvalidOperation as DecimalInvalidOperation
+from decimal import Decimal
 import logging
 from math import floor, log10
 from typing import Any, Final, cast, final
@@ -560,9 +560,6 @@ class SensorExtraStoredData(ExtraStoredData):
             pass
         except KeyError:
             # native_value is a dict, but does not have all values
-            return None
-        except DecimalInvalidOperation:
-            # native value couldn't be cast back to Decimal
             return None
 
         return cls(native_value, native_unit_of_measurement)

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation as DecimalInvalidOperation
 import logging
 from math import floor, log10
 from typing import Any, Final, cast, final
@@ -560,6 +560,9 @@ class SensorExtraStoredData(ExtraStoredData):
             pass
         except KeyError:
             # native_value is a dict, but does not have all values
+            return None
+        except DecimalInvalidOperation:
+            # native_value coulnd't be returned from decimal_str
             return None
 
         return cls(native_value, native_unit_of_measurement)

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -529,10 +529,10 @@ class SensorExtraStoredData(ExtraStoredData):
                 "__type": str(type(native_value)),
                 "isoformat": native_value.isoformat(),
             }
-        if isinstance(native_value, (Decimal)):
+        if isinstance(native_value, Decimal):
             native_value = {
                 "__type": str(type(native_value)),
-                "value": str(native_value),
+                "decimal_str": str(native_value),
             }
         return {
             "native_value": native_value,
@@ -554,7 +554,7 @@ class SensorExtraStoredData(ExtraStoredData):
             elif type_ == "<class 'datetime.date'>":
                 native_value = dt_util.parse_date(native_value["isoformat"])
             elif type_ == "<class 'decimal.Decimal'>":
-                native_value = Decimal(native_value["value"])
+                native_value = Decimal(native_value["decimal_str"])
         except TypeError:
             # native_value is not a dict
             pass

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -447,7 +447,7 @@ class UtilityMeterSensor(RestoreSensor):
             self._last_period = last_sensor_data.last_period
             self._last_reset = last_sensor_data.last_reset
             if last_sensor_data.status == COLLECTING:
-                # Fake cancellation function to init the meter in similar state
+                # Null lambda to allow cancelling the collection on tariff change
                 self._collecting = lambda: None
 
         elif state := await self.async_get_last_state():

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -257,6 +257,9 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
         except KeyError:
             # restored is a dict, but does not have all values
             return None
+        except InvalidOperation:
+            # last_period is corrupted
+            return None
 
         return cls(
             extra.native_value,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -254,9 +254,6 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
             last_period: Decimal = Decimal(restored["last_period"])
             last_reset: datetime | None = dt_util.parse_datetime(restored["last_reset"])
             status: str = restored["status"]
-
-        except InvalidOperation:
-            return None
         except TypeError:
             # restored is not a dict
             return None

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -252,10 +252,17 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
 
         try:
             last_period: Decimal = Decimal(restored["last_period"])
+            last_reset: datetime | None = dt_util.parse_datetime(restored["last_reset"])
+            status: str = restored["status"]
+
         except InvalidOperation:
             return None
-        last_reset: datetime | None = dt_util.parse_datetime(restored["last_reset"])
-        status: str = restored["status"]
+        except TypeError:
+            # restored is not a dict
+            return None
+        except KeyError:
+            # restored is a dict, but does not have all values
+            return None
 
         return cls(
             extra.native_value,
@@ -473,7 +480,7 @@ class UtilityMeterSensor(RestoreSensor):
                     dt_util.parse_datetime(state.attributes.get(ATTR_LAST_RESET))
                 )
                 if state.attributes.get(ATTR_STATUS) == COLLECTING:
-                    # Fake cancellation function to init the meter in similar state
+                    # Null lambda to allow cancelling the collection on tariff change
                     self._collecting = lambda: None
 
         @callback

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -254,9 +254,6 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
             last_period: Decimal = Decimal(restored["last_period"])
             last_reset: datetime | None = dt_util.parse_datetime(restored["last_reset"])
             status: str = restored["status"]
-        except TypeError:
-            # restored is not a dict
-            return None
         except KeyError:
             # restored is a dict, but does not have all values
             return None

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -253,7 +253,7 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
         try:
             last_period: Decimal = Decimal(restored["last_period"])
         except InvalidOperation:
-            last_period = Decimal(0)
+            return None
         last_reset: datetime | None = dt_util.parse_datetime(restored["last_reset"])
         status: str = restored["status"]
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -251,7 +251,7 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
         try:
             native_value = Decimal(restored["native_value"])
         except InvalidOperation:
-            native_value = restored["native_value"]
+            native_value = None
         native_unit_of_measurement = restored["native_unit_of_measurement"]
         try:
             last_period = Decimal(restored["last_period"])

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -579,11 +579,6 @@ class UtilityMeterSensor(RestoreSensor):
         return ICON
 
     @property
-    def last_reset(self):
-        """Return the last time the sensor was reset."""
-        return self._last_reset
-
-    @property
     def extra_restore_state_data(self) -> UtilitySensorExtraStoredData:
         """Return sensor specific state data to be restored."""
         return UtilitySensorExtraStoredData(
@@ -595,7 +590,7 @@ class UtilityMeterSensor(RestoreSensor):
         )
 
     async def async_get_last_sensor_data(self) -> UtilitySensorExtraStoredData | None:
-        """Restore native_value and native_unit_of_measurement."""
+        """Restore Utility Meter Sensor Extra Stored Data."""
         if (restored_last_extra_data := await self.async_get_last_extra_data()) is None:
             return None
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -237,7 +237,7 @@ class UtilitySensorExtraStoredData(SensorExtraStoredData):
         """Return a dict representation of the utility sensor data."""
         data = super().as_dict()
         data["last_period"] = str(self.last_period)
-        if self.last_reset:
+        if isinstance(self.last_reset, (datetime)):
             data["last_reset"] = self.last_reset.isoformat()
         data["status"] = self.status
 

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -238,6 +238,13 @@ RESTORE_DATA = {
             "decimal_str": "123.4",
         },
     },
+    "BadDecimal": {
+        "native_unit_of_measurement": "°F",
+        "native_value": {
+            "__type": "<class 'decimal.Decimal'>",
+            "decimal_str": "123f",
+        },
+    },
 }
 
 
@@ -323,6 +330,7 @@ async def test_restore_sensor_save_state(
             None,
             None,
         ),
+        (None, type(None), RESTORE_DATA["BadDecimal"], SensorDeviceClass.ENERGY, None),
     ],
 )
 async def test_restore_sensor_restore_state(

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1,5 +1,6 @@
 """The test for sensor entity."""
 from datetime import date, datetime, timezone
+from decimal import Decimal
 
 import pytest
 from pytest import approx
@@ -230,10 +231,17 @@ RESTORE_DATA = {
             "isoformat": datetime(2020, 2, 8, 15, tzinfo=timezone.utc).isoformat(),
         },
     },
+    "Decimal": {
+        "native_unit_of_measurement": "°F",
+        "native_value": {
+            "__type": "<class 'decimal.Decimal'>",
+            "decimal_str": "123.4",
+        },
+    },
 }
 
 
-# None | str | int | float | date | datetime:
+# None | str | int | float | date | datetime | Decimal:
 @pytest.mark.parametrize(
     "native_value, native_value_type, expected_extra_data, device_class",
     [
@@ -247,6 +255,7 @@ RESTORE_DATA = {
             RESTORE_DATA["datetime"],
             SensorDeviceClass.TIMESTAMP,
         ),
+        (Decimal("123.4"), dict, RESTORE_DATA["Decimal"], SensorDeviceClass.ENERGY),
     ],
 )
 async def test_restore_sensor_save_state(
@@ -295,6 +304,13 @@ async def test_restore_sensor_save_state(
             datetime,
             RESTORE_DATA["datetime"],
             SensorDeviceClass.TIMESTAMP,
+            "°F",
+        ),
+        (
+            Decimal("123.4"),
+            Decimal,
+            RESTORE_DATA["Decimal"],
+            SensorDeviceClass.ENERGY,
             "°F",
         ),
         (None, type(None), None, None, None),

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -500,7 +500,13 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
                     },
                 ),
-                {},
+                {
+                    "native_value": {
+                        "__type": "<class 'decimal.Decimal'>",
+                        "decimal_str": "3f",
+                    },
+                    "native_unit_of_measurement": "kWh",
+                },
             ),
             (
                 State(

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -41,7 +41,11 @@ from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, mock_restore_cache_with_extra_data
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache_with_extra_data,
+)
 
 
 @contextmanager
@@ -458,7 +462,7 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                     },
                 ),
                 {
-                    "native_value": "3",
+                    "native_value": {"__type": "<class 'decimal.Decimal'>", "value": 3},
                     "native_unit_of_measurement": "kWh",
                     "last_reset": last_reset,
                     "last_period": "7",
@@ -471,7 +475,10 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                     "error",
                 ),
                 {
-                    "native_value": "dog",
+                    "native_value": {
+                        "__type": "<class 'decimal.Decimal'>",
+                        "value": "dog",
+                    },
                     "native_unit_of_measurement": "kWh",
                     "last_reset": last_reset,
                     "last_period": "cat",

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -41,7 +41,7 @@ from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, mock_restore_cache
+from tests.common import MockConfigEntry, async_fire_time_changed, mock_restore_cache_with_extra_data
 
 
 @contextmanager
@@ -443,29 +443,49 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
     hass.state = CoreState.not_running
 
     last_reset = "2020-12-21T00:00:00.013073+00:00"
-    mock_restore_cache(
+
+    mock_restore_cache_with_extra_data(
         hass,
         [
-            State(
-                "sensor.energy_bill_onpeak",
-                "3",
-                attributes={
-                    ATTR_STATUS: PAUSED,
-                    ATTR_LAST_RESET: last_reset,
-                    ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+            (
+                State(
+                    "sensor.energy_bill_onpeak",
+                    "3",
+                    attributes={
+                        ATTR_STATUS: PAUSED,
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+                    },
+                ),
+                {
+                    "native_value": "3",
+                    "native_unit_of_measurement": "kWh",
+                    "last_reset": last_reset,
+                    "last_period": "7",
                 },
             ),
-            State(
-                "sensor.energy_bill_midpeak",
-                "error",
+            (
+                State(
+                    "sensor.energy_bill_midpeak",
+                    "error",
+                ),
+                {},
             ),
-            State(
-                "sensor.energy_bill_offpeak",
-                "6",
-                attributes={
-                    ATTR_STATUS: COLLECTING,
-                    ATTR_LAST_RESET: last_reset,
-                    ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+            (
+                State(
+                    "sensor.energy_bill_offpeak",
+                    "6",
+                    attributes={
+                        ATTR_STATUS: COLLECTING,
+                        ATTR_LAST_RESET: last_reset,
+                        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+                    },
+                ),
+                {
+                    "native_value": "6",
+                    "native_unit_of_measurement": "kWh",
+                    "last_reset": last_reset,
+                    "last_period": "7",
                 },
             ),
         ],

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -462,6 +462,7 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                     "native_unit_of_measurement": "kWh",
                     "last_reset": last_reset,
                     "last_period": "7",
+                    "status": "paused",
                 },
             ),
             (
@@ -486,6 +487,7 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                     "native_unit_of_measurement": "kWh",
                     "last_reset": last_reset,
                     "last_period": "7",
+                    "status": "collecting",
                 },
             ),
         ],

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -470,7 +470,13 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                     "sensor.energy_bill_midpeak",
                     "error",
                 ),
-                {},
+                {
+                    "native_value": "dog",
+                    "native_unit_of_measurement": "kWh",
+                    "last_reset": last_reset,
+                    "last_period": "cat",
+                    "status": "collecting",
+                },
             ),
             (
                 State(

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -488,13 +488,7 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
                     },
                 ),
-                {
-                    "native_value": "6",
-                    "native_unit_of_measurement": "kWh",
-                    "last_reset": last_reset,
-                    "last_period": "7",
-                    "status": "collecting",
-                },
+                {},
             ),
         ],
     )

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -462,7 +462,10 @@ async def test_restore_state(hass, yaml_config, config_entry_config):
                     },
                 ),
                 {
-                    "native_value": {"__type": "<class 'decimal.Decimal'>", "value": 3},
+                    "native_value": {
+                        "__type": "<class 'decimal.Decimal'>",
+                        "value": "3",
+                    },
                     "native_unit_of_measurement": "kWh",
                     "last_reset": last_reset,
                     "last_period": "7",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Proper handling of the types handled by the utility_meter sensors (Decimal)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
