### PR TITLE
Fix binary sensor translations for carbon_monoxide

### DIFF
--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -115,9 +115,9 @@
       "off": "Not charging",
       "on": "Charging"
     },
-    "co": {
-      "off": "Clear",
-      "on": "Detected"
+    "carbon_monoxide": {
+      "off": "[%key:component::binary_sensor::state::gas::off%]",
+      "on": "[%key:component::binary_sensor::state::gas::on%]"
     },
     "cold": {
       "off": "[%key:component::binary_sensor::state::battery::off%]",
@@ -136,8 +136,8 @@
       "on": "[%key:common::state::open%]"
     },
     "gas": {
-      "off": "Clear",
-      "on": "Detected"
+      "off": "[%key:component::binary_sensor::state::gas::off%]",
+      "on": "[%key:component::binary_sensor::state::gas::on%]"
     },
     "heat": {
       "off": "[%key:component::binary_sensor::state::battery::off%]",

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -136,8 +136,8 @@
       "on": "[%key:common::state::open%]"
     },
     "gas": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "off": "Clear",
+      "on": "Detected"
     },
     "heat": {
       "off": "[%key:component::binary_sensor::state::battery::off%]",

--- a/homeassistant/components/binary_sensor/translations/en.json
+++ b/homeassistant/components/binary_sensor/translations/en.json
@@ -133,8 +133,8 @@
             "on": "Charging"
         },
         "carbon_monoxide": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "cold": {
             "off": "Normal",
@@ -153,8 +153,8 @@
             "on": "Open"
         },
         "gas": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "heat": {
             "off": "Normal",
@@ -173,16 +173,16 @@
             "on": "Wet"
         },
         "motion": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "moving": {
             "off": "Not moving",
             "on": "Moving"
         },
         "occupancy": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "opening": {
             "off": "Closed",
@@ -209,20 +209,20 @@
             "on": "Unsafe"
         },
         "smoke": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "sound": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "update": {
             "off": "Up-to-date",
             "on": "Update available"
         },
         "vibration": {
-            "off": "[%key:component::binary_sensor::state::gas::off%]",
-            "on": "[%key:component::binary_sensor::state::gas::on%]"
+            "off": "Clear",
+            "on": "Detected"
         },
         "window": {
             "off": "Closed",

--- a/homeassistant/components/binary_sensor/translations/en.json
+++ b/homeassistant/components/binary_sensor/translations/en.json
@@ -59,8 +59,6 @@
             "connected": "{entity_name} connected",
             "gas": "{entity_name} started detecting gas",
             "hot": "{entity_name} became hot",
-            "is_not_tampered": "{entity_name} stopped detecting tampering",
-            "is_tampered": "{entity_name} started detecting tampering",
             "light": "{entity_name} started detecting light",
             "locked": "{entity_name} locked",
             "moist": "{entity_name} became moist",
@@ -134,9 +132,9 @@
             "off": "Not charging",
             "on": "Charging"
         },
-        "co": {
-            "off": "Clear",
-            "on": "Detected"
+        "carbon_monoxide": {
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "cold": {
             "off": "Normal",
@@ -155,8 +153,8 @@
             "on": "Open"
         },
         "gas": {
-            "off": "Clear",
-            "on": "Detected"
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "heat": {
             "off": "Normal",
@@ -175,16 +173,16 @@
             "on": "Wet"
         },
         "motion": {
-            "off": "Clear",
-            "on": "Detected"
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "moving": {
             "off": "Not moving",
             "on": "Moving"
         },
         "occupancy": {
-            "off": "Clear",
-            "on": "Detected"
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "opening": {
             "off": "Closed",
@@ -195,8 +193,8 @@
             "on": "Plugged in"
         },
         "presence": {
-            "off": "Away",
-            "on": "Home"
+            "off": "[%key:common::state::not_home%]",
+            "on": "[%key:common::state::home%]"
         },
         "problem": {
             "off": "OK",
@@ -211,20 +209,20 @@
             "on": "Unsafe"
         },
         "smoke": {
-            "off": "Clear",
-            "on": "Detected"
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "sound": {
-            "off": "Clear",
-            "on": "Detected"
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "update": {
             "off": "Up-to-date",
             "on": "Update available"
         },
         "vibration": {
-            "off": "Clear",
-            "on": "Detected"
+            "off": "[%key:component::binary_sensor::state::gas::off%]",
+            "on": "[%key:component::binary_sensor::state::gas::on%]"
         },
         "window": {
             "off": "Closed",

--- a/homeassistant/components/binary_sensor/translations/en.json
+++ b/homeassistant/components/binary_sensor/translations/en.json
@@ -193,8 +193,8 @@
             "on": "Plugged in"
         },
         "presence": {
-            "off": "[%key:common::state::not_home%]",
-            "on": "[%key:common::state::home%]"
+            "off": "Away",
+            "on": "Home"
         },
         "problem": {
             "off": "OK",

--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -75,7 +75,13 @@ def substitute_reference(value, flattened_translations):
     new = value
     for key in matches:
         if key in flattened_translations:
-            new = new.replace(f"[%key:{key}%]", flattened_translations[key])
+            new = new.replace(
+                f"[%key:{key}%]",
+                # New value can also be a substitution reference
+                substitute_reference(
+                    flattened_translations[key], flattened_translations
+                ),
+            )
         else:
             print(f"Invalid substitution key '{key}' found in string '{value}'")
             sys.exit(1)


### PR DESCRIPTION
## Proposed change
While developing a custom component, I noticed that the state key for carbon_monoxide in strings.json is not correct. 

Before:
<img width="276" alt="Screen Shot 2022-02-19 at 00 51 16" src="https://user-images.githubusercontent.com/1424596/154777387-a4c1c8e1-f94f-441c-ab8e-a3e1d9eee6c0.png">

After:
<img width="274" alt="Screen Shot 2022-02-19 at 01 17 25" src="https://user-images.githubusercontent.com/1424596/154777398-fa62d1fd-bccf-44e8-8830-897ff35dff86.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
