### PR TITLE
Remove async_setup_component() from tests

### DIFF
--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -16,26 +16,21 @@ from homeassistant.components.modbus.const import (
     CONF_VERIFY,
     CONF_WRITE_TYPE,
     MODBUS_DOMAIN,
-    TCP,
 )
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
-    CONF_HOST,
     CONF_NAME,
-    CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
-    CONF_TYPE,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from .conftest import TEST_ENTITY_NAME, TEST_MODBUS_HOST, TEST_PORT_TCP, ReadResult
+from .conftest import TEST_ENTITY_NAME, ReadResult
 
 ENTITY_ID = f"{FAN_DOMAIN}.{TEST_ENTITY_NAME}"
 ENTITY_ID2 = f"{ENTITY_ID}2"
@@ -221,14 +216,10 @@ async def test_restore_state_fan(hass, mock_test_state, mock_modbus):
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
 
-async def test_fan_service_turn(hass, caplog, mock_pymodbus):
-    """Run test for service turn_on/turn_off."""
-
-    config = {
-        MODBUS_DOMAIN: {
-            CONF_TYPE: TCP,
-            CONF_HOST: TEST_MODBUS_HOST,
-            CONF_PORT: TEST_PORT_TCP,
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
             CONF_FANS: [
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
@@ -245,9 +236,11 @@ async def test_fan_service_turn(hass, caplog, mock_pymodbus):
                 },
             ],
         },
-    }
-    assert await async_setup_component(hass, MODBUS_DOMAIN, config) is True
-    await hass.async_block_till_done()
+    ],
+)
+async def test_fan_service_turn(hass, caplog, mock_modbus):
+    """Run test for service turn_on/turn_off."""
+
     assert MODBUS_DOMAIN in hass.config.components
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -262,27 +255,27 @@ async def test_fan_service_turn(hass, caplog, mock_pymodbus):
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x01])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     await hass.services.async_call(
         "fan", "turn_on", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_ON
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x00])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
         "fan", "turn_off", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
 
-    mock_pymodbus.write_register.side_effect = ModbusException("fail write_")
+    mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "fan", "turn_on", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
-    mock_pymodbus.write_coil.side_effect = ModbusException("fail write_")
+    mock_modbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "fan", "turn_off", service_data={"entity_id": ENTITY_ID}
     )

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -15,27 +15,22 @@ from homeassistant.components.modbus.const import (
     CONF_VERIFY,
     CONF_WRITE_TYPE,
     MODBUS_DOMAIN,
-    TCP,
 )
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
-    CONF_HOST,
     CONF_LIGHTS,
     CONF_NAME,
-    CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
-    CONF_TYPE,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 
-from .conftest import TEST_ENTITY_NAME, TEST_MODBUS_HOST, TEST_PORT_TCP, ReadResult
+from .conftest import TEST_ENTITY_NAME, ReadResult
 
 ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_ENTITY_NAME}"
 ENTITY_ID2 = f"{ENTITY_ID}2"
@@ -221,14 +216,10 @@ async def test_restore_state_light(hass, mock_test_state, mock_modbus):
     assert hass.states.get(ENTITY_ID).state == mock_test_state[0].state
 
 
-async def test_light_service_turn(hass, caplog, mock_pymodbus):
-    """Run test for service turn_on/turn_off."""
-
-    config = {
-        MODBUS_DOMAIN: {
-            CONF_TYPE: TCP,
-            CONF_HOST: TEST_MODBUS_HOST,
-            CONF_PORT: TEST_PORT_TCP,
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
             CONF_LIGHTS: [
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
@@ -245,9 +236,11 @@ async def test_light_service_turn(hass, caplog, mock_pymodbus):
                 },
             ],
         },
-    }
-    assert await async_setup_component(hass, MODBUS_DOMAIN, config) is True
-    await hass.async_block_till_done()
+    ],
+)
+async def test_light_service_turn(hass, caplog, mock_modbus):
+    """Run test for service turn_on/turn_off."""
+
     assert MODBUS_DOMAIN in hass.config.components
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -262,27 +255,27 @@ async def test_light_service_turn(hass, caplog, mock_pymodbus):
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x01])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     await hass.services.async_call(
         "light", "turn_on", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_ON
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x00])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
         "light", "turn_off", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
 
-    mock_pymodbus.write_register.side_effect = ModbusException("fail write_")
+    mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "light", "turn_on", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
-    mock_pymodbus.write_coil.side_effect = ModbusException("fail write_")
+    mock_modbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "light", "turn_off", service_data={"entity_id": ENTITY_ID}
     )

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -17,7 +17,6 @@ from homeassistant.components.modbus.const import (
     CONF_VERIFY,
     CONF_WRITE_TYPE,
     MODBUS_DOMAIN,
-    TCP,
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -26,28 +25,18 @@ from homeassistant.const import (
     CONF_COMMAND_ON,
     CONF_DELAY,
     CONF_DEVICE_CLASS,
-    CONF_HOST,
     CONF_NAME,
-    CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     CONF_SWITCHES,
-    CONF_TYPE,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import State
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from .conftest import (
-    TEST_ENTITY_NAME,
-    TEST_MODBUS_HOST,
-    TEST_PORT_TCP,
-    ReadResult,
-    do_next_cycle,
-)
+from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
 from tests.common import async_fire_time_changed
 
@@ -280,14 +269,10 @@ async def test_restore_state_switch(hass, mock_test_state, mock_modbus):
     assert hass.states.get(ENTITY_ID).state == mock_test_state[0].state
 
 
-async def test_switch_service_turn(hass, caplog, mock_pymodbus):
-    """Run test for service turn_on/turn_off."""
-
-    config = {
-        MODBUS_DOMAIN: {
-            CONF_TYPE: TCP,
-            CONF_HOST: TEST_MODBUS_HOST,
-            CONF_PORT: TEST_PORT_TCP,
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
             CONF_SWITCHES: [
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
@@ -304,9 +289,10 @@ async def test_switch_service_turn(hass, caplog, mock_pymodbus):
                 },
             ],
         },
-    }
-    assert await async_setup_component(hass, MODBUS_DOMAIN, config) is True
-    await hass.async_block_till_done()
+    ],
+)
+async def test_switch_service_turn(hass, caplog, mock_modbus):
+    """Run test for service turn_on/turn_off."""
     assert MODBUS_DOMAIN in hass.config.components
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -321,27 +307,27 @@ async def test_switch_service_turn(hass, caplog, mock_pymodbus):
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x01])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     await hass.services.async_call(
         "switch", "turn_on", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_ON
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x00])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
         "switch", "turn_off", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
 
-    mock_pymodbus.write_register.side_effect = ModbusException("fail write_")
+    mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "switch", "turn_on", service_data={"entity_id": ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
-    mock_pymodbus.write_coil.side_effect = ModbusException("fail write_")
+    mock_modbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "switch", "turn_off", service_data={"entity_id": ENTITY_ID}
     )
@@ -377,33 +363,28 @@ async def test_service_switch_update(hass, mock_modbus, mock_ha):
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
 
-async def test_delay_switch(hass, mock_pymodbus):
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_SCAN_INTERVAL: 0,
+                    CONF_VERIFY: {
+                        CONF_DELAY: 1,
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    },
+                }
+            ],
+        },
+    ],
+)
+async def test_delay_switch(hass, mock_modbus):
     """Run test for switch verify delay."""
-    config = {
-        MODBUS_DOMAIN: [
-            {
-                CONF_TYPE: TCP,
-                CONF_HOST: TEST_MODBUS_HOST,
-                CONF_PORT: TEST_PORT_TCP,
-                CONF_SWITCHES: [
-                    {
-                        CONF_NAME: TEST_ENTITY_NAME,
-                        CONF_ADDRESS: 51,
-                        CONF_SCAN_INTERVAL: 0,
-                        CONF_VERIFY: {
-                            CONF_DELAY: 1,
-                            CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-                        },
-                    }
-                ],
-            }
-        ]
-    }
-    mock_pymodbus.read_holding_registers.return_value = ReadResult([0x01])
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     now = dt_util.utcnow()
-    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
-        assert await async_setup_component(hass, MODBUS_DOMAIN, config) is True
-        await hass.async_block_till_done()
     await hass.services.async_call(
         "switch", "turn_on", service_data={"entity_id": ENTITY_ID}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify test cases by using the mock available instead of calling async_setup_component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
