### PR TITLE
Set slave default to 0, as already documented in Modbus

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -118,7 +118,7 @@ BASE_COMPONENT_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_ADDRESS): cv.positive_int,
-        vol.Optional(CONF_SLAVE): cv.positive_int,
+        vol.Optional(CONF_SLAVE, default=0): cv.positive_int,
         vol.Optional(
             CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
         ): cv.positive_int,

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -209,8 +209,7 @@ def duplicate_entity_validator(config: dict) -> dict:
                     addr += "_" + str(entry[CONF_COMMAND_ON])
                 if CONF_COMMAND_OFF in entry:
                     addr += "_" + str(entry[CONF_COMMAND_OFF])
-                if CONF_SLAVE in entry:
-                    addr += "_" + str(entry[CONF_SLAVE])
+                addr += "_" + str(entry[CONF_SLAVE])
                 if addr in addresses:
                     err = f"Modbus {component}/{name} address {addr} is duplicate, second entry not loaded!"
                     _LOGGER.warning(err)

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -9,7 +9,7 @@ from pymodbus.exceptions import ModbusException
 import pytest
 
 from homeassistant.components.modbus.const import MODBUS_DOMAIN as DOMAIN, TCP
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SLAVE, CONF_TYPE
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -82,9 +82,12 @@ async def mock_modbus_fixture(
 ):
     """Load integration modbus using mocked pymodbus."""
     conf = copy.deepcopy(do_config)
-    if config_addon:
-        for key in conf.keys():
+    for key in conf.keys():
+        if config_addon:
             conf[key][0].update(config_addon)
+        for entity in conf[key]:
+            if CONF_SLAVE not in entity:
+                entity[CONF_SLAVE] = 0
     caplog.set_level(logging.WARNING)
     config = {
         DOMAIN: [

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -76,6 +76,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SENSORS,
+    CONF_SLAVE,
     CONF_STRUCTURE,
     CONF_TIMEOUT,
     CONF_TYPE,
@@ -272,10 +273,12 @@ async def test_duplicate_modbus_validator(do_config):
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
                         CONF_ADDRESS: 117,
+                        CONF_SLAVE: 0,
                     },
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
                         CONF_ADDRESS: 119,
+                        CONF_SLAVE: 0,
                     },
                 ],
             }
@@ -290,10 +293,12 @@ async def test_duplicate_modbus_validator(do_config):
                     {
                         CONF_NAME: TEST_ENTITY_NAME,
                         CONF_ADDRESS: 117,
+                        CONF_SLAVE: 0,
                     },
                     {
                         CONF_NAME: TEST_ENTITY_NAME + "2",
                         CONF_ADDRESS: 117,
+                        CONF_SLAVE: 0,
                     },
                 ],
             }
@@ -409,6 +414,7 @@ async def test_duplicate_entity_validator(do_config):
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 117,
+                    CONF_SLAVE: 0,
                     CONF_SCAN_INTERVAL: 0,
                 }
             ],
@@ -544,6 +550,7 @@ async def mock_modbus_read_pymodbus_fixture(
                         CONF_INPUT_TYPE: do_type,
                         CONF_NAME: TEST_ENTITY_NAME,
                         CONF_ADDRESS: 51,
+                        CONF_SLAVE: 0,
                         CONF_SCAN_INTERVAL: do_scan_interval,
                     }
                 ],
@@ -688,6 +695,7 @@ async def test_delay(hass, mock_pymodbus):
                         CONF_INPUT_TYPE: CALL_TYPE_COIL,
                         CONF_NAME: TEST_ENTITY_NAME,
                         CONF_ADDRESS: 52,
+                        CONF_SLAVE: 0,
                         CONF_SCAN_INTERVAL: set_scan_interval,
                     },
                 ],
@@ -736,6 +744,7 @@ async def test_delay(hass, mock_pymodbus):
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 117,
+                    CONF_SLAVE: 0,
                     CONF_SCAN_INTERVAL: 0,
                 }
             ],
@@ -759,6 +768,7 @@ async def test_shutdown(hass, caplog, mock_pymodbus, mock_modbus_with_pymodbus):
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
+                    CONF_SLAVE: 0,
                 }
             ]
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The documentation (and the code expects) slave to be 0 is not positively added to configuration.yaml, we depended on the pymodbus library to secure this, however there are cases where this is not done.

To secure consistency a default = 0 is added to the optional "slave" attribute.

The tests needed to be updated, since the config dicts (used to setup the tests) are not passing voluptuous and thus the default is not set.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This PR contains a schema change, so it should not be added to a dot release (even though the change makes no difference seen from a user POW).

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
Documentation already states that slave is 0 by default.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
