### PR TITLE
Add Yamaha MusicCast Switch Entities

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1455,6 +1455,7 @@ omit =
     homeassistant/components/yamaha_musiccast/media_player.py
     homeassistant/components/yamaha_musiccast/number.py
     homeassistant/components/yamaha_musiccast/select.py
+    homeassistant/components/yamaha_musiccast/switch.py
     homeassistant/components/yandex_transport/*
     homeassistant/components/yeelightsunflower/light.py
     homeassistant/components/yi/camera.py

--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -30,7 +30,7 @@ from .const import (
     ENTITY_CATEGORY_MAPPING,
 )
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.SELECT]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.SELECT, Platform.SWITCH]
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/yamaha_musiccast/switch.py
+++ b/homeassistant/components/yamaha_musiccast/switch.py
@@ -4,14 +4,11 @@ from typing import Any
 from aiomusiccast.capabilities import BinarySetter
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.components.yamaha_musiccast import (
-    DOMAIN,
-    MusicCastCapabilityEntity,
-    MusicCastDataUpdateCoordinator,
-)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN, MusicCastCapabilityEntity, MusicCastDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/yamaha_musiccast/switch.py
+++ b/homeassistant/components/yamaha_musiccast/switch.py
@@ -1,0 +1,55 @@
+"""The switch entities for musiccast."""
+from typing import Any
+
+from aiomusiccast.capabilities import BinarySetter
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.yamaha_musiccast import (
+    DOMAIN,
+    MusicCastCapabilityEntity,
+    MusicCastDataUpdateCoordinator,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up MusicCast sensor based on a config entry."""
+    coordinator: MusicCastDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    switch_entities = []
+
+    for capability in coordinator.data.capabilities:
+        if isinstance(capability, BinarySetter):
+            switch_entities.append(SwitchCapability(coordinator, capability))
+
+    for zone, data in coordinator.data.zones.items():
+        for capability in data.capabilities:
+            if isinstance(capability, BinarySetter):
+                switch_entities.append(SwitchCapability(coordinator, capability, zone))
+
+    async_add_entities(switch_entities)
+
+
+class SwitchCapability(MusicCastCapabilityEntity, SwitchEntity):
+    """Representation of a MusicCast switch entity."""
+
+    capability: BinarySetter
+
+    @property
+    def is_on(self) -> bool:
+        """Return the current status."""
+        return self.capability.current
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the capability."""
+        await self.capability.set(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the capability."""
+        await self.capability.set(False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
After adding select and number entities for configuration purposes, we will now also add the following switch entities for devices supporting them:
  * Device Level
    * Speaker A
      * A switch to turn on the speaker set A
    * Speaker B
      * A switch to turn on the speaker set B
    * Party Mode
      * Lets all zones play the same content like the main zone
  * Zone Level
    * Bass Extension
      * Extend the bass to more speakers (especially useful in configurations without a subwoofer)
    * Extra Bass
      * Seems to be the same as bass extension, but on other devices
    * Enhancer
      * Enhances compressed audio formats
    * Pure Direct
      * Lets the device play the audio directly without any additional processing
    * Adaptive DRC
      * Adjusts the volume of high and low frequency levels for better sound at low volume


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21705

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
