### PR TITLE
Plugwise bump module version to fix heating-state and OnOff devices

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -114,11 +114,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             heater_central_data = self.coordinator.data.devices[
                 self.coordinator.data.gateway["heater_id"]
             ]
-            if "binary_sensors" in heater_central_data:
-                if heater_central_data["binary_sensors"].get("heating_state"):
-                    return CURRENT_HVAC_HEAT
-                if heater_central_data["binary_sensors"].get("cooling_state"):
-                    return CURRENT_HVAC_COOL
+            if heater_central_data["binary_sensors"].get("heating_state"):
+                return CURRENT_HVAC_HEAT
+            if heater_central_data["binary_sensors"].get("cooling_state"):
+                return CURRENT_HVAC_COOL
         return CURRENT_HVAC_IDLE
 
     @property

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -107,7 +107,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         if "control_state" in self.device:
             if self.device.get("control_state") == "cooling":
                 return CURRENT_HVAC_COOL
-            if self.device.get("control_state") == "heating":
+            # Support preheating state as heating, until preheating is added as a separate state
+            if self.device.get("control_state") in ["heating", "preheating"]:
                 return CURRENT_HVAC_HEAT
         else:
             heater_central_data = self.coordinator.data.devices[

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -114,10 +114,11 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             heater_central_data = self.coordinator.data.devices[
                 self.coordinator.data.gateway["heater_id"]
             ]
-            if heater_central_data.get("heating_state"):
-                return CURRENT_HVAC_HEAT
-            if heater_central_data.get("cooling_state"):
-                return CURRENT_HVAC_COOL
+            if "binary_sensors" in heater_central_data:
+                if heater_central_data["binary_sensors"].get("heating_state"):
+                    return CURRENT_HVAC_HEAT
+                if heater_central_data["binary_sensors"].get("cooling_state"):
+                    return CURRENT_HVAC_COOL
         return CURRENT_HVAC_IDLE
 
     @property

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -25,7 +25,6 @@ PLATFORMS_GATEWAY = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
-SENSOR_PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 ZEROCONF_MAP = {
     "smile": "P1",
     "smile_thermo": "Anna",

--- a/homeassistant/components/plugwise/gateway.py
+++ b/homeassistant/components/plugwise/gateway.py
@@ -16,14 +16,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
 
-from .const import (
-    DEFAULT_PORT,
-    DEFAULT_USERNAME,
-    DOMAIN,
-    LOGGER,
-    PLATFORMS_GATEWAY,
-    SENSOR_PLATFORMS,
-)
+from .const import DEFAULT_PORT, DEFAULT_USERNAME, DOMAIN, LOGGER, PLATFORMS_GATEWAY
 from .coordinator import PlugwiseDataUpdateCoordinator
 
 
@@ -77,11 +70,7 @@ async def async_setup_entry_gw(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         sw_version=api.smile_version[0],
     )
 
-    platforms = PLATFORMS_GATEWAY
-    if coordinator.data.gateway["single_master_thermostat"] is None:
-        platforms = SENSOR_PLATFORMS
-
-    hass.config_entries.async_setup_platforms(entry, platforms)
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS_GATEWAY)
 
     return True
 

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["plugwise==0.16.5"],
+  "requirements": ["plugwise==0.16.6"],
   "codeowners": ["@CoMPaTech", "@bouwew", "@brefra", "@frenck"],
   "zeroconf": ["_plugwise._tcp.local."],
   "config_flow": true,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1267,7 +1267,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.16.5
+plugwise==0.16.6
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -795,7 +795,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.13
 
 # homeassistant.components.plugwise
-plugwise==0.16.5
+plugwise==0.16.6
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plugwise/fixtures/adam_multiple_devices_per_zone/all_data.json
+++ b/tests/components/plugwise/fixtures/adam_multiple_devices_per_zone/all_data.json
@@ -1,11 +1,9 @@
 [
   {
-    "active_device": true,
-    "cooling_present": false,
+    "smile_name": "Adam",
     "gateway_id": "fe799307f1624099878210aa0b9f1475",
     "heater_id": "90986d591dcd426cae3ec3e8111ff730",
-    "single_master_thermostat": false,
-    "smile_name": "Adam",
+    "cooling_present": false,
     "notifications": {
       "af82e4ccf9c548528166d38e560662a4": {
         "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."
@@ -260,8 +258,9 @@
       "lower_bound": 10,
       "upper_bound": 90,
       "resolution": 1,
-      "cooling_active": false,
-      "heating_state": true,
+      "binary_sensors": {
+        "heating_state": true
+      },
       "sensors": {
         "water_temperature": 70.0,
         "intended_boiler_temperature": 70.0,

--- a/tests/components/plugwise/fixtures/anna_heatpump/all_data.json
+++ b/tests/components/plugwise/fixtures/anna_heatpump/all_data.json
@@ -1,11 +1,9 @@
 [
   {
-    "active_device": true,
-    "cooling_present": true,
+    "smile_name": "Anna",
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "single_master_thermostat": true,
-    "smile_name": "Anna",
+    "cooling_present": true,
     "notifications": {}
   },
   {
@@ -21,12 +19,11 @@
       "lower_bound": -10,
       "upper_bound": 40,
       "resolution": 1,
-      "heating_state": true,
       "compressor_state": true,
-      "cooling_state": false,
-      "cooling_active": false,
       "binary_sensors": {
         "dhw_state": false,
+        "heating_state": true,
+        "cooling_state": false,
         "slave_boiler_state": false,
         "flame_state": false
       },
@@ -40,7 +37,8 @@
       },
       "switches": {
         "dhw_cm_switch": false
-      }
+      },
+      "cooling_active": false
     },
     "015ae9ea3f964e668e490fa39da3870b": {
       "class": "gateway",

--- a/tests/components/plugwise/fixtures/p1v3_full_option/all_data.json
+++ b/tests/components/plugwise/fixtures/p1v3_full_option/all_data.json
@@ -1,11 +1,7 @@
 [
   {
-    "active_device": false,
-    "cooling_present": false,
-    "gateway_id": "e950c7d5e1ee407a858e2a8b5016c8b3",
-    "heater_id": null,
-    "single_master_thermostat": false,
     "smile_name": "P1",
+    "gateway_id": "e950c7d5e1ee407a858e2a8b5016c8b3",
     "notifications": {}
   },
   {

--- a/tests/components/plugwise/fixtures/stretch_v31/all_data.json
+++ b/tests/components/plugwise/fixtures/stretch_v31/all_data.json
@@ -1,11 +1,7 @@
 [
   {
-    "active_device": false,
-    "cooling_present": false,
-    "gateway_id": "0000aaaa0000aaaa0000aaaa0000aa00",
-    "heater_id": null,
-    "single_master_thermostat": false,
     "smile_name": "Stretch",
+    "gateway_id": "0000aaaa0000aaaa0000aaaa0000aa00",
     "notifications": {}
   },
   {

--- a/tests/components/plugwise/test_diagnostics.py
+++ b/tests/components/plugwise/test_diagnostics.py
@@ -20,12 +20,10 @@ async def test_diagnostics(
         hass, hass_client, init_integration
     ) == {
         "gateway": {
-            "active_device": True,
-            "cooling_present": False,
+            "smile_name": "Adam",
             "gateway_id": "fe799307f1624099878210aa0b9f1475",
             "heater_id": "90986d591dcd426cae3ec3e8111ff730",
-            "single_master_thermostat": False,
-            "smile_name": "Adam",
+            "cooling_present": False,
             "notifications": {
                 "af82e4ccf9c548528166d38e560662a4": {
                     "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."
@@ -221,8 +219,7 @@ async def test_diagnostics(
                 "lower_bound": 10,
                 "upper_bound": 90,
                 "resolution": 1,
-                "cooling_active": False,
-                "heating_state": True,
+                "binary_sensors": {"heating_state": True},
                 "sensors": {
                     "water_temperature": 70.0,
                     "intended_boiler_temperature": 70.0,


### PR DESCRIPTION
## Proposed change
Updates `plugwise` module to accommodate for `preheating` state on Plugwise Adam and `binary_sensor.onoff_heating` for OnOff (i.e. non-OpenTherm) devices such as older boilers or city-heating. Great work by @bouwew 

Release notes: https://github.com/plugwise/python-plugwise/releases/tag/v0.16.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
