### PR TITLE
Add more surround settings for Sonos

### DIFF
--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -20,6 +20,8 @@ LEVEL_TYPES = {
     "bass": (-10, 10),
     "treble": (-10, 10),
     "sub_gain": (-15, 15),
+    "surround_volume_tv": (-15, 15),
+    "surround_volume_music": (-15, 15),
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +40,7 @@ async def async_setup_entry(
             if (state := getattr(speaker.soco, level_type, None)) is not None:
                 setattr(speaker, level_type, state)
                 features.append((level_type, valid_range))
+
         return features
 
     async def _async_create_entities(speaker: SonosSpeaker) -> None:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -494,7 +494,6 @@ class SonosSpeaker:
             sonos_variable: str  # name in notification
             variable_type: type
             local_variable: str | None = None  # our local variable name
-            true_value: str | None = None  # for true value (surround_mode is reversed)
 
         variable_list = [
             # Switch variables
@@ -504,9 +503,8 @@ class SonosSpeaker:
             Variable(sonos_variable="surround_enabled", variable_type=bool),
             Variable(
                 sonos_variable="surround_mode",
-                local_variable="surround_ambient_enabled",
+                local_variable="surround_full_volume_enabled",
                 variable_type=bool,
-                true_value="0",
             ),
             # Number entity variables
             Variable(
@@ -530,7 +528,7 @@ class SonosSpeaker:
         for var in variables:
             info = variable_map.get(var)
             if info is None:
-                _LOGGER.debug("No definition for %s", var)
+                _LOGGER.debug("No mapping for %s", var)
                 continue
 
             # If local_variable is not defined, fall back to sonos one
@@ -538,8 +536,7 @@ class SonosSpeaker:
             variable_type = info.variable_type
 
             if variable_type == bool:
-                true_value = info.true_value or "1"
-                setattr(self, target, variables[info.sonos_variable] == true_value)
+                setattr(self, target, variables[info.sonos_variable] == "1")
             elif variable_type == int:
                 setattr(self, target, variables[info.sonos_variable])
             else:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -494,6 +494,7 @@ class SonosSpeaker:
             sonos_variable: str  # name in notification
             variable_type: type
             local_variable: str | None = None  # our local variable name
+            true_value: str | None = None  # for true value (surround_mode is reversed)
 
         variable_list = [
             # Switch variables
@@ -505,6 +506,7 @@ class SonosSpeaker:
                 sonos_variable="surround_mode",
                 local_variable="surround_ambient_enabled",
                 variable_type=bool,
+                true_value="0",
             ),
             # Number entity variables
             Variable(
@@ -536,7 +538,8 @@ class SonosSpeaker:
             variable_type = info.variable_type
 
             if variable_type == bool:
-                setattr(self, target, variables[info.sonos_variable] == "1")
+                true_value = info.true_value or "1"
+                setattr(self, target, variables[info.sonos_variable] == true_value)
             elif variable_type == int:
                 setattr(self, target, variables[info.sonos_variable])
             else:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -154,9 +154,9 @@ class SonosSpeaker:
         self.sub_enabled: bool | None = None
         self.sub_gain: int | None = None
         self.surround_enabled: bool | None = None
-        self.surround_mode: bool | None = None  # surround ambient mode
-        self.surround_level: int | None = None
-        self.music_surround_level: int | None = None
+        self.surround_full_volume_enabled: bool | None = None
+        self.surround_volume_tv: int | None = None
+        self.surround_volume_music: int | None = None
         # Misc features
         self.buttons_enabled: bool | None = None
         self.mic_enabled: bool | None = None
@@ -489,11 +489,14 @@ class SonosSpeaker:
             self.muted = variables["mute"]["Master"] == "1"
 
         class Variable(NamedTuple):
-            """Container for mapping sonos notification variable to our local one."""
+            """Container for mapping sonos notification variable to our local one.
+
+            If local_variable is None, the sonos naming will be used.
+            """
 
             sonos_variable: str  # name in notification
             variable_type: type
-            local_variable: str | None = None  # our local variable name
+            local_variable: str | None = None
 
         variable_list = [
             # Switch variables

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -43,6 +43,7 @@ ATTR_SPEECH_ENHANCEMENT = "dialog_level"
 ATTR_STATUS_LIGHT = "status_light"
 ATTR_SUB_ENABLED = "sub_enabled"
 ATTR_SURROUND_ENABLED = "surround_enabled"
+ATTR_SURROUND_AMBIENT_ENABLED = "surround_ambient_enabled"
 ATTR_TOUCH_CONTROLS = "buttons_enabled"
 
 ALL_FEATURES = (
@@ -52,6 +53,7 @@ ALL_FEATURES = (
     ATTR_SPEECH_ENHANCEMENT,
     ATTR_SUB_ENABLED,
     ATTR_SURROUND_ENABLED,
+    ATTR_SURROUND_AMBIENT_ENABLED,
     ATTR_STATUS_LIGHT,
 )
 
@@ -69,6 +71,7 @@ FRIENDLY_NAMES = {
     ATTR_STATUS_LIGHT: "Status Light",
     ATTR_SUB_ENABLED: "Subwoofer Enabled",
     ATTR_SURROUND_ENABLED: "Surround Enabled",
+    ATTR_SURROUND_AMBIENT_ENABLED: "Surround Ambient Mode",
     ATTR_TOUCH_CONTROLS: "Touch Controls",
 }
 
@@ -79,6 +82,7 @@ FEATURE_ICONS = {
     ATTR_STATUS_LIGHT: "mdi:led-on",
     ATTR_SUB_ENABLED: "mdi:dog",
     ATTR_SURROUND_ENABLED: "mdi:surround-sound",
+    ATTR_SURROUND_AMBIENT_ENABLED: "mdi:surround-sound",
     ATTR_TOUCH_CONTROLS: "mdi:gesture-tap",
 }
 

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -43,7 +43,7 @@ ATTR_SPEECH_ENHANCEMENT = "dialog_level"
 ATTR_STATUS_LIGHT = "status_light"
 ATTR_SUB_ENABLED = "sub_enabled"
 ATTR_SURROUND_ENABLED = "surround_enabled"
-ATTR_SURROUND_AMBIENT_ENABLED = "surround_ambient_enabled"
+ATTR_SURROUND_FULL_VOLUME_ENABLED = "surround_full_volume_enabled"
 ATTR_TOUCH_CONTROLS = "buttons_enabled"
 
 ALL_FEATURES = (
@@ -53,7 +53,7 @@ ALL_FEATURES = (
     ATTR_SPEECH_ENHANCEMENT,
     ATTR_SUB_ENABLED,
     ATTR_SURROUND_ENABLED,
-    ATTR_SURROUND_AMBIENT_ENABLED,
+    ATTR_SURROUND_FULL_VOLUME_ENABLED,
     ATTR_STATUS_LIGHT,
 )
 
@@ -71,7 +71,7 @@ FRIENDLY_NAMES = {
     ATTR_STATUS_LIGHT: "Status Light",
     ATTR_SUB_ENABLED: "Subwoofer Enabled",
     ATTR_SURROUND_ENABLED: "Surround Enabled",
-    ATTR_SURROUND_AMBIENT_ENABLED: "Surround Ambient Mode",
+    ATTR_SURROUND_FULL_VOLUME_ENABLED: "Surround Full Volume Enabled",
     ATTR_TOUCH_CONTROLS: "Touch Controls",
 }
 
@@ -82,7 +82,7 @@ FEATURE_ICONS = {
     ATTR_STATUS_LIGHT: "mdi:led-on",
     ATTR_SUB_ENABLED: "mdi:dog",
     ATTR_SURROUND_ENABLED: "mdi:surround-sound",
-    ATTR_SURROUND_AMBIENT_ENABLED: "mdi:surround-sound",
+    ATTR_SURROUND_FULL_VOLUME_ENABLED: "mdi:surround-sound",
     ATTR_TOUCH_CONTROLS: "mdi:gesture-tap",
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the following new entities for surround setups:
* Surround Ambient Mode switch [on/off]
* Surround volume tv for tv playback surround volume adjustment [-15, 15]
* Surround volume music  for music surround volume adjustment [-15, 15]

![image](https://user-images.githubusercontent.com/3705853/154857487-d0f4b783-c0e1-4666-91a2-0170524b2f3a.png)

Related to https://github.com/SoCo/SoCo/pull/780

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
