### PR TITLE
Remove deprecated yaml config from bmw_connected_drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -26,10 +26,17 @@ from homeassistant.helpers import device_registry, discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
 
-from .const import ATTRIBUTION, CONF_ACCOUNT, CONF_READ_ONLY, DATA_ENTRIES
+from .const import (
+    ATTRIBUTION,
+    CONF_ACCOUNT,
+    CONF_READ_ONLY,
+    DATA_ENTRIES,
+    DATA_HASS_CONFIG,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,6 +77,15 @@ _SERVICE_MAP = {
 }
 
 UNDO_UPDATE_LISTENER = "undo_update_listener"
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the BMW Connected Drive component from configuration.yaml."""
+    # Store full yaml config in data for platform.NOTIFY
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][DATA_HASS_CONFIG] = config
+
+    return True
 
 
 @callback
@@ -134,7 +150,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             Platform.NOTIFY,
             DOMAIN,
             {CONF_NAME: DOMAIN},
-            dict(entry.data),
+            hass.data[DOMAIN][DATA_HASS_CONFIG],
         )
     )
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -11,7 +11,7 @@ from bimmer_connected.vehicle import ConnectedDriveVehicle
 import voluptuous as vol
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_NAME,
@@ -26,7 +26,6 @@ from homeassistant.helpers import device_registry, discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import track_utc_time_change
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
 
@@ -36,7 +35,6 @@ from .const import (
     CONF_ALLOWED_REGIONS,
     CONF_READ_ONLY,
     DATA_ENTRIES,
-    DATA_HASS_CONFIG,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,22 +85,6 @@ _SERVICE_MAP = {
 }
 
 UNDO_UPDATE_LISTENER = "undo_update_listener"
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the BMW Connected Drive component from configuration.yaml."""
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][DATA_HASS_CONFIG] = config
-
-    if DOMAIN in config:
-        for entry_config in config[DOMAIN].values():
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry_config
-                )
-            )
-
-    return True
 
 
 @callback
@@ -167,7 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             Platform.NOTIFY,
             DOMAIN,
             {CONF_NAME: DOMAIN},
-            hass.data[DOMAIN][DATA_HASS_CONFIG],
+            dict(entry.data),
         )
     )
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -29,29 +29,14 @@ from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
 
-from .const import (
-    ATTRIBUTION,
-    CONF_ACCOUNT,
-    CONF_ALLOWED_REGIONS,
-    CONF_READ_ONLY,
-    DATA_ENTRIES,
-)
+from .const import ATTRIBUTION, CONF_ACCOUNT, CONF_READ_ONLY, DATA_ENTRIES
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "bmw_connected_drive"
 ATTR_VIN = "vin"
 
-ACCOUNT_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_REGION): vol.In(CONF_ALLOWED_REGIONS),
-        vol.Optional(CONF_READ_ONLY): cv.boolean,
-    }
-)
-
-CONFIG_SCHEMA = vol.Schema({DOMAIN: {cv.string: ACCOUNT_SCHEMA}}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = cv.deprecated(DOMAIN, raise_if_present=False)
 
 SERVICE_SCHEMA = vol.Schema(
     vol.Any(

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -36,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "bmw_connected_drive"
 ATTR_VIN = "vin"
 
-CONFIG_SCHEMA = cv.deprecated(DOMAIN, raise_if_present=False)
+CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
 SERVICE_SCHEMA = vol.Schema(
     vol.Any(

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -74,10 +74,6 @@ class BMWConnectedDriveConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
-    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
-        """Handle import."""
-        return await self.async_step_user(user_input)
-
     @staticmethod
     @callback
     def async_get_options_flow(

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -15,6 +15,7 @@ CONF_READ_ONLY = "read_only"
 
 CONF_ACCOUNT = "account"
 
+DATA_HASS_CONFIG = "hass_config"
 DATA_ENTRIES = "entries"
 
 UNIT_MAP = {

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -12,11 +12,9 @@ ATTR_DIRECTION = "direction"
 
 CONF_ALLOWED_REGIONS = ["china", "north_america", "rest_of_world"]
 CONF_READ_ONLY = "read_only"
-CONF_USE_LOCATION = "use_location"
 
 CONF_ACCOUNT = "account"
 
-DATA_HASS_CONFIG = "hass_config"
 DATA_ENTRIES = "entries"
 
 UNIT_MAP = {

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -1,13 +1,10 @@
 """Test the for the BMW Connected Drive config flow."""
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.bmw_connected_drive.config_flow import DOMAIN
 from homeassistant.components.bmw_connected_drive.const import CONF_READ_ONLY
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
-from homeassistant.data_entry_flow import UnknownStep
 
 from tests.common import MockConfigEntry
 
@@ -84,25 +81,6 @@ async def test_full_user_flow_implementation(hass):
         assert result2["data"] == FIXTURE_COMPLETE_ENTRY
 
         assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_full_config_flow_implementation(hass):
-    """Test registering an integration from YAML and raising an error."""
-    with patch(
-        "bimmer_connected.account.ConnectedDriveAccount._get_vehicles",
-        return_value=[],
-    ), patch(
-        "homeassistant.components.bmw_connected_drive.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        with pytest.raises(UnknownStep):
-            await hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data=FIXTURE_USER_INPUT,
-            )
-
-        assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_options_flow_implementation(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated YAML configuration of the BMW Connected Drive integration has been removed.

BMW Connected Drive is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated YAML config from bmw_connected_drive.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21714

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
