### PR TITLE
Add Switch entity to SleepIQ

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--net=host"],
+  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
   "extensions": [
     "ms-python.vscode-pylance",
     "visualstudioexptteam.vscodeintellicode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--net=host"],
   "extensions": [
     "ms-python.vscode-pylance",
     "visualstudioexptteam.vscodeintellicode",

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -22,7 +22,7 @@ from .coordinator import SleepIQDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR, Platform.SWITCH]
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -18,7 +18,11 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
-from .coordinator import SleepIQDataUpdateCoordinator, SleepIQPauseUpdateCoordinator
+from .coordinator import (
+    SleepIQData,
+    SleepIQDataUpdateCoordinator,
+    SleepIQPauseUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +87,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
     await pause_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (coordinator, pause_coordinator)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = SleepIQData(
+        data_coordinator=coordinator,
+        pause_coordinator=pause_coordinator,
+        client=gateway,
+    )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
-from .coordinator import SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQDataUpdateCoordinator, SleepIQPauseUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,11 +77,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(str(err) or "Error reading from SleepIQ API") from err
 
     coordinator = SleepIQDataUpdateCoordinator(hass, gateway, email)
+    pause_coordinator = SleepIQPauseUpdateCoordinator(hass, gateway, email)
 
     # Call the SleepIQ API to refresh data
     await coordinator.async_config_entry_first_refresh()
+    await pause_coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (coordinator, pause_coordinator)
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/sleepiq/binary_sensor.py
+++ b/homeassistant/components/sleepiq/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, ICON_EMPTY, ICON_OCCUPIED, IS_IN_BED
-from .coordinator import SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQData
 from .entity import SleepIQSensor
 
 
@@ -21,10 +21,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed binary sensors."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][0]
+    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        IsInBedBinarySensor(coordinator, bed, sleeper)
-        for bed in coordinator.client.beds.values()
+        IsInBedBinarySensor(data.data_coordinator, bed, sleeper)
+        for bed in data.client.beds.values()
         for sleeper in bed.sleepers
     )
 

--- a/homeassistant/components/sleepiq/binary_sensor.py
+++ b/homeassistant/components/sleepiq/binary_sensor.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed binary sensors."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][0]
     async_add_entities(
         IsInBedBinarySensor(coordinator, bed, sleeper)
         for bed in coordinator.client.beds.values()

--- a/homeassistant/components/sleepiq/button.py
+++ b/homeassistant/components/sleepiq/button.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQData
 from .entity import SleepIQEntity
 
 
@@ -53,11 +53,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sleep number buttons."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][0]
+    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         SleepNumberButton(bed, ed)
-        for bed in coordinator.client.beds.values()
+        for bed in data.client.beds.values()
         for ed in ENTITY_DESCRIPTIONS
     )
 

--- a/homeassistant/components/sleepiq/button.py
+++ b/homeassistant/components/sleepiq/button.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sleep number buttons."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][0]
 
     async_add_entities(
         SleepNumberButton(bed, ed)

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 UPDATE_INTERVAL = timedelta(seconds=60)
+LONGER_UPDATE_INTERVAL = timedelta(minutes=5)
 
 
 class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
@@ -30,3 +31,27 @@ class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
             update_interval=UPDATE_INTERVAL,
         )
         self.client = client
+
+
+class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
+    """SleepIQ data update coordinator."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: AsyncSleepIQ,
+        username: str,
+    ) -> None:
+        """Initialize coordinator."""
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{username}@SleepIQPause",
+            update_interval=LONGER_UPDATE_INTERVAL,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> None:
+        for bed in self.client.beds.values():
+            await bed.fetch_pause_mode()

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -63,7 +63,7 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
 
 @dataclass
 class SleepIQData:
-    """Data for the lookin integration."""
+    """Data for the sleepiq integration."""
 
     data_coordinator: SleepIQDataUpdateCoordinator
     pause_coordinator: SleepIQPauseUpdateCoordinator

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -1,4 +1,5 @@
 """Coordinator for SleepIQ."""
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -55,8 +56,9 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
         self.client = client
 
     async def _async_update_data(self) -> None:
-        for bed in self.client.beds.values():
-            await bed.fetch_pause_mode()
+        await asyncio.gather(
+            *[bed.fetch_pause_mode() for bed in self.client.beds.values()]
+        )
 
 
 @dataclass

--- a/homeassistant/components/sleepiq/entity.py
+++ b/homeassistant/components/sleepiq/entity.py
@@ -65,3 +65,24 @@ class SleepIQSensor(CoordinatorEntity):
     @abstractmethod
     def _async_update_attrs(self) -> None:
         """Update sensor attributes."""
+
+
+class SleepIQBedCoordinator(CoordinatorEntity):
+    """Implementation of a SleepIQ sensor."""
+
+    _attr_icon = ICON_OCCUPIED
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        bed: SleepIQBed,
+    ) -> None:
+        """Initialize the SleepIQ sensor entity."""
+        super().__init__(coordinator)
+        self.bed = bed
+        self._attr_device_info = DeviceInfo(
+            connections={(device_registry.CONNECTION_NETWORK_MAC, bed.mac_addr)},
+            manufacturer="SleepNumber",
+            name=bed.name,
+            model=bed.model,
+        )

--- a/homeassistant/components/sleepiq/entity.py
+++ b/homeassistant/components/sleepiq/entity.py
@@ -14,18 +14,23 @@ from homeassistant.helpers.update_coordinator import (
 from .const import ICON_OCCUPIED, SENSOR_TYPES
 
 
+def device_from_bed(bed: SleepIQBed) -> DeviceInfo:
+    """Create a device given a bed."""
+    return DeviceInfo(
+        connections={(device_registry.CONNECTION_NETWORK_MAC, bed.mac_addr)},
+        manufacturer="SleepNumber",
+        name=bed.name,
+        model=bed.model,
+    )
+
+
 class SleepIQEntity(Entity):
     """Implementation of a SleepIQ entity."""
 
     def __init__(self, bed: SleepIQBed) -> None:
         """Initialize the SleepIQ entity."""
         self.bed = bed
-        self._attr_device_info = DeviceInfo(
-            connections={(device_registry.CONNECTION_NETWORK_MAC, bed.mac_addr)},
-            manufacturer="SleepNumber",
-            name=bed.name,
-            model=bed.model,
-        )
+        self._attr_device_info = device_from_bed(bed)
 
 
 class SleepIQSensor(CoordinatorEntity):
@@ -44,12 +49,7 @@ class SleepIQSensor(CoordinatorEntity):
         super().__init__(coordinator)
         self.sleeper = sleeper
         self.bed = bed
-        self._attr_device_info = DeviceInfo(
-            connections={(device_registry.CONNECTION_NETWORK_MAC, bed.mac_addr)},
-            manufacturer="SleepNumber",
-            name=bed.name,
-            model=bed.model,
-        )
+        self._attr_device_info = device_from_bed(bed)
 
         self._attr_name = f"SleepNumber {bed.name} {sleeper.name} {SENSOR_TYPES[name]}"
         self._attr_unique_id = f"{bed.id}_{sleeper.name}_{name}"
@@ -80,9 +80,4 @@ class SleepIQBedCoordinator(CoordinatorEntity):
         """Initialize the SleepIQ sensor entity."""
         super().__init__(coordinator)
         self.bed = bed
-        self._attr_device_info = DeviceInfo(
-            connections={(device_registry.CONNECTION_NETWORK_MAC, bed.mac_addr)},
-            manufacturer="SleepNumber",
-            name=bed.name,
-            model=bed.model,
-        )
+        self._attr_device_info = device_from_bed(bed)

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, SLEEP_NUMBER
-from .coordinator import SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQData
 from .entity import SleepIQSensor
 
 
@@ -20,10 +20,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed sensors."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][0]
+    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        SleepNumberSensorEntity(coordinator, bed, sleeper)
-        for bed in coordinator.client.beds.values()
+        SleepNumberSensorEntity(data.data_coordinator, bed, sleeper)
+        for bed in data.client.beds.values()
         for sleeper in bed.sleepers
     )
 

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the SleepIQ bed sensors."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][0]
     async_add_entities(
         SleepNumberSensorEntity(coordinator, bed, sleeper)
         for bed in coordinator.client.beds.values()

--- a/homeassistant/components/sleepiq/switch.py
+++ b/homeassistant/components/sleepiq/switch.py
@@ -1,0 +1,59 @@
+"""Support for SleepIQ switches."""
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from asyncsleepiq import SleepIQBed
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import Throttle
+
+from .const import DOMAIN
+from .coordinator import SleepIQDataUpdateCoordinator
+from .entity import SleepIQEntity
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the sleep number switches."""
+    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        SleepNumberPrivateSwitch(bed) for bed in coordinator.client.beds.values()
+    )
+
+
+class SleepNumberPrivateSwitch(SleepIQEntity, SwitchEntity):
+    """Representation of SleepIQ privacy mode."""
+
+    def __init__(self, bed: SleepIQBed) -> None:
+        """Initialize the switch."""
+        super().__init__(bed)
+        self._attr_name = f"SleepNumber {bed.name} Pause Mode"
+        self._attr_unique_id = f"{bed.id}-pause-mode"
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the switch is on or off."""
+        return bool(self.bed.paused)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on switch."""
+        await self.bed.set_pause_mode(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off switch."""
+        await self.bed.set_pause_mode(False)
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    async def async_update(self, **kwargs: Any) -> None:
+        """Get the latest data from the SleepIQ API."""
+        await self.bed.fetch_pause_mode()

--- a/homeassistant/components/sleepiq/switch.py
+++ b/homeassistant/components/sleepiq/switch.py
@@ -15,8 +15,6 @@ from .const import DOMAIN
 from .coordinator import SleepIQData, SleepIQPauseUpdateCoordinator
 from .entity import SleepIQBedCoordinator
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/sleepiq/switch.py
+++ b/homeassistant/components/sleepiq/switch.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import SleepIQPauseUpdateCoordinator
+from .coordinator import SleepIQData, SleepIQPauseUpdateCoordinator
 from .entity import SleepIQBedCoordinator
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
@@ -24,10 +24,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sleep number switches."""
-    coordinator: SleepIQPauseUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][1]
+    data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        SleepNumberPrivateSwitch(coordinator, bed)
-        for bed in coordinator.client.beds.values()
+        SleepNumberPrivateSwitch(data.pause_coordinator, bed)
+        for bed in data.client.beds.values()
     )
 
 

--- a/homeassistant/components/sleepiq/switch.py
+++ b/homeassistant/components/sleepiq/switch.py
@@ -10,11 +10,10 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import Throttle
 
 from .const import DOMAIN
-from .coordinator import SleepIQDataUpdateCoordinator
-from .entity import SleepIQEntity
+from .coordinator import SleepIQPauseUpdateCoordinator
+from .entity import SleepIQBedCoordinator
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
@@ -25,18 +24,21 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sleep number switches."""
-    coordinator: SleepIQDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SleepIQPauseUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][1]
     async_add_entities(
-        SleepNumberPrivateSwitch(bed) for bed in coordinator.client.beds.values()
+        SleepNumberPrivateSwitch(coordinator, bed)
+        for bed in coordinator.client.beds.values()
     )
 
 
-class SleepNumberPrivateSwitch(SleepIQEntity, SwitchEntity):
+class SleepNumberPrivateSwitch(SleepIQBedCoordinator, SwitchEntity):
     """Representation of SleepIQ privacy mode."""
 
-    def __init__(self, bed: SleepIQBed) -> None:
+    def __init__(
+        self, coordinator: SleepIQPauseUpdateCoordinator, bed: SleepIQBed
+    ) -> None:
         """Initialize the switch."""
-        super().__init__(bed)
+        super().__init__(coordinator, bed)
         self._attr_name = f"SleepNumber {bed.name} Pause Mode"
         self._attr_unique_id = f"{bed.id}-pause-mode"
 
@@ -52,8 +54,3 @@ class SleepNumberPrivateSwitch(SleepIQEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self.bed.set_pause_mode(False)
-
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    async def async_update(self, **kwargs: Any) -> None:
-        """Get the latest data from the SleepIQ API."""
-        await self.bed.fetch_pause_mode()

--- a/homeassistant/components/sleepiq/switch.py
+++ b/homeassistant/components/sleepiq/switch.py
@@ -1,7 +1,6 @@
 """Support for SleepIQ switches."""
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import Any
 
 from asyncsleepiq import SleepIQBed

--- a/tests/components/sleepiq/test_switch.py
+++ b/tests/components/sleepiq/test_switch.py
@@ -1,0 +1,69 @@
+"""The tests for SleepIQ switch platform."""
+from homeassistant.components.sleepiq.switch import MIN_TIME_BETWEEN_UPDATES
+from homeassistant.components.switch import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+from tests.components.sleepiq.conftest import (
+    BED_ID,
+    BED_NAME,
+    BED_NAME_LOWER,
+    setup_platform,
+)
+
+
+async def test_setup(hass, mock_asyncsleepiq):
+    """Test for successfully setting up the SleepIQ platform."""
+    entry = await setup_platform(hass, DOMAIN)
+    entity_registry = er.async_get(hass)
+
+    assert len(entity_registry.entities) == 1
+
+    entry = entity_registry.async_get(f"switch.sleepnumber_{BED_NAME_LOWER}_pause_mode")
+    assert entry
+    assert entry.original_name == f"SleepNumber {BED_NAME} Pause Mode"
+    assert entry.unique_id == f"{BED_ID}-pause-mode"
+
+
+async def test_switch_set_states(hass, mock_asyncsleepiq):
+    """Test button press."""
+    await setup_platform(hass, DOMAIN)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "turn_off",
+        {ATTR_ENTITY_ID: f"switch.sleepnumber_{BED_NAME_LOWER}_pause_mode"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_asyncsleepiq.beds[BED_ID].set_pause_mode.assert_called_with(False)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: f"switch.sleepnumber_{BED_NAME_LOWER}_pause_mode"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_asyncsleepiq.beds[BED_ID].set_pause_mode.assert_called_with(True)
+
+
+async def test_switch_get_states(hass, mock_asyncsleepiq):
+    """Test button press."""
+    await setup_platform(hass, DOMAIN)
+
+    assert (
+        hass.states.get(f"switch.sleepnumber_{BED_NAME_LOWER}_pause_mode").state
+        == STATE_OFF
+    )
+    mock_asyncsleepiq.beds[BED_ID].paused = True
+
+    async_fire_time_changed(hass, utcnow() + MIN_TIME_BETWEEN_UPDATES)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get(f"switch.sleepnumber_{BED_NAME_LOWER}_pause_mode").state
+        == STATE_ON
+    )

--- a/tests/components/sleepiq/test_switch.py
+++ b/tests/components/sleepiq/test_switch.py
@@ -1,5 +1,5 @@
 """The tests for SleepIQ switch platform."""
-from homeassistant.components.sleepiq.switch import MIN_TIME_BETWEEN_UPDATES
+from homeassistant.components.sleepiq.coordinator import LONGER_UPDATE_INTERVAL
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_registry as er
@@ -60,7 +60,7 @@ async def test_switch_get_states(hass, mock_asyncsleepiq):
     )
     mock_asyncsleepiq.beds[BED_ID].paused = True
 
-    async_fire_time_changed(hass, utcnow() + MIN_TIME_BETWEEN_UPDATES)
+    async_fire_time_changed(hass, utcnow() + LONGER_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     assert (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a switch entity for a bed to enable/disable "Pause mode" (also known as "Privacy mode")

Some notes on the implementation:
 - The `async_update` function is used with a throttle as the state is returned by a different call than that which the 
` SleepIQDataUpdateCoordinator` is returning.  As the pause state is unlikely to change much, it is called at a longer interval (5 minutes instead of 1).  The internal state will also update when the pause mode is set without requiring the `async_update` to be called.
- Due to the above, the state just returns the `paused` variable form the bed object for the `is_on` property rather than setting the attribute as the attribute would then have to be set in the other three functions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
