### PR TITLE
Diferentiate between attr_name and entity_id in Modbus tests

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -126,7 +126,7 @@ class SlaveSensor(CoordinatorEntity, RestoreEntity, BinarySensorEntity):
     ) -> None:
         """Initialize the Modbus binary sensor."""
         idx += 1
-        self._attr_name = f"{entry[CONF_NAME]}_{idx}"
+        self._attr_name = f"{entry[CONF_NAME]} {idx}"
         self._attr_device_class = entry.get(CONF_DEVICE_CLASS)
         self._attr_available = False
         self._result_inx = int(idx / 8)

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -16,7 +16,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import async_fire_time_changed, mock_restore_cache
 
 TEST_MODBUS_NAME = "modbusTest"
-TEST_ENTITY_NAME = "test_entity"
+TEST_ENTITY_NAME = "test entity"
 TEST_MODBUS_HOST = "modbusHost"
 TEST_PORT_TCP = 5501
 TEST_PORT_SERIAL = "usb01"

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -25,7 +25,7 @@ from homeassistant.core import State
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
-ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
 
 
 @pytest.mark.parametrize(
@@ -244,8 +244,8 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
     """Run config test for binary sensor."""
     assert SENSOR_DOMAIN in hass.config.components
 
-    for addon in ["", "_1", "_2", "_3"]:
-        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}{addon}"
+    for addon in ["", " 1", " 2", " 3"]:
+        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}{addon}".replace(" ", "_")
         assert hass.states.get(entity_id) is not None
 
 
@@ -315,5 +315,5 @@ async def test_slave_binary_sensor(hass, expected, slaves, mock_do_cycle):
     assert hass.states.get(ENTITY_ID).state == expected
 
     for i in range(8):
-        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i+1}"
+        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i+1}".replace(" ", "_")
         assert hass.states.get(entity_id).state == slaves[i]

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -22,7 +22,7 @@ from homeassistant.core import State
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
 
-ENTITY_ID = f"{CLIMATE_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID = f"{CLIMATE_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -32,8 +32,8 @@ from homeassistant.core import State
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
-ENTITY_ID = f"{COVER_DOMAIN}.{TEST_ENTITY_NAME}"
-ENTITY_ID2 = f"{ENTITY_ID}2"
+ENTITY_ID = f"{COVER_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+ENTITY_ID2 = f"{ENTITY_ID}_2"
 
 
 @pytest.mark.parametrize(
@@ -270,7 +270,7 @@ async def test_restore_state_cover(hass, mock_test_state, mock_modbus):
                     CONF_SCAN_INTERVAL: 0,
                 },
                 {
-                    CONF_NAME: f"{TEST_ENTITY_NAME}2",
+                    CONF_NAME: f"{TEST_ENTITY_NAME} 2",
                     CONF_INPUT_TYPE: CALL_TYPE_COIL,
                     CONF_ADDRESS: 1235,
                     CONF_SCAN_INTERVAL: 0,

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -32,8 +32,8 @@ from homeassistant.core import State
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
 
-ENTITY_ID = f"{FAN_DOMAIN}.{TEST_ENTITY_NAME}"
-ENTITY_ID2 = f"{ENTITY_ID}2"
+ENTITY_ID = f"{FAN_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+ENTITY_ID2 = f"{ENTITY_ID}_2"
 
 
 @pytest.mark.parametrize(
@@ -228,7 +228,7 @@ async def test_restore_state_fan(hass, mock_test_state, mock_modbus):
                     CONF_SCAN_INTERVAL: 0,
                 },
                 {
-                    CONF_NAME: f"{TEST_ENTITY_NAME}2",
+                    CONF_NAME: f"{TEST_ENTITY_NAME} 2",
                     CONF_ADDRESS: 18,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                     CONF_SCAN_INTERVAL: 0,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -234,7 +234,7 @@ async def test_exception_struct_validator(do_config):
             {
                 CONF_NAME: TEST_MODBUS_NAME,
                 CONF_TYPE: TCP,
-                CONF_HOST: TEST_MODBUS_HOST + "2",
+                CONF_HOST: TEST_MODBUS_HOST + " 2",
                 CONF_PORT: TEST_PORT_TCP,
             },
         ],
@@ -246,7 +246,7 @@ async def test_exception_struct_validator(do_config):
                 CONF_PORT: TEST_PORT_TCP,
             },
             {
-                CONF_NAME: TEST_MODBUS_NAME + "2",
+                CONF_NAME: TEST_MODBUS_NAME + " 2",
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
@@ -296,7 +296,7 @@ async def test_duplicate_modbus_validator(do_config):
                         CONF_SLAVE: 0,
                     },
                     {
-                        CONF_NAME: TEST_ENTITY_NAME + "2",
+                        CONF_NAME: TEST_ENTITY_NAME + " 2",
                         CONF_ADDRESS: 117,
                         CONF_SLAVE: 0,
                     },
@@ -392,7 +392,7 @@ async def test_duplicate_entity_validator(do_config):
                 CONF_TYPE: TCP,
                 CONF_HOST: TEST_MODBUS_HOST,
                 CONF_PORT: TEST_PORT_TCP,
-                CONF_NAME: f"{TEST_MODBUS_NAME}2",
+                CONF_NAME: f"{TEST_MODBUS_NAME} 2",
             },
             {
                 CONF_TYPE: SERIAL,
@@ -402,7 +402,7 @@ async def test_duplicate_entity_validator(do_config):
                 CONF_PORT: TEST_PORT_SERIAL,
                 CONF_PARITY: "E",
                 CONF_STOPBITS: 1,
-                CONF_NAME: f"{TEST_MODBUS_NAME}3",
+                CONF_NAME: f"{TEST_MODBUS_NAME} 3",
             },
         ],
         {
@@ -599,7 +599,7 @@ async def test_pb_read(
     """Run test for different read."""
 
     # Check state
-    entity_id = f"{do_domain}.{TEST_ENTITY_NAME}"
+    entity_id = f"{do_domain}.{TEST_ENTITY_NAME}".replace(" ", "_")
     state = hass.states.get(entity_id).state
     assert hass.states.get(entity_id).state
 
@@ -681,7 +681,7 @@ async def test_delay(hass, mock_pymodbus):
     # We "hijiack" a binary_sensor to make a proper blackbox test.
     set_delay = 15
     set_scan_interval = 5
-    entity_id = f"{BINARY_SENSOR_DOMAIN}.{TEST_ENTITY_NAME}"
+    entity_id = f"{BINARY_SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
     config = {
         DOMAIN: [
             {
@@ -778,7 +778,7 @@ async def test_stop_restart(hass, caplog, mock_modbus):
     """Run test for service stop."""
 
     caplog.set_level(logging.INFO)
-    entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}"
+    entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
     hass.states.async_set(entity_id, 17)
     await hass.async_block_till_done()

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -32,8 +32,8 @@ from homeassistant.core import State
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
 
-ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_ENTITY_NAME}"
-ENTITY_ID2 = f"{ENTITY_ID}2"
+ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+ENTITY_ID2 = f"{ENTITY_ID}_2"
 
 
 @pytest.mark.parametrize(
@@ -228,7 +228,7 @@ async def test_restore_state_light(hass, mock_test_state, mock_modbus):
                     CONF_SCAN_INTERVAL: 0,
                 },
                 {
-                    CONF_NAME: f"{TEST_ENTITY_NAME}2",
+                    CONF_NAME: f"{TEST_ENTITY_NAME} 2",
                     CONF_ADDRESS: 18,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                     CONF_SCAN_INTERVAL: 0,

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -37,7 +37,7 @@ from homeassistant.core import State
 
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
-ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -40,8 +40,8 @@ from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
 from tests.common import async_fire_time_changed
 
-ENTITY_ID = f"{SWITCH_DOMAIN}.{TEST_ENTITY_NAME}"
-ENTITY_ID2 = f"{ENTITY_ID}2"
+ENTITY_ID = f"{SWITCH_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+ENTITY_ID2 = f"{ENTITY_ID}_2"
 
 
 @pytest.mark.parametrize(
@@ -281,7 +281,7 @@ async def test_restore_state_switch(hass, mock_test_state, mock_modbus):
                     CONF_SCAN_INTERVAL: 0,
                 },
                 {
-                    CONF_NAME: f"{TEST_ENTITY_NAME}2",
+                    CONF_NAME: f"{TEST_ENTITY_NAME} 2",
                     CONF_ADDRESS: 18,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                     CONF_SCAN_INTERVAL: 0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Secure that attr_name can contain spaces, and entity_id not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
