### PR TITLE
Enrich PlayMedia with extra info

### DIFF
--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -141,7 +141,7 @@ def get_domain_data(hass: HomeAssistant) -> DlnaDmsData:
 class DidlPlayMedia(PlayMedia):
     """Playable media with DIDL metadata."""
 
-    didl_metadata: didl_lite.DidlObject
+    didl_metadata: didl_lite.DidlObject | None = None
 
 
 class DlnaDmsDeviceError(BrowseError, Unresolvable):
@@ -593,7 +593,7 @@ class DmsDeviceSource:
             if mime_type := _resource_mime_type(resource):
                 url = self._device.get_absolute_url(resource.uri)
                 LOGGER.debug("Resolved to url %s MIME %s", url, mime_type)
-                return DidlPlayMedia(url, mime_type, item)
+                return DidlPlayMedia(url, mime_type, didl_metadata=item)
 
         LOGGER.debug("Object %s has no playable resources", item.id)
         raise Unresolvable("Object has no playable resources")

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -172,11 +172,12 @@ async def websocket_resolve_media(
 
     data = dataclasses.asdict(media)
 
-    if data["url"][0] == "/":
-        data["url"] = async_sign_path(
-            hass,
-            quote(data["url"]),
-            timedelta(seconds=msg["expires"]),
-        )
+    for key in ("url", "thumbnail"):
+        if data[key][0] == "/":
+            data[key] = async_sign_path(
+                hass,
+                quote(data[key]),
+                timedelta(seconds=msg["expires"]),
+            )
 
     connection.send_result(msg["id"], data)

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -73,7 +73,9 @@ class LocalSource(MediaSource):
         path = self.async_full_path(source_dir_id, location)
         mime_type, _ = mimetypes.guess_type(str(path))
         assert isinstance(mime_type, str)
-        return PlayMedia(f"/media/{item.identifier}", mime_type)
+        return PlayMedia(
+            f"/media/{item.identifier}", mime_type, title=path.name[: -len(path.suffix)]
+        )
 
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return media."""

--- a/homeassistant/components/media_source/models.py
+++ b/homeassistant/components/media_source/models.py
@@ -22,6 +22,10 @@ class PlayMedia:
 
     url: str
     mime_type: str
+    # Same data as BrowseMedia, but optional
+    media_class: str | None = None
+    title: str | None = None
+    thumbnail: str | None = None
 
 
 class BrowseMediaSource(BrowseMedia):

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -804,7 +804,7 @@ async def test_play_media_didl_metadata(
     class DidlPlayMedia(PlayMedia):
         """Playable media with DIDL metadata."""
 
-        didl_metadata: didl_lite.DidlObject
+        didl_metadata: didl_lite.DidlObject | None = None
 
     didl_metadata = didl_lite.VideoItem(
         id="120$22$33",

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -6,6 +6,7 @@ import yarl
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import MEDIA_CLASS_DIRECTORY, BrowseError
+from homeassistant.components.media_player.const import MEDIA_CLASS_MUSIC
 from homeassistant.components.media_source import const
 from homeassistant.setup import async_setup_component
 
@@ -162,6 +163,9 @@ async def test_websocket_resolve_media(hass, hass_ws_client, filename):
     media = media_source.models.PlayMedia(
         f"/media/local/{filename}",
         "audio/mpeg",
+        media_class=MEDIA_CLASS_MUSIC,
+        title="Epic Sax",
+        thumbnail="/hello-world.jpg",
     )
 
     with patch(
@@ -181,6 +185,14 @@ async def test_websocket_resolve_media(hass, hass_ws_client, filename):
     assert msg["success"]
     assert msg["id"] == 1
     assert msg["result"]["mime_type"] == media.mime_type
+    assert msg["result"]["media_class"] == MEDIA_CLASS_MUSIC
+    assert msg["result"]["title"] == "Epic Sax"
+
+    # Validate url and thumbnail are signed.
+    for key in ("url", "thumbnail"):
+        parsed = yarl.URL(msg["result"][key])
+        assert parsed.path == getattr(media, key)
+        assert "authSig" in parsed.query
 
     # Validate url is signed.
     parsed = yarl.URL(msg["result"]["url"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enrich PlayMedia items with more info normally found in the BrowseMedia model. This way players that can send extra info to a generic media player have some more info to show.

Fields marked as optional so it's backwards compatible.

To do:
- [x] tests

CC @ctalkington 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
