### PR TITLE
Fix lyric climate

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -282,9 +282,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     heatSetpoint=target_temp_low,
                     mode=HVAC_MODES[device.changeableValues.heatCoolMode],
                 )
-                except LYRIC_EXCEPTIONS as exception:
-                    _LOGGER.error(exception)
-                    await self.coordinator.async_refresh()
+            except LYRIC_EXCEPTIONS as exception:
+                _LOGGER.error(exception)
+            await self.coordinator.async_refresh()
         else:
             temp = kwargs.get(ATTR_TEMPERATURE)
             _LOGGER.debug("Set temperature: %s", temp)
@@ -301,9 +301,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         device,
                         heatSetpoint=temp
                     )
-                    except LYRIC_EXCEPTIONS as exception:
-                        _LOGGER.error(exception)
-                        await self.coordinator.async_refresh()
+            except LYRIC_EXCEPTIONS as exception:
+                _LOGGER.error(exception)
+            await self.coordinator.async_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set hvac mode."""

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -48,8 +48,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 """ Only LCC models support presets """
-SUPPORT_FLAGS_LCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE_RANGE | SUPPORT_FAN_MODE
-SUPPORT_FLAGS_TCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE | SUPPORT_FAN_MODE
+SUPPORT_FLAGS_LCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE_RANGE
+SUPPORT_FLAGS_TCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE
 
 LYRIC_HVAC_ACTION_OFF = "EquipmentOff"
 LYRIC_HVAC_ACTION_HEAT = "Heat"
@@ -90,6 +90,7 @@ SCHEMA_HOLD_TIME = {
         lambda td: strftime("%H:%M:%S", localtime(time() + td.total_seconds())),
     )
 }
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -264,11 +265,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         device = self.device
-        
+
         if HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF:
             target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
             target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-            
+
             if device.changeableValues.autoChangeoverActive:
                 if target_temp_low is None or target_temp_high is None:
                     raise HomeAssistantError(
@@ -310,9 +311,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         _LOGGER.debug("HVAC mode from frontend: %s", hvac_mode)
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
-                """ If the system is off, turn it to Heat first then to Auto, otherwise it turns to
-                Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the
-                behavior that happens with the native app as well, so likely a bug in the api itself """
+                #If the system is off, turn it to Heat first then to Auto, otherwise it turns to
+                #Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the
+                #behavior that happens with the native app as well, so likely a bug in the api itself
+
                 if HVAC_MODES[self.device.changeableValues.mode] == HVAC_MODE_OFF:
                     _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[LYRIC_HVAC_MODE_COOL])
                     await self._update_thermostat(

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -310,8 +310,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         _LOGGER.debug("HVAC mode from frontend: %s", hvac_mode)
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
-                """ If the system is off, turn it to Heat first then to Auto, otherwise it turns to 
-                Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the 
+                """ If the system is off, turn it to Heat first then to Auto, otherwise it turns to
+                Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the
                 behavior that happens with the native app as well, so likely a bug in the api itself """
                 if HVAC_MODES[self.device.changeableValues.mode] == HVAC_MODE_OFF:
                     _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[LYRIC_HVAC_MODE_COOL])

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -311,9 +311,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         _LOGGER.debug("HVAC mode from frontend: %s", hvac_mode)
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
-                #If the system is off, turn it to Heat first then to Auto, otherwise it turns to
-                #Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the
-                #behavior that happens with the native app as well, so likely a bug in the api itself
+                # If the system is off, turn it to Heat first then to Auto, otherwise it turns to
+                # Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the
+                # behavior that happens with the native app as well, so likely a bug in the api itself
 
                 if HVAC_MODES[self.device.changeableValues.mode] == HVAC_MODE_OFF:
                     _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[LYRIC_HVAC_MODE_COOL])
@@ -323,7 +323,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
                         autoChangeoverActive=False
                     )
-                    """ Sleep 3 seconds before proceeding """
+                    # Sleep 3 seconds before proceeding
                     await asyncio.sleep(3)
                     _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[LYRIC_HVAC_MODE_HEAT])
                     await self._update_thermostat(

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -48,7 +48,9 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 # Only LCC models support presets
-SUPPORT_FLAGS_LCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE_RANGE
+SUPPORT_FLAGS_LCC = (
+    SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE_RANGE
+)
 SUPPORT_FLAGS_TCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE
 
 LYRIC_HVAC_ACTION_OFF = "EquipmentOff"
@@ -208,7 +210,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         device = self.device
-        if not device.changeableValues.autoChangeoverActive and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF:
+        if (
+            not device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+        ):
             if self.hvac_mode == HVAC_MODE_COOL:
                 return device.changeableValues.coolSetpoint
             return device.changeableValues.heatSetpoint
@@ -291,15 +296,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             try:
                 if self.hvac_mode == HVAC_MODE_COOL:
                     await self._update_thermostat(
-                        self.location,
-                        device,
-                        coolSetpoint=temp
+                        self.location, device, coolSetpoint=temp
                     )
                 else:
                     await self._update_thermostat(
-                        self.location,
-                        device,
-                        heatSetpoint=temp
+                        self.location, device, heatSetpoint=temp
                     )
             except LYRIC_EXCEPTIONS as exception:
                 _LOGGER.error(exception)
@@ -315,36 +316,45 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 # behavior that happens with the native app as well, so likely a bug in the api itself
 
                 if HVAC_MODES[self.device.changeableValues.mode] == HVAC_MODE_OFF:
-                    _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[LYRIC_HVAC_MODE_COOL])
+                    _LOGGER.debug(
+                        "HVAC mode passed to lyric: %s",
+                        HVAC_MODES[LYRIC_HVAC_MODE_COOL],
+                    )
                     await self._update_thermostat(
                         self.location,
                         self.device,
                         mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                        autoChangeoverActive=False
+                        autoChangeoverActive=False,
                     )
                     # Sleep 3 seconds before proceeding
                     await asyncio.sleep(3)
-                    _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[LYRIC_HVAC_MODE_HEAT])
+                    _LOGGER.debug(
+                        "HVAC mode passed to lyric: %s",
+                        HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                    )
                     await self._update_thermostat(
                         self.location,
                         self.device,
                         mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                        autoChangeoverActive=True
+                        autoChangeoverActive=True,
                     )
                 else:
-                    _LOGGER.debug("HVAC mode passed to lyric: %s", HVAC_MODES[self.device.changeableValues.mode])
+                    _LOGGER.debug(
+                        "HVAC mode passed to lyric: %s",
+                        HVAC_MODES[self.device.changeableValues.mode],
+                    )
                     await self._update_thermostat(
-                        self.location,
-                        self.device,
-                        autoChangeoverActive=True
+                        self.location, self.device, autoChangeoverActive=True
                     )
             else:
-                _LOGGER.debug("HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
+                _LOGGER.debug(
+                    "HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode]
+                )
                 await self._update_thermostat(
                     self.location,
                     self.device,
                     mode=LYRIC_HVAC_MODES[hvac_mode],
-                    autoChangeoverActive=False
+                    autoChangeoverActive=False,
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
@@ -355,9 +365,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         _LOGGER.debug("Set preset mode: %s", preset_mode)
         try:
             await self._update_thermostat(
-                self.location,
-                self.device,
-                thermostatSetpointStatus=preset_mode
+                self.location, self.device, thermostatSetpointStatus=preset_mode
             )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
@@ -371,7 +379,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 self.location,
                 self.device,
                 thermostatSetpointStatus=PRESET_HOLD_UNTIL,
-                nextPeriodTime=time_period
+                nextPeriodTime=time_period,
             )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -307,7 +307,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set hvac mode."""
-        _LOGGER.debug("HVAC mode from frontend: %s", hvac_mode)
+        _LOGGER.debug("HVAC mode: %s", hvac_mode)
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
                 # If the system is off, turn it to Heat first then to Auto, otherwise it turns to

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -348,7 +348,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
-            await self.coordinator.async_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset (PermanentHold, HoldUntil, NoHold, VacationHold) mode."""
@@ -361,7 +361,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
-            await self.coordinator.async_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_set_hold_time(self, time_period: str) -> None:
         """Set the time to hold until."""
@@ -375,4 +375,4 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
-            await self.coordinator.async_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -265,7 +265,6 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         device = self.device
-        
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
@@ -283,8 +282,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     heatSetpoint=target_temp_low,
                     mode=HVAC_MODES[device.changeableValues.heatCoolMode],
                 )
-            except LYRIC_EXCEPTIONS as exception:
-                _LOGGER.error(exception)
+                except LYRIC_EXCEPTIONS as exception:
+                    _LOGGER.error(exception)
+                    await self.coordinator.async_refresh()
         else:
             temp = kwargs.get(ATTR_TEMPERATURE)
             _LOGGER.debug("Set temperature: %s", temp)
@@ -301,9 +301,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         device,
                         heatSetpoint=temp
                     )
-            except LYRIC_EXCEPTIONS as exception:
-                _LOGGER.error(exception)
-            await self.coordinator.async_refresh()
+                    except LYRIC_EXCEPTIONS as exception:
+                        _LOGGER.error(exception)
+                        await self.coordinator.async_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set hvac mode."""
@@ -348,7 +348,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
-        await self.coordinator.async_refresh()
+            await self.coordinator.async_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset (PermanentHold, HoldUntil, NoHold, VacationHold) mode."""
@@ -361,7 +361,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
-        await self.coordinator.async_refresh()
+            await self.coordinator.async_refresh()
 
     async def async_set_hold_time(self, time_period: str) -> None:
         """Set the time to hold until."""
@@ -375,4 +375,4 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
-        await self.coordinator.async_refresh()
+            await self.coordinator.async_refresh()

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -47,7 +47,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-""" Only LCC models support presets """
+# Only LCC models support presets
 SUPPORT_FLAGS_LCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE_RANGE
 SUPPORT_FLAGS_TCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE
 

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -281,6 +281,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         coolSetpoint=target_temp_high,
                         heatSetpoint=target_temp_low,
                         mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
+                        autoChangeoverActive=True
                     )
                 except LYRIC_EXCEPTIONS as exception:
                     _LOGGER.error(exception)
@@ -293,12 +294,18 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                             self.location,
                             device,
                             coolSetpoint=temp,
+                            heatSetpoint=self.device.changeableValues.heatSetpoint,
+                            mode=HVAC_MODES[LYRIC_HVAC_MODE_COOL],
+                            autoChangeoverActive=False
                         )
                     else:
                         await self._update_thermostat(
                             self.location,
                             device,
+                            coolSetpoint=self.device.changeableValues.coolSetpoint,
                             heatSetpoint=temp,
+                            mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                            autoChangeoverActive=False
                         )
                 except LYRIC_EXCEPTIONS as exception:
                     _LOGGER.error(exception)
@@ -314,6 +321,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     await self._update_thermostat(
                         self.location,
                         self.device,
+                        coolSetpoint=self.device.changeableValues.coolSetpoint,
+                        heatSetpoint=self.device.changeableValues.heatSetpoint,
                         mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
                         autoChangeoverActive=True
                     )
@@ -322,6 +331,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     await self._update_thermostat(
                         self.location,
                         self.device,
+                        coolSetpoint=self.device.changeableValues.coolSetpoint,
+                        heatSetpoint=self.device.changeableValues.heatSetpoint,
                         mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
                         autoChangeoverActive=True
                     )
@@ -330,6 +341,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 await self._update_thermostat(
                     self.location,
                     self.device,
+                    coolSetpoint=self.device.changeableValues.coolSetpoint,
+                    heatSetpoint=self.device.changeableValues.heatSetpoint,
                     mode=LYRIC_HVAC_MODES[hvac_mode],
                     autoChangeoverActive=False
                 )

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -22,7 +22,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE
+    SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE
@@ -170,9 +170,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def supported_features(self) -> int:
         """Return the list of supported features."""
         if self.device.changeableValues.thermostatSetpointStatus:
-            return SUPPORT_FLAGS_LCC
+            support_flags = SUPPORT_FLAGS_LCC
         else:
-            return SUPPORT_FLAGS_TCC
+            support_flags = SUPPORT_FLAGS_TCC
+        return support_flags
 
     @property
     def temperature_unit(self) -> str:
@@ -261,9 +262,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         return device.maxCoolSetpoint
 
     async def async_set_temperature(self, **kwargs) -> None:
+        """Set new target temperature."""
         device = self.device
+        
         if HVAC_MODES[device.changeableValues.heatCoolMode] != HVAC_MODE_OFF:
-            """Set new target temperature."""
             target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
             target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
             

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -304,24 +304,27 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set hvac mode."""
-        _LOGGER.debug("Set hvac mode: %s", hvac_mode)
+        _LOGGER.debug("Set point from frontent: %s", hvac_mode)
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
                 if HVAC_MODES[self.device.changeableValues.heatCoolMode] == HVAC_MODE_OFF:
+                    _LOGGER.debug("Set point passed to lyric: %s", LYRIC_HVAC_MODES[HVAC_MODE_HEAT])
                     await self._update_thermostat(
                         self.location,
                         self.device,
-                        mode=LYRIC_HVAC_MODES[HVAC_MODE_HEAT],
+                        mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
                         autoChangeoverActive=True
-                        )
+                    )
                 else:
+                    _LOGGER.debug("Set point passed to lyric: %s", HVAC_MODES[self.device.changeableValues.heatCoolMode])
                     await self._update_thermostat(
                         self.location,
                         self.device,
                         mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
                         autoChangeoverActive=True
-                        )
+                    )
             else:
+                _LOGGER.debug("Set point passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
                 await self._update_thermostat(
                     self.location,
                     self.device,

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -314,7 +314,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set hvac mode."""
-        _LOGGER.debug("Set point from frontent: %s", hvac_mode)
+        _LOGGER.debug("Set point from frontend: %s", hvac_mode)
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
                 if HVAC_MODES[self.device.changeableValues.heatCoolMode] == HVAC_MODE_OFF:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -280,7 +280,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         coolSetpoint=target_temp_high,
                         heatSetpoint=target_temp_low,
                         mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
-                        autoChangeoverActive=True
+                        autoChangeoverActive=True,
                     )
                 except LYRIC_EXCEPTIONS as exception:
                     _LOGGER.error(exception)
@@ -295,7 +295,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                             coolSetpoint=temp,
                             heatSetpoint=self.device.changeableValues.heatSetpoint,
                             mode=HVAC_MODES[LYRIC_HVAC_MODE_COOL],
-                            autoChangeoverActive=False
+                            autoChangeoverActive=False,
                         )
                     else:
                         await self._update_thermostat(
@@ -304,7 +304,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                             coolSetpoint=self.device.changeableValues.coolSetpoint,
                             heatSetpoint=temp,
                             mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                            autoChangeoverActive=False
+                            autoChangeoverActive=False,
                         )
                 except LYRIC_EXCEPTIONS as exception:
                     _LOGGER.error(exception)
@@ -323,7 +323,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         coolSetpoint=self.device.changeableValues.coolSetpoint,
                         heatSetpoint=self.device.changeableValues.heatSetpoint,
                         mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
-                        autoChangeoverActive=True
+                        autoChangeoverActive=True,
                     )
                 else:
                     _LOGGER.debug("Set point passed to lyric: %s", HVAC_MODES[self.device.changeableValues.heatCoolMode])
@@ -333,7 +333,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                         coolSetpoint=self.device.changeableValues.coolSetpoint,
                         heatSetpoint=self.device.changeableValues.heatSetpoint,
                         mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
-                        autoChangeoverActive=True
+                        autoChangeoverActive=True,
                     )
             else:
                 _LOGGER.debug("Set point passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode])
@@ -343,7 +343,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     coolSetpoint=self.device.changeableValues.coolSetpoint,
                     heatSetpoint=self.device.changeableValues.heatSetpoint,
                     mode=LYRIC_HVAC_MODES[hvac_mode],
-                    autoChangeoverActive=False
+                    autoChangeoverActive=False,
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
@@ -359,14 +359,14 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     self.device,
                     mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
                     autoChangeoverActive=True,
-                    thermostatSetpointStatus=preset_mode
+                    thermostatSetpointStatus=preset_mode,
                 )
             else:
                 await self._update_thermostat(
                     self.location,
                     self.device,
                     autoChangeoverActive=False,
-                    thermostatSetpointStatus=preset_mode
+                    thermostatSetpointStatus=preset_mode,
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
@@ -383,7 +383,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
                     autoChangeoverActive=True,
                     thermostatSetpointStatus=PRESET_HOLD_UNTIL,
-                    nextPeriodTime=time_period
+                    nextPeriodTime=time_period,
                 )
             else:
                 await self._update_thermostat(
@@ -391,7 +391,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     self.device,
                     autoChangeoverActive=False,
                     thermostatSetpointStatus=PRESET_HOLD_UNTIL,
-                    nextPeriodTime=time_period
+                    nextPeriodTime=time_period,
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -169,7 +169,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
-        if self.device.changeableValues.thermostatSetpointStatus: 
+        if self.device.changeableValues.thermostatSetpointStatus:
             return SUPPORT_FLAGS_LCC
         else:
             return SUPPORT_FLAGS_TCC
@@ -262,12 +262,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs) -> None:
         device = self.device
-
         if HVAC_MODES[device.changeableValues.heatCoolMode] != HVAC_MODE_OFF:
             """Set new target temperature."""
             target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
             target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-    
+            
             if device.changeableValues.autoChangeoverActive:
                 if target_temp_low is None or target_temp_high is None:
                     raise HomeAssistantError(

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -214,7 +214,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         if device.changeableValues.autoChangeoverActive:
             return device.changeableValues.coolSetpoint
         return None
-        
+
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
@@ -284,15 +284,15 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             try:
                 if self.hvac_mode == HVAC_MODE_COOL:
                     await self._update_thermostat(
-                        self.location, 
-                        device, 
+                        self.location,
+                        device,
                         coolSetpoint=temp,
                         thermostatSetpointStatus=PRESET_TEMPORARY_HOLD
                     )
                 else:
                     await self._update_thermostat(
-                        self.location, 
-                        device, 
+                        self.location,
+                        device,
                         heatSetpoint=temp,
                         thermostatSetpointStatus=PRESET_TEMPORARY_HOLD
                     )
@@ -306,17 +306,17 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         try:
             if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
                 await self._update_thermostat(
-                    self.location, 
-                    self.device, 
-                    mode=HVAC_MODES[self.device.changeableValues.heatCoolMode], 
-                    autoChangeoverActive=True 
+                    self.location,
+                    self.device,
+                    mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
+                    autoChangeoverActive=True
                 )
-            else: 
+            else:
                 await self._update_thermostat(
-                    self.location, 
-                    self.device, 
-                    mode=LYRIC_HVAC_MODES[hvac_mode], 
-                    autoChangeoverActive=False 
+                    self.location,
+                    self.device,
+                    mode=LYRIC_HVAC_MODES[hvac_mode],
+                    autoChangeoverActive=False
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
@@ -328,16 +328,16 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         try:
             if self.device.changeableValues.mode == LYRIC_HVAC_MODE_HEAT_COOL:
                 await self._update_thermostat(
-                    self.location, 
-                    self.device, 
-                    mode=HVAC_MODES[self.device.changeableValues.heatCoolMode], 
+                    self.location,
+                    self.device,
+                    mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
                     autoChangeoverActive=True,
                     thermostatSetpointStatus=preset_mode
                 )
-            else: 
+            else:
                 await self._update_thermostat(
-                    self.location, 
-                    self.device, 
+                    self.location,
+                    self.device,
                     autoChangeoverActive=False,
                     thermostatSetpointStatus=preset_mode
                 )
@@ -351,20 +351,20 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         try:
             if self.device.changeableValues.mode == LYRIC_HVAC_MODE_HEAT_COOL:
                 await self._update_thermostat(
-                    self.location, 
-                    self.device, 
-                    mode=HVAC_MODES[self.device.changeableValues.heatCoolMode], 
+                    self.location,
+                    self.device,
+                    mode=HVAC_MODES[self.device.changeableValues.heatCoolMode],
                     autoChangeoverActive=True,
                     thermostatSetpointStatus=PRESET_HOLD_UNTIL,
-                    nextPeriodTime=time_period,
+                    nextPeriodTime=time_period
                 )
-            else: 
+            else:
                 await self._update_thermostat(
-                    self.location, 
-                    self.device, 
+                    self.location,
+                    self.device,
                     autoChangeoverActive=False,
                     thermostatSetpointStatus=PRESET_HOLD_UNTIL,
-                    nextPeriodTime=time_period,
+                    nextPeriodTime=time_period
                 )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)


### PR DESCRIPTION
I was having the same issues as described in #63403, specifically, the error stating that Mode 7 is not valid, only Heat, Cool, Off when trying to do anything while the thermostat is set to Auto. This error originates with the way the Lyric API handles the modes. Basically, when one queries the changeableValues dict, you get a mode=Auto, as well as a heatCoolMode, which is set to either Heat, Cool, Off. Per the documentation, heatCoolMode contains the "heat cool mode when system switch is in Auto mode". It would make sense that when changing the thermostat settings, mode=Auto should be valid, but it's not. The way the API understands that the mode should be set to Auto when changing the thermostat settings is by setting the autoChangeoverActive variable to true, not the mode itself. This require changes in the async_set_hvac_mode, async_set_temperature, and async_set_preset_mode functions. Related to this issue, I got rid of the references to hasDualSetpointStatus, as it seems that it always remains false in the API, even when the mode is set to auto, so again, the key variable for this is autoChangeoverActive.

While I was working on this I also noticed another issue. The support flag SUPPORT_TARGET_TEMPERATURE_RANGE had not been included, which did not allow for the temperature range to be available, thus invalidating the target_temperature_low and target_temperature_high functions. I added this flag and sorted out which set point (heat vs cool) should be called for each of them so things work as expected in Lovelace. I have tested all of these functionalities and they all work great on my end, so I thought I'd share.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
