### PR TITLE
Add Remote Engine Start status to Renault integration

### DIFF
--- a/homeassistant/components/renault/renault_vehicle.py
+++ b/homeassistant/components/renault/renault_vehicle.py
@@ -153,4 +153,9 @@ COORDINATORS: tuple[RenaultCoordinatorDescription, ...] = (
         key="lock_status",
         update_method=lambda x: x.get_lock_status,
     ),
+    RenaultCoordinatorDescription(
+        endpoint="res-state",
+        key="res_state",
+        update_method=lambda x: x.get_res_state,
+    ),
 )

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -339,7 +339,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription, ...] = (
         coordinator="res_state",
         data_key="details",
         entity_class=RenaultSensor[KamereonVehicleResStateData],
-        name="Remote Engine Start State",
+        name="Remote Engine Start",
     ),
     RenaultSensorEntityDescription(
         key="res_state_code",
@@ -347,6 +347,6 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription, ...] = (
         data_key="code",
         entity_class=RenaultSensor[KamereonVehicleResStateData],
         entity_registry_enabled_default=False,
-        name="Remote Engine Start State Code",
+        name="Remote Engine Start Code",
     ),
 )

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -12,6 +12,7 @@ from renault_api.kamereon.models import (
     KamereonVehicleCockpitData,
     KamereonVehicleHvacStatusData,
     KamereonVehicleLocationData,
+    KamereonVehicleResStateData,
 )
 
 from homeassistant.components.sensor import (
@@ -332,5 +333,20 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         name="Location Last Activity",
         value_lambda=_get_utc_value,
+    ),
+    RenaultSensorEntityDescription(
+        key="res_state",
+        coordinator="res_state",
+        data_key="details",
+        entity_class=RenaultSensor[KamereonVehicleResStateData],
+        name="RES State",
+    ),
+    RenaultSensorEntityDescription(
+        key="res_state_code",
+        coordinator="res_state",
+        data_key="code",
+        entity_class=RenaultSensor[KamereonVehicleResStateData],
+        entity_registry_enabled_default=False,
+        name="RES State Code",
     ),
 )

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -339,7 +339,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription, ...] = (
         coordinator="res_state",
         data_key="details",
         entity_class=RenaultSensor[KamereonVehicleResStateData],
-        name="RES State",
+        name="Remote Engine Start State",
     ),
     RenaultSensorEntityDescription(
         key="res_state_code",
@@ -347,6 +347,6 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription, ...] = (
         data_key="code",
         entity_class=RenaultSensor[KamereonVehicleResStateData],
         entity_registry_enabled_default=False,
-        name="RES State Code",
+        name="Remote Engine Start State Code",
     ),
 )

--- a/tests/components/renault/conftest.py
+++ b/tests/components/renault/conftest.py
@@ -107,6 +107,11 @@ def _get_fixtures(vehicle_type: str) -> MappingProxyType:
             if "lock_status" in mock_vehicle["endpoints"]
             else load_fixture("renault/no_data.json")
         ).get_attributes(schemas.KamereonVehicleLockStatusDataSchema),
+        "res_state": schemas.KamereonVehicleDataResponseSchema.loads(
+            load_fixture(f"renault/{mock_vehicle['endpoints']['res_state']}")
+            if "res_state" in mock_vehicle["endpoints"]
+            else load_fixture("renault/no_data.json")
+        ).get_attributes(schemas.KamereonVehicleResStateDataSchema),
     }
 
 
@@ -133,6 +138,9 @@ def patch_fixtures_with_data(vehicle_type: str):
     ), patch(
         "renault_api.renault_vehicle.RenaultVehicle.get_lock_status",
         return_value=mock_fixtures["lock_status"],
+    ), patch(
+        "renault_api.renault_vehicle.RenaultVehicle.get_res_state",
+        return_value=mock_fixtures["res_state"],
     ):
         yield
 
@@ -160,6 +168,9 @@ def patch_fixtures_with_no_data():
     ), patch(
         "renault_api.renault_vehicle.RenaultVehicle.get_lock_status",
         return_value=mock_fixtures["lock_status"],
+    ), patch(
+        "renault_api.renault_vehicle.RenaultVehicle.get_res_state",
+        return_value=mock_fixtures["res_state"],
     ):
         yield
 
@@ -184,6 +195,9 @@ def _patch_fixtures_with_side_effect(side_effect: Any):
         side_effect=side_effect,
     ), patch(
         "renault_api.renault_vehicle.RenaultVehicle.get_lock_status",
+        side_effect=side_effect,
+    ), patch(
+        "renault_api.renault_vehicle.RenaultVehicle.get_res_state",
         side_effect=side_effect,
     ):
         yield

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -237,13 +237,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_plug_state",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_code",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state_code",
             },
@@ -469,13 +469,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_location_last_activity",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start",
                 ATTR_STATE: "Stopped, ready for RES",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_code",
                 ATTR_STATE: "10",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state_code",
             },
@@ -689,13 +689,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_location_last_activity",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start",
                 ATTR_STATE: "Stopped, ready for RES",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_code",
                 ATTR_STATE: "10",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state_code",
             },
@@ -811,13 +811,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_location_last_activity",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start",
                 ATTR_STATE: "Stopped, ready for RES",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_code",
                 ATTR_STATE: "10",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state_code",
             },

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -237,13 +237,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_plug_state",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
                 ATTR_STATE: STATE_UNKNOWN,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state_code",
             },
@@ -469,13 +469,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_location_last_activity",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
                 ATTR_STATE: "Stopped, ready for RES",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
                 ATTR_STATE: "10",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state_code",
             },
@@ -689,13 +689,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_location_last_activity",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
                 ATTR_STATE: "Stopped, ready for RES",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
                 ATTR_STATE: "10",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state_code",
             },
@@ -811,13 +811,13 @@ MOCK_VEHICLES = {
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_location_last_activity",
             },
             {
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state",
                 ATTR_STATE: "Stopped, ready for RES",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state",
             },
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_ENTITY_ID: "sensor.reg_number_remote_engine_start_state_code",
                 ATTR_STATE: "10",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state_code",
             },

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -236,6 +236,17 @@ MOCK_VEHICLES = {
                 ATTR_STATE: "plugged",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_plug_state",
             },
+            {
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state",
+            },
+            {
+                ATTR_DEFAULT_DISABLED: True,
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state_code",
+            },
         ],
     },
     "zoe_50": {
@@ -261,6 +272,7 @@ MOCK_VEHICLES = {
             "hvac_status": "hvac_status.2.json",
             "location": "location.json",
             "lock_status": "lock_status.1.json",
+            "res_state": "res_state.1.json",
         },
         Platform.BINARY_SENSOR: [
             {
@@ -456,6 +468,17 @@ MOCK_VEHICLES = {
                 ATTR_STATE: "2020-02-18T16:58:38+00:00",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_location_last_activity",
             },
+            {
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_STATE: "Stopped, ready for RES",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state",
+            },
+            {
+                ATTR_DEFAULT_DISABLED: True,
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_STATE: "10",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_res_state_code",
+            },
         ],
     },
     "captur_phev": {
@@ -480,6 +503,7 @@ MOCK_VEHICLES = {
             "cockpit": "cockpit_fuel.json",
             "location": "location.json",
             "lock_status": "lock_status.1.json",
+            "res_state": "res_state.1.json",
         },
         Platform.BINARY_SENSOR: [
             {
@@ -664,6 +688,17 @@ MOCK_VEHICLES = {
                 ATTR_STATE: "2020-02-18T16:58:38+00:00",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_location_last_activity",
             },
+            {
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_STATE: "Stopped, ready for RES",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state",
+            },
+            {
+                ATTR_DEFAULT_DISABLED: True,
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_STATE: "10",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state_code",
+            },
         ],
     },
     "captur_fuel": {
@@ -686,6 +721,7 @@ MOCK_VEHICLES = {
             "cockpit": "cockpit_fuel.json",
             "location": "location.json",
             "lock_status": "lock_status.1.json",
+            "res_state": "res_state.1.json",
         },
         Platform.BINARY_SENSOR: [
             {
@@ -773,6 +809,17 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "sensor.reg_number_location_last_activity",
                 ATTR_STATE: "2020-02-18T16:58:38+00:00",
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_location_last_activity",
+            },
+            {
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state",
+                ATTR_STATE: "Stopped, ready for RES",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state",
+            },
+            {
+                ATTR_DEFAULT_DISABLED: True,
+                ATTR_ENTITY_ID: "sensor.reg_number_res_state_code",
+                ATTR_STATE: "10",
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_res_state_code",
             },
         ],
     },

--- a/tests/components/renault/fixtures/res_state.1.json
+++ b/tests/components/renault/fixtures/res_state.1.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+      "type": "ResState",
+      "id": "VF1AAAAA555777999",
+      "attributes": {
+        "details": "Stopped, ready for RES",
+        "code": "10"
+      }
+    }
+  }

--- a/tests/components/renault/test_diagnostics.py
+++ b/tests/components/renault/test_diagnostics.py
@@ -157,6 +157,7 @@ VEHICLE_DATA = {
         "externalTemperature": 8.0,
         "hvacStatus": "off",
     },
+    "res_state": {},
 }
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Remote Engine Start status to Renault integration, as follow-up to #67016

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
