### PR TITLE
Expose Samsung wrapper as async

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -132,9 +132,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     bridge.register_new_token_callback(new_token_callback)
 
-    def stop_bridge(event: Event) -> None:
+    async def stop_bridge(event: Event) -> None:
         """Stop SamsungTV bridge connection."""
-        bridge.stop()
+        await bridge.stop()
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_bridge)
@@ -197,7 +197,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN][entry.entry_id].stop()
+        await hass.data[DOMAIN][entry.entry_id].stop()
     return unload_ok
 
 

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -177,7 +177,7 @@ async def _async_create_bridge_with_updated_data(
         if info:
             mac = mac_from_device_info(info)
         else:
-            mac = await hass.async_add_executor_job(bridge.mac_from_device)
+            mac = await bridge.mac_from_device()
 
     if not mac:
         mac = await hass.async_add_executor_job(

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -134,7 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def stop_bridge(event: Event) -> None:
         """Stop SamsungTV bridge connection."""
-        await bridge.stop()
+        await bridge.async_stop()
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_bridge)
@@ -177,7 +177,7 @@ async def _async_create_bridge_with_updated_data(
         if info:
             mac = mac_from_device_info(info)
         else:
-            mac = await bridge.mac_from_device()
+            mac = await bridge.async_mac_from_device()
 
     if not mac:
         mac = await hass.async_add_executor_job(
@@ -197,7 +197,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        await hass.data[DOMAIN][entry.entry_id].stop()
+        await hass.data[DOMAIN][entry.entry_id].async_stop()
     return unload_ok
 
 

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -100,10 +100,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 @callback
 def _async_get_device_bridge(
-    data: dict[str, Any]
+    hass: HomeAssistant, data: dict[str, Any]
 ) -> SamsungTVLegacyBridge | SamsungTVWSBridge:
     """Get device bridge."""
     return SamsungTVBridge.get_bridge(
+        hass,
         data[CONF_METHOD],
         data[CONF_HOST],
         data[CONF_PORT],
@@ -169,7 +170,7 @@ async def _async_create_bridge_with_updated_data(
         updated_data[CONF_PORT] = port
         updated_data[CONF_METHOD] = method
 
-    bridge = _async_get_device_bridge({**entry.data, **updated_data})
+    bridge = _async_get_device_bridge(hass, {**entry.data, **updated_data})
 
     mac = entry.data.get(CONF_MAC)
     if not mac and bridge.method == METHOD_WEBSOCKET:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -125,7 +125,11 @@ class SamsungTVBridge(ABC):
     async def get_app_list(self) -> dict[str, str] | None:
         """Get installed app list."""
 
-    def is_on(self) -> bool:
+    async def is_on(self) -> bool:
+        """Tells if the TV is on."""
+        return await self.hass.async_add_executor_job(self._is_on)
+
+    def _is_on(self) -> bool:
         """Tells if the TV is on."""
         if self._remote is not None:
             self.close_remote()

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -122,7 +122,7 @@ class SamsungTVBridge(ABC):
         """Try to fetch the mac address of the TV."""
 
     @abstractmethod
-    def get_app_list(self) -> dict[str, str] | None:
+    async def get_app_list(self) -> dict[str, str] | None:
         """Get installed app list."""
 
     def is_on(self) -> bool:
@@ -218,7 +218,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         """Try to fetch the mac address of the TV."""
         return None
 
-    def get_app_list(self) -> dict[str, str]:
+    async def get_app_list(self) -> dict[str, str]:
         """Get installed app list."""
         return {}
 
@@ -307,7 +307,11 @@ class SamsungTVWSBridge(SamsungTVBridge):
         info = await self.device_info()
         return mac_from_device_info(info) if info else None
 
-    def get_app_list(self) -> dict[str, str] | None:
+    async def get_app_list(self) -> dict[str, str] | None:
+        """Get installed app list."""
+        return await self.hass.async_add_executor_job(self._get_app_list)
+
+    def _get_app_list(self) -> dict[str, str] | None:
         """Get installed app list."""
         if self._app_list is None:
             if remote := self._get_remote():

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -128,7 +128,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Try to connect and check auth."""
         for method in SUPPORTED_METHODS:
             self._bridge = SamsungTVBridge.get_bridge(self.hass, method, self._host)
-            result = await self._bridge.try_connect()
+            result = await self._bridge.async_try_connect()
             if result == RESULT_SUCCESS:
                 return
             if result != RESULT_CANNOT_CONNECT:
@@ -345,7 +345,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._reauth_entry.data[CONF_METHOD],
                 self._reauth_entry.data[CONF_HOST],
             )
-            result = await bridge.try_connect()
+            result = await bridge.async_try_connect()
             if result == RESULT_SUCCESS:
                 new_data = dict(self._reauth_entry.data)
                 new_data[CONF_TOKEN] = bridge.token

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -127,7 +127,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _try_connect(self) -> None:
         """Try to connect and check auth."""
         for method in SUPPORTED_METHODS:
-            self._bridge = SamsungTVBridge.get_bridge(method, self._host)
+            self._bridge = SamsungTVBridge.get_bridge(self.hass, method, self._host)
             result = self._bridge.try_connect()
             if result == RESULT_SUCCESS:
                 return
@@ -341,7 +341,9 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         assert self._reauth_entry
         if user_input is not None:
             bridge = SamsungTVBridge.get_bridge(
-                self._reauth_entry.data[CONF_METHOD], self._reauth_entry.data[CONF_HOST]
+                self.hass,
+                self._reauth_entry.data[CONF_METHOD],
+                self._reauth_entry.data[CONF_HOST],
             )
             result = await self.hass.async_add_executor_job(bridge.try_connect)
             if result == RESULT_SUCCESS:

--- a/homeassistant/components/samsungtv/diagnostics.py
+++ b/homeassistant/components/samsungtv/diagnostics.py
@@ -23,5 +23,5 @@ async def async_get_config_entry_diagnostics(
     ]
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "device_info": await hass.async_add_executor_job(bridge.device_info),
+        "device_info": await bridge.device_info(),
     }

--- a/homeassistant/components/samsungtv/diagnostics.py
+++ b/homeassistant/components/samsungtv/diagnostics.py
@@ -23,5 +23,5 @@ async def async_get_config_entry_diagnostics(
     ]
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "device_info": await bridge.device_info(),
+        "device_info": await bridge.async_device_info(),
     }

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -160,7 +160,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         if self._power_off_in_progress():
             self._attr_state = STATE_OFF
         else:
-            self._attr_state = STATE_ON if self._bridge.is_on() else STATE_OFF
+            self._attr_state = STATE_ON if await self._bridge.is_on() else STATE_OFF
 
         if self._attr_state == STATE_ON and self._app_list is None:
             self._app_list = {}  # Ensure that we don't update it twice in parallel

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -153,7 +153,7 @@ class SamsungTVDevice(MediaPlayerEntity):
             )
         )
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Update state of device."""
         if self._auth_failed or self.hass.is_stopping:
             return
@@ -164,10 +164,10 @@ class SamsungTVDevice(MediaPlayerEntity):
 
         if self._attr_state == STATE_ON and self._app_list is None:
             self._app_list = {}  # Ensure that we don't update it twice in parallel
-            self._update_app_list()
+            await self._update_app_list()
 
-    def _update_app_list(self) -> None:
-        self._app_list = self._bridge.get_app_list()
+    async def _update_app_list(self) -> None:
+        self._app_list = await self._bridge.get_app_list()
         if self._app_list is not None:
             self._attr_source_list.extend(self._app_list)
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -202,7 +202,7 @@ class SamsungTVDevice(MediaPlayerEntity):
 
         await self.send_key("KEY_POWEROFF")
         # Force closing of remote session to provide instant UI feedback
-        self._bridge.close_remote()
+        await self._bridge.close_remote()
 
     async def async_volume_up(self) -> None:
         """Volume up the media player."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -171,12 +171,12 @@ class SamsungTVDevice(MediaPlayerEntity):
         if self._app_list is not None:
             self._attr_source_list.extend(self._app_list)
 
-    def send_key(self, key: str, key_type: str | None = None) -> None:
+    async def send_key(self, key: str, key_type: str | None = None) -> None:
         """Send a key to the tv and handles exceptions."""
         if self._power_off_in_progress() and key != "KEY_POWEROFF":
             LOGGER.info("TV is powering off, not sending command: %s", key)
             return
-        self._bridge.send_key(key, key_type)
+        await self._bridge.send_key(key, key_type)
 
     def _power_off_in_progress(self) -> bool:
         return (
@@ -196,57 +196,57 @@ class SamsungTVDevice(MediaPlayerEntity):
             or self._power_off_in_progress()
         )
 
-    def turn_off(self) -> None:
+    async def async_turn_off(self) -> None:
         """Turn off media player."""
         self._end_of_power_off = dt_util.utcnow() + SCAN_INTERVAL_PLUS_OFF_TIME
 
-        self.send_key("KEY_POWEROFF")
+        await self.send_key("KEY_POWEROFF")
         # Force closing of remote session to provide instant UI feedback
         self._bridge.close_remote()
 
-    def volume_up(self) -> None:
+    async def async_volume_up(self) -> None:
         """Volume up the media player."""
-        self.send_key("KEY_VOLUP")
+        await self.send_key("KEY_VOLUP")
 
-    def volume_down(self) -> None:
+    async def async_volume_down(self) -> None:
         """Volume down media player."""
-        self.send_key("KEY_VOLDOWN")
+        await self.send_key("KEY_VOLDOWN")
 
-    def mute_volume(self, mute: bool) -> None:
+    async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
-        self.send_key("KEY_MUTE")
+        await self.send_key("KEY_MUTE")
 
-    def media_play_pause(self) -> None:
+    async def async_media_play_pause(self) -> None:
         """Simulate play pause media player."""
         if self._playing:
-            self.media_pause()
+            await self.async_media_pause()
         else:
-            self.media_play()
+            await self.async_media_play()
 
-    def media_play(self) -> None:
+    async def async_media_play(self) -> None:
         """Send play command."""
         self._playing = True
-        self.send_key("KEY_PLAY")
+        await self.send_key("KEY_PLAY")
 
-    def media_pause(self) -> None:
+    async def async_media_pause(self) -> None:
         """Send media pause command to media player."""
         self._playing = False
-        self.send_key("KEY_PAUSE")
+        await self.send_key("KEY_PAUSE")
 
-    def media_next_track(self) -> None:
+    async def async_media_next_track(self) -> None:
         """Send next track command."""
-        self.send_key("KEY_CHUP")
+        await self.send_key("KEY_CHUP")
 
-    def media_previous_track(self) -> None:
+    async def async_media_previous_track(self) -> None:
         """Send the previous track command."""
-        self.send_key("KEY_CHDOWN")
+        await self.send_key("KEY_CHDOWN")
 
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
     ) -> None:
         """Support changing a channel."""
         if media_type == MEDIA_TYPE_APP:
-            await self.hass.async_add_executor_job(self.send_key, media_id, "run_app")
+            await self.send_key(media_id, "run_app")
             return
 
         if media_type != MEDIA_TYPE_CHANNEL:
@@ -261,9 +261,9 @@ class SamsungTVDevice(MediaPlayerEntity):
             return
 
         for digit in media_id:
-            await self.hass.async_add_executor_job(self.send_key, f"KEY_{digit}")
+            await self.send_key(f"KEY_{digit}")
             await asyncio.sleep(KEY_PRESS_TIMEOUT)
-        await self.hass.async_add_executor_job(self.send_key, "KEY_ENTER")
+        await self.send_key("KEY_ENTER")
 
     def _wake_on_lan(self) -> None:
         """Wake the device via wake on lan."""
@@ -279,14 +279,14 @@ class SamsungTVDevice(MediaPlayerEntity):
         elif self._mac:
             await self.hass.async_add_executor_job(self._wake_on_lan)
 
-    def select_source(self, source: str) -> None:
+    async def async_select_source(self, source: str) -> None:
         """Select input source."""
         if self._app_list and source in self._app_list:
-            self.send_key(self._app_list[source], "run_app")
+            await self.send_key(self._app_list[source], "run_app")
             return
 
         if source in SOURCES:
-            self.send_key(SOURCES[source])
+            await self.send_key(SOURCES[source])
             return
 
         LOGGER.error("Unsupported source")

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -322,7 +322,7 @@ async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
     ):
         # confirm to add the entry
@@ -351,7 +351,7 @@ async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO_2,
     ):
         # confirm to add the entry
@@ -399,7 +399,7 @@ async def test_ssdp_legacy_missing_auth(hass: HomeAssistant) -> None:
         # missing authentication
 
         with patch(
-            "homeassistant.components.samsungtv.bridge.SamsungTVLegacyBridge.try_connect",
+            "homeassistant.components.samsungtv.bridge.SamsungTVLegacyBridge.async_try_connect",
             return_value=RESULT_AUTH_MISSING,
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -421,7 +421,7 @@ async def test_ssdp_legacy_not_supported(hass: HomeAssistant) -> None:
     assert result["step_id"] == "confirm"
 
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVLegacyBridge.try_connect",
+        "homeassistant.components.samsungtv.bridge.SamsungTVLegacyBridge.async_try_connect",
         return_value=RESULT_NOT_SUPPORTED,
     ):
         # device not supported
@@ -498,7 +498,7 @@ async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
         "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=OSError("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
     ):
 
@@ -527,7 +527,7 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
         "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=ConnectionFailure("Boom"),
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
     ):
 
@@ -554,7 +554,7 @@ async def test_ssdp_already_in_progress(
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
     ):
 
@@ -581,7 +581,7 @@ async def test_ssdp_already_configured(
 
     no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
     ):
 

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -83,7 +83,7 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant) 
         "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
         side_effect=OSError,
     ), patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=None,
     ):
         await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I am planning to migrate the library from sync to async, but first we need to ensure the brigde/wrapper is exposed as async.

- [ ] make bridge aware of hass, to be able to add executor jobs #67043
- [ ] expose try_connect as async #67043
- [ ] expose device_info as async
- [ ] expose app_list as async
- [ ] expose is_on as async
- [ ] expose send_key as async
- [ ] expose close_remote as async
- [ ] use samsungtvws[async] dependency for the websocket implementation (followup PR)
- [ ] use ??? for the legacy implementation (followup PR)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
