### PR TITLE
Add a new validate config WS command

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -63,6 +63,7 @@ def async_register_commands(
     async_reg(hass, handle_subscribe_trigger)
     async_reg(hass, handle_test_condition)
     async_reg(hass, handle_unsubscribe_events)
+    async_reg(hass, handle_validate_config)
 
 
 def pong_message(iden: int) -> dict[str, Any]:
@@ -116,7 +117,7 @@ def handle_subscribe_events(
         event_type, forward_events
     )
 
-    connection.send_message(messages.result_message(msg["id"]))
+    connection.send_result(msg["id"])
 
 
 @callback
@@ -139,7 +140,7 @@ def handle_subscribe_bootstrap_integrations(
         hass, SIGNAL_BOOTSTRAP_INTEGRATONS, forward_bootstrap_integrations
     )
 
-    connection.send_message(messages.result_message(msg["id"]))
+    connection.send_result(msg["id"])
 
 
 @callback
@@ -157,13 +158,9 @@ def handle_unsubscribe_events(
 
     if subscription in connection.subscriptions:
         connection.subscriptions.pop(subscription)()
-        connection.send_message(messages.result_message(msg["id"]))
+        connection.send_result(msg["id"])
     else:
-        connection.send_message(
-            messages.error_message(
-                msg["id"], const.ERR_NOT_FOUND, "Subscription not found."
-            )
-        )
+        connection.send_error(msg["id"], const.ERR_NOT_FOUND, "Subscription not found.")
 
 
 @decorators.websocket_command(
@@ -196,36 +193,20 @@ async def handle_call_service(
             context,
             target=target,
         )
-        connection.send_message(
-            messages.result_message(msg["id"], {"context": context})
-        )
+        connection.send_result(msg["id"], {"context": context})
     except ServiceNotFound as err:
         if err.domain == msg["domain"] and err.service == msg["service"]:
-            connection.send_message(
-                messages.error_message(
-                    msg["id"], const.ERR_NOT_FOUND, "Service not found."
-                )
-            )
+            connection.send_error(msg["id"], const.ERR_NOT_FOUND, "Service not found.")
         else:
-            connection.send_message(
-                messages.error_message(
-                    msg["id"], const.ERR_HOME_ASSISTANT_ERROR, str(err)
-                )
-            )
+            connection.send_error(msg["id"], const.ERR_HOME_ASSISTANT_ERROR, str(err))
     except vol.Invalid as err:
-        connection.send_message(
-            messages.error_message(msg["id"], const.ERR_INVALID_FORMAT, str(err))
-        )
+        connection.send_error(msg["id"], const.ERR_INVALID_FORMAT, str(err))
     except HomeAssistantError as err:
         connection.logger.exception(err)
-        connection.send_message(
-            messages.error_message(msg["id"], const.ERR_HOME_ASSISTANT_ERROR, str(err))
-        )
+        connection.send_error(msg["id"], const.ERR_HOME_ASSISTANT_ERROR, str(err))
     except Exception as err:  # pylint: disable=broad-except
         connection.logger.exception(err)
-        connection.send_message(
-            messages.error_message(msg["id"], const.ERR_UNKNOWN_ERROR, str(err))
-        )
+        connection.send_error(msg["id"], const.ERR_UNKNOWN_ERROR, str(err))
 
 
 @callback
@@ -244,7 +225,7 @@ def handle_get_states(
             if entity_perm(state.entity_id, "read")
         ]
 
-    connection.send_message(messages.result_message(msg["id"], states))
+    connection.send_result(msg["id"], states)
 
 
 @decorators.websocket_command({vol.Required("type"): "get_services"})
@@ -254,7 +235,7 @@ async def handle_get_services(
 ) -> None:
     """Handle get services command."""
     descriptions = await async_get_all_descriptions(hass)
-    connection.send_message(messages.result_message(msg["id"], descriptions))
+    connection.send_result(msg["id"], descriptions)
 
 
 @callback
@@ -263,7 +244,7 @@ def handle_get_config(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle get config command."""
-    connection.send_message(messages.result_message(msg["id"], hass.config.as_dict()))
+    connection.send_result(msg["id"], hass.config.as_dict())
 
 
 @decorators.websocket_command({vol.Required("type"): "manifest/list"})
@@ -417,7 +398,7 @@ def handle_entity_source(
                 if entity_perm(entity_id, "read")
             }
 
-        connection.send_message(messages.result_message(msg["id"], sources))
+        connection.send_result(msg["id"], sources)
         return
 
     sources = {}
@@ -535,7 +516,7 @@ async def handle_execute_script(
     context = connection.context(msg)
     script_obj = Script(hass, msg["sequence"], f"{const.DOMAIN} script", const.DOMAIN)
     await script_obj.async_run(msg.get("variables"), context=context)
-    connection.send_message(messages.result_message(msg["id"], {"context": context}))
+    connection.send_result(msg["id"], {"context": context})
 
 
 @decorators.websocket_command(
@@ -555,3 +536,40 @@ async def handle_fire_event(
 
     hass.bus.async_fire(msg["event_type"], msg.get("event_data"), context=context)
     connection.send_result(msg["id"], {"context": context})
+
+
+@decorators.websocket_command(
+    {
+        vol.Required("type"): "validate_config",
+        vol.Optional("trigger"): cv.match_all,
+        vol.Optional("condition"): cv.match_all,
+        vol.Optional("action"): cv.match_all,
+    }
+)
+@decorators.async_response
+async def handle_validate_config(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle validate config command."""
+    # Circular dep
+    # pylint: disable=import-outside-toplevel
+    from homeassistant.helpers import condition, script, trigger
+
+    result = {}
+
+    for key, schema, validator in (
+        ("trigger", cv.TRIGGER_SCHEMA, trigger.async_validate_trigger_config),
+        ("condition", cv.CONDITION_SCHEMA, condition.async_validate_condition_config),
+        ("action", cv.SCRIPT_SCHEMA, script.async_validate_actions_config),
+    ):
+        if key not in msg:
+            continue
+
+        try:
+            await validator(hass, schema(msg[key]))  # type: ignore
+        except vol.Invalid as err:
+            result[key] = {"valid": False, "error": str(err)}
+        else:
+            result[key] = {"valid": True, "error": None}
+
+    connection.send_result(msg["id"], result)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1033,7 +1033,12 @@ def script_action(value: Any) -> dict:
     if not isinstance(value, dict):
         raise vol.Invalid("expected dictionary")
 
-    return ACTION_TYPE_SCHEMAS[determine_script_action(value)](value)
+    try:
+        action = determine_script_action(value)
+    except ValueError as err:
+        raise vol.Invalid(str(err))
+
+    return ACTION_TYPE_SCHEMAS[action](value)
 
 
 SCRIPT_SCHEMA = vol.All(ensure_list, [script_action])
@@ -1444,7 +1449,10 @@ def determine_script_action(action: dict[str, Any]) -> str:
     if CONF_VARIABLES in action:
         return SCRIPT_ACTION_VARIABLES
 
-    return SCRIPT_ACTION_CALL_SERVICE
+    if CONF_SERVICE in action or CONF_SERVICE_TEMPLATE in action:
+        return SCRIPT_ACTION_CALL_SERVICE
+
+    raise ValueError("Unable to determine action")
 
 
 ACTION_TYPE_SCHEMAS: dict[str, Callable[[Any], dict]] = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new websocket command to validate configuration for triggers, conditions and actions.

This allows us to give better feedback in the frontend without triggering errors in the logs.

Docs https://github.com/home-assistant/developers.home-assistant/pull/1223

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
