### PR TITLE
Add buttons for dmaker.airfresh.a1/t2017 to xiaomi_miio

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1430,6 +1430,7 @@ omit =
     homeassistant/components/xiaomi_miio/air_quality.py
     homeassistant/components/xiaomi_miio/alarm_control_panel.py
     homeassistant/components/xiaomi_miio/binary_sensor.py
+    homeassistant/components/xiaomi_miio/button.py
     homeassistant/components/xiaomi_miio/device.py
     homeassistant/components/xiaomi_miio/device_tracker.py
     homeassistant/components/xiaomi_miio/fan.py

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -91,6 +91,7 @@ GATEWAY_PLATFORMS = [
 SWITCH_PLATFORMS = [Platform.SWITCH]
 FAN_PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.FAN,
     Platform.NUMBER,
     Platform.SELECT,

--- a/homeassistant/components/xiaomi_miio/button.py
+++ b/homeassistant/components/xiaomi_miio/button.py
@@ -24,7 +24,6 @@ from .const import (
 )
 from .device import XiaomiCoordinatedMiioEntity
 
-DATA_KEY = "button.xiaomi_miio"
 
 ATTR_RESET_DUST_FILTER = "reset_dust_filter"
 ATTR_RESET_UPPER_FILTER = "reset_upper_filter"
@@ -52,12 +51,12 @@ BUTTON_TYPES = (
         name="Reset Upper Filter",
         icon="mdi:air-filter",
         method_press="reset_upper_filter",
-        method_press_error_message="Resetting the dust filter lifetime failed.",
+        method_press_error_message="Resetting the upper filter lifetime failed.",
         entity_category=EntityCategory.CONFIG,
     ),
 )
 
-MODEL_TO_BUTTON_MAP = {
+MODEL_TO_BUTTON_MAP: dict[str, tuple[str, ...]] = {
     MODEL_AIRFRESH_A1: (ATTR_RESET_DUST_FILTER,),
     MODEL_AIRFRESH_T2017: (
         ATTR_RESET_DUST_FILTER,
@@ -78,14 +77,10 @@ async def async_setup_entry(
     device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
 
-    if DATA_KEY not in hass.data:
-        hass.data[DATA_KEY] = {}
-
-    buttons: tuple[str, ...] = ()
-    if model in MODEL_TO_BUTTON_MAP:
-        buttons = MODEL_TO_BUTTON_MAP[model]
-    else:
+    if model not in MODEL_TO_BUTTON_MAP:
         return
+
+    buttons = MODEL_TO_BUTTON_MAP[model]
 
     for description in BUTTON_TYPES:
         if description.key not in buttons:

--- a/homeassistant/components/xiaomi_miio/button.py
+++ b/homeassistant/components/xiaomi_miio/button.py
@@ -17,8 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     CONF_MODEL,
     DOMAIN,
-    FEATURE_FLAGS_AIRFRESH_A1,
-    FEATURE_FLAGS_AIRFRESH_T2017,
     KEY_COORDINATOR,
     KEY_DEVICE,
     MODEL_AIRFRESH_A1,
@@ -31,17 +29,13 @@ DATA_KEY = "button.xiaomi_miio"
 ATTR_RESET_DUST_FILTER = "reset_dust_filter"
 ATTR_RESET_UPPER_FILTER = "reset_upper_filter"
 
-MODEL_TO_FEATURES_MAP = {
-    MODEL_AIRFRESH_A1: FEATURE_FLAGS_AIRFRESH_A1,
-    MODEL_AIRFRESH_T2017: FEATURE_FLAGS_AIRFRESH_T2017,
-}
-
 
 @dataclass
 class XiaomiMiioButtonDescription(ButtonEntityDescription):
     """A class that describes button entities."""
 
     method_press: str = ""
+    method_press_error_message: str = ""
     available_with_device_off: bool = True
 
 
@@ -50,14 +44,16 @@ BUTTON_TYPES = (
         key=ATTR_RESET_DUST_FILTER,
         name="Reset Dust Filter",
         icon="mdi:air-filter",
-        method_press="async_reset_dust_filter",
+        method_press="reset_dust_filter",
+        method_press_error_message="Resetting the dust filter lifetime of the miio device failed",
         entity_category=EntityCategory.CONFIG,
     ),
     XiaomiMiioButtonDescription(
         key=ATTR_RESET_UPPER_FILTER,
         name="Reset Upper Filter",
         icon="mdi:air-filter",
-        method_press="async_reset_upper_filter",
+        method_press="reset_upper_filter",
+        method_press_error_message="Resetting the dust filter lifetime of the miio device failed.",
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -133,19 +129,8 @@ class XiaomiGenericCoordinatedButton(XiaomiCoordinatedMiioEntity, ButtonEntity):
 
     async def async_press(self, **kwargs: Any) -> None:
         """Press the button."""
-        method = getattr(self, self.entity_description.method_press)
-        await method()
-
-    async def async_reset_dust_filter(self) -> None:
-        """Reset the dust filter lifetime and usage."""
+        method = getattr(self._device, self.entity_description.method_press)
         await self._try_command(
-            "Resetting the dust filter lifetime of the miio device failed.",
-            self._device.reset_dust_filter,
-        )
-
-    async def async_reset_upper_filter(self) -> None:
-        """Reset the upper filter lifetime and usage."""
-        await self._try_command(
-            "Resetting the upper filter lifetime of the miio device failed.",
-            self._device.reset_upper_filter,
+            self.entity_description.method_press_error_message,
+            method,
         )

--- a/homeassistant/components/xiaomi_miio/button.py
+++ b/homeassistant/components/xiaomi_miio/button.py
@@ -24,7 +24,6 @@ from .const import (
 )
 from .device import XiaomiCoordinatedMiioEntity
 
-
 ATTR_RESET_DUST_FILTER = "reset_dust_filter"
 ATTR_RESET_UPPER_FILTER = "reset_upper_filter"
 
@@ -71,16 +70,16 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the button from a config entry."""
-    entities = []
     model = config_entry.data[CONF_MODEL]
-    unique_id = config_entry.unique_id
-    device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
 
     if model not in MODEL_TO_BUTTON_MAP:
         return
 
+    entities = []
     buttons = MODEL_TO_BUTTON_MAP[model]
+    unique_id = config_entry.unique_id
+    device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
 
     for description in BUTTON_TYPES:
         if description.key not in buttons:

--- a/homeassistant/components/xiaomi_miio/button.py
+++ b/homeassistant/components/xiaomi_miio/button.py
@@ -1,0 +1,151 @@
+"""Support for Xiaomi buttons."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    CONF_MODEL,
+    DOMAIN,
+    FEATURE_FLAGS_AIRFRESH_A1,
+    FEATURE_FLAGS_AIRFRESH_T2017,
+    KEY_COORDINATOR,
+    KEY_DEVICE,
+    MODEL_AIRFRESH_A1,
+    MODEL_AIRFRESH_T2017,
+)
+from .device import XiaomiCoordinatedMiioEntity
+
+DATA_KEY = "button.xiaomi_miio"
+
+ATTR_RESET_DUST_FILTER = "reset_dust_filter"
+ATTR_RESET_UPPER_FILTER = "reset_upper_filter"
+
+MODEL_TO_FEATURES_MAP = {
+    MODEL_AIRFRESH_A1: FEATURE_FLAGS_AIRFRESH_A1,
+    MODEL_AIRFRESH_T2017: FEATURE_FLAGS_AIRFRESH_T2017,
+}
+
+
+@dataclass
+class XiaomiMiioButtonDescription(ButtonEntityDescription):
+    """A class that describes button entities."""
+
+    method_press: str = ""
+    available_with_device_off: bool = True
+
+
+BUTTON_TYPES = (
+    XiaomiMiioButtonDescription(
+        key=ATTR_RESET_DUST_FILTER,
+        name="Reset Dust Filter",
+        icon="mdi:air-filter",
+        method_press="async_reset_dust_filter",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    XiaomiMiioButtonDescription(
+        key=ATTR_RESET_UPPER_FILTER,
+        name="Reset Upper Filter",
+        icon="mdi:air-filter",
+        method_press="async_reset_upper_filter",
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+AIRFRESH_BUTTON_A1 = (ATTR_RESET_DUST_FILTER,)
+AIRFRESH_BUTTON_T2017 = (
+    ATTR_RESET_DUST_FILTER,
+    ATTR_RESET_UPPER_FILTER,
+)
+
+MODEL_TO_BUTTON_MAP = {
+    MODEL_AIRFRESH_A1: AIRFRESH_BUTTON_A1,
+    MODEL_AIRFRESH_T2017: AIRFRESH_BUTTON_T2017,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the button from a config entry."""
+    entities = []
+    model = config_entry.data[CONF_MODEL]
+    unique_id = config_entry.unique_id
+    device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
+    if DATA_KEY not in hass.data:
+        hass.data[DATA_KEY] = {}
+    buttons: tuple[str, ...] = ()
+    if model in MODEL_TO_BUTTON_MAP:
+        buttons = MODEL_TO_BUTTON_MAP[model]
+    else:
+        return
+    for description in BUTTON_TYPES:
+        if description.key not in buttons:
+            continue
+        entities.append(
+            XiaomiGenericCoordinatedButton(
+                f"{config_entry.title} {description.name}",
+                device,
+                config_entry,
+                f"{description.key}_{unique_id}",
+                coordinator,
+                description,
+            )
+        )
+    async_add_entities(entities)
+
+
+class XiaomiGenericCoordinatedButton(XiaomiCoordinatedMiioEntity, ButtonEntity):
+    """A button implementation for Xiaomi."""
+
+    entity_description: XiaomiMiioButtonDescription
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+
+    def __init__(self, name, device, entry, unique_id, coordinator, description):
+        """Initialize the plug switch."""
+        super().__init__(name, device, entry, unique_id, coordinator)
+        self.entity_description = description
+
+    @property
+    def available(self):
+        """Return true when state is known."""
+        if (
+            super().available
+            and not self.coordinator.data.is_on
+            and not self.entity_description.available_with_device_off
+        ):
+            return False
+        return super().available
+
+    async def async_press(self, **kwargs: Any) -> None:
+        """Press the button."""
+        method = getattr(self, self.entity_description.method_press)
+        await method()
+
+    async def async_reset_dust_filter(self) -> None:
+        """Reset the dust filter lifetime and usage."""
+        await self._try_command(
+            "Resetting the dust filter lifetime of the miio device failed.",
+            self._device.reset_dust_filter,
+        )
+
+    async def async_reset_upper_filter(self) -> None:
+        """Reset the upper filter lifetime and usage."""
+        await self._try_command(
+            "Resetting the upper filter lifetime of the miio device failed.",
+            self._device.reset_upper_filter,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Final step to support dmaker.airfresh.a1/t2017 i added button like:
| Name                     | Comment                  
| -------------------- | -----------------------
| Reset Dust Filter    | Work with both  dmaker.airfresh.a1 and dmaker.airfresh.t2017
| Reset Upper Filter | Work only with dmaker.airfresh.t2017

We can use this workflow and easily add button for other devices (But I have only these). 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21857

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
