### PR TITLE
Add (basic) diagnostics support for Hue integration

### DIFF
--- a/homeassistant/components/hue/diagnostics.py
+++ b/homeassistant/components/hue/diagnostics.py
@@ -1,0 +1,22 @@
+"""Diagnostics support for Hue."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .bridge import HueBridge
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    bridge: HueBridge = hass.data[DOMAIN][entry.entry_id]
+    if bridge.api_version == 1:
+        # diagnostics is only implemented for V2 bridges.
+        return {}
+    # Hue diagnostics are already redacted
+    return await bridge.api.get_diagnostics()

--- a/tests/components/hue/test_diagnostics.py
+++ b/tests/components/hue/test_diagnostics.py
@@ -1,0 +1,22 @@
+"""Test Hue diagnostics."""
+
+from .conftest import setup_platform
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+
+
+async def test_diagnostics_v1(hass, hass_client, mock_bridge_v1):
+    """Test diagnostics v1."""
+    await setup_platform(hass, mock_bridge_v1, [])
+    config_entry = hass.config_entries.async_entries("hue")[0]
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert result == {}
+
+
+async def test_diagnostics_v2(hass, hass_client, mock_bridge_v2):
+    """Test diagnostics v2."""
+    mock_bridge_v2.api.get_diagnostics.return_value = {"hello": "world"}
+    await setup_platform(hass, mock_bridge_v2, [])
+    config_entry = hass.config_entries.async_entries("hue")[0]
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert result == {"hello": "world"}


### PR DESCRIPTION
## Proposed change
Adds support for downloading diagnostics to the Hue integration, first phase is just integration diagnostics containing a full (redacted) dump of the Hue bridge (v2 resources endpoint) and the last received events.

Device specific diagnostics not yet implemented.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
