### PR TITLE
Bump PyOverkiz and improve code quality (late review)

### DIFF
--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyoverkiz.enums import OverkizCommand, OverkizState, UIClass, UIWidget
+from pyoverkiz.enums import (
+    OverkizCommand,
+    OverkizCommandParam,
+    OverkizState,
+    UIClass,
+    UIWidget,
+)
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -132,5 +138,7 @@ class LowSpeedCover(VerticalCover):
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
         await self.executor.async_execute_command(
-            OverkizCommand.SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed"
+            OverkizCommand.SET_CLOSURE_AND_LINEAR_SPEED,
+            position,
+            OverkizCommandParam.LOWSPEED,
         )

--- a/homeassistant/components/overkiz/manifest.json
+++ b/homeassistant/components/overkiz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/overkiz",
   "requirements": [
-    "pyoverkiz==1.3.6"
+    "pyoverkiz==1.3.8"
   ],
   "zeroconf": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1753,7 +1753,7 @@ pyotgw==1.1b1
 pyotp==2.6.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.3.6
+pyoverkiz==1.3.8
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1125,7 +1125,7 @@ pyotgw==1.1b1
 pyotp==2.6.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.3.6
+pyoverkiz==1.3.8
 
 # homeassistant.components.openweathermap
 pyowm==3.2.0


### PR DESCRIPTION
## Proposed change
Very small fix, but previous PR was already merged. This will move the string to an string enum.

[compare 1.3.6 ... 1.3.8](https://github.com/iMicknl/python-overkiz-api/compare/v1.3.6...v1.3.8)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
