### PR TITLE
Prefer internal docker URL for VLC telnet when possible

### DIFF
--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -31,7 +31,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
 from homeassistant.const import CONF_NAME, STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -125,6 +125,7 @@ class VlcDevice(MediaPlayerEntity):
             manufacturer="VideoLAN",
             name=name,
         )
+        self._using_addon = config_entry.source == SOURCE_HASSIO
 
     @catch_vlc_errors
     async def async_update(self) -> None:
@@ -316,7 +317,9 @@ class VlcDevice(MediaPlayerEntity):
             )
 
         # If media ID is a relative URL, we serve it from HA.
-        media_id = async_process_play_media_url(self.hass, media_id)
+        media_id = async_process_play_media_url(
+            self.hass, media_id, allow_hostname=self._using_addon
+        )
 
         await self._vlc.add(media_id)
         self._state = STATE_PLAYING

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -318,7 +318,7 @@ class VlcDevice(MediaPlayerEntity):
 
         # If media ID is a relative URL, we serve it from HA.
         media_id = async_process_play_media_url(
-            self.hass, media_id, allow_hostname=self._using_addon
+            self.hass, media_id, for_addon=self._using_addon
         )
 
         await self._vlc.add(media_id)

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -318,7 +318,7 @@ class VlcDevice(MediaPlayerEntity):
 
         # If media ID is a relative URL, we serve it from HA.
         media_id = async_process_play_media_url(
-            self.hass, media_id, for_addon=self._using_addon
+            self.hass, media_id, for_supervisor_network=self._using_addon
         )
 
         await self._vlc.add(media_id)

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -13,6 +13,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import bind_hass
 from homeassistant.util.network import is_ip_address, is_loopback, normalize_url
 
+from .supervisor import has_supervisor
+
+TYPE_URL_HOSTNAME = "hostname_url"
 TYPE_URL_INTERNAL = "internal_url"
 TYPE_URL_EXTERNAL = "external_url"
 
@@ -80,6 +83,7 @@ def get_url(
     require_current_request: bool = False,
     require_ssl: bool = False,
     require_standard_port: bool = False,
+    allow_hostname: bool = False,
     allow_internal: bool = True,
     allow_external: bool = True,
     allow_cloud: bool = True,
@@ -97,12 +101,21 @@ def get_url(
     if allow_ip is None:
         allow_ip = hass.config.api is None or not hass.config.api.use_ssl
 
-    order = [TYPE_URL_INTERNAL, TYPE_URL_EXTERNAL]
+    order = [TYPE_URL_HOSTNAME, TYPE_URL_INTERNAL, TYPE_URL_EXTERNAL]
     if prefer_external:
         order.reverse()
 
     # Try finding an URL in the order specified
     for url_type in order:
+
+        if allow_hostname and url_type == TYPE_URL_HOSTNAME:
+            with suppress(NoURLAvailableError):
+                return _get_hostname_url(
+                    hass,
+                    require_current_request=require_current_request,
+                    require_ssl=require_ssl,
+                    require_standard_port=require_standard_port,
+                )
 
         if allow_internal and url_type == TYPE_URL_INTERNAL:
             with suppress(NoURLAvailableError):
@@ -169,6 +182,32 @@ def _get_request_host() -> str | None:
     if (request := http.current_request.get()) is None:
         raise NoURLAvailableError
     return yarl.URL(request.url).host
+
+
+@bind_hass
+def _get_hostname_url(
+    hass: HomeAssistant,
+    *,
+    require_current_request: bool = False,
+    require_ssl: bool = False,
+    require_standard_port: bool = False,
+) -> str:
+    """Get hostname of this instance."""
+    if has_supervisor() and not (
+        require_ssl or hass.config.api is None or hass.config.api.use_ssl
+    ):
+        # SSL not an option since certificate won't be valid for hostname
+        hostname_url = yarl.URL.build(
+            scheme="http",
+            host=hass.components.hassio.get_host_info()["hostname"],
+            port=hass.config.api.port,
+        )
+        if (
+            not require_current_request or hostname_url.host == _get_request_host()
+        ) and (not require_standard_port or hostname_url.is_default_port()):
+            return normalize_url(str(hostname_url))
+
+    raise NoURLAvailableError
 
 
 @bind_hass

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.network import (
     _get_external_url,
     _get_internal_url,
     _get_request_host,
+    get_supervisor_network_url,
     get_url,
     is_hass_url,
     is_internal_request,
@@ -693,7 +694,7 @@ async def test_is_hass_url(hass):
 
 
 async def test_is_hass_url_addon_url(hass):
-    """Test is_hass_url with an addon URL."""
+    """Test is_hass_url with a supervisor network URL."""
     assert is_hass_url(hass, "http://homeassistant:8123") is False
 
     hass.config.api = Mock(use_ssl=False, port=8123, local_ip="192.168.123.123")
@@ -704,7 +705,27 @@ async def test_is_hass_url_addon_url(hass):
     assert is_hass_url(hass, "http://homeassistant:8123") is False
 
     mock_component(hass, "hassio")
-    hass.components.hassio.get_host_info = Mock(
-        return_value={"hostname": "homeassistant"}
-    )
     assert is_hass_url(hass, "http://homeassistant:8123")
+    assert not is_hass_url(hass, "https://homeassistant:8123")
+
+    hass.config.api = Mock(use_ssl=True, port=8123, local_ip="192.168.123.123")
+    assert not is_hass_url(hass, "http://homeassistant:8123")
+    assert is_hass_url(hass, "https://homeassistant:8123")
+
+
+async def test_get_supervisor_network_url(hass):
+    """Test get_supervisor_network_url."""
+    assert get_supervisor_network_url(hass) is None
+
+    hass.config.api = Mock(use_ssl=False, port=8123, local_ip="192.168.123.123")
+    await async_process_ha_core_config(hass, {})
+    assert get_supervisor_network_url(hass) is None
+
+    mock_component(hass, "hassio")
+    assert get_supervisor_network_url(hass) == "http://homeassistant:8123"
+
+    hass.config.api = Mock(use_ssl=True, port=8123, local_ip="192.168.123.123")
+    assert get_supervisor_network_url(hass) is None
+    assert (
+        get_supervisor_network_url(hass, allow_ssl=True) == "https://homeassistant:8123"
+    )

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -690,3 +690,77 @@ async def test_is_hass_url(hass):
         assert is_hass_url(hass, "https://example.nabu.casa") is True
         assert is_hass_url(hass, "http://example.nabu.casa:443") is False
         assert is_hass_url(hass, "http://example.nabu.casa") is False
+
+
+async def test_get_hostname_url(hass):
+    """Test getting an instance URL for use within network managed by supervisor."""
+    await async_process_ha_core_config(
+        hass,
+        {"external_url": "https://example.com"},
+    )
+    assert hass.config.external_url == "https://example.com"
+
+    with patch("homeassistant.helpers.network.has_supervisor", return_value=False):
+        assert get_url(hass, allow_hostname=True) == "https://example.com"
+
+    with patch("homeassistant.helpers.network.has_supervisor", return_value=True):
+        # API didn't set up so neither did hassio integration, can't get hostname
+        assert get_url(hass, allow_hostname=True) == "https://example.com"
+
+        hass.config.api = Mock(use_ssl=False, port=8123, local_ip="192.168.123.123")
+        mock_component(hass, "hassio")
+        hass.components.hassio.get_host_info = Mock(
+            return_value={"hostname": "homeassistant"}
+        )
+        assert get_url(hass, allow_hostname=True) == "http://homeassistant:8123"
+        assert (
+            get_url(hass, allow_hostname=True, require_ssl=True)
+            == "https://example.com"
+        )
+        assert (
+            get_url(hass, allow_hostname=True, prefer_external=True)
+            == "https://example.com"
+        )
+
+        # Test require_current_request works with hostname option
+        with patch("homeassistant.components.http.current_request"):
+            with patch(
+                "homeassistant.helpers.network._get_request_host",
+                return_value="homeassistant",
+            ):
+                assert (
+                    get_url(hass, allow_hostname=True, require_current_request=True)
+                    == "http://homeassistant:8123"
+                )
+            with patch(
+                "homeassistant.helpers.network._get_request_host",
+                return_value="example.com",
+            ):
+                assert (
+                    get_url(hass, allow_hostname=True, require_current_request=True)
+                    == "https://example.com"
+                )
+
+        # Require standard port skips hostname unless port is 80
+        assert (
+            get_url(hass, allow_hostname=True, require_standard_port=True)
+            == "https://example.com"
+        )
+        hass.config.api = Mock(use_ssl=False, port=80, local_ip="192.168.123.123")
+        assert (
+            get_url(hass, allow_hostname=True, require_standard_port=True)
+            == "http://homeassistant"
+        )
+
+        # Hostname skipped if ssl is on
+        hass.config.api = Mock(use_ssl=True, port=8123, local_ip="192.168.123.123")
+        assert get_url(hass, allow_hostname=True) == "https://example.com"
+
+        # Prefer hostname over normal internal if allowed
+        hass.config.api = Mock(use_ssl=False, port=8123, local_ip="192.168.123.123")
+        await async_process_ha_core_config(
+            hass,
+            {"internal_url": "http://192.168.1.1:8123"},
+        )
+        assert hass.config.internal_url == "http://192.168.1.1:8123"
+        assert get_url(hass, allow_hostname=True) == "http://homeassistant:8123"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When VLC Telnet integration is set up via discovery from the addon it should use the ha hostname instead of the internal URL in the media content ID for local media playback. Add an option to `get_url` and `async_process_play_media_url` to enable this and leveraged it in the vlc telnet integration.

This enhancement would also make sense for a few other integrations but no others are affected by it right now. Each would need to make a change in a separate PR and specifically add `allow_hostname` if they want `get_url` to generate URLs starting from the hostname instead of from the internal or external URLs.

Somewhat related to https://github.com/home-assistant/addons/issues/2390. It won't directly fix the issue presented there since the user has SSL enabled on HA. However it will at least enable us to give them a way forward (namely advise to set up a reverse proxy and serve certificate from there).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
