### PR TITLE
Mobile app: Drop descriptive emoji name support

### DIFF
--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from contextlib import suppress
 from http import HTTPStatus
 import secrets
-from typing import cast
 
 from aiohttp.web import Request, Response
 from nacl.secret import SecretBox

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -7,7 +7,6 @@ import secrets
 from typing import cast
 
 from aiohttp.web import Request, Response
-import emoji
 from nacl.secret import SecretBox
 import voluptuous as vol
 
@@ -82,18 +81,8 @@ class RegistrationsView(HomeAssistantView):
 
         data[CONF_USER_ID] = request["hass_user"].id
 
-        if slugify(data[ATTR_DEVICE_NAME], separator=""):
-            # if slug is not empty and would not only be underscores
-            # use DEVICE_NAME
-            pass
-        elif emoji.emoji_count(data[ATTR_DEVICE_NAME]):
-            # If otherwise empty string contains emoji
-            # use descriptive name of the first emoji
-            data[ATTR_DEVICE_NAME] = emoji.demojize(
-                cast(str, emoji.emoji_lis(data[ATTR_DEVICE_NAME])[0]["emoji"])
-            ).replace(":", "")
-        else:
-            # Fallback to DEVICE_ID
+        # Fallback to DEVICE_ID if slug is empty.
+        if not slugify(data[ATTR_DEVICE_NAME], separator=""):
             data[ATTR_DEVICE_NAME] = data[ATTR_DEVICE_ID]
 
         await hass.async_create_task(

--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -3,11 +3,11 @@
   "name": "Mobile App",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
-  "requirements": ["PyNaCl==1.4.0", "emoji==1.6.3"],
+  "requirements": ["PyNaCl==1.4.0"],
   "dependencies": ["http", "webhook", "person", "tag", "websocket_api"],
   "after_dependencies": ["cloud", "camera", "notify"],
   "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal",
   "iot_class": "local_push",
-  "loggers": ["emoji", "nacl"]
+  "loggers": ["nacl"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,6 @@ bcrypt==3.1.7
 certifi>=2021.5.30
 ciso8601==2.2.0
 cryptography==35.0.0
-emoji==1.6.3
 hass-nabucasa==0.53.1
 home-assistant-frontend==20220222.0
 httpx==0.21.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -608,9 +608,6 @@ elkm1-lib==1.2.0
 # homeassistant.components.elmax
 elmax_api==0.0.2
 
-# homeassistant.components.mobile_app
-emoji==1.6.3
-
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -400,9 +400,6 @@ elkm1-lib==1.2.0
 # homeassistant.components.elmax
 elmax_api==0.0.2
 
-# homeassistant.components.mobile_app
-emoji==1.6.3
-
 # homeassistant.components.emulated_roku
 emulated_roku==0.2.1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mobile app will no longer use the description of the first emoji if the device name consists of just emojis. 

This allows us to drop the `emoji` package and avoid having to parse a 1.5MB Python file which was loaded as part of default config.

CC @TomBrien 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
