### PR TITLE
Fix RTS device delays in Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -61,6 +61,12 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self.areas = self._places_to_area(places)
         self.config_entry_id = config_entry_id
 
+        for device in devices:
+            print(device.protocol)
+
+        print("Is stateless?")
+        print(self.is_stateless)
+
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Overkiz data via event listener."""
         try:

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -61,12 +61,6 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         self.areas = self._places_to_area(places)
         self.config_entry_id = config_entry_id
 
-        for device in devices:
-            print(device.protocol)
-
-        print("Is stateless?")
-        print(self.is_stateless)
-
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Overkiz data via event listener."""
         try:

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import urlparse
 
-from pyoverkiz.enums.command import OverkizCommand
+from pyoverkiz.enums import OverkizCommand, Protocol
 from pyoverkiz.models import Command, Device
 from pyoverkiz.types import StateType as OverkizStateType
 
@@ -58,6 +58,11 @@ class OverkizExecutor:
 
     async def async_execute_command(self, command_name: str, *args: Any) -> None:
         """Execute device command in async context."""
+        # Set the execution duration to 0 seconds for RTS devices without other args
+        # Default execution duration is 30 seconds and will block consecutive commands
+        if self.device.protocol == Protocol.RTS and not args:
+            args = (0,)
+
         exec_id = await self.coordinator.client.execute_command(
             self.device.device_url,
             Command(command_name, list(args)),

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -10,6 +10,16 @@ from pyoverkiz.types import StateType as OverkizStateType
 
 from .coordinator import OverkizDataUpdateCoordinator
 
+# Commands that don't support setting
+# the delay to another value
+COMMANDS_WITHOUT_DELAY = [
+    OverkizCommand.IDENTIFY,
+    "test",
+    OverkizCommand.ON,
+    OverkizCommand.OFF,
+    "onWithTimer",
+]
+
 
 class OverkizExecutor:
     """Representation of an Overkiz device with execution handler."""
@@ -60,8 +70,11 @@ class OverkizExecutor:
         """Execute device command in async context."""
         # Set the execution duration to 0 seconds for RTS devices without other args
         # Default execution duration is 30 seconds and will block consecutive commands
-        if self.device.protocol == Protocol.RTS and not args:
-            args = (0,)
+        if (
+            self.device.protocol == Protocol.RTS
+            and command_name not in COMMANDS_WITHOUT_DELAY
+        ):
+            args = args + (0,)
 
         exec_id = await self.coordinator.client.execute_command(
             self.device.device_url,

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -14,10 +14,10 @@ from .coordinator import OverkizDataUpdateCoordinator
 # the delay to another value
 COMMANDS_WITHOUT_DELAY = [
     OverkizCommand.IDENTIFY,
-    OverkizCommand.TEST,
-    OverkizCommand.ON,
     OverkizCommand.OFF,
+    OverkizCommand.ON,
     OverkizCommand.ON_WITH_TIMER,
+    OverkizCommand.TEST,
 ]
 
 
@@ -68,7 +68,6 @@ class OverkizExecutor:
 
     async def async_execute_command(self, command_name: str, *args: Any) -> None:
         """Execute device command in async context."""
-
         # Set the execution duration to 0 seconds for RTS devices on supported commands
         # Default execution duration is 30 seconds and will block consecutive commands
         if (

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -14,10 +14,10 @@ from .coordinator import OverkizDataUpdateCoordinator
 # the delay to another value
 COMMANDS_WITHOUT_DELAY = [
     OverkizCommand.IDENTIFY,
-    "test",
+    OverkizCommand.TEST,
     OverkizCommand.ON,
     OverkizCommand.OFF,
-    "onWithTimer",
+    OverkizCommand.ON_WITH_TIMER,
 ]
 
 
@@ -68,7 +68,8 @@ class OverkizExecutor:
 
     async def async_execute_command(self, command_name: str, *args: Any) -> None:
         """Execute device command in async context."""
-        # Set the execution duration to 0 seconds for RTS devices without other args
+
+        # Set the execution duration to 0 seconds for RTS devices on supported commands
         # Default execution duration is 30 seconds and will block consecutive commands
         if (
             self.device.protocol == Protocol.RTS


### PR DESCRIPTION
## Proposed change
Currently users face issues when the execute a command for an RTS device (stateless). When they for example open their cover, they can only stop it after 30 seconds. By default, Overkiz sets a duration of 30 seconds on every command, while we want to have this set to 0.

This PR will fix this by setting the duration argument (last arg) to zero on every command, except on a few commands that don't support this.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
