### PR TITLE
Media source to verify domain to avoid KeyError

### DIFF
--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -84,14 +84,16 @@ def _get_media_item(
     hass: HomeAssistant, media_content_id: str | None
 ) -> MediaSourceItem:
     """Return media item."""
-    if not media_content_id:
+    if media_content_id:
+        item = MediaSourceItem.from_uri(hass, media_content_id)
+    else:
         # We default to our own domain if its only one registered
         domain = None if len(hass.data[DOMAIN]) > 1 else DOMAIN
         return MediaSourceItem(hass, domain, "")
 
-    item = MediaSourceItem.from_uri(hass, media_content_id)
     if item.domain is not None and item.domain not in hass.data[DOMAIN]:
         raise ValueError("Unknown media source")
+
     return item
 
 

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -84,12 +84,15 @@ def _get_media_item(
     hass: HomeAssistant, media_content_id: str | None
 ) -> MediaSourceItem:
     """Return media item."""
-    if media_content_id:
-        return MediaSourceItem.from_uri(hass, media_content_id)
+    if not media_content_id:
+        # We default to our own domain if its only one registered
+        domain = None if len(hass.data[DOMAIN]) > 1 else DOMAIN
+        return MediaSourceItem(hass, domain, "")
 
-    # We default to our own domain if its only one registered
-    domain = None if len(hass.data[DOMAIN]) > 1 else DOMAIN
-    return MediaSourceItem(hass, domain, "")
+    item = MediaSourceItem.from_uri(hass, media_content_id)
+    if item.domain is not None and item.domain not in hass.data[DOMAIN]:
+        raise ValueError("Unknown media source")
+    return item
 
 
 @bind_hass
@@ -106,7 +109,7 @@ async def async_browse_media(
     try:
         item = await _get_media_item(hass, media_content_id).async_browse()
     except ValueError as err:
-        raise BrowseError("Not a media source item") from err
+        raise BrowseError(str(err)) from err
 
     if content_filter is None or item.children is None:
         return item
@@ -128,7 +131,7 @@ async def async_resolve_media(hass: HomeAssistant, media_content_id: str) -> Pla
     try:
         item = _get_media_item(hass, media_content_id)
     except ValueError as err:
-        raise Unresolvable("Not a media source item") from err
+        raise Unresolvable(str(err)) from err
 
     return await item.async_resolve()
 

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -98,6 +98,10 @@ async def test_async_unresolve_media(hass):
     with pytest.raises(media_source.Unresolvable):
         await media_source.async_resolve_media(hass, "invalid")
 
+    # Test invalid media source
+    with pytest.raises(media_source.Unresolvable):
+        await media_source.async_resolve_media(hass, "media-source://media_source2")
+
 
 async def test_websocket_browse_media(hass, hass_ws_client):
     """Test browse media websocket."""

--- a/tests/components/netatmo/test_media_source.py
+++ b/tests/components/netatmo/test_media_source.py
@@ -54,7 +54,7 @@ async def test_async_browse_media(hass):
     # Test invalid base
     with pytest.raises(media_source.BrowseError) as excinfo:
         await media_source.async_browse_media(hass, f"{const.URI_SCHEME}{DOMAIN}/")
-    assert str(excinfo.value) == "Not a media source item"
+    assert str(excinfo.value) == "Invalid media source URI"
 
     # Test successful listing
     media = await media_source.async_browse_media(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I noticed you could trigger a KeyError if you pass in invalid domain in your media source. This verifies domains exist when browsing/resolving.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
