### PR TITLE
Make Google sync_seralize a callback

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -590,18 +590,20 @@ class GoogleEntity:
             device["roomHint"] = area_entry.name
 
         # Add deviceInfo
-        if device_entry:
-            device_info = {}
+        if not device_entry:
+            return device
 
-            if device_entry.manufacturer:
-                device_info["manufacturer"] = device_entry.manufacturer
-            if device_entry.model:
-                device_info["model"] = device_entry.model
-            if device_entry.sw_version:
-                device_info["swVersion"] = device_entry.sw_version
+        device_info = {}
 
-            if device_info:
-                device["deviceInfo"] = device_info
+        if device_entry.manufacturer:
+            device_info["manufacturer"] = device_entry.manufacturer
+        if device_entry.model:
+            device_info["model"] = device_entry.model
+        if device_entry.sw_version:
+            device_info["swVersion"] = device_entry.sw_version
+
+        if device_info:
+            device["deviceInfo"] = device_info
 
         return device
 

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -4,6 +4,7 @@ from itertools import product
 import logging
 
 from homeassistant.const import ATTR_ENTITY_ID, __version__
+from homeassistant.helpers import instance_id
 from homeassistant.util.decorator import Registry
 
 from .const import (
@@ -86,22 +87,17 @@ async def async_devices_sync(hass, data, payload):
     await data.config.async_connect_agent_user(agent_user_id)
 
     entities = async_get_entities(hass, data.config)
-    results = await asyncio.gather(
-        *(
-            entity.sync_serialize(agent_user_id)
-            for entity in entities
-            if entity.should_expose()
-        ),
-        return_exceptions=True,
-    )
-
+    instance_uuid = await instance_id.async_get(hass)
     devices = []
 
-    for entity, result in zip(entities, results):
-        if isinstance(result, Exception):
-            _LOGGER.error("Error serializing %s", entity.entity_id, exc_info=result)
-        else:
-            devices.append(result)
+    for entity in entities:
+        if not entity.should_expose():
+            continue
+
+        try:
+            devices.append(entity.sync_serialize(agent_user_id, instance_uuid))
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Error serializing %s", entity.entity_id)
 
     response = {"agentUserId": agent_user_id, "devices": devices}
 

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -47,30 +47,29 @@ async def test_google_entity_sync_serialize_with_local_sdk(hass):
     )
     entity = helpers.GoogleEntity(hass, config, hass.states.get("light.ceiling_lights"))
 
-    serialized = await entity.sync_serialize(None)
+    serialized = entity.sync_serialize(None, "mock-uuid")
     assert "otherDeviceIds" not in serialized
     assert "customData" not in serialized
 
     config.async_enable_local_sdk()
 
-    with patch("homeassistant.helpers.instance_id.async_get", return_value="abcdef"):
-        serialized = await entity.sync_serialize("mock-user-id")
-        assert serialized["otherDeviceIds"] == [{"deviceId": "light.ceiling_lights"}]
-        assert serialized["customData"] == {
-            "httpPort": 1234,
-            "httpSSL": False,
-            "proxyDeviceId": "mock-user-id",
-            "webhookId": "mock-webhook-id",
-            "baseUrl": "https://hostname:1234",
-            "uuid": "abcdef",
-        }
+    serialized = entity.sync_serialize("mock-user-id", "abcdef")
+    assert serialized["otherDeviceIds"] == [{"deviceId": "light.ceiling_lights"}]
+    assert serialized["customData"] == {
+        "httpPort": 1234,
+        "httpSSL": False,
+        "proxyDeviceId": "mock-user-id",
+        "webhookId": "mock-webhook-id",
+        "baseUrl": "https://hostname:1234",
+        "uuid": "abcdef",
+    }
 
     for device_type in NOT_EXPOSE_LOCAL:
         with patch(
             "homeassistant.components.google_assistant.helpers.get_google_type",
             return_value=device_type,
         ):
-            serialized = await entity.sync_serialize(None)
+            serialized = entity.sync_serialize(None, "mock-uuid")
             assert "otherDeviceIds" not in serialized
             assert "customData" not in serialized
 

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -875,7 +875,7 @@ async def test_serialize_input_boolean(hass):
     state = State("input_boolean.bla", "on")
     # pylint: disable=protected-access
     entity = sh.GoogleEntity(hass, BASIC_CONFIG, state)
-    result = await entity.sync_serialize(None)
+    result = entity.sync_serialize(None, "mock-uuid")
     assert result == {
         "id": "input_boolean.bla",
         "attributes": {},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While I was looking into something unrelated, I realized that the `GoogleEntity.sync_serialize` method was async because it relied on async fetching of the entity/device/area registries. This PR rewrites it to be callbacks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
