### PR TITLE
Remove deprecated YAML configuration from CPU Speed

### DIFF
--- a/homeassistant/components/cpuspeed/config_flow.py
+++ b/homeassistant/components/cpuspeed/config_flow.py
@@ -6,7 +6,6 @@ from typing import Any
 from cpuinfo import cpuinfo
 
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
@@ -36,8 +35,3 @@ class CPUSpeedFlowHandler(ConfigFlow, domain=DOMAIN):
             title=self._imported_name or "CPU Speed",
             data={},
         )
-
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Handle a flow initialized by importing a config."""
-        self._imported_name = config.get(CONF_NAME)
-        return await self.async_step_user(user_input={})

--- a/homeassistant/components/cpuspeed/sensor.py
+++ b/homeassistant/components/cpuspeed/sensor.py
@@ -2,17 +2,12 @@
 from __future__ import annotations
 
 from cpuinfo import cpuinfo
-import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_NAME, FREQUENCY_GIGAHERTZ
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import FREQUENCY_GIGAHERTZ
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-
-from .const import DOMAIN, LOGGER
 
 ATTR_BRAND = "brand"
 ATTR_HZ = "ghz_advertised"
@@ -20,34 +15,6 @@ ATTR_ARCH = "arch"
 
 HZ_ACTUAL = "hz_actual"
 HZ_ADVERTISED = "hz_advertised"
-
-DEFAULT_NAME = "CPU speed"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string}
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the CPU speed sensor."""
-    LOGGER.warning(
-        "Configuration of the CPU Speed platform in YAML is deprecated and will be "
-        "removed in Home Assistant 2022.4; Your existing configuration "
-        "has been imported into the UI automatically and can be safely removed "
-        "from your configuration.yaml file"
-    )
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={CONF_NAME: config[CONF_NAME]},
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/cpuspeed/test_config_flow.py
+++ b/tests/components/cpuspeed/test_config_flow.py
@@ -3,8 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.cpuspeed.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import CONF_NAME
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -60,26 +59,6 @@ async def test_already_configured(
 
     assert len(mock_setup_entry.mock_calls) == 0
     assert len(mock_cpuinfo_config_flow.mock_calls) == 0
-
-
-async def test_import_flow(
-    hass: HomeAssistant,
-    mock_cpuinfo_config_flow: MagicMock,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test the import configuration flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={CONF_NAME: "Frenck's CPU"},
-    )
-
-    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
-    assert result.get("title") == "Frenck's CPU"
-    assert result.get("data") == {}
-
-    assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_cpuinfo_config_flow.mock_calls) == 1
 
 
 async def test_not_compatible(

--- a/tests/components/cpuspeed/test_init.py
+++ b/tests/components/cpuspeed/test_init.py
@@ -4,10 +4,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from homeassistant.components.cpuspeed.const import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -48,19 +46,3 @@ async def test_config_entry_not_compatible(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert len(mock_cpuinfo.mock_calls) == 1
     assert "is not compatible with your system" in caplog.text
-
-
-async def test_import_config(
-    hass: HomeAssistant,
-    mock_cpuinfo: MagicMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test the CPU Speed being set up from config via import."""
-    assert await async_setup_component(
-        hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: {"platform": DOMAIN}}
-    )
-    await hass.async_block_till_done()
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert len(mock_cpuinfo.mock_calls) == 3
-    assert "the CPU Speed platform in YAML is deprecated" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration of the CPU Speed
integration has been removed.

CPU Speed is now configured via the UI, any existing YAML
configuration has been imported in previous releases and can now be safely
removed from your YAML configuration files.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
