### PR TITLE
Add mode setting to RFXtrx device configuration

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     COMMAND_GROUP_LIST,
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
+    CONF_PROTOCOLS,
     DATA_RFXOBJECT,
     DEVICE_PACKET_TYPE_LIGHTING4,
     EVENT_RFXTRX_EVENT,
@@ -123,15 +124,28 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 def _create_rfx(config):
     """Construct a rfx object based on config."""
+
+    modes = config.get(CONF_PROTOCOLS)
+
+    if modes:
+        _LOGGER.debug("Using modes: %s", ",".join(modes))
+    else:
+        _LOGGER.debug("No modes defined, using device configuration")
+
     if config[CONF_PORT] is not None:
         # If port is set then we create a TCP connection
         rfx = rfxtrxmod.Connect(
             (config[CONF_HOST], config[CONF_PORT]),
             None,
             transport_protocol=rfxtrxmod.PyNetworkTransport,
+            modes=modes,
         )
     else:
-        rfx = rfxtrxmod.Connect(config[CONF_DEVICE], None)
+        rfx = rfxtrxmod.Connect(
+            config[CONF_DEVICE],
+            None,
+            modes=modes,
+        )
 
     return rfx
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import itertools
 import os
 from typing import TypedDict, cast
 
@@ -23,6 +24,7 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import (
     DeviceEntry,
     DeviceRegistry,
@@ -40,6 +42,7 @@ from .const import (
     CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
+    CONF_PROTOCOLS,
     CONF_REPLACE_DEVICE,
     CONF_SIGNAL_REPETITIONS,
     CONF_VENETIAN_BLIND_MODE,
@@ -54,6 +57,8 @@ from .switch import supported as switch_supported
 
 CONF_EVENT_CODE = "event_code"
 CONF_MANUAL_PATH = "Enter Manually"
+
+RECV_MODES = sorted(itertools.chain(*rfxtrxmod.lowlevel.Status.RECMODES))
 
 
 class DeviceData(TypedDict):
@@ -96,6 +101,7 @@ class OptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             self._global_options = {
                 CONF_AUTOMATIC_ADD: user_input[CONF_AUTOMATIC_ADD],
+                CONF_PROTOCOLS: user_input[CONF_PROTOCOLS] or None,
             }
             if CONF_DEVICE in user_input:
                 entry_id = user_input[CONF_DEVICE]
@@ -145,6 +151,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                 CONF_AUTOMATIC_ADD,
                 default=self._config_entry.data[CONF_AUTOMATIC_ADD],
             ): bool,
+            vol.Optional(
+                CONF_PROTOCOLS,
+                default=self._config_entry.data.get(CONF_PROTOCOLS) or [],
+            ): cv.multi_select(RECV_MODES),
             vol.Optional(CONF_EVENT_CODE): str,
             vol.Optional(CONF_DEVICE): vol.In(configure_devices),
         }

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -5,6 +5,7 @@ CONF_AUTOMATIC_ADD = "automatic_add"
 CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 CONF_OFF_DELAY = "off_delay"
 CONF_VENETIAN_BLIND_MODE = "venetian_blind_mode"
+CONF_PROTOCOLS = "protocols"
 
 CONF_REPLACE_DEVICE = "replace_device"
 

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -41,6 +41,7 @@
         "data": {
           "debug": "Enable debugging",
           "automatic_add": "Enable automatic add",
+          "protocols": "Protocols",
           "event_code": "Enter event code to add",
           "device": "Select device to configure"
         },

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -61,6 +61,7 @@
                     "debug": "Enable debugging",
                     "device": "Select device to configure",
                     "event_code": "Enter event code to add",
+                    "protocols": "Protocols",
                     "remove_device": "Select device to delete"
                 },
                 "title": "Rfxtrx Options"

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -14,13 +14,16 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
-def create_rfx_test_cfg(device="abcd", automatic_add=False, devices=None):
+def create_rfx_test_cfg(
+    device="abcd", automatic_add=False, protocols=None, devices=None
+):
     """Create rfxtrx config entry data."""
     return {
         "device": device,
         "host": None,
         "port": None,
         "automatic_add": automatic_add,
+        "protocols": protocols,
         "debug": False,
         "devices": devices,
     }

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,14 +1,20 @@
 """The tests for the Rfxtrx component."""
 from __future__ import annotations
 
-from unittest.mock import call
+from unittest.mock import ANY, call, patch
 
+import RFXtrx as rfxtrxmod
+
+from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from tests.components.rfxtrx.conftest import setup_rfx_test_cfg
+from tests.common import MockConfigEntry
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg, setup_rfx_test_cfg
+
+SOME_PROTOCOLS = ["ac", "arc"]
 
 
 async def test_fire_event(hass, rfxtrx):
@@ -118,3 +124,31 @@ async def test_ws_device_remove(hass, hass_ws_client):
 
     # Verify that the config entry has removed the device
     assert mock_entry.data["devices"] == {}
+
+
+async def test_connect(hass):
+    """Test that we attempt to connect to the device."""
+    entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake")
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    with patch.object(rfxtrxmod, "Connect") as connect:
+        mock_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    connect.assert_called_once_with("/dev/ttyUSBfake", ANY, modes=ANY)
+
+
+async def test_connect_with_protocols(hass):
+    """Test that we attempt to set protocols."""
+    entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake", protocols=SOME_PROTOCOLS)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    with patch.object(rfxtrxmod, "Connect") as connect:
+        mock_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    connect.assert_called_once_with("/dev/ttyUSBfake", ANY, modes=SOME_PROTOCOLS)


### PR DESCRIPTION
## Proposed change
This allows users to configure the modes on their RFXtrx device without
downloading additional software that only runs on Windows. It also
enables the use of modes that cannot be permanently enabled on the
device, such as for undecoded and raw messages.

Would fix #64710 although that one was solved in another way.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #64710
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21773

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
