### PR TITLE
Adjust Sonos visibility checks

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -182,6 +182,9 @@ class SonosDiscoveryManager:
             soco = SoCo(ip_address)
             # Ensure that the player is available and UID is cached
             uid = soco.uid
+            # Abort early if the device is not visible
+            if not soco.is_visible:
+                return None
             _ = soco.volume
             return soco
         except NotSupportedException as exc:
@@ -240,8 +243,7 @@ class SonosDiscoveryManager:
                 None,
             )
             if not known_uid:
-                soco = self._create_soco(ip_addr, SoCoCreationSource.CONFIGURED)
-                if soco and soco.is_visible:
+                if soco := self._create_soco(ip_addr, SoCoCreationSource.CONFIGURED):
                     self._discovered_player(soco)
 
         self.data.hosts_heartbeat = call_later(
@@ -249,8 +251,7 @@ class SonosDiscoveryManager:
         )
 
     def _discovered_ip(self, ip_address):
-        soco = self._create_soco(ip_address, SoCoCreationSource.DISCOVERED)
-        if soco and soco.is_visible:
+        if soco := self._create_soco(ip_address, SoCoCreationSource.DISCOVERED):
             self._discovered_player(soco)
 
     async def _async_create_discovered_player(self, uid, discovered_ip, boot_seqnum):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sonos devices can sometimes fall into a state where a satellite speaker has lost track of its coordinator. Those devices will respond to certain commands, but will fail with a UPnP error when `volume` is requested from the speaker:
```
[homeassistant.components.sonos] Failed to connect to discovered player '192.168.222.111': UPnP Error 1024 received:  from 192.168.222.111
```
This PR makes a slight adjustment to abort the connection early if it's determined to be invisible. This is a fast operation because it uses a `soco`-level cache which is already populated by calling `soco.uid`. This avoids handling an unnecessary exception when accessing the `volume` attribute if we know the device can already be ignored.

cc: @rytilahti 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56724
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
