### PR TITLE
Add a UI config flow for greeneye_monitor

### DIFF
--- a/homeassistant/components/greeneye_monitor/config_flow.py
+++ b/homeassistant/components/greeneye_monitor/config_flow.py
@@ -1,0 +1,33 @@
+"""Config flows for greeneye_monitor."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_PORT
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN
+
+
+class GreeneyeMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for greeneye_monitor."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Create a config entry from UI."""
+        if await self.async_set_unique_id(DOMAIN):
+            self._abort_if_unique_id_configured()
+
+        if user_input is not None:
+            data = {CONF_PORT: user_input[CONF_PORT]}
+            return self.async_create_entry(title="GreenEye Monitor", data=data)
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema({vol.Required(CONF_PORT): cv.port})
+        )

--- a/homeassistant/components/greeneye_monitor/const.py
+++ b/homeassistant/components/greeneye_monitor/const.py
@@ -13,7 +13,8 @@ CONF_TEMPERATURE_SENSORS = "temperature_sensors"
 CONF_TIME_UNIT = "time_unit"
 CONF_VOLTAGE_SENSORS = "voltage"
 
-DATA_GREENEYE_MONITOR = "greeneye_monitor"
+DATA_MONITORS = "monitors"
+DATA_PORTS = "ports"
 DOMAIN = "greeneye_monitor"
 
 SENSOR_TYPE_CURRENT = "current_sensor"

--- a/homeassistant/components/greeneye_monitor/manifest.json
+++ b/homeassistant/components/greeneye_monitor/manifest.json
@@ -11,5 +11,6 @@
   "iot_class": "local_push",
   "loggers": [
     "greeneye"
-  ]
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/greeneye_monitor/strings.json
+++ b/homeassistant/components/greeneye_monitor/strings.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "description": "Choose the port on which to listen for packets from your GEM(s).",
+                "data": {
+                    "port": "[%key:common::config_flow::data::port%]"
+                }
+            }
+        },
+        "abort": {
+            "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+        }
+    }
+}

--- a/homeassistant/components/greeneye_monitor/translations/en.json
+++ b/homeassistant/components/greeneye_monitor/translations/en.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Already configured. Only a single configuration possible."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "port": "Port"
+                },
+                "description": "Choose the port on which to listen for packets from your GEM(s)."
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -127,6 +127,7 @@ FLOWS = [
     "google_travel_time",
     "gpslogger",
     "gree",
+    "greeneye_monitor",
     "growatt_server",
     "guardian",
     "habitica",

--- a/tests/components/greeneye_monitor/conftest.py
+++ b/tests/components/greeneye_monitor/conftest.py
@@ -1,4 +1,6 @@
 """Common fixtures for testing greeneye_monitor."""
+from __future__ import annotations
+
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -36,7 +38,7 @@ def assert_temperature_sensor_registered(
     hass: HomeAssistant,
     serial_number: int,
     number: int,
-    name: str,
+    name: str | None,
 ):
     """Assert that a temperature sensor entity was registered properly."""
     sensor = assert_sensor_registered(hass, serial_number, "temp", number, name)
@@ -47,7 +49,7 @@ def assert_pulse_counter_registered(
     hass: HomeAssistant,
     serial_number: int,
     number: int,
-    name: str,
+    name: str | None,
     quantity: str,
     per_time: str,
 ):
@@ -57,7 +59,7 @@ def assert_pulse_counter_registered(
 
 
 def assert_power_sensor_registered(
-    hass: HomeAssistant, serial_number: int, number: int, name: str
+    hass: HomeAssistant, serial_number: int, number: int, name: str | None
 ) -> None:
     """Assert that a power sensor entity was registered properly."""
     sensor = assert_sensor_registered(hass, serial_number, "current", number, name)
@@ -66,7 +68,7 @@ def assert_power_sensor_registered(
 
 
 def assert_voltage_sensor_registered(
-    hass: HomeAssistant, serial_number: int, number: int, name: str
+    hass: HomeAssistant, serial_number: int, number: int, name: str | None
 ) -> None:
     """Assert that a voltage sensor entity was registered properly."""
     sensor = assert_sensor_registered(hass, serial_number, "volts", number, name)
@@ -96,7 +98,7 @@ def assert_sensor_registered(
     return sensor
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def monitors() -> AsyncMock:
     """Provide a mock greeneye.Monitors object that has listeners and can add new monitors."""
     with patch("greeneye.Monitors", new=AsyncMock) as mock_monitors:

--- a/tests/components/greeneye_monitor/test_config_flow.py
+++ b/tests/components/greeneye_monitor/test_config_flow.py
@@ -1,0 +1,46 @@
+"""Tests for greeneye_monitor config_flow."""
+
+from homeassistant import config_entries
+from homeassistant.components.greeneye_monitor.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from .common import make_new_config_entry
+
+
+async def test_new_config_entry(hass: HomeAssistant) -> None:
+    """Test that the config flow for a newly added integration creates an entry of the expected format."""
+    expected = make_new_config_entry()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={**expected.data}
+    )
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == expected.data
+    assert result["options"] == expected.options
+    assert result["version"] == expected.version
+
+
+async def test_single_instance(hass: HomeAssistant) -> None:
+    """Test that we only allow a single instance of the integration."""
+
+    config_entry = make_new_config_entry()
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_ABORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is part of a series of pull requests aiming to support the energy dashboard and long-term statistics in the greeneye_monitor component (tracking issue: #55112).

Home Assistant policy requires device integrations to have a UI config flow, and does not allow additions to existing YAML configuration. Supporting the energy dashboard and long-term statistics for `greeneye_monitor` will require new configuration, so we must first migrate `greeneye_monitor` to a UI config flow.

This PR adds a basic UI config flow for `greeneye_monitor`. It simply requires the user to specify a port to listen on. Almost everything else in the YAML is either autodetected (temperature unit, net metering), or can be done via other UI in Home Assistant (entity names). 

The one exception is customizing how pulse counters are displayed, which I will attempt to add via an options flow in a later PR. (If you have a pulse counter on your water meter, for example, the YAML config lets you specify that each pulse is 2 gallons, and that you want the Home Assistant entity to display gallons per minute. The UI config flow, for now, just configures all pulse counters to show up as pulses per second.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #55112
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21798

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
