### PR TITLE
Adjust SamsungTV abstraction layer

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -39,7 +39,6 @@ from .const import (
     LEGACY_PORT,
     LOGGER,
     METHOD_LEGACY,
-    METHOD_WEBSOCKET,
 )
 
 
@@ -173,7 +172,7 @@ async def _async_create_bridge_with_updated_data(
     bridge = _async_get_device_bridge(hass, {**entry.data, **updated_data})
 
     mac: str | None = entry.data.get(CONF_MAC)
-    if not mac and bridge.method == METHOD_WEBSOCKET:
+    if not mac:
         if info:
             mac = mac_from_device_info(info)
         else:

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -133,7 +133,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def stop_bridge(event: Event) -> None:
         """Stop SamsungTV bridge connection."""
-        await bridge.async_stop()
+        LOGGER.debug("Stopping SamsungTVBridge %s", bridge.host)
+        await bridge.async_close_remote()
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_bridge)
@@ -196,7 +197,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        await hass.data[DOMAIN][entry.entry_id].async_stop()
+        bridge: SamsungTVBridge = hass.data[DOMAIN][entry.entry_id]
+        LOGGER.debug("Stopping SamsungTVBridge %s", bridge.host)
+        await bridge.async_close_remote()
     return unload_ok
 
 

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -149,11 +149,11 @@ async def _async_create_bridge_with_updated_data(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> SamsungTVLegacyBridge | SamsungTVWSBridge:
     """Create a bridge object and update any missing data in the config entry."""
-    updated_data = {}
-    host = entry.data[CONF_HOST]
-    port = entry.data.get(CONF_PORT)
-    method = entry.data.get(CONF_METHOD)
-    info = None
+    updated_data: dict[str, str | int] = {}
+    host: str = entry.data[CONF_HOST]
+    port: int | None = entry.data.get(CONF_PORT)
+    method: str | None = entry.data.get(CONF_METHOD)
+    info: dict[str, Any] | None = None
 
     if not port or not method:
         if method == METHOD_LEGACY:
@@ -162,7 +162,7 @@ async def _async_create_bridge_with_updated_data(
             # When we imported from yaml we didn't setup the method
             # because we didn't know it
             port, method, info = await async_get_device_info(hass, None, host)
-            if not port:
+            if not port or not method:
                 raise ConfigEntryNotReady(
                     "Failed to determine connection method, make sure the device is on."
                 )
@@ -172,7 +172,7 @@ async def _async_create_bridge_with_updated_data(
 
     bridge = _async_get_device_bridge(hass, {**entry.data, **updated_data})
 
-    mac = entry.data.get(CONF_MAC)
+    mac: str | None = entry.data.get(CONF_MAC)
     if not mac and bridge.method == METHOD_WEBSOCKET:
         if info:
             mac = mac_from_device_info(info)

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -97,7 +97,7 @@ class SamsungTVBridge(ABC):
         self.method = method
         self.host = host
         self.token: str | None = None
-        self._remote: Remote | None = None
+        self._remote: Remote | SamsungTVWS | None = None
         self._reauth_callback: CALLBACK_TYPE | None = None
         self._new_token_callback: CALLBACK_TYPE | None = None
 
@@ -125,24 +125,9 @@ class SamsungTVBridge(ABC):
     async def async_get_app_list(self) -> dict[str, str] | None:
         """Get installed app list."""
 
+    @abstractmethod
     async def async_is_on(self) -> bool:
         """Tells if the TV is on."""
-        if self._remote is not None:
-            await self.async_close_remote()
-
-        try:
-            remote = await self.hass.async_add_executor_job(self._get_remote)
-            return remote is not None
-        except (
-            UnhandledResponse,
-            AccessDenied,
-            ConnectionFailure,
-        ):
-            # We got a response so it's working.
-            return True
-        except OSError:
-            # Different reasons, e.g. hostname not resolveable
-            return False
 
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send a key to the tv and handles exceptions."""
@@ -222,6 +207,25 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
     async def async_get_app_list(self) -> dict[str, str]:
         """Get installed app list."""
         return {}
+
+    async def async_is_on(self) -> bool:
+        """Tells if the TV is on."""
+        if self._remote is not None:
+            await self.async_close_remote()
+
+        try:
+            remote = await self.hass.async_add_executor_job(self._get_remote)
+            return remote is not None
+        except (
+            UnhandledResponse,
+            AccessDenied,
+            ConnectionFailure,
+        ):
+            # We got a response so it's working.
+            return True
+        except OSError:
+            # Different reasons, e.g. hostname not resolveable
+            return False
 
     async def async_try_connect(self) -> str:
         """Try to connect to the Legacy TV."""
@@ -327,6 +331,25 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 }
 
         return self._app_list
+
+    async def async_is_on(self) -> bool:
+        """Tells if the TV is on."""
+        if self._remote is not None:
+            await self.async_close_remote()
+
+        try:
+            remote = await self.hass.async_add_executor_job(self._get_remote)
+            return remote is not None
+        except (
+            UnhandledResponse,
+            AccessDenied,
+            ConnectionFailure,
+        ):
+            # We got a response so it's working.
+            return True
+        except OSError:
+            # Different reasons, e.g. hostname not resolveable
+            return False
 
     async def async_try_connect(self) -> str:
         """Try to connect to the Websocket TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -255,11 +255,11 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         return self._remote
 
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
-        """Send a key to the tv and handles exceptions."""
+        """Send the key using legacy protocol."""
         await self.hass.async_add_executor_job(self._send_key, key)
 
     def _send_key(self, key: str) -> None:
-        """Send a key to the tv and handles exceptions."""
+        """Send the key using legacy protocol."""
         try:
             # recreate connection if connection was dead
             retry_count = 1
@@ -424,11 +424,11 @@ class SamsungTVWSBridge(SamsungTVBridge):
         return None
 
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
-        """Send a key to the tv and handles exceptions."""
+        """Send the key using websocket protocol."""
         await self.hass.async_add_executor_job(self._send_key, key, key_type)
 
     def _send_key(self, key: str, key_type: str | None = None) -> None:
-        """Send a key to the tv and handles exceptions."""
+        """Send the key using websocket protocol."""
         if key == "KEY_POWEROFF":
             key = "KEY_POWER"
         try:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -190,11 +190,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         try:
             remote = self._get_remote()
             return remote is not None
-        except (
-            UnhandledResponse,
-            AccessDenied,
-            ConnectionFailure,
-        ):
+        except (UnhandledResponse, AccessDenied):
             # We got a response so it's working.
             return True
         except OSError:
@@ -353,11 +349,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         try:
             remote = self._get_remote()
             return remote is not None
-        except (
-            UnhandledResponse,
-            AccessDenied,
-            ConnectionFailure,
-        ):
+        except ConnectionFailure:
             # We got a response so it's working.
             return True
         except OSError:
@@ -443,16 +435,12 @@ class SamsungTVWSBridge(SamsungTVBridge):
                             remote.send_key(key)
                     break
                 except (
-                    ConnectionClosed,
                     BrokenPipeError,
                     WebSocketException,
                 ):
                     # BrokenPipe can occur when the commands is sent to fast
                     # WebSocketException can occur when timed out
                     self._remote = None
-        except (UnhandledResponse, AccessDenied):
-            # We got a response so it's on.
-            LOGGER.debug("Failed sending command %s", key, exc_info=True)
         except OSError:
             # Different reasons, e.g. hostname not resolveable
             pass

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -137,15 +137,9 @@ class SamsungTVBridge(ABC):
     def _get_remote(self, avoid_open: bool = False) -> Remote | SamsungTVWS:
         """Get Remote object."""
 
+    @abstractmethod
     async def async_close_remote(self) -> None:
         """Close remote object."""
-        try:
-            if self._remote is not None:
-                # Close the current remote connection
-                await self.hass.async_add_executor_job(self._remote.close)
-            self._remote = None
-        except OSError:
-            LOGGER.debug("Could not establish connection")
 
     def _notify_reauth_callback(self) -> None:
         """Notify access denied callback."""
@@ -288,6 +282,16 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         """Send the key using legacy protocol."""
         if remote := self._get_remote():
             remote.control(key)
+
+    async def async_close_remote(self) -> None:
+        """Close remote object."""
+        try:
+            if self._remote is not None:
+                # Close the current remote connection
+                await self.hass.async_add_executor_job(self._remote.close)
+            self._remote = None
+        except OSError:
+            LOGGER.debug("Could not establish connection")
 
     async def async_stop(self) -> None:
         """Stop Bridge."""
@@ -483,6 +487,16 @@ class SamsungTVWSBridge(SamsungTVBridge):
                     self.token = self._remote.token
                     self._notify_new_token_callback()
         return self._remote
+
+    async def async_close_remote(self) -> None:
+        """Close remote object."""
+        try:
+            if self._remote is not None:
+                # Close the current remote connection
+                await self.hass.async_add_executor_job(self._remote.close)
+            self._remote = None
+        except OSError:
+            LOGGER.debug("Could not establish connection")
 
     async def async_stop(self) -> None:
         """Stop Bridge."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -264,13 +264,8 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
                     if remote := self._get_remote():
                         remote.control(key)
                     break
-                except (
-                    ConnectionClosed,
-                    BrokenPipeError,
-                    WebSocketException,
-                ):
+                except (ConnectionClosed, BrokenPipeError):
                     # BrokenPipe can occur when the commands is sent to fast
-                    # WebSocketException can occur when timed out
                     self._remote = None
         except (UnhandledResponse, AccessDenied):
             # We got a response so it's on.

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -97,7 +97,6 @@ class SamsungTVBridge(ABC):
         self.method = method
         self.host = host
         self.token: str | None = None
-        self._remote: Remote | SamsungTVWS | None = None
         self._reauth_callback: CALLBACK_TYPE | None = None
         self._new_token_callback: CALLBACK_TYPE | None = None
 
@@ -134,10 +133,6 @@ class SamsungTVBridge(ABC):
         """Send a key to the tv and handles exceptions."""
 
     @abstractmethod
-    def _get_remote(self, avoid_open: bool = False) -> Remote | SamsungTVWS:
-        """Get Remote object."""
-
-    @abstractmethod
     async def async_close_remote(self) -> None:
         """Close remote object."""
 
@@ -169,6 +164,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             CONF_PORT: None,
             CONF_TIMEOUT: 1,
         }
+        self._remote: Remote | None = None
 
     async def async_mac_from_device(self) -> None:
         """Try to fetch the mac address of the TV."""
@@ -232,7 +228,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         """Try to gather infos of this device."""
         return None
 
-    def _get_remote(self, avoid_open: bool = False) -> Remote:
+    def _get_remote(self) -> Remote:
         """Create or return a remote control instance."""
         if self._remote is None:
             # We need to create a new instance to reconnect.
@@ -314,6 +310,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         super().__init__(hass, method, host, port)
         self.token = token
         self._app_list: dict[str, str] | None = None
+        self._remote: SamsungTVWS | None = None
 
     async def async_mac_from_device(self) -> str | None:
         """Try to fetch the mac address of the TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -337,11 +337,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         if self._remote is not None:
             self._close_remote()
 
-        try:
-            return self._get_remote() is not None
-        except ConnectionFailure:
-            # We got a response so it's working.
-            return True
+        return self._get_remote() is not None
 
     async def async_try_connect(self) -> str:
         """Try to connect to the Websocket TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -192,9 +192,6 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         except (UnhandledResponse, AccessDenied):
             # We got a response so it's working.
             return True
-        except OSError:
-            # Different reasons, e.g. hostname not resolveable
-            return False
 
     async def async_try_connect(self) -> str:
         """Try to connect to the Legacy TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -342,9 +342,6 @@ class SamsungTVWSBridge(SamsungTVBridge):
         except ConnectionFailure:
             # We got a response so it's working.
             return True
-        except OSError:
-            # Different reasons, e.g. hostname not resolveable
-            return False
 
     async def async_try_connect(self) -> str:
         """Try to connect to the Websocket TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -67,7 +67,7 @@ async def async_get_device_info(
     bridge = SamsungTVBridge.get_bridge(hass, METHOD_LEGACY, host, LEGACY_PORT)
     result = await bridge.async_try_connect()
     if result in (RESULT_SUCCESS, RESULT_AUTH_MISSING):
-        return LEGACY_PORT, METHOD_LEGACY, None
+        return LEGACY_PORT, METHOD_LEGACY, await bridge.async_device_info()
 
     return None, None, None
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -129,33 +129,9 @@ class SamsungTVBridge(ABC):
     async def async_is_on(self) -> bool:
         """Tells if the TV is on."""
 
+    @abstractmethod
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send a key to the tv and handles exceptions."""
-        try:
-            # recreate connection if connection was dead
-            retry_count = 1
-            for _ in range(retry_count + 1):
-                try:
-                    await self._async_send_key(key, key_type)
-                    break
-                except (
-                    ConnectionClosed,
-                    BrokenPipeError,
-                    WebSocketException,
-                ):
-                    # BrokenPipe can occur when the commands is sent to fast
-                    # WebSocketException can occur when timed out
-                    self._remote = None
-        except (UnhandledResponse, AccessDenied):
-            # We got a response so it's on.
-            LOGGER.debug("Failed sending command %s", key, exc_info=True)
-        except OSError:
-            # Different reasons, e.g. hostname not resolveable
-            pass
-
-    @abstractmethod
-    async def _async_send_key(self, key: str, key_type: str | None = None) -> None:
-        """Send the key."""
 
     @abstractmethod
     def _get_remote(self, avoid_open: bool = False) -> Remote | SamsungTVWS:
@@ -279,6 +255,30 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             except (ConnectionClosed, OSError):
                 pass
         return self._remote
+
+    async def async_send_key(self, key: str, key_type: str | None = None) -> None:
+        """Send a key to the tv and handles exceptions."""
+        try:
+            # recreate connection if connection was dead
+            retry_count = 1
+            for _ in range(retry_count + 1):
+                try:
+                    await self._async_send_key(key, key_type)
+                    break
+                except (
+                    ConnectionClosed,
+                    BrokenPipeError,
+                    WebSocketException,
+                ):
+                    # BrokenPipe can occur when the commands is sent to fast
+                    # WebSocketException can occur when timed out
+                    self._remote = None
+        except (UnhandledResponse, AccessDenied):
+            # We got a response so it's on.
+            LOGGER.debug("Failed sending command %s", key, exc_info=True)
+        except OSError:
+            # Different reasons, e.g. hostname not resolveable
+            pass
 
     async def _async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send the key using legacy protocol."""
@@ -407,6 +407,30 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 return device_info
 
         return None
+
+    async def async_send_key(self, key: str, key_type: str | None = None) -> None:
+        """Send a key to the tv and handles exceptions."""
+        try:
+            # recreate connection if connection was dead
+            retry_count = 1
+            for _ in range(retry_count + 1):
+                try:
+                    await self._async_send_key(key, key_type)
+                    break
+                except (
+                    ConnectionClosed,
+                    BrokenPipeError,
+                    WebSocketException,
+                ):
+                    # BrokenPipe can occur when the commands is sent to fast
+                    # WebSocketException can occur when timed out
+                    self._remote = None
+        except (UnhandledResponse, AccessDenied):
+            # We got a response so it's on.
+            LOGGER.debug("Failed sending command %s", key, exc_info=True)
+        except OSError:
+            # Different reasons, e.g. hostname not resolveable
+            pass
 
     async def _async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send the key using websocket protocol."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -136,6 +136,10 @@ class SamsungTVBridge(ABC):
     async def async_close_remote(self) -> None:
         """Close remote object."""
 
+    @abstractmethod
+    async def async_stop(self) -> None:
+        """Stop Bridge."""
+
     def _notify_reauth_callback(self) -> None:
         """Notify access denied callback."""
         if self._reauth_callback is not None:
@@ -296,7 +300,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
     async def async_stop(self) -> None:
         """Stop Bridge."""
         LOGGER.debug("Stopping SamsungTVLegacyBridge")
-        await self.hass.async_add_executor_job(self._close_remote)
+        await self.async_close_remote()
 
 
 class SamsungTVWSBridge(SamsungTVBridge):
@@ -508,4 +512,4 @@ class SamsungTVWSBridge(SamsungTVBridge):
     async def async_stop(self) -> None:
         """Stop Bridge."""
         LOGGER.debug("Stopping SamsungTVWSBridge")
-        await self.hass.async_add_executor_job(self._close_remote)
+        await self.async_close_remote()

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PORT,
     CONF_TIMEOUT,
-    CONF_TOKEN,
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
@@ -367,8 +366,6 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 ) as remote:
                     remote.open("samsung.remote.control")
                     self.token = remote.token
-                    if self.token is None:
-                        config[CONF_TOKEN] = "*****"
                     LOGGER.debug("Working config: %s", config)
                     return RESULT_SUCCESS
             except WebSocketException as err:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -188,8 +188,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             self._close_remote()
 
         try:
-            remote = self._get_remote()
-            return remote is not None
+            return self._get_remote() is not None
         except (UnhandledResponse, AccessDenied):
             # We got a response so it's working.
             return True
@@ -342,8 +341,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             self._close_remote()
 
         try:
-            remote = self._get_remote()
-            return remote is not None
+            return self._get_remote() is not None
         except ConnectionFailure:
             # We got a response so it's working.
             return True

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -135,10 +135,6 @@ class SamsungTVBridge(ABC):
     async def async_close_remote(self) -> None:
         """Close remote object."""
 
-    @abstractmethod
-    async def async_stop(self) -> None:
-        """Stop Bridge."""
-
     def _notify_reauth_callback(self) -> None:
         """Notify access denied callback."""
         if self._reauth_callback is not None:
@@ -282,11 +278,6 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             self._remote = None
         except OSError:
             LOGGER.debug("Could not establish connection")
-
-    async def async_stop(self) -> None:
-        """Stop Bridge."""
-        LOGGER.debug("Stopping SamsungTVLegacyBridge")
-        await self.async_close_remote()
 
 
 class SamsungTVWSBridge(SamsungTVBridge):
@@ -476,8 +467,3 @@ class SamsungTVWSBridge(SamsungTVBridge):
             self._remote = None
         except OSError:
             LOGGER.debug("Could not establish connection")
-
-    async def async_stop(self) -> None:
-        """Stop Bridge."""
-        LOGGER.debug("Stopping SamsungTVWSBridge")
-        await self.async_close_remote()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -451,6 +451,17 @@ async def test_send_key_websocketexception(hass: HomeAssistant, remotews: Mock) 
     assert state.state == STATE_ON
 
 
+async def test_send_key_os_error_ws(hass: HomeAssistant, remotews: Mock) -> None:
+    """Testing unhandled response exception."""
+    await setup_samsungtv(hass, MOCK_CONFIGWS)
+    remotews.send_key = Mock(side_effect=OSError("Boom"))
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+
+
 async def test_send_key_os_error(hass: HomeAssistant, remote: Mock) -> None:
     """Testing broken pipe Exception."""
     await setup_samsungtv(hass, MOCK_CONFIG)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -582,6 +582,19 @@ async def test_turn_off_os_error(
     assert "Could not establish connection" in caplog.text
 
 
+async def test_turn_off_ws_os_error(
+    hass: HomeAssistant, remotews: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test for turn_off with OSError."""
+    caplog.set_level(logging.DEBUG)
+    await setup_samsungtv(hass, MOCK_CONFIGWS)
+    remotews.close = Mock(side_effect=OSError("BOOM"))
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert "Could not establish connection" in caplog.text
+
+
 async def test_volume_up(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_up."""
     await setup_samsungtv(hass, MOCK_CONFIG)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -274,6 +274,26 @@ async def test_update_off(hass: HomeAssistant, mock_now: datetime) -> None:
         assert state.state == STATE_OFF
 
 
+async def test_update_off_ws(
+    hass: HomeAssistant, remotews: Mock, mock_now: datetime
+) -> None:
+    """Testing update tv off."""
+    await setup_samsungtv(hass, MOCK_CONFIGWS)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+
+    remotews.open = Mock(side_effect=WebSocketException("Boom"))
+
+    next_update = mock_now + timedelta(minutes=5)
+    with patch("homeassistant.util.dt.utcnow", return_value=next_update):
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
+
+
 @pytest.mark.usefixtures("remote")
 async def test_update_access_denied(hass: HomeAssistant, mock_now: datetime) -> None:
     """Testing update tv access denied exception."""

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -440,10 +440,10 @@ async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Mock) ->
     assert state.state == STATE_ON
 
 
-async def test_send_key_websocketexception(hass: HomeAssistant, remote: Mock) -> None:
+async def test_send_key_websocketexception(hass: HomeAssistant, remotews: Mock) -> None:
     """Testing unhandled response exception."""
-    await setup_samsungtv(hass, MOCK_CONFIG)
-    remote.control = Mock(side_effect=WebSocketException("Boom"))
+    await setup_samsungtv(hass, MOCK_CONFIGWS)
+    remotews.send_key = Mock(side_effect=WebSocketException("Boom"))
     assert await hass.services.async_call(
         DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -588,6 +588,12 @@ async def test_turn_off_websocket(hass: HomeAssistant, remotews: Mock) -> None:
         assert remotews.send_key.call_count == 1
         assert remotews.send_key.call_args_list == [call("KEY_POWER")]
 
+        assert await hass.services.async_call(
+            DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        )
+        # key not called
+        assert remotews.send_key.call_count == 1
+
 
 async def test_turn_off_legacy(hass: HomeAssistant, remote: Mock) -> None:
     """Test for turn_off."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust the SamsungTV to ensure that:
- all public methods are abstract (this result is a slight code duplication right now, but it will make it easier to adjust for Legacy versus WebSocket in the future)
- ensure that `async_add_executor_job` is only called in the public methods (at the top level of the abstraction layer) to avoid not needed context switches inside the abstraction implementations
- adjust exception handling to ensure we do not catch samsungtvws exceptions in legacy implementation and samsungctl in websocket implementation

As follow-up to #67042, and preliminary work for #67127

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
