### PR TITLE
Fix zwave_js migration luminance sensor

### DIFF
--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -9,7 +9,7 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import LIGHT_LUX, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import (
     DeviceEntry,
@@ -90,6 +90,8 @@ CC_ID_LABEL_TO_PROPERTY = {
     49: SENSOR_MULTILEVEL_CC_LABEL_TO_PROPERTY_NAME,
     113: NOTIFICATION_CC_LABEL_TO_PROPERTY_NAME,
 }
+
+UNIT_LEGACY_MIGRATION_MAP = {LIGHT_LUX: "Lux"}
 
 
 class ZWaveMigrationData(TypedDict):
@@ -209,7 +211,8 @@ class LegacyZWaveMigration:
 
         # Normalize unit of measurement.
         if unit := entity_entry.unit_of_measurement:
-            unit = unit.lower()
+            _unit = UNIT_LEGACY_MIGRATION_MAP.get(unit, unit)
+            unit = _unit.lower()
         if unit == "":
             unit = None
 

--- a/tests/components/zwave_js/test_migrate.py
+++ b/tests/components/zwave_js/test_migrate.py
@@ -8,6 +8,7 @@ from zwave_js_server.model.node import Node
 from homeassistant.components.zwave_js.api import ENTRY_ID, ID, TYPE
 from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id
+from homeassistant.const import LIGHT_LUX
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import AIR_TEMPERATURE_SENSOR, NOTIFICATION_MOTION_BINARY_SENSOR
@@ -341,6 +342,7 @@ async def test_migrate_zwave(
     assert luminance_entry.unique_id == "3245146787.52-49-0-Illuminance"
     assert luminance_entry.name == ZWAVE_LUMINANCE_NAME
     assert luminance_entry.icon == ZWAVE_LUMINANCE_ICON
+    assert luminance_entry.unit_of_measurement == LIGHT_LUX
 
     # check that the zwave config entry has been removed
     assert not hass.config_entries.async_entries("zwave")

--- a/tests/components/zwave_js/test_migrate.py
+++ b/tests/components/zwave_js/test_migrate.py
@@ -33,6 +33,10 @@ ZWAVE_MULTISENSOR_DEVICE_NAME = "Z-Wave Multisensor Device"
 ZWAVE_MULTISENSOR_DEVICE_AREA = "Z-Wave Multisensor Area"
 ZWAVE_SOURCE_NODE_ENTITY = "sensor.zwave_source_node"
 ZWAVE_SOURCE_NODE_UNIQUE_ID = "52-4321"
+ZWAVE_LUMINANCE_ENTITY = "sensor.zwave_luminance"
+ZWAVE_LUMINANCE_UNIQUE_ID = "52-6543"
+ZWAVE_LUMINANCE_NAME = "Z-Wave Luminance"
+ZWAVE_LUMINANCE_ICON = "mdi:zwave-test-luminance"
 ZWAVE_BATTERY_ENTITY = "sensor.zwave_battery_level"
 ZWAVE_BATTERY_UNIQUE_ID = "52-1234"
 ZWAVE_BATTERY_NAME = "Z-Wave Battery Level"
@@ -68,6 +72,14 @@ def zwave_migration_data_fixture(hass):
         unique_id=ZWAVE_SOURCE_NODE_UNIQUE_ID,
         platform="zwave",
         name="Z-Wave Source Node",
+    )
+    zwave_luminance_entry = er.RegistryEntry(
+        entity_id=ZWAVE_LUMINANCE_ENTITY,
+        unique_id=ZWAVE_LUMINANCE_UNIQUE_ID,
+        platform="zwave",
+        name=ZWAVE_LUMINANCE_NAME,
+        icon=ZWAVE_LUMINANCE_ICON,
+        unit_of_measurement="lux",
     )
     zwave_battery_entry = er.RegistryEntry(
         entity_id=ZWAVE_BATTERY_ENTITY,
@@ -131,6 +143,18 @@ def zwave_migration_data_fixture(hass):
             "unique_id": ZWAVE_SOURCE_NODE_UNIQUE_ID,
             "unit_of_measurement": zwave_source_node_entry.unit_of_measurement,
         },
+        ZWAVE_LUMINANCE_ENTITY: {
+            "node_id": 52,
+            "node_instance": 1,
+            "command_class": 49,
+            "command_class_label": "Luminance",
+            "value_index": 3,
+            "device_id": zwave_multisensor_device.id,
+            "domain": zwave_luminance_entry.domain,
+            "entity_id": zwave_luminance_entry.entity_id,
+            "unique_id": ZWAVE_LUMINANCE_UNIQUE_ID,
+            "unit_of_measurement": zwave_luminance_entry.unit_of_measurement,
+        },
         ZWAVE_BATTERY_ENTITY: {
             "node_id": 52,
             "node_instance": 1,
@@ -169,6 +193,7 @@ def zwave_migration_data_fixture(hass):
         {
             ZWAVE_SWITCH_ENTITY: zwave_switch_entry,
             ZWAVE_SOURCE_NODE_ENTITY: zwave_source_node_entry,
+            ZWAVE_LUMINANCE_ENTITY: zwave_luminance_entry,
             ZWAVE_BATTERY_ENTITY: zwave_battery_entry,
             ZWAVE_POWER_ENTITY: zwave_power_entry,
             ZWAVE_TAMPERING_ENTITY: zwave_tampering_entry,
@@ -218,6 +243,7 @@ async def test_migrate_zwave(
 
     migration_entity_map = {
         ZWAVE_SWITCH_ENTITY: "switch.smart_switch_6",
+        ZWAVE_LUMINANCE_ENTITY: "sensor.multisensor_6_illuminance",
         ZWAVE_BATTERY_ENTITY: "sensor.multisensor_6_battery_level",
     }
 
@@ -225,6 +251,7 @@ async def test_migrate_zwave(
         ZWAVE_SWITCH_ENTITY,
         ZWAVE_POWER_ENTITY,
         ZWAVE_SOURCE_NODE_ENTITY,
+        ZWAVE_LUMINANCE_ENTITY,
         ZWAVE_BATTERY_ENTITY,
         ZWAVE_TAMPERING_ENTITY,
     ]
@@ -279,6 +306,7 @@ async def test_migrate_zwave(
 
     # this should have been migrated and no longer present under that id
     assert not ent_reg.async_is_registered("sensor.multisensor_6_battery_level")
+    assert not ent_reg.async_is_registered("sensor.multisensor_6_illuminance")
 
     # these should not have been migrated and is still in the registry
     assert ent_reg.async_is_registered(ZWAVE_SOURCE_NODE_ENTITY)
@@ -295,6 +323,7 @@ async def test_migrate_zwave(
     # this is the new entity_ids of the zwave_js entities
     assert ent_reg.async_is_registered(ZWAVE_SWITCH_ENTITY)
     assert ent_reg.async_is_registered(ZWAVE_BATTERY_ENTITY)
+    assert ent_reg.async_is_registered(ZWAVE_LUMINANCE_ENTITY)
 
     # check that the migrated entries have correct attributes
     switch_entry = ent_reg.async_get(ZWAVE_SWITCH_ENTITY)
@@ -307,6 +336,11 @@ async def test_migrate_zwave(
     assert battery_entry.unique_id == "3245146787.52-128-0-level"
     assert battery_entry.name == ZWAVE_BATTERY_NAME
     assert battery_entry.icon == ZWAVE_BATTERY_ICON
+    luminance_entry = ent_reg.async_get(ZWAVE_LUMINANCE_ENTITY)
+    assert luminance_entry
+    assert luminance_entry.unique_id == "3245146787.52-49-0-Illuminance"
+    assert luminance_entry.name == ZWAVE_LUMINANCE_NAME
+    assert luminance_entry.icon == ZWAVE_LUMINANCE_ICON
 
     # check that the zwave config entry has been removed
     assert not hass.config_entries.async_entries("zwave")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We've standardized the luminance unit of measurement in zwave_js, after introducing the migration, to use `"lx"` instead of `"Lux"`. The latter is used in the zwave integration. This breaks the migration of this sensor. Fix this by adding a unit map for the migration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
