### PR TITLE
Fix powerwall data incompatibility with energy integration

### DIFF
--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -97,7 +97,7 @@ class PowerWallEnergySensor(PowerWallEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         """Get the current value in kW."""
-        return self.data.meters.get_meter(self._meter).get_power(precision=3)
+        return abs(self.data.meters.get_meter(self._meter).get_power(precision=3))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -160,7 +160,7 @@ class PowerWallExportSensor(PowerWallEnergyDirectionSensor):
     @property
     def native_value(self) -> float:
         """Get the current value in kWh."""
-        return self.meter.get_energy_exported()
+        return abs(self.meter.get_energy_exported())
 
 
 class PowerWallImportSensor(PowerWallEnergyDirectionSensor):
@@ -177,4 +177,4 @@ class PowerWallImportSensor(PowerWallEnergyDirectionSensor):
     @property
     def native_value(self) -> float:
         """Get the current value in kWh."""
-        return self.meter.get_energy_imported()
+        return abs(self.meter.get_energy_imported())

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -97,7 +97,7 @@ class PowerWallEnergySensor(PowerWallEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         """Get the current value in kW."""
-        return abs(self.data.meters.get_meter(self._meter).get_power(precision=3))
+        return self.data.meters.get_meter(self._meter).get_power(precision=3)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
~Powerwall import and export sensors are reported now reported as positive values since any negative values are not compatible with state class total increasing.~ This is being reverted in https://github.com/home-assistant/core/pull/67300

~Fixes~
```
2022-02-25 18:35:21 WARNING (Recorder) [homeassistant.components.sensor.recorder] Entity sensor.powerwall_site_export from integration powerwall has state class total_increasing, but its state is negative. Triggered by state -47025.4 with last_updated set to 2022-02-25T18:29:59.999999+00:00. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+powerwall%22
2022-02-25 18:35:21 WARNING (Recorder) [homeassistant.components.sensor.recorder] Entity sensor.powerwall_site_import from integration powerwall has state class total_increasing, but its state is negative. Triggered by state -33046.6 with last_updated set to 2022-02-25T18:29:59.999999+00:00. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+powerwall%22
```

When a value of 0 is reported, we now reject the data by reporting the state as unavailable.  These are likely read failures.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Fixes #67237 Fixes #67244 Fixes #63909
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
Fixes #67237