### PR TITLE
Correct tests to use data_type in Modbus

### DIFF
--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -13,7 +13,6 @@ from homeassistant.components.modbus.const import (
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_ADDRESS,
-    CONF_COUNT,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
@@ -46,7 +45,7 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                     CONF_ADDRESS: 117,
                     CONF_SLAVE: 10,
                     CONF_SCAN_INTERVAL: 20,
-                    CONF_COUNT: 2,
+                    CONF_DATA_TYPE: DataType.INT32,
                     CONF_LAZY_ERROR: 10,
                 }
             ],
@@ -68,7 +67,7 @@ async def test_config_climate(hass, mock_modbus):
                     CONF_SLAVE: 1,
                     CONF_TARGET_TEMP: 117,
                     CONF_ADDRESS: 117,
-                    CONF_COUNT: 2,
+                    CONF_DATA_TYPE: DataType.INT32,
                 },
             ],
         },
@@ -94,7 +93,6 @@ async def test_temperature_climate(hass, expected, mock_do_cycle):
         {
             CONF_CLIMATES: [
                 {
-                    CONF_COUNT: 2,
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_TARGET_TEMP: 117,
                     CONF_ADDRESS: 117,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -146,13 +146,11 @@ async def test_number_validator():
         },
         {
             CONF_NAME: TEST_ENTITY_NAME,
-            CONF_COUNT: 2,
-            CONF_DATA_TYPE: DataType.INT,
+            CONF_DATA_TYPE: DataType.INT32,
         },
         {
             CONF_NAME: TEST_ENTITY_NAME,
-            CONF_COUNT: 2,
-            CONF_DATA_TYPE: DataType.INT,
+            CONF_DATA_TYPE: DataType.INT32,
             CONF_SWAP: CONF_SWAP_BYTE,
         },
         {

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -48,6 +48,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
+                    CONF_DATA_TYPE: DataType.INT16,
                 }
             ]
         },
@@ -57,8 +58,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
                     CONF_SLAVE: 10,
-                    CONF_COUNT: 1,
-                    CONF_DATA_TYPE: "int",
+                    CONF_DATA_TYPE: DataType.INT16,
                     CONF_PRECISION: 0,
                     CONF_SCALE: 1,
                     CONF_OFFSET: 0,
@@ -75,8 +75,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
                     CONF_SLAVE: 10,
-                    CONF_COUNT: 1,
-                    CONF_DATA_TYPE: "int",
+                    CONF_DATA_TYPE: DataType.INT16,
                     CONF_PRECISION: 0,
                     CONF_SCALE: 1,
                     CONF_OFFSET: 0,
@@ -90,7 +89,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
-                    CONF_COUNT: 1,
+                    CONF_DATA_TYPE: DataType.INT16,
                     CONF_SWAP: CONF_SWAP_NONE,
                 }
             ]
@@ -100,7 +99,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
-                    CONF_COUNT: 1,
+                    CONF_DATA_TYPE: DataType.INT16,
                     CONF_SWAP: CONF_SWAP_BYTE,
                 }
             ]
@@ -110,7 +109,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
-                    CONF_COUNT: 2,
+                    CONF_DATA_TYPE: DataType.INT32,
                     CONF_SWAP: CONF_SWAP_WORD,
                 }
             ]
@@ -120,7 +119,7 @@ ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
-                    CONF_COUNT: 2,
+                    CONF_DATA_TYPE: DataType.INT32,
                     CONF_SWAP: CONF_SWAP_WORD_BYTE,
                 }
             ]
@@ -253,8 +252,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
     [
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -271,8 +269,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 13,
                 CONF_PRECISION: 0,
@@ -283,8 +280,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: 3,
                 CONF_OFFSET: 13,
                 CONF_PRECISION: 0,
@@ -295,8 +291,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT16,
                 CONF_SCALE: 3,
                 CONF_OFFSET: 13,
                 CONF_PRECISION: 4,
@@ -307,8 +302,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: 1.5,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -319,8 +313,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: "1.5",
                 CONF_OFFSET: "5",
                 CONF_PRECISION: "1",
@@ -331,8 +324,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: 2.4,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 2,
@@ -343,8 +335,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SCALE: 1,
                 CONF_OFFSET: -10.3,
                 CONF_PRECISION: 1,
@@ -355,8 +346,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT32,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -367,8 +357,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT32,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -379,8 +368,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 4,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT64,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -391,8 +379,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 4,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT64,
                 CONF_SCALE: 2,
                 CONF_OFFSET: 3,
                 CONF_PRECISION: 0,
@@ -403,8 +390,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 4,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT64,
                 CONF_SCALE: 2.0,
                 CONF_OFFSET: 3.0,
                 CONF_PRECISION: 0,
@@ -415,9 +401,8 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
                 CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT32,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -428,9 +413,8 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
                 CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT32,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -441,9 +425,8 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
                 CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-                CONF_DATA_TYPE: DataType.FLOAT,
+                CONF_DATA_TYPE: DataType.FLOAT32,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 5,
@@ -480,9 +463,8 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
                 CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
-                CONF_DATA_TYPE: DataType.UINT,
+                CONF_DATA_TYPE: DataType.UINT32,
                 CONF_SCALE: 1,
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
@@ -493,8 +475,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SWAP: CONF_SWAP_NONE,
             },
             [0x0102],
@@ -503,8 +484,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 1,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
                 CONF_SWAP: CONF_SWAP_BYTE,
             },
             [0x0201],
@@ -513,8 +493,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT32,
                 CONF_SWAP: CONF_SWAP_BYTE,
             },
             [0x0102, 0x0304],
@@ -523,8 +502,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT32,
                 CONF_SWAP: CONF_SWAP_WORD,
             },
             [0x0102, 0x0304],
@@ -533,8 +511,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT32,
                 CONF_SWAP: CONF_SWAP_WORD_BYTE,
             },
             [0x0102, 0x0304],
@@ -543,7 +520,6 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
         (
             {
-                CONF_COUNT: 2,
                 CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
                 CONF_DATA_TYPE: DataType.FLOAT32,
                 CONF_PRECISION: 2,
@@ -578,14 +554,12 @@ async def test_all_sensor(hass, mock_do_cycle, expected):
     [
         (
             {
-                CONF_COUNT: 1,
                 CONF_DATA_TYPE: DataType.INT16,
             },
             [7, 9],
         ),
         (
             {
-                CONF_COUNT: 2,
                 CONF_DATA_TYPE: DataType.INT32,
             },
             [7],
@@ -675,9 +649,8 @@ async def test_lazy_error_sensor(hass, mock_do_cycle, start_expect, end_expect):
         ),
         (
             {
-                CONF_COUNT: 1,
                 CONF_PRECISION: 0,
-                CONF_DATA_TYPE: DataType.INT,
+                CONF_DATA_TYPE: DataType.INT16,
             },
             [0x0101],
             "257",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The tests used the old data_type "int", "uint", "float", which we have not supported for a long time, but converted (with a deprecated warning) to the new types "int16" etc.

Update all tests to use the new data_types. This step enables us to eliminate the old data_types for good.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
