### PR TITLE
Prevent the wrong WiZ device from being used when the IP is a different device

### DIFF
--- a/homeassistant/components/wiz/__init__.py
+++ b/homeassistant/components/wiz/__init__.py
@@ -60,6 +60,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await bulb.async_close()
         raise ConfigEntryNotReady(f"{ip_address}: {err}") from err
 
+    if bulb.mac != entry.unique_id:
+        # The ip address of the bulb has changed and its likely offline
+        # and another WiZ device has taken the IP. Avoid setting up
+        # since its the wrong device. As soon as the device comes back
+        # online the ip will get updated and setup will proceed.
+        raise ConfigEntryNotReady(
+            "Found bulb {bulb.mac} at {ip_address}, expected {entry.unique_id}"
+        )
+
     async def _async_update() -> None:
         """Update the WiZ device."""
         try:

--- a/tests/components/wiz/test_init.py
+++ b/tests/components/wiz/test_init.py
@@ -50,3 +50,11 @@ async def test_cleanup_on_failed_first_update(hass: HomeAssistant) -> None:
     _, entry = await async_setup_integration(hass, wizlight=bulb)
     assert entry.state == config_entries.ConfigEntryState.SETUP_RETRY
     bulb.async_close.assert_called_once()
+
+
+async def test_wrong_device_now_has_our_ip(hass: HomeAssistant) -> None:
+    """Test setup is retried when the wrong device is found."""
+    bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
+    bulb.mac = "dddddddddddd"
+    _, entry = await async_setup_integration(hass, wizlight=bulb)
+    assert entry.state == config_entries.ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If WiZ device is not the one we expect at the IP address, we retry
later so we can wait for the correct one to come back online and
announce its ip.

Fixes two config entries trying to get push updates for the same device
```
2022-02-25 09:24:27 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry WiZ Dimmable White 3F0805 for wiz
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/config_entries.py", line 474, in async_unload
    result = await component.async_unload_entry(hass, self)
  File "/Users/bdraco/home-assistant/homeassistant/components/wiz/__init__.py", line 118, in async_unload_entry
    await data.bulb.async_close()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/pywizlight/bulb.py", line 789, in async_close
    self._async_close()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/pywizlight/bulb.py", line 797, in _async_close
    self.push_cancel()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/pywizlight/push_manager.py", line 110, in _cancel
    del self.subscriptions[mac]
KeyError: '6c29903f0805'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
