### PR TITLE
Clean up RFXtrx tests

### DIFF
--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -36,7 +36,7 @@ def com_port():
 
 
 async def start_options_flow(hass, entry):
-    """Init hass with the entry under test."""
+    """Start the options flow with the entry under test."""
     entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -35,7 +35,7 @@ def com_port():
     return port
 
 
-async def init_hass_with_entry(hass, entry):
+async def start_options_flow(hass, entry):
     """Init hass with the entry under test."""
     entry.add_to_hass(hass)
 
@@ -304,7 +304,7 @@ async def test_options_global(hass):
         unique_id=DOMAIN,
     )
     with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
-        result = await init_hass_with_entry(hass, entry)
+        result = await start_options_flow(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -339,7 +339,7 @@ async def test_no_protocols(hass):
         unique_id=DOMAIN,
     )
     with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
-        result = await init_hass_with_entry(hass, entry)
+        result = await start_options_flow(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -372,7 +372,7 @@ async def test_options_add_device(hass):
         },
         unique_id=DOMAIN,
     )
-    result = await init_hass_with_entry(hass, entry)
+    result = await start_options_flow(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -473,7 +473,7 @@ async def test_options_replace_sensor_device(hass):
         },
         unique_id=DOMAIN,
     )
-    await init_hass_with_entry(hass, entry)
+    await start_options_flow(hass, entry)
 
     state = hass.states.get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
@@ -636,7 +636,7 @@ async def test_options_replace_control_device(hass):
         },
         unique_id=DOMAIN,
     )
-    await init_hass_with_entry(hass, entry)
+    await start_options_flow(hass, entry)
 
     state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
@@ -732,7 +732,7 @@ async def test_options_add_and_configure_device(hass):
         },
         unique_id=DOMAIN,
     )
-    result = await init_hass_with_entry(hass, entry)
+    result = await start_options_flow(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -846,7 +846,7 @@ async def test_options_configure_rfy_cover_device(hass):
         },
         unique_id=DOMAIN,
     )
-    result = await init_hass_with_entry(hass, entry)
+    result = await start_options_flow(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -35,6 +35,16 @@ def com_port():
     return port
 
 
+async def init_hass_with_entry(hass, entry):
+    """Init hass with the entry under test."""
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    return await hass.config_entries.options.async_init(entry.entry_id)
+
+
 @patch("homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport", autospec=True)
 async def test_setup_network(transport_mock, hass):
     """Test we can setup network."""
@@ -293,9 +303,8 @@ async def test_options_global(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await init_hass_with_entry(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -329,9 +338,8 @@ async def test_no_protocols(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
+        result = await init_hass_with_entry(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -364,9 +372,7 @@ async def test_options_add_device(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await init_hass_with_entry(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -467,10 +473,7 @@ async def test_options_replace_sensor_device(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    await init_hass_with_entry(hass, entry)
 
     state = hass.states.get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
@@ -633,10 +636,7 @@ async def test_options_replace_control_device(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    await init_hass_with_entry(hass, entry)
 
     state = hass.states.get("binary_sensor.ac_118cdea_2")
     assert state
@@ -732,9 +732,7 @@ async def test_options_add_and_configure_device(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await init_hass_with_entry(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"
@@ -848,12 +846,7 @@ async def test_options_configure_rfy_cover_device(hass):
         },
         unique_id=DOMAIN,
     )
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await init_hass_with_entry(hass, entry)
 
     assert result["type"] == "form"
     assert result["step_id"] == "prompt_options"

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -131,9 +131,9 @@ async def test_connect(hass):
     entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake")
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
-    with patch.object(rfxtrxmod, "Connect") as connect:
-        mock_entry.add_to_hass(hass)
+    mock_entry.add_to_hass(hass)
 
+    with patch.object(rfxtrxmod, "Connect") as connect:
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -145,9 +145,9 @@ async def test_connect_with_protocols(hass):
     entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake", protocols=SOME_PROTOCOLS)
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
-    with patch.object(rfxtrxmod, "Connect") as connect:
-        mock_entry.add_to_hass(hass)
+    mock_entry.add_to_hass(hass)
 
+    with patch.object(rfxtrxmod, "Connect") as connect:
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
Test cleanup from post-merge comments on #67173

FYI @MartinHjelmare 

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: #67173
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
