### PR TITLE
Repository event subscription

### DIFF
--- a/homeassistant/components/github/__init__.py
+++ b/homeassistant/components/github/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from aiogithubapi import GitHubAPI
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ACCESS_TOKEN, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import (
@@ -39,7 +39,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await coordinator.async_config_entry_first_refresh()
         await coordinator.subscribe()
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.unsubscribe)
 
         hass.data[DOMAIN][repository] = coordinator
 

--- a/homeassistant/components/github/const.py
+++ b/homeassistant/components/github/const.py
@@ -11,7 +11,18 @@ DOMAIN = "github"
 CLIENT_ID = "1440cafcc86e3ea5d6a2"
 
 DEFAULT_REPOSITORIES = ["home-assistant/core", "esphome/esphome"]
-DEFAULT_UPDATE_INTERVAL = timedelta(seconds=300)
+FALLBACK_UPDATE_INTERVAL = timedelta(hours=1, minutes=30)
 
 CONF_ACCESS_TOKEN = "access_token"
 CONF_REPOSITORIES = "repositories"
+
+
+REFRESH_EVENT_TYPES = (
+    "CreateEvent",
+    "ForkEvent",
+    "IssuesEvent",
+    "PullRequestEvent",
+    "PushEvent",
+    "ReleaseEvent",
+    "WatchEvent",
+)

--- a/homeassistant/components/github/coordinator.py
+++ b/homeassistant/components/github/coordinator.py
@@ -6,15 +6,17 @@ from typing import Any
 from aiogithubapi import (
     GitHubAPI,
     GitHubConnectionException,
+    GitHubEventModel,
     GitHubException,
     GitHubRatelimitException,
     GitHubResponseModel,
 )
 
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, LOGGER
+from .const import DOMAIN, FALLBACK_UPDATE_INTERVAL, LOGGER, REFRESH_EVENT_TYPES
 
 GRAPHQL_REPOSITORY_QUERY = """
 query ($owner: String!, $repository: String!) {
@@ -109,13 +111,14 @@ class GitHubDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.repository = repository
         self._client = client
         self._last_response: GitHubResponseModel[dict[str, Any]] | None = None
+        self._subscription_id: str | None = None
         self.data = {}
 
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=DEFAULT_UPDATE_INTERVAL,
+            update_interval=FALLBACK_UPDATE_INTERVAL,
         )
 
     async def _async_update_data(self) -> GitHubResponseModel[dict[str, Any]]:
@@ -136,3 +139,26 @@ class GitHubDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             self._last_response = response
             return response.data["data"]["repository"]
+
+    async def _handle_event(self, event: GitHubEventModel) -> None:
+        """Handle an event."""
+        if event.type in REFRESH_EVENT_TYPES:
+            await self.async_request_refresh()
+
+    @staticmethod
+    async def _handle_error(error: GitHubException) -> None:
+        """Handle an error."""
+        LOGGER.error("An error occurred while processing new event - %s", error)
+
+    async def subscribe(self) -> None:
+        """Subscribe to repository events."""
+        self._subscription_id = await self._client.repos.events.subscribe(
+            self.repository,
+            event_callback=self._handle_event,
+            error_callback=self._handle_error,
+        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.unsubscribe)
+
+    def unsubscribe(self, *args) -> None:
+        """Unsubscribe to repository events."""
+        self._client.repos.events.unsubscribe(subscription_id=self._subscription_id)

--- a/homeassistant/components/github/coordinator.py
+++ b/homeassistant/components/github/coordinator.py
@@ -148,7 +148,7 @@ class GitHubDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @staticmethod
     async def _handle_error(error: GitHubException) -> None:
         """Handle an error."""
-        LOGGER.error("An error occurred while processing new event - %s", error)
+        LOGGER.error("An error occurred while processing new events - %s", error)
 
     async def subscribe(self) -> None:
         """Subscribe to repository events."""

--- a/tests/components/github/common.py
+++ b/tests/components/github/common.py
@@ -31,6 +31,11 @@ async def setup_github_integration(
             },
             headers=headers,
         )
+        aioclient_mock.get(
+            f"https://api.github.com/repos/{repository}/events",
+            json=[],
+            headers=headers,
+        )
     aioclient_mock.post(
         "https://api.github.com/graphql",
         json=json.loads(load_fixture("graphql.json", DOMAIN)),

--- a/tests/components/github/test_sensor.py
+++ b/tests/components/github/test_sensor.py
@@ -1,9 +1,11 @@
 """Test GitHub sensor."""
 import json
 
-from homeassistant.components.github.const import DEFAULT_UPDATE_INTERVAL, DOMAIN
+from homeassistant.components.github.const import DOMAIN, FALLBACK_UPDATE_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt
+
+from .common import TEST_REPOSITORY
 
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -22,15 +24,21 @@ async def test_sensor_updates_with_empty_release_array(
 
     response_json = json.loads(load_fixture("graphql.json", DOMAIN))
     response_json["data"]["repository"]["release"] = None
+    headers = json.loads(load_fixture("base_headers.json", DOMAIN))
 
     aioclient_mock.clear_requests()
+    aioclient_mock.get(
+        f"https://api.github.com/repos/{TEST_REPOSITORY}/events",
+        json=[],
+        headers=headers,
+    )
     aioclient_mock.post(
         "https://api.github.com/graphql",
         json=response_json,
-        headers=json.loads(load_fixture("base_headers.json", DOMAIN)),
+        headers=headers,
     )
 
-    async_fire_time_changed(hass, dt.utcnow() + DEFAULT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt.utcnow() + FALLBACK_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     new_state = hass.states.get(TEST_SENSOR_ENTITY)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Subscribe to repository events and refresh when needed.
- The update interval has been changed from 5min to 1,5h as a fallback.

```
2022-02-26 10:27:35 DEBUG (MainThread) [homeassistant.components.github] Finished fetching github data in 0.519 seconds (success: True)
2022-02-26 10:27:35 DEBUG (MainThread) [aiogithubapi] Starting event subscription for github.com/home-assistant/core
2022-02-26 10:29:37 DEBUG (MainThread) [aiogithubapi] New PullRequestEvent for home-assistant/core
2022-02-26 10:29:37 DEBUG (MainThread) [homeassistant.components.github] Finished fetching github data in 0.544 seconds (success: True)
2022-02-26 10:29:37 DEBUG (MainThread) [aiogithubapi] New IssueCommentEvent for home-assistant/core
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
