### PR TITLE
Add codeowner to internal integrations that are without

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,6 +33,8 @@ homeassistant/components/advantage_air/* @Bre77
 tests/components/advantage_air/* @Bre77
 homeassistant/components/agent_dvr/* @ispysoftware
 tests/components/agent_dvr/* @ispysoftware
+homeassistant/components/air_quality/* @home-assistant/core
+tests/components/air_quality/* @home-assistant/core
 homeassistant/components/airly/* @bieniu
 tests/components/airly/* @bieniu
 homeassistant/components/airnow/* @asymworks
@@ -43,6 +45,10 @@ homeassistant/components/airtouch4/* @LonePurpleWolf
 tests/components/airtouch4/* @LonePurpleWolf
 homeassistant/components/airvisual/* @bachya
 tests/components/airvisual/* @bachya
+homeassistant/components/alarm_control_panel/* @home-assistant/core
+tests/components/alarm_control_panel/* @home-assistant/core
+homeassistant/components/alert/* @home-assistant/core
+tests/components/alert/* @home-assistant/core
 homeassistant/components/alexa/* @home-assistant/cloud @ochlocracy
 tests/components/alexa/* @home-assistant/cloud @ochlocracy
 homeassistant/components/almond/* @gcampax @balloob
@@ -108,6 +114,8 @@ homeassistant/components/azure_service_bus/* @hfurubotten
 homeassistant/components/balboa/* @garbled1
 tests/components/balboa/* @garbled1
 homeassistant/components/beewi_smartclim/* @alemuro
+homeassistant/components/binary_sensor/* @home-assistant/core
+tests/components/binary_sensor/* @home-assistant/core
 homeassistant/components/bitcoin/* @fabaff
 homeassistant/components/bizkaibus/* @UgaitzEtxebarria
 homeassistant/components/blebox/* @bbx-a @bbx-jp
@@ -139,6 +147,10 @@ homeassistant/components/buienradar/* @mjj4791 @ties @Robbie1221
 tests/components/buienradar/* @mjj4791 @ties @Robbie1221
 homeassistant/components/button/* @home-assistant/core
 tests/components/button/* @home-assistant/core
+homeassistant/components/calendar/* @home-assistant/core
+tests/components/calendar/* @home-assistant/core
+homeassistant/components/camera/* @home-assistant/core
+tests/components/camera/* @home-assistant/core
 homeassistant/components/cast/* @emontnemery
 tests/components/cast/* @emontnemery
 homeassistant/components/cert_expiry/* @Cereal2nd @jjlawren
@@ -149,6 +161,8 @@ homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/climacell/* @raman325
 tests/components/climacell/* @raman325
+homeassistant/components/climate/* @home-assistant/core
+tests/components/climate/* @home-assistant/core
 homeassistant/components/cloud/* @home-assistant/cloud
 tests/components/cloud/* @home-assistant/cloud
 homeassistant/components/cloudflare/* @ludeeus @ctalkington
@@ -190,6 +204,8 @@ homeassistant/components/debugpy/* @frenck
 tests/components/debugpy/* @frenck
 homeassistant/components/deconz/* @Kane610
 tests/components/deconz/* @Kane610
+homeassistant/components/default_config/* @home-assistant/core
+tests/components/default_config/* @home-assistant/core
 homeassistant/components/delijn/* @bollewolle @Emilv2
 homeassistant/components/demo/* @home-assistant/core
 tests/components/demo/* @home-assistant/core
@@ -199,6 +215,8 @@ homeassistant/components/derivative/* @afaucogney
 tests/components/derivative/* @afaucogney
 homeassistant/components/device_automation/* @home-assistant/core
 tests/components/device_automation/* @home-assistant/core
+homeassistant/components/device_tracker/* @home-assistant/core
+tests/components/device_tracker/* @home-assistant/core
 homeassistant/components/devolo_home_control/* @2Fake @Shutgun
 tests/components/devolo_home_control/* @2Fake @Shutgun
 homeassistant/components/devolo_home_network/* @2Fake @Shutgun
@@ -211,6 +229,8 @@ homeassistant/components/diagnostics/* @home-assistant/core
 tests/components/diagnostics/* @home-assistant/core
 homeassistant/components/digital_ocean/* @fabaff
 homeassistant/components/discogs/* @thibmaek
+homeassistant/components/discovery/* @home-assistant/core
+tests/components/discovery/* @home-assistant/core
 homeassistant/components/dlna_dmr/* @StevenLooman @chishm
 tests/components/dlna_dmr/* @StevenLooman @chishm
 homeassistant/components/dlna_dms/* @chishm
@@ -278,6 +298,8 @@ homeassistant/components/ezviz/* @RenierM26 @baqs
 tests/components/ezviz/* @RenierM26 @baqs
 homeassistant/components/faa_delays/* @ntilley905
 tests/components/faa_delays/* @ntilley905
+homeassistant/components/fan/* @home-assistant/core
+tests/components/fan/* @home-assistant/core
 homeassistant/components/fastdotcom/* @rohankapoorcom
 homeassistant/components/file/* @fabaff
 tests/components/file/* @fabaff
@@ -333,6 +355,8 @@ tests/components/generic_hygrostat/* @Shulyaka
 homeassistant/components/geniushub/* @zxdavb
 homeassistant/components/geo_json_events/* @exxamalte
 tests/components/geo_json_events/* @exxamalte
+homeassistant/components/geo_location/* @home-assistant/core
+tests/components/geo_location/* @home-assistant/core
 homeassistant/components/geo_rss_events/* @exxamalte
 tests/components/geo_rss_events/* @exxamalte
 homeassistant/components/geonetnz_quakes/* @exxamalte
@@ -435,6 +459,8 @@ homeassistant/components/ign_sismologia/* @exxamalte
 tests/components/ign_sismologia/* @exxamalte
 homeassistant/components/image/* @home-assistant/core
 tests/components/image/* @home-assistant/core
+homeassistant/components/image_processing/* @home-assistant/core
+tests/components/image_processing/* @home-assistant/core
 homeassistant/components/incomfort/* @zxdavb
 homeassistant/components/influxdb/* @fabaff @mdegat01
 tests/components/influxdb/* @fabaff @mdegat01
@@ -512,6 +538,8 @@ homeassistant/components/lcn/* @alengwenus
 tests/components/lcn/* @alengwenus
 homeassistant/components/lg_netcast/* @Drafteed
 homeassistant/components/life360/* @pnbruckner
+homeassistant/components/light/* @home-assistant/core
+tests/components/light/* @home-assistant/core
 homeassistant/components/linux_battery/* @fabaff
 homeassistant/components/litejet/* @joncar
 tests/components/litejet/* @joncar
@@ -519,6 +547,10 @@ homeassistant/components/litterrobot/* @natekspencer
 tests/components/litterrobot/* @natekspencer
 homeassistant/components/local_ip/* @issacg
 tests/components/local_ip/* @issacg
+homeassistant/components/lock/* @home-assistant/core
+tests/components/lock/* @home-assistant/core
+homeassistant/components/logbook/* @home-assistant/core
+tests/components/logbook/* @home-assistant/core
 homeassistant/components/logger/* @home-assistant/core
 tests/components/logger/* @home-assistant/core
 homeassistant/components/logi_circle/* @evanjd
@@ -540,6 +572,9 @@ homeassistant/components/mastodon/* @fabaff
 homeassistant/components/matrix/* @tinloaf
 homeassistant/components/mazda/* @bdr99
 tests/components/mazda/* @bdr99
+homeassistant/components/mcp23017/* @jardiamj
+homeassistant/components/media_player/* @home-assistant/core
+tests/components/media_player/* @home-assistant/core
 homeassistant/components/media_source/* @hunterjm
 tests/components/media_source/* @hunterjm
 homeassistant/components/mediaroom/* @dgomes
@@ -618,6 +653,8 @@ tests/components/netatmo/* @cgtobi
 homeassistant/components/netdata/* @fabaff
 homeassistant/components/netgear/* @hacf-fr @Quentame @starkillerOG
 tests/components/netgear/* @hacf-fr @Quentame @starkillerOG
+homeassistant/components/network/* @home-assistant/core
+tests/components/network/* @home-assistant/core
 homeassistant/components/nexia/* @bdraco
 tests/components/nexia/* @bdraco
 homeassistant/components/nextbus/* @vividboarder
@@ -773,6 +810,8 @@ tests/components/recollect_waste/* @bachya
 homeassistant/components/recorder/* @home-assistant/core
 tests/components/recorder/* @home-assistant/core
 homeassistant/components/rejseplanen/* @DarkFox
+homeassistant/components/remote/* @home-assistant/core
+tests/components/remote/* @home-assistant/core
 homeassistant/components/renault/* @epenet
 tests/components/renault/* @epenet
 homeassistant/components/repetier/* @MTrab @ShadowBr0ther
@@ -798,6 +837,8 @@ homeassistant/components/roon/* @pavoni
 tests/components/roon/* @pavoni
 homeassistant/components/rpi_power/* @shenxn @swetoast
 tests/components/rpi_power/* @shenxn @swetoast
+homeassistant/components/rss_feed_template/* @home-assistant/core
+tests/components/rss_feed_template/* @home-assistant/core
 homeassistant/components/rtsp_to_webrtc/* @allenporter
 tests/components/rtsp_to_webrtc/* @allenporter
 homeassistant/components/ruckus_unleashed/* @gabe565
@@ -826,6 +867,8 @@ homeassistant/components/senseme/* @mikelawrence @bdraco
 tests/components/senseme/* @mikelawrence @bdraco
 homeassistant/components/sensibo/* @andrey-git @gjohansson-ST
 tests/components/sensibo/* @andrey-git @gjohansson-ST
+homeassistant/components/sensor/* @home-assistant/core
+tests/components/sensor/* @home-assistant/core
 homeassistant/components/sentry/* @dcramer @frenck
 tests/components/sentry/* @dcramer @frenck
 homeassistant/components/serial/* @fabaff
@@ -929,6 +972,8 @@ homeassistant/components/surepetcare/* @benleb @danielhiversen
 tests/components/surepetcare/* @benleb @danielhiversen
 homeassistant/components/swiss_hydrological_data/* @fabaff
 homeassistant/components/swiss_public_transport/* @fabaff
+homeassistant/components/switch/* @home-assistant/core
+tests/components/switch/* @home-assistant/core
 homeassistant/components/switchbot/* @danielhiversen @RenierM26
 tests/components/switchbot/* @danielhiversen @RenierM26
 homeassistant/components/switcher_kis/* @tomerfi @thecode
@@ -1020,6 +1065,8 @@ homeassistant/components/usgs_earthquakes_feed/* @exxamalte
 tests/components/usgs_earthquakes_feed/* @exxamalte
 homeassistant/components/utility_meter/* @dgomes
 tests/components/utility_meter/* @dgomes
+homeassistant/components/vacuum/* @home-assistant/core
+tests/components/vacuum/* @home-assistant/core
 homeassistant/components/vallox/* @andre-richter @slovdahl @viiru-
 tests/components/vallox/* @andre-richter @slovdahl @viiru-
 homeassistant/components/velbus/* @Cereal2nd @brefra
@@ -1054,6 +1101,8 @@ tests/components/wake_on_lan/* @ntilley905
 homeassistant/components/wallbox/* @hesselonline
 tests/components/wallbox/* @hesselonline
 homeassistant/components/waqi/* @andrey-git
+homeassistant/components/water_heater/* @home-assistant/core
+tests/components/water_heater/* @home-assistant/core
 homeassistant/components/watson_tts/* @rutkai
 homeassistant/components/watttime/* @bachya
 tests/components/watttime/* @bachya
@@ -1061,6 +1110,8 @@ homeassistant/components/waze_travel_time/* @eifinger
 tests/components/waze_travel_time/* @eifinger
 homeassistant/components/weather/* @fabaff
 tests/components/weather/* @fabaff
+homeassistant/components/webhook/* @home-assistant/core
+tests/components/webhook/* @home-assistant/core
 homeassistant/components/webostv/* @bendavid @thecode
 tests/components/webostv/* @bendavid @thecode
 homeassistant/components/websocket_api/* @home-assistant/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -572,7 +572,6 @@ homeassistant/components/mastodon/* @fabaff
 homeassistant/components/matrix/* @tinloaf
 homeassistant/components/mazda/* @bdr99
 tests/components/mazda/* @bdr99
-homeassistant/components/mcp23017/* @jardiamj
 homeassistant/components/media_player/* @home-assistant/core
 tests/components/media_player/* @home-assistant/core
 homeassistant/components/media_source/* @hunterjm

--- a/homeassistant/components/air_quality/manifest.json
+++ b/homeassistant/components/air_quality/manifest.json
@@ -2,6 +2,6 @@
   "domain": "air_quality",
   "name": "Air Quality",
   "documentation": "https://www.home-assistant.io/integrations/air_quality",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/alarm_control_panel/manifest.json
+++ b/homeassistant/components/alarm_control_panel/manifest.json
@@ -2,6 +2,6 @@
   "domain": "alarm_control_panel",
   "name": "Alarm Control Panel",
   "documentation": "https://www.home-assistant.io/integrations/alarm_control_panel",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/alert/manifest.json
+++ b/homeassistant/components/alert/manifest.json
@@ -3,7 +3,7 @@
   "name": "Alert",
   "documentation": "https://www.home-assistant.io/integrations/alert",
   "after_dependencies": ["notify"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal",
   "iot_class": "local_push"
 }

--- a/homeassistant/components/binary_sensor/manifest.json
+++ b/homeassistant/components/binary_sensor/manifest.json
@@ -2,6 +2,6 @@
   "domain": "binary_sensor",
   "name": "Binary Sensor",
   "documentation": "https://www.home-assistant.io/integrations/binary_sensor",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/calendar/manifest.json
+++ b/homeassistant/components/calendar/manifest.json
@@ -3,6 +3,6 @@
   "name": "Calendar",
   "documentation": "https://www.home-assistant.io/integrations/calendar",
   "dependencies": ["http"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/camera/manifest.json
+++ b/homeassistant/components/camera/manifest.json
@@ -5,6 +5,6 @@
   "dependencies": ["http"],
   "requirements": ["PyTurboJPEG==1.6.5"],
   "after_dependencies": ["media_player"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/climate/manifest.json
+++ b/homeassistant/components/climate/manifest.json
@@ -2,6 +2,6 @@
   "domain": "climate",
   "name": "Climate",
   "documentation": "https://www.home-assistant.io/integrations/climate",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -35,6 +35,6 @@
     "zeroconf",
     "zone"
   ],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",
   "dependencies": ["zone"],
   "after_dependencies": [],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/discovery/manifest.json
+++ b/homeassistant/components/discovery/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/discovery",
   "requirements": ["netdisco==3.0.0"],
   "after_dependencies": ["zeroconf"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal",
   "loggers": ["netdisco"]
 }

--- a/homeassistant/components/fan/manifest.json
+++ b/homeassistant/components/fan/manifest.json
@@ -2,6 +2,6 @@
   "domain": "fan",
   "name": "Fan",
   "documentation": "https://www.home-assistant.io/integrations/fan",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/geo_location/manifest.json
+++ b/homeassistant/components/geo_location/manifest.json
@@ -2,6 +2,6 @@
   "domain": "geo_location",
   "name": "Geolocation",
   "documentation": "https://www.home-assistant.io/integrations/geo_location",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/image_processing/manifest.json
+++ b/homeassistant/components/image_processing/manifest.json
@@ -3,6 +3,6 @@
   "name": "Image Processing",
   "documentation": "https://www.home-assistant.io/integrations/image_processing",
   "dependencies": ["camera"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/light/manifest.json
+++ b/homeassistant/components/light/manifest.json
@@ -2,6 +2,6 @@
   "domain": "light",
   "name": "Light",
   "documentation": "https://www.home-assistant.io/integrations/light",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/lock/manifest.json
+++ b/homeassistant/components/lock/manifest.json
@@ -2,6 +2,6 @@
   "domain": "lock",
   "name": "Lock",
   "documentation": "https://www.home-assistant.io/integrations/lock",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/logbook/manifest.json
+++ b/homeassistant/components/logbook/manifest.json
@@ -3,6 +3,6 @@
   "name": "Logbook",
   "documentation": "https://www.home-assistant.io/integrations/logbook",
   "dependencies": ["frontend", "http", "recorder"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/media_player/manifest.json
+++ b/homeassistant/components/media_player/manifest.json
@@ -3,6 +3,6 @@
   "name": "Media Player",
   "documentation": "https://www.home-assistant.io/integrations/media_player",
   "dependencies": ["http"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -253,6 +253,7 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_STATE_CLASS): SENSOR_STATE_CLASSES_SCHEMA,
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+            vol.Optional(CONF_SLAVE_COUNT, default=0): cv.positive_int,
         }
     ),
 )

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -253,7 +253,6 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_STATE_CLASS): SENSOR_STATE_CLASSES_SCHEMA,
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-            vol.Optional(CONF_SLAVE_COUNT, default=0): cv.positive_int,
         }
     ),
 )

--- a/homeassistant/components/network/manifest.json
+++ b/homeassistant/components/network/manifest.json
@@ -3,7 +3,7 @@
   "name": "Network Configuration",
   "documentation": "https://www.home-assistant.io/integrations/network",
   "requirements": ["ifaddr==0.1.7"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "dependencies": ["websocket_api"],
   "quality_scale": "internal",
   "iot_class": "local_push"

--- a/homeassistant/components/remote/manifest.json
+++ b/homeassistant/components/remote/manifest.json
@@ -2,6 +2,6 @@
   "domain": "remote",
   "name": "Remote",
   "documentation": "https://www.home-assistant.io/integrations/remote",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/rss_feed_template/manifest.json
+++ b/homeassistant/components/rss_feed_template/manifest.json
@@ -3,7 +3,7 @@
   "name": "RSS Feed Template",
   "documentation": "https://www.home-assistant.io/integrations/rss_feed_template",
   "dependencies": ["http"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal",
   "iot_class": "local_push"
 }

--- a/homeassistant/components/sensor/manifest.json
+++ b/homeassistant/components/sensor/manifest.json
@@ -2,7 +2,7 @@
   "domain": "sensor",
   "name": "Sensor",
   "documentation": "https://www.home-assistant.io/integrations/sensor",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal",
   "after_dependencies": ["recorder"]
 }

--- a/homeassistant/components/switch/manifest.json
+++ b/homeassistant/components/switch/manifest.json
@@ -2,6 +2,6 @@
   "domain": "switch",
   "name": "Switch",
   "documentation": "https://www.home-assistant.io/integrations/switch",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/vacuum/manifest.json
+++ b/homeassistant/components/vacuum/manifest.json
@@ -2,6 +2,6 @@
   "domain": "vacuum",
   "name": "Vacuum",
   "documentation": "https://www.home-assistant.io/integrations/vacuum",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/water_heater/manifest.json
+++ b/homeassistant/components/water_heater/manifest.json
@@ -2,6 +2,6 @@
   "domain": "water_heater",
   "name": "Water Heater",
   "documentation": "https://www.home-assistant.io/integrations/water_heater",
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }

--- a/homeassistant/components/webhook/manifest.json
+++ b/homeassistant/components/webhook/manifest.json
@@ -3,6 +3,6 @@
   "name": "Webhook",
   "documentation": "https://www.home-assistant.io/integrations/webhook",
   "dependencies": ["http"],
-  "codeowners": [],
+  "codeowners": ["@home-assistant/core"],
   "quality_scale": "internal"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add codeowner core to internal integrations that are component entities. Some internal integrations had a codeowner some did not, this is correct according to:
https://github.com/home-assistant/architecture/blob/master/adr/0008-code-owners.md
Exceptions
  In the following cases, code ownership may be omitted:
  Contributions to integrations marked as "internal". These integrations are code owned by the Home Assistant core team.

But as adr-8 states "may be omitted" so it is also correct to add a codeowner.

Not having a codeowner signals in general that the integration is not maintained (apart for this one special case) so we send a wrong signal to people looking at the integrations without being aware of adr-8.

Furthermore not having a codeowner means there are no notifications or assignments for issues, PR etc.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I am currently working on a suggestion for integrations without code owners, that makes users aware of the missing maintenance, and asking them politely to think about maintaining the integration (first step is an architecture discussion).


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
