### PR TITLE
Fix dhcp None hostname

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -159,7 +159,7 @@ class WatcherBase:
     async def async_start(self):
         """Start the watcher."""
 
-    def process_client(self, ip_address, hostname, mac_address):
+    def process_client(self, ip_address: str, hostname: str, mac_address: str) -> None:
         """Process a client."""
         return run_callback_threadsafe(
             self.hass.loop,
@@ -170,7 +170,9 @@ class WatcherBase:
         ).result()
 
     @callback
-    def async_process_client(self, ip_address, hostname, mac_address):
+    def async_process_client(
+        self, ip_address: str, hostname: str, mac_address: str
+    ) -> None:
         """Process a client."""
         made_ip_address = make_ip_address(ip_address)
 
@@ -355,15 +357,15 @@ class DeviceTrackerRegisteredWatcher(WatcherBase):
     async def async_start(self):
         """Stop watching for device tracker registrations."""
         self._unsub = async_dispatcher_connect(
-            self.hass, CONNECTED_DEVICE_REGISTERED, self._async_process_device_state
+            self.hass, CONNECTED_DEVICE_REGISTERED, self._async_process_device_data
         )
 
     @callback
-    def _async_process_device_state(self, data: dict[str, Any]) -> None:
+    def _async_process_device_data(self, data: dict[str, str | None]) -> None:
         """Process a device tracker state."""
-        ip_address = data.get(ATTR_IP)
-        hostname = data.get(ATTR_HOST_NAME, "")
-        mac_address = data.get(ATTR_MAC)
+        ip_address = data[ATTR_IP]
+        hostname = data[ATTR_HOST_NAME] or ""
+        mac_address = data[ATTR_MAC]
 
         if ip_address is None or mac_address is None:
             return

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -663,6 +663,28 @@ async def test_device_tracker_registered(hass):
     await hass.async_block_till_done()
 
 
+async def test_device_tracker_registered_hostname_none(hass):
+    """Test handle None hostname."""
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
+        device_tracker_watcher = dhcp.DeviceTrackerRegisteredWatcher(
+            hass,
+            {},
+            [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
+        )
+        await device_tracker_watcher.async_start()
+        await hass.async_block_till_done()
+        async_dispatcher_send(
+            hass,
+            CONNECTED_DEVICE_REGISTERED,
+            {"ip": "192.168.210.56", "mac": "b8b7f16db533", "host_name": None},
+        )
+        await hass.async_block_till_done()
+
+    assert len(mock_init.mock_calls) == 0
+    await device_tracker_watcher.async_stop()
+    await hass.async_block_till_done()
+
+
 async def test_device_tracker_hostname_and_macaddress_after_start(hass):
     """Test matching based on hostname and macaddress after start."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Make sure that dhcp handles hostname set to None dispatched from the device tracker integration.
- Fixes this:

```
2022-02-26 13:28:19 ERROR (MainThread) [homeassistant.util.logging] Exception in _async_process_device_state when dispatching 'device_tracker_connected_device_registered': ({'ip': '192.168.1.31', 'mac': '42:1b:cc:f8:0e:69', 'host_name': None},)
Traceback (most recent call last):
  File "/home/martin/dev/home-assistant/core/homeassistant/components/dhcp/__init__.py", line 376, in _async_process_device_state
    self.async_process_client(ip_address, hostname, _format_mac(mac_address))
  File "/home/martin/dev/home-assistant/core/homeassistant/components/dhcp/__init__.py", line 203, in async_process_client
    lowercase_hostname = data[HOSTNAME].lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
