### PR TITLE
Simplify google calendar authentication setup

### DIFF
--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -1,11 +1,17 @@
 """Test configuration and mocks for the google integration."""
+from __future__ import annotations
+
 from collections.abc import Callable
+import datetime
 from typing import Any, Generator, TypeVar
 from unittest.mock import Mock, patch
 
+from oauth2client.client import Credentials, OAuth2Credentials
 import pytest
 
 from homeassistant.components.google import GoogleCalendarService
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
 
 ApiResult = Callable[[dict[str, Any]], None]
 T = TypeVar("T")
@@ -34,6 +40,62 @@ TEST_CALENDAR = {
 def test_calendar():
     """Return a test calendar."""
     return TEST_CALENDAR
+
+
+class FakeStorage:
+    """A fake storage object for persiting creds."""
+
+    def __init__(self) -> None:
+        """Initialize FakeStorage."""
+        self._creds: Credentials | None = None
+
+    def get(self) -> Credentials | None:
+        """Get credentials from storage."""
+        return self._creds
+
+    def put(self, creds: Credentials) -> None:
+        """Put credentials in storage."""
+        self._creds = creds
+
+
+@pytest.fixture
+async def token_scopes() -> list[str]:
+    """Fixture for scopes used during test."""
+    return ["https://www.googleapis.com/auth/calendar"]
+
+
+@pytest.fixture
+async def creds(token_scopes: list[str]) -> OAuth2Credentials:
+    """Fixture that defines creds used in the test."""
+    token_expiry = utcnow() + datetime.timedelta(days=7)
+    return OAuth2Credentials(
+        access_token="ACCESS_TOKEN",
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_token="REFRESH_TOKEN",
+        token_expiry=token_expiry,
+        token_uri="http://example.com",
+        user_agent="n/a",
+        scopes=token_scopes,
+    )
+
+
+@pytest.fixture(autouse=True)
+async def storage() -> YieldFixture[FakeStorage]:
+    """Fixture to populate an existing token file for read on startup."""
+    storage = FakeStorage()
+    with patch("homeassistant.components.google.Storage", return_value=storage):
+        yield storage
+
+
+@pytest.fixture
+async def mock_token_read(
+    hass: HomeAssistant,
+    creds: OAuth2Credentials,
+    storage: FakeStorage,
+) -> None:
+    """Fixture to populate an existing token file for read on startup."""
+    storage.put(creds)
 
 
 @pytest.fixture

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -21,7 +21,6 @@ from homeassistant.components.google import (
     CONF_TRACK,
     DEVICE_SCHEMA,
     SERVICE_SCAN_CALENDARS,
-    do_setup,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.template import DATE_STR_FORMAT
@@ -86,21 +85,18 @@ def get_calendar_info(calendar):
 
 
 @pytest.fixture(autouse=True)
-def mock_google_setup(hass, test_calendar):
+def mock_google_setup(hass, test_calendar, mock_token_read):
     """Mock the google set up functions."""
     hass.loop.run_until_complete(async_setup_component(hass, "group", {"group": {}}))
     calendar = get_calendar_info(test_calendar)
     calendars = {calendar[CONF_CAL_ID]: calendar}
-    patch_google_auth = patch(
-        "homeassistant.components.google.do_authentication", side_effect=do_setup
-    )
     patch_google_load = patch(
         "homeassistant.components.google.load_config", return_value=calendars
     )
     patch_google_services = patch("homeassistant.components.google.setup_services")
     async_mock_service(hass, "google", SERVICE_SCAN_CALENDARS)
 
-    with patch_google_auth, patch_google_load, patch_google_services:
+    with patch_google_load, patch_google_services:
         yield
 
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -54,53 +54,12 @@ async def mock_code_flow(
 
 
 @pytest.fixture
-async def token_scopes() -> list[str]:
-    """Fixture for scopes used during test."""
-    return ["https://www.googleapis.com/auth/calendar"]
-
-
-@pytest.fixture
-async def creds(token_scopes: list[str]) -> OAuth2Credentials:
-    """Fixture that defines creds used in the test."""
-    token_expiry = utcnow() + datetime.timedelta(days=7)
-    return OAuth2Credentials(
-        access_token="ACCESS_TOKEN",
-        client_id="client-id",
-        client_secret="client-secret",
-        refresh_token="REFRESH_TOKEN",
-        token_expiry=token_expiry,
-        token_uri="http://example.com",
-        user_agent="n/a",
-        scopes=token_scopes,
-    )
-
-
-@pytest.fixture
 async def mock_exchange(creds: OAuth2Credentials) -> YieldFixture[Mock]:
     """Fixture for mocking out the exchange for credentials."""
     with patch(
         "oauth2client.client.OAuth2WebServerFlow.step2_exchange", return_value=creds
     ) as mock:
         yield mock
-
-
-@pytest.fixture(autouse=True)
-async def mock_token_write(hass: HomeAssistant) -> None:
-    """Fixture to avoid writing token files to disk."""
-    with patch(
-        "homeassistant.components.google.os.path.isfile", return_value=True
-    ), patch("homeassistant.components.google.Storage.put"):
-        yield
-
-
-@pytest.fixture
-async def mock_token_read(
-    hass: HomeAssistant,
-    creds: OAuth2Credentials,
-) -> None:
-    """Fixture to populate an existing token file."""
-    with patch("homeassistant.components.google.Storage.get", return_value=creds):
-        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify google calendar authentication to combine some of the cases together, and reduce unecessarily checks. Make the
tests share common authentication setup and reduce use of mocks by introducing a fake for holding on to credentials.
This makes future refactoring simpler, so we don't have to care as much about the interactions with the credentials
storage.

The change was tested manually with and without an existing token file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
