### PR TITLE
Rfxtrx: Always create device entries for seen devices (RFC)

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -167,7 +167,6 @@ async def async_setup_internal(hass, entry: ConfigEntry):
 
     # Setup some per device config
     devices = _get_device_lookup(config[CONF_DEVICES])
-    pt2262_devices: list[str] = []
 
     device_registry = dr.async_get(hass)
 
@@ -198,10 +197,6 @@ async def async_setup_internal(hass, entry: ConfigEntry):
                 _add_device(event, device_id)
             else:
                 return
-
-        if event.device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
-            find_possible_pt2262_device(pt2262_devices, event.device.id_string)
-            pt2262_devices.append(event.device.id_string)
 
         device_entry = device_registry.async_get_device(
             identifiers={(DOMAIN, *device_id)},
@@ -384,33 +379,6 @@ def get_device_data_bits(
                 data_bits = bits
                 break
     return data_bits
-
-
-def find_possible_pt2262_device(device_ids: list[str], device_id: str) -> str | None:
-    """Look for the device which id matches the given device_id parameter."""
-    for dev_id in device_ids:
-        if len(dev_id) == len(device_id):
-            size = None
-            for i, (char1, char2) in enumerate(zip(dev_id, device_id)):
-                if char1 != char2:
-                    break
-                size = i
-            if size is not None:
-                size = len(dev_id) - size - 1
-                _LOGGER.info(
-                    "Found possible device %s for %s "
-                    "with the following configuration:\n"
-                    "data_bits=%d\n"
-                    "command_on=0x%s\n"
-                    "command_off=0x%s\n",
-                    device_id,
-                    dev_id,
-                    size * 4,
-                    dev_id[-size:],
-                    device_id[-size:],
-                )
-                return dev_id
-    return None
 
 
 def get_device_id(

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -175,22 +175,25 @@ async def async_setup_internal(hass, entry: ConfigEntry):
     def async_handle_receive(event):
         """Handle received messages from RFXtrx gateway."""
         # Log RFXCOM event
-        if not event.device.id_string:
+        device: rfxtrxmod.RFXtrxDevice = event.device
+        if not device.id_string:
             return
 
+        event_code = binascii.hexlify(event.data).decode("ASCII")
+
         event_data = {
-            "packet_type": event.device.packettype,
-            "sub_type": event.device.subtype,
-            "type_string": event.device.type_string,
-            "id_string": event.device.id_string,
-            "data": binascii.hexlify(event.data).decode("ASCII"),
+            "packet_type": device.packettype,
+            "sub_type": device.subtype,
+            "type_string": device.type_string,
+            "id_string": device.id_string,
+            "data": event_code,
             "values": getattr(event, "values", None),
         }
 
         _LOGGER.debug("Receive RFXCOM event: %s", event_data)
 
-        data_bits = get_device_data_bits(event.device, devices)
-        device_id = get_device_id(event.device, data_bits=data_bits)
+        data_bits = get_device_data_bits(device, devices)
+        device_id = get_device_id(device, data_bits=data_bits)
 
         if device_id not in devices:
             if config[CONF_AUTOMATIC_ADD]:

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import asyncio
 import binascii
 from collections.abc import Callable
-import copy
 import logging
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple, cast
 
 import RFXtrx as rfxtrxmod
 import async_timeout
@@ -25,6 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryDisabler
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -36,7 +36,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .const import (
     ATTR_EVENT,
     COMMAND_GROUP_LIST,
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_PROTOCOLS,
     DATA_RFXOBJECT,
@@ -49,6 +48,7 @@ from .const import (
 DEFAULT_OFF_DELAY = 2.0
 
 SIGNAL_EVENT = f"{DOMAIN}_event"
+SIGNAL_ADDED = f"{DOMAIN}_added"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -179,7 +179,22 @@ async def async_setup_internal(hass, entry: ConfigEntry):
         if not device.id_string:
             return
 
+        data_bits = get_device_data_bits(device, devices)
+        device_id = get_device_id(device, data_bits=data_bits)
         event_code = binascii.hexlify(event.data).decode("ASCII")
+        model = device.type_string
+        name = f"{device.type_string} {device.id_string}"
+
+        if device_id not in devices:
+            entity_config = _add_device(event_code, device_id)
+            async_dispatcher_send(hass, SIGNAL_ADDED, event, device_id, entity_config)
+
+        device_entry = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, *device_id)},
+            model=model,
+            name=name,
+        )
 
         event_data = {
             "packet_type": device.packettype,
@@ -188,51 +203,32 @@ async def async_setup_internal(hass, entry: ConfigEntry):
             "id_string": device.id_string,
             "data": event_code,
             "values": getattr(event, "values", None),
+            ATTR_DEVICE_ID: device_entry.id,
         }
 
         _LOGGER.debug("Receive RFXCOM event: %s", event_data)
 
-        data_bits = get_device_data_bits(device, devices)
-        device_id = get_device_id(device, data_bits=data_bits)
-
-        if device_id not in devices:
-            if config[CONF_AUTOMATIC_ADD]:
-                _add_device(event, device_id)
-            else:
-                return
-
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, *device_id)},
-        )
-        if device_entry:
-            event_data[ATTR_DEVICE_ID] = device_entry.id
-
-        # Callback to HA registered components.
-        async_dispatcher_send(hass, SIGNAL_EVENT, event, device_id)
-
         # Signal event to any other listeners
-        hass.bus.async_fire(EVENT_RFXTRX_EVENT, event_data)
+        if not device_entry.disabled:
+            async_dispatcher_send(hass, SIGNAL_EVENT, event, device_id)
+            hass.bus.async_fire(EVENT_RFXTRX_EVENT, event_data)
 
-    @callback
-    def _add_device(event, device_id):
+    def _add_device(event_code: str, device_id: DeviceTuple) -> dict[str, Any]:
         """Add a device to config entry."""
-        config = {}
-        config[CONF_DEVICE_ID] = device_id
+        entity_config = {CONF_DEVICE_ID: list(device_id)}
 
-        _LOGGER.info(
-            "Added device (Device ID: %s Class: %s Sub: %s, Event: %s)",
-            event.device.id_string.lower(),
-            event.device.__class__.__name__,
-            event.device.subtype,
-            "".join(f"{x:02x}" for x in event.data),
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, *device_id)},  # type: ignore[arg-type]
+            disabled_by=DeviceEntryDisabler.INTEGRATION,
         )
-
-        data = entry.data.copy()
-        data[CONF_DEVICES] = copy.deepcopy(entry.data[CONF_DEVICES])
-        event_code = binascii.hexlify(event.data).decode("ASCII")
-        data[CONF_DEVICES][event_code] = config
+        data = {
+            **entry.data,
+            CONF_DEVICES: {**entry.data[CONF_DEVICES], event_code: entity_config},
+        }
         hass.config_entries.async_update_entry(entry=entry, data=data)
-        devices[device_id] = config
+        devices[device_id] = entity_config
+        return entity_config
 
     @callback
     def _remove_device(device_id: DeviceTuple):
@@ -292,7 +288,6 @@ async def async_setup_platform_entry(
 ):
     """Set up config entry."""
     entry_data = config_entry.data
-    device_ids: set[DeviceTuple] = set()
 
     # Add entities from config
     entities = []
@@ -306,31 +301,22 @@ async def async_setup_platform_entry(
         device_id = get_device_id(
             event.device, data_bits=entity_info.get(CONF_DATA_BITS)
         )
-        if device_id in device_ids:
-            continue
-        device_ids.add(device_id)
-
         entities.extend(constructor(event, None, device_id, entity_info))
 
     async_add_entities(entities)
 
-    # If automatic add is on, hookup listener
-    if entry_data[CONF_AUTOMATIC_ADD]:
+    @callback
+    def _added(
+        event: rfxtrxmod.RFXtrxEvent, device_tuple: DeviceTuple, entity_info: dict
+    ):
+        """Handle light updates from the RFXtrx gateway."""
+        if not supported(event):
+            return
+        async_add_entities(constructor(event, event, device_tuple, entity_info))
 
-        @callback
-        def _update(event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple):
-            """Handle light updates from the RFXtrx gateway."""
-            if not supported(event):
-                return
-
-            if device_id in device_ids:
-                return
-            device_ids.add(device_id)
-            async_add_entities(constructor(event, event, device_id, {}))
-
-        config_entry.async_on_unload(
-            async_dispatcher_connect(hass, SIGNAL_EVENT, _update)
-        )
+    config_entry.async_on_unload(
+        hass.helpers.dispatcher.async_dispatcher_connect(SIGNAL_ADDED, _added)
+    )
 
 
 def get_rfx_object(packetid: str) -> rfxtrxmod.RFXtrxEvent | None:
@@ -487,8 +473,6 @@ class RfxtrxEntity(RestoreEntity):
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, *self._device_id)},
-            model=self._device.type_string,
-            name=f"{self._device.type_string} {self._device.id_string}",
         )
 
     def _event_applies(self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple):

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -39,7 +39,6 @@ from . import (
 )
 from .binary_sensor import supported as binary_supported
 from .const import (
-    CONF_AUTOMATIC_ADD,
     CONF_DATA_BITS,
     CONF_OFF_DELAY,
     CONF_PROTOCOLS,
@@ -96,7 +95,6 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         if user_input is not None:
             self._global_options = {
-                CONF_AUTOMATIC_ADD: user_input[CONF_AUTOMATIC_ADD],
                 CONF_PROTOCOLS: user_input[CONF_PROTOCOLS] or None,
             }
             if CONF_DEVICE in user_input:
@@ -143,10 +141,6 @@ class OptionsFlow(config_entries.OptionsFlow):
         }
 
         options = {
-            vol.Optional(
-                CONF_AUTOMATIC_ADD,
-                default=self._config_entry.data[CONF_AUTOMATIC_ADD],
-            ): bool,
             vol.Optional(
                 CONF_PROTOCOLS,
                 default=self._config_entry.data.get(CONF_PROTOCOLS) or [],
@@ -526,7 +520,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_HOST: host,
             CONF_PORT: port,
             CONF_DEVICE: device,
-            CONF_AUTOMATIC_ADD: False,
             CONF_DEVICES: {},
         }
         return data

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -1,7 +1,6 @@
 """Constants for RFXtrx integration."""
 
 CONF_DATA_BITS = "data_bits"
-CONF_AUTOMATIC_ADD = "automatic_add"
 CONF_OFF_DELAY = "off_delay"
 CONF_VENETIAN_BLIND_MODE = "venetian_blind_mode"
 CONF_PROTOCOLS = "protocols"

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -14,28 +14,36 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
-def create_rfx_test_cfg(
-    device="abcd", automatic_add=False, protocols=None, devices=None
-):
+def create_rfx_test_cfg(device="abcd", protocols=None, devices=None):
     """Create rfxtrx config entry data."""
     return {
         "device": device,
         "host": None,
         "port": None,
-        "automatic_add": automatic_add,
         "protocols": protocols,
         "debug": False,
         "devices": devices,
     }
 
 
+async def rfxtrx_mock_entry(hass, device="abcd", devices=None):
+    """Create a mock config entry and run setup."""
+    entry_data = create_rfx_test_cfg(device=device, devices=devices)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+    return mock_entry
+
+
 async def setup_rfx_test_cfg(
-    hass, device="abcd", automatic_add=False, devices: dict[str, dict] | None = None
+    hass, device="abcd", devices: dict[str, dict] | None = None
 ):
     """Construct a rfxtrx config entry."""
-    entry_data = create_rfx_test_cfg(
-        device=device, automatic_add=automatic_add, devices=devices
-    )
+    entry_data = create_rfx_test_cfg(device=device, devices=devices)
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
     mock_entry.supports_remove_device = True
     mock_entry.add_to_hass(hass)
@@ -72,7 +80,7 @@ async def rfxtrx_fixture(hass):
 @pytest.fixture(name="rfxtrx_automatic")
 async def rfxtrx_automatic_fixture(hass, rfxtrx):
     """Fixture that starts up with automatic additions."""
-    await setup_rfx_test_cfg(hass, automatic_add=True, devices={})
+    await setup_rfx_test_cfg(hass, devices={})
     yield rfxtrx
 
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -76,7 +76,6 @@ async def test_setup_network(transport_mock, hass):
         "host": "10.10.0.1",
         "port": 1234,
         "device": None,
-        "automatic_add": False,
         "devices": {},
     }
 
@@ -122,7 +121,6 @@ async def test_setup_serial(com_mock, connect_mock, hass):
         "host": None,
         "port": None,
         "device": port.device,
-        "automatic_add": False,
         "devices": {},
     }
 
@@ -174,7 +172,6 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass):
         "host": None,
         "port": None,
         "device": "/dev/ttyUSB0",
-        "automatic_add": False,
         "devices": {},
     }
 
@@ -297,7 +294,6 @@ async def test_options_global(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "protocols": None,
             "devices": {},
         },
@@ -311,14 +307,12 @@ async def test_options_global(hass):
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"automatic_add": True, "protocols": SOME_PROTOCOLS},
+        user_input={"protocols": SOME_PROTOCOLS},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert entry.data["automatic_add"]
 
     assert not set(entry.data["protocols"]) ^ set(SOME_PROTOCOLS)
 
@@ -332,7 +326,6 @@ async def test_no_protocols(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": True,
             "protocols": SOME_PROTOCOLS,
             "devices": {},
         },
@@ -346,14 +339,12 @@ async def test_no_protocols(hass):
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"automatic_add": False, "protocols": []},
+        user_input={"protocols": []},
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert not entry.data["automatic_add"]
 
     assert entry.data["protocols"] is None
 
@@ -367,7 +358,6 @@ async def test_options_add_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -380,7 +370,7 @@ async def test_options_add_device(hass):
     # Try with invalid event code
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"automatic_add": True, "event_code": "1234"},
+        user_input={"event_code": "1234"},
     )
 
     assert result["type"] == "form"
@@ -392,7 +382,6 @@ async def test_options_add_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
     )
@@ -407,8 +396,6 @@ async def test_options_add_device(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
     await hass.async_block_till_done()
-
-    assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
     assert "delay_off" not in entry.data["devices"]["0b1100cd0213c7f230010f71"]
@@ -429,7 +416,6 @@ async def test_options_add_duplicate_device(hass):
             "port": None,
             "device": "/dev/tty123",
             "debug": False,
-            "automatic_add": False,
             "devices": {"0b1100cd0213c7f230010f71": {}},
         },
         unique_id=DOMAIN,
@@ -444,7 +430,6 @@ async def test_options_add_duplicate_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0b1100cd0213c7f230010f71",
         },
     )
@@ -464,7 +449,6 @@ async def test_options_replace_sensor_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {
                 "0a520101f00400e22d0189": {"device_id": ["52", "1", "f0:04"]},
                 "0a520105230400c3260279": {"device_id": ["52", "1", "23:04"]},
@@ -543,7 +527,6 @@ async def test_options_replace_sensor_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": old_device,
         },
     )
@@ -621,7 +604,6 @@ async def test_options_replace_control_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {
                 "0b1100100118cdea02010f70": {
                     "device_id": ["11", "0", "118cdea:2"],
@@ -676,7 +658,6 @@ async def test_options_replace_control_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": old_device,
         },
     )
@@ -724,7 +705,6 @@ async def test_options_add_and_configure_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -737,7 +717,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "0913000022670e013970",
         },
     )
@@ -776,8 +755,6 @@ async def test_options_add_and_configure_device(hass):
 
     await hass.async_block_till_done()
 
-    assert entry.data["automatic_add"]
-
     assert entry.data["devices"]["0913000022670e013970"]
     assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
 
@@ -799,7 +776,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": device_entries[0].id,
         },
     )
@@ -833,7 +809,6 @@ async def test_options_configure_rfy_cover_device(hass):
             "host": None,
             "port": None,
             "device": "/dev/tty123",
-            "automatic_add": False,
             "devices": {},
         },
         unique_id=DOMAIN,
@@ -846,7 +821,6 @@ async def test_options_configure_rfy_cover_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": True,
             "event_code": "071a000001020301",
         },
     )
@@ -878,7 +852,6 @@ async def test_options_configure_rfy_cover_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "automatic_add": False,
             "device": device_entries[0].id,
         },
     )

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -22,7 +22,6 @@ async def test_fire_event(hass, rfxtrx):
     await setup_rfx_test_cfg(
         hass,
         device="/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0",
-        automatic_add=True,
         devices={
             "0b1100cd0213c7f210010f51": {},
             "0716000100900970": {},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Always create rfxtrx entities and devices. Create them in disabled state by default and use normal UI to enable the ones the user is interested in. This gives better knowledge over what devices are in proximity, without always loading all entities. It also reduces configuration needs in config flow.

Known Issues:
  * Somewhat harder to find a device if you are able to force it to trigger

Open Questions
 * Should we trigger a notification on a newly found device?
 * Can we visualize somehow the last time we "saw" a device without actually enabling the device?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
