### PR TITLE
Changed ISY994 FanLinc to use preset speed names

### DIFF
--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -9,12 +9,12 @@ from pyisy.constants import ISY_VALUE_UNKNOWN, PROTO_INSTEON
 
 from homeassistant.components.fan import (
     DOMAIN as FAN,
-    SUPPORT_SET_SPEED,
-    SUPPORT_PRESET_MODE,
-    SPEED_OFF,
+    SPEED_HIGH,
     SPEED_LOW,
     SPEED_MEDIUM,
-    SPEED_HIGH,
+    SPEED_OFF,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_SET_SPEED,
     FanEntity,
 )
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -1,9 +1,9 @@
 """Support for ISY994 fans."""
 from __future__ import annotations
 
+from collections import OrderedDict
 import math
 from typing import Any
-from collections import OrderedDict
 
 from pyisy.constants import ISY_VALUE_UNKNOWN, PROTO_INSTEON
 

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the ISY994 fan platform."""
     hass_isy_data = hass.data[ISY994_DOMAIN][entry.entry_id]
-    entities: list[ISYFanEntity | ISYFanProgramEntity] = []
+    entities: list[ISYFanLincEntity | ISYFanEntity | ISYFanProgramEntity] = []
 
     for node in hass_isy_data[ISY994_NODES][FAN]:
         if hasattr(node, "node_def_id") and node.node_def_id == "FanLincMotor":
@@ -100,7 +100,8 @@ class ISYFanLincEntity(ISYNodeEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Send the turn on command to the ISY994 fan device."""
-        await self.async_set_preset_mode(preset_mode)
+        if preset_mode:
+            await self.async_set_preset_mode(preset_mode)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY994 fan device."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The FanLinc device exposed will no longer use percentages but will now use named presets off, low, medium, and high. Any fan that is not a FanLinc and Fan programs (virtual fans) will continue to function as they did before.

## Proposed change
FanLinc devices are always 3 speed devices, low, medium, and high. This change looks at the type of fan being added and if it is a FanLinc is uses a different class. This was done to prevent spaghetti coding the fan class. ISY supports Insteon, Z-Wave, and Zigbee devices, and a virtual fan type using ISY programs. I do not have Z-Wave or Zigbee fans to see if this could apply to them so they will continue to use the existing fan class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I marked this as a breaking change because some UI components might need to be adjusted since it no longer uses percentages. Also if you are using something like Alexa, you'll need to start using the names instead of telling it to use a percentage.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
