### PR TITLE
Add device_info and entity_category to Vallox

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -321,32 +321,21 @@ class ValloxServiceHandler:
 class ValloxEntity(CoordinatorEntity[ValloxDataUpdateCoordinator]):
     """Representation of a Vallox entity."""
 
-    _device_config_url: str | None
-
     def __init__(self, name: str, coordinator: ValloxDataUpdateCoordinator) -> None:
         """Initialize a Vallox entity."""
         super().__init__(coordinator)
 
-        if self.coordinator.config_entry is not None:
-            self._device_config_url = (
-                f"http://{self.coordinator.config_entry.data[CONF_HOST]}"
-            )
-        else:
-            self._device_config_url = None
-
         self._device_uuid = self.coordinator.data.get_uuid()
-        self._device_model = self.coordinator.data.get_model()
-        self._device_name = name
-        self._device_sw_version = self.coordinator.data.get_sw_version()
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information of the entity."""
-        return DeviceInfo(
-            configuration_url=self._device_config_url,
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(self._device_uuid))},
             manufacturer=DEFAULT_NAME,
-            model=self._device_model,
-            name=self._device_name,
-            sw_version=self._device_sw_version,
+            model=self.coordinator.data.get_model(),
+            name=name,
+            sw_version=self.coordinator.data.get_sw_version(),
         )
+
+        if self.coordinator.config_entry is not None:
+            self._attr_device_info[
+                "configuration_url"
+            ] = f"http://{self.coordinator.config_entry.data[CONF_HOST]}"

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import date
 import ipaddress
 import logging
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, cast
 from uuid import UUID
 
 from vallox_websocket_api import PROFILE as VALLOX_PROFILE, Vallox
@@ -19,7 +19,7 @@ from vallox_websocket_api.vallox import (
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, Platform
+from homeassistant.const import ATTR_CONFIGURATION_URL, CONF_HOST, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
@@ -123,21 +123,16 @@ class ValloxState:
 
     def get_model(self) -> str | None:
         """Return the model, if any."""
-        model = _api_get_model(self.metric_cache)
+        model = cast(str, _api_get_model(self.metric_cache))
 
-        if not isinstance(model, str) or model == "Unknown":
+        if model == "Unknown":
             return None
 
         return model
 
-    def get_sw_version(self) -> str | None:
+    def get_sw_version(self) -> str:
         """Return the SW version."""
-        sw_version = _api_get_sw_version(self.metric_cache)
-
-        if not isinstance(sw_version, str):
-            return None
-
-        return sw_version
+        return cast(str, _api_get_sw_version(self.metric_cache))
 
     def get_uuid(self) -> UUID | None:
         """Return cached UUID value."""
@@ -337,5 +332,5 @@ class ValloxEntity(CoordinatorEntity[ValloxDataUpdateCoordinator]):
 
         if self.coordinator.config_entry is not None:
             self._attr_device_info[
-                "configuration_url"
+                ATTR_CONFIGURATION_URL
             ] = f"http://{self.coordinator.config_entry.data[CONF_HOST]}"

--- a/homeassistant/components/vallox/binary_sensor.py
+++ b/homeassistant/components/vallox/binary_sensor.py
@@ -9,19 +9,18 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import ValloxDataUpdateCoordinator
+from . import ValloxDataUpdateCoordinator, ValloxEntity
 from .const import DOMAIN
 
 
-class ValloxBinarySensor(
-    CoordinatorEntity[ValloxDataUpdateCoordinator], BinarySensorEntity
-):
+class ValloxBinarySensor(ValloxEntity, BinarySensorEntity):
     """Representation of a Vallox binary sensor."""
 
     entity_description: ValloxBinarySensorEntityDescription
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -30,14 +29,12 @@ class ValloxBinarySensor(
         description: ValloxBinarySensorEntityDescription,
     ) -> None:
         """Initialize the Vallox binary sensor."""
-        super().__init__(coordinator)
+        super().__init__(name, coordinator)
 
         self.entity_description = description
 
         self._attr_name = f"{name} {description.name}"
-
-        uuid = self.coordinator.data.get_uuid()
-        self._attr_unique_id = f"{uuid}-{description.key}"
+        self._attr_unique_id = f"{self._device_uuid}-{description.key}"
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -17,9 +17,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import ValloxDataUpdateCoordinator
+from . import ValloxDataUpdateCoordinator, ValloxEntity
 from .const import (
     DOMAIN,
     METRIC_KEY_MODE,
@@ -80,7 +79,7 @@ async def async_setup_entry(
     async_add_entities([device])
 
 
-class ValloxFan(CoordinatorEntity[ValloxDataUpdateCoordinator], FanEntity):
+class ValloxFan(ValloxEntity, FanEntity):
     """Representation of the fan."""
 
     def __init__(
@@ -90,13 +89,12 @@ class ValloxFan(CoordinatorEntity[ValloxDataUpdateCoordinator], FanEntity):
         coordinator: ValloxDataUpdateCoordinator,
     ) -> None:
         """Initialize the fan."""
-        super().__init__(coordinator)
+        super().__init__(name, coordinator)
 
         self._client = client
 
         self._attr_name = name
-
-        self._attr_unique_id = str(self.coordinator.data.get_uuid())
+        self._attr_unique_id = str(self._device_uuid)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -17,12 +17,12 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
 
-from . import ValloxDataUpdateCoordinator
+from . import ValloxDataUpdateCoordinator, ValloxEntity
 from .const import (
     DOMAIN,
     METRIC_KEY_MODE,
@@ -32,10 +32,11 @@ from .const import (
 )
 
 
-class ValloxSensor(CoordinatorEntity[ValloxDataUpdateCoordinator], SensorEntity):
+class ValloxSensor(ValloxEntity, SensorEntity):
     """Representation of a Vallox sensor."""
 
     entity_description: ValloxSensorEntityDescription
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -44,14 +45,12 @@ class ValloxSensor(CoordinatorEntity[ValloxDataUpdateCoordinator], SensorEntity)
         description: ValloxSensorEntityDescription,
     ) -> None:
         """Initialize the Vallox sensor."""
-        super().__init__(coordinator)
+        super().__init__(name, coordinator)
 
         self.entity_description = description
 
         self._attr_name = f"{name} {description.name}"
-
-        uuid = self.coordinator.data.get_uuid()
-        self._attr_unique_id = f"{uuid}-{description.key}"
+        self._attr_unique_id = f"{self._device_uuid}-{description.key}"
 
     @property
     def native_value(self) -> StateType | datetime:

--- a/tests/components/vallox/conftest.py
+++ b/tests/components/vallox/conftest.py
@@ -50,10 +50,30 @@ def patch_profile_home():
 
 
 @pytest.fixture(autouse=True)
-def patch_uuid():
-    """Patch the Vallox entity UUID."""
+def patch_model():
+    """Patch the Vallox model response."""
     with patch(
-        "homeassistant.components.vallox.calculate_uuid",
+        "homeassistant.components.vallox._api_get_model",
+        return_value="Vallox Testmodel",
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_sw_version():
+    """Patch the Vallox SW version response."""
+    with patch(
+        "homeassistant.components.vallox._api_get_sw_version",
+        return_value="0.1.2",
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_uuid():
+    """Patch the Vallox UUID response."""
+    with patch(
+        "homeassistant.components.vallox._api_get_uuid",
         return_value=_random_uuid(),
     ):
         yield

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -51,7 +51,7 @@ async def test_remaining_filter_returns_timestamp(
     """Test that the remaining time for filter sensor returns a timestamp."""
     # Act
     with patch(
-        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        "homeassistant.components.vallox._api_get_next_filter_change_date",
         return_value=dt.now().date(),
     ), patch_metrics(metrics={}):
         await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -68,7 +68,7 @@ async def test_remaining_time_for_filter_none_returned_from_vallox(
     """Test that the remaining time for filter sensor returns 'unknown' when Vallox returns None."""
     # Act
     with patch(
-        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        "homeassistant.components.vallox._api_get_next_filter_change_date",
         return_value=None,
     ), patch_metrics(metrics={}):
         await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -98,7 +98,7 @@ async def test_remaining_time_for_filter_in_the_future(
 
     # Act
     with patch(
-        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        "homeassistant.components.vallox._api_get_next_filter_change_date",
         return_value=mocked_filter_end_date,
     ), patch_metrics(metrics={}):
         await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -122,7 +122,7 @@ async def test_remaining_time_for_filter_today(
 
     # Act
     with patch(
-        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        "homeassistant.components.vallox._api_get_next_filter_change_date",
         return_value=mocked_filter_end_date,
     ), patch_metrics(metrics={}):
         await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -146,7 +146,7 @@ async def test_remaining_time_for_filter_in_the_past(
 
     # Act
     with patch(
-        "homeassistant.components.vallox.calculate_next_filter_change_date",
+        "homeassistant.components.vallox._api_get_next_filter_change_date",
         return_value=mocked_filter_end_date,
     ), patch_metrics(metrics={}):
         await hass.config_entries.async_setup(mock_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds [Device Registry](https://developers.home-assistant.io/docs/device_registry_index/) and [entity categorization](https://www.home-assistant.io/blog/2021/11/03/release-202111/#entity-categorization) support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
