### PR TITLE
Use async rest api in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -378,12 +378,13 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
     async def async_device_info(self) -> dict[str, Any] | None:
         """Try to gather infos of this TV."""
-        if self._get_remote(avoid_open=True):
+        if self.port:
             if self._rest_api is None:
                 self._rest_api = SamsungTVAsyncRest(
-                    self.host,
+                    host=self.host,
                     session=async_get_clientsession(self.hass),
                     port=self.port,
+                    timeout=TIMEOUT_WEBSOCKET,
                 )
 
             with contextlib.suppress(HttpApiError, RequestsTimeout):

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -389,6 +389,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
             with contextlib.suppress(HttpApiError, RequestsTimeout):
                 device_info: dict[str, Any] = await self._rest_api.rest_device_info()
+                LOGGER.debug("Device info on %s is: %s", self.host, device_info)
                 return device_info
 
         return None

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
 import contextlib
 from typing import Any
 
-from requests.exceptions import Timeout as RequestsTimeout
 from samsungctl import Remote
 from samsungctl.exceptions import AccessDenied, ConnectionClosed, UnhandledResponse
 from samsungtvws import SamsungTVWS
@@ -387,7 +387,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                     timeout=TIMEOUT_WEBSOCKET,
                 )
 
-            with contextlib.suppress(HttpApiError, RequestsTimeout):
+            with contextlib.suppress(HttpApiError, AsyncioTimeoutError):
                 device_info: dict[str, Any] = await self._rest_api.rest_device_info()
                 LOGGER.debug("Device info on %s is: %s", self.host, device_info)
                 return device_info

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -424,7 +424,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             # Different reasons, e.g. hostname not resolveable
             pass
 
-    def _get_remote(self, avoid_open: bool = False) -> SamsungTVWS:
+    def _get_remote(self) -> SamsungTVWS:
         """Create or return a remote control instance."""
         if self._remote is None:
             # We need to create a new instance to reconnect.
@@ -439,8 +439,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                     timeout=TIMEOUT_WEBSOCKET,
                     name=VALUE_CONF_NAME,
                 )
-                if not avoid_open:
-                    self._remote.open()
+                self._remote.open()
             # This is only happening when the auth was switched to DENY
             # A removed auth will lead to socket timeout because waiting for auth popup is just an open socket
             except ConnectionFailure as err:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -378,19 +378,21 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
     async def async_device_info(self) -> dict[str, Any] | None:
         """Try to gather infos of this TV."""
-        if self.port:
-            if self._rest_api is None:
-                self._rest_api = SamsungTVAsyncRest(
-                    host=self.host,
-                    session=async_get_clientsession(self.hass),
-                    port=self.port,
-                    timeout=TIMEOUT_WEBSOCKET,
-                )
+        if not self.port:
+            return None
 
-            with contextlib.suppress(HttpApiError, AsyncioTimeoutError):
-                device_info: dict[str, Any] = await self._rest_api.rest_device_info()
-                LOGGER.debug("Device info on %s is: %s", self.host, device_info)
-                return device_info
+        if self._rest_api is None:
+            self._rest_api = SamsungTVAsyncRest(
+                host=self.host,
+                session=async_get_clientsession(self.hass),
+                port=self.port,
+                timeout=TIMEOUT_WEBSOCKET,
+            )
+
+        with contextlib.suppress(HttpApiError, AsyncioTimeoutError):
+            device_info: dict[str, Any] = await self._rest_api.rest_device_info()
+            LOGGER.debug("Device info on %s is: %s", self.host, device_info)
+            return device_info
 
         return None
 

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 import pytest
 from samsungctl import Remote
 from samsungtvws import SamsungTVWS
-from samsungtvws.async_rest import SamsungTVAsyncRest
 
 import homeassistant.util.dt as dt_util
 
@@ -33,19 +32,14 @@ def remote_fixture() -> Mock:
         yield remote
 
 
-@pytest.fixture(name="remotews")
-def remotews_fixture() -> Mock:
-    """Patch the samsungtvws SamsungTVWS."""
+@pytest.fixture(name="rest_api", autouse=True)
+def rest_api_fixture() -> Mock:
+    """Patch the samsungtvws SamsungTVAsyncRest."""
     with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class, patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest"
+        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
+        autospec=True,
     ) as rest_api_class:
-        rest_api = Mock(SamsungTVAsyncRest)
-        remotews = Mock(SamsungTVWS)
-        remotews.__enter__ = Mock(return_value=remotews)
-        remotews.__exit__ = Mock()
-        rest_api.rest_device_info.return_value = {
+        rest_api_class.return_value.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
             "device": {
                 "modelName": "82GXARRS",
@@ -55,56 +49,20 @@ def remotews_fixture() -> Mock:
                 "networkType": "wireless",
             },
         }
+        yield rest_api_class.return_value
+
+
+@pytest.fixture(name="remotews")
+def remotews_fixture() -> Mock:
+    """Patch the samsungtvws SamsungTVWS."""
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
+    ) as remotews_class:
+        remotews = Mock(SamsungTVWS)
+        remotews.__enter__ = Mock(return_value=remotews)
+        remotews.__exit__ = Mock()
         remotews.app_list.return_value = SAMPLE_APP_LIST
         remotews.token = "FAKE_TOKEN"
-        rest_api_class.return_value = rest_api
-        remotews_class.return_value = remotews
-        yield remotews
-
-
-@pytest.fixture(name="remotews_no_device_info")
-def remotews_no_device_info_fixture() -> Mock:
-    """Patch the samsungtvws SamsungTVWS."""
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class, patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest"
-    ) as rest_api_class:
-        rest_api = Mock(SamsungTVAsyncRest)
-        remotews = Mock(SamsungTVWS)
-        remotews.__enter__ = Mock(return_value=remotews)
-        remotews.__exit__ = Mock()
-        rest_api.rest_device_info.return_value = None
-        remotews.token = "FAKE_TOKEN"
-        rest_api_class.return_value = rest_api
-        remotews_class.return_value = remotews
-        yield remotews
-
-
-@pytest.fixture(name="remotews_soundbar")
-def remotews_soundbar_fixture() -> Mock:
-    """Patch the samsungtvws SamsungTVWS."""
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class, patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest"
-    ) as rest_api_class:
-        rest_api = Mock(SamsungTVAsyncRest)
-        remotews = Mock(SamsungTVWS)
-        remotews.__enter__ = Mock(return_value=remotews)
-        remotews.__exit__ = Mock()
-        rest_api.rest_device_info.return_value = {
-            "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
-            "device": {
-                "modelName": "82GXARRS",
-                "wifiMac": "aa:bb:cc:dd:ee:ff",
-                "mac": "aa:bb:cc:dd:ee:ff",
-                "name": "[TV] Living Room",
-                "type": "Samsung SoundBar",
-            },
-        }
-        remotews.token = "FAKE_TOKEN"
-        rest_api_class.return_value = rest_api
         remotews_class.return_value = remotews
         yield remotews
 

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 from samsungctl import Remote
 from samsungtvws import SamsungTVWS
+from samsungtvws.async_rest import SamsungTVAsyncRest
 
 import homeassistant.util.dt as dt_util
 
@@ -37,11 +38,14 @@ def remotews_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class:
+    ) as remotews_class, patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest"
+    ) as rest_api_class:
+        rest_api = Mock(SamsungTVAsyncRest)
         remotews = Mock(SamsungTVWS)
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
-        remotews.rest_device_info.return_value = {
+        rest_api.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
             "device": {
                 "modelName": "82GXARRS",
@@ -53,6 +57,7 @@ def remotews_fixture() -> Mock:
         }
         remotews.app_list.return_value = SAMPLE_APP_LIST
         remotews.token = "FAKE_TOKEN"
+        rest_api_class.return_value = rest_api
         remotews_class.return_value = remotews
         yield remotews
 
@@ -62,12 +67,16 @@ def remotews_no_device_info_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class:
+    ) as remotews_class, patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest"
+    ) as rest_api_class:
+        rest_api = Mock(SamsungTVAsyncRest)
         remotews = Mock(SamsungTVWS)
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
-        remotews.rest_device_info.return_value = None
+        rest_api.rest_device_info.return_value = None
         remotews.token = "FAKE_TOKEN"
+        rest_api_class.return_value = rest_api
         remotews_class.return_value = remotews
         yield remotews
 
@@ -77,11 +86,14 @@ def remotews_soundbar_fixture() -> Mock:
     """Patch the samsungtvws SamsungTVWS."""
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remotews_class:
+    ) as remotews_class, patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest"
+    ) as rest_api_class:
+        rest_api = Mock(SamsungTVAsyncRest)
         remotews = Mock(SamsungTVWS)
         remotews.__enter__ = Mock(return_value=remotews)
         remotews.__exit__ = Mock()
-        remotews.rest_device_info.return_value = {
+        rest_api.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
             "device": {
                 "modelName": "82GXARRS",
@@ -92,6 +104,7 @@ def remotews_soundbar_fixture() -> Mock:
             },
         }
         remotews.token = "FAKE_TOKEN"
+        rest_api_class.return_value = rest_api
         remotews_class.return_value = remotews
         yield remotews
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -834,6 +834,10 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
     ) as remotews, patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
     ) as rest_api_class:
+        remote = Mock(SamsungTVWS)
+        remote.__enter__ = Mock(return_value=remote)
+        remote.__exit__ = Mock(return_value=False)
+        remote.app_list.return_value = SAMPLE_APP_LIST
         rest_api_class.return_value.rest_device_info = AsyncMock(
             return_value={
                 "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -848,11 +852,6 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
                 },
             }
         )
-        remote = Mock(SamsungTVWS)
-        remote.__enter__ = Mock(return_value=remote)
-        remote.__exit__ = Mock(return_value=False)
-        remote.app_list.return_value = SAMPLE_APP_LIST
-
         remote.token = "123456789"
         remotews.return_value = remote
 
@@ -883,6 +882,10 @@ async def test_websocket_no_mac(hass: HomeAssistant) -> None:
     ) as rest_api_class, patch(
         "getmac.get_mac_address", return_value="gg:hh:ii:ll:mm:nn"
     ):
+        remote = Mock(SamsungTVWS)
+        remote.__enter__ = Mock(return_value=remote)
+        remote.__exit__ = Mock(return_value=False)
+        remote.app_list.return_value = SAMPLE_APP_LIST
         rest_api_class.return_value.rest_device_info = AsyncMock(
             return_value={
                 "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -895,10 +898,6 @@ async def test_websocket_no_mac(hass: HomeAssistant) -> None:
                 },
             }
         )
-        remote = Mock(SamsungTVWS)
-        remote.__enter__ = Mock(return_value=remote)
-        remote.__exit__ = Mock(return_value=False)
-        remote.app_list.return_value = SAMPLE_APP_LIST
 
         remote.token = "123456789"
         remotews.return_value = remote

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -171,11 +171,8 @@ async def test_setup_websocket(hass: HomeAssistant) -> None:
 
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-        assert remote_class.call_count == 2
-        assert remote_class.call_args_list == [
-            call(**MOCK_CALLS_WS),
-            call(**MOCK_CALLS_WS),
-        ]
+        assert remote_class.call_count == 1
+        assert remote_class.call_args_list == [call(**MOCK_CALLS_WS)]
         assert hass.states.get(ENTITY_ID)
 
         await hass.async_block_till_done()
@@ -231,7 +228,7 @@ async def test_setup_websocket_2(
 
     state = hass.states.get(entity_id)
     assert state
-    assert remote_class.call_count == 3
+    assert remote_class.call_count == 2
     assert remote_class.call_args_list[0] == call(**MOCK_CALLS_WS)
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #67351, use the async API for REST calls.
Websocket calls will be moved to async in a follow-up PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
