### PR TITLE
Motion blinds support direct wifi blinds

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -162,7 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if TYPE_CHECKING:
         assert entry.unique_id is not None
 
-    if blind.device_type not in DEVICE_TYPES_WIFI:
+    if motion_gateway.device_type not in DEVICE_TYPES_WIFI:
         device_registry = dr.async_get(hass)
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -4,7 +4,7 @@ import logging
 from socket import timeout
 from typing import TYPE_CHECKING
 
-from motionblinds import AsyncMotionMulticast, ParseException
+from motionblinds import AsyncMotionMulticast, DEVICE_TYPES_WIFI, ParseException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     KEY_COORDINATOR,
     KEY_GATEWAY,
     KEY_MULTICAST_LISTENER,
+    KEY_VERSION,
     MANUFACTURER,
     PLATFORMS,
     UPDATE_INTERVAL,
@@ -147,29 +148,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        KEY_GATEWAY: motion_gateway,
-        KEY_COORDINATOR: coordinator,
-    }
-
     if motion_gateway.firmware is not None:
         version = f"{motion_gateway.firmware}, protocol: {motion_gateway.protocol}"
     else:
         version = f"Protocol: {motion_gateway.protocol}"
 
+    hass.data[DOMAIN][entry.entry_id] = {
+        KEY_GATEWAY: motion_gateway,
+        KEY_COORDINATOR: coordinator,
+        KEY_VERSION: version,
+    }
+
     if TYPE_CHECKING:
         assert entry.unique_id is not None
 
-    device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, motion_gateway.mac)},
-        identifiers={(DOMAIN, motion_gateway.mac)},
-        manufacturer=MANUFACTURER,
-        name=entry.title,
-        model="Wi-Fi bridge",
-        sw_version=version,
-    )
+    if blind.device_type not in DEVICE_TYPES_WIFI:
+        device_registry = dr.async_get(hass)
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, motion_gateway.mac)},
+            identifiers={(DOMAIN, motion_gateway.mac)},
+            manufacturer=MANUFACTURER,
+            name=entry.title,
+            model="Wi-Fi bridge",
+            sw_version=version,
+        )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -4,7 +4,7 @@ import logging
 from socket import timeout
 from typing import TYPE_CHECKING
 
-from motionblinds import AsyncMotionMulticast, DEVICE_TYPES_WIFI, ParseException
+from motionblinds import DEVICE_TYPES_WIFI, AsyncMotionMulticast, ParseException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -15,6 +15,7 @@ DEFAULT_INTERFACE = "any"
 KEY_GATEWAY = "gateway"
 KEY_COORDINATOR = "coordinator"
 KEY_MULTICAST_LISTENER = "multicast_listener"
+KEY_VERSION = "version"
 
 ATTR_WIDTH = "width"
 ATTR_ABSOLUTE_POSITION = "absolute_position"

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -116,7 +116,13 @@ async def async_setup_entry(
             )
 
         else:
-            _LOGGER.warning("Blind type '%s' not yet supported", blind.blind_type)
+            _LOGGER.warning("Blind type '%s' not yet supported, "
+                            "assuming RollerBlind", blind.blind_type)
+            entities.append(
+                MotionPositionDevice(
+                    coordinator, blind, POSITION_DEVICE_MAP[BlindType.RollerBlind], config_entry
+                )
+            )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -1,7 +1,7 @@
 """Support for Motion Blinds using their WLAN API."""
 import logging
 
-from motionblinds import BlindType
+from motionblinds import BlindType, DEVICE_TYPES_WIFI
 import voluptuous as vol
 
 from homeassistant.components.cover import (
@@ -144,15 +144,22 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
         self._blind = blind
         self._config_entry = config_entry
 
+        if blind.device_type in DEVICE_TYPES_WIFI:
+            via_device = ()
+            name = blind.blind_type
+        else:
+            via_device=(DOMAIN, blind._gateway.mac)
+            name = f"{blind.blind_type}-{blind.mac[12:]}"
+
         self._attr_device_class = device_class
-        self._attr_name = f"{blind.blind_type}-{blind.mac[12:]}"
+        self._attr_name = name
         self._attr_unique_id = blind.mac
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, blind.mac)},
             manufacturer=MANUFACTURER,
             model=blind.blind_type,
-            name=f"{blind.blind_type}-{blind.mac[12:]}",
-            via_device=(DOMAIN, blind._gateway.mac),
+            name=name,
+            via_device=via_device,
             hw_version=blind.wireless_name,
         )
 

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -1,7 +1,7 @@
 """Support for Motion Blinds using their WLAN API."""
 import logging
 
-from motionblinds import BlindType, DEVICE_TYPES_WIFI
+from motionblinds import DEVICE_TYPES_WIFI, BlindType
 import voluptuous as vol
 
 from homeassistant.components.cover import (
@@ -12,7 +12,11 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_platform
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_platform,
+)
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -81,21 +85,34 @@ async def async_setup_entry(
         if blind.type in POSITION_DEVICE_MAP:
             entities.append(
                 MotionPositionDevice(
-                    coordinator, blind, POSITION_DEVICE_MAP[blind.type], config_entry, sw_version
+                    coordinator,
+                    blind,
+                    POSITION_DEVICE_MAP[blind.type],
+                    config_entry,
+                    sw_version,
                 )
             )
 
         elif blind.type in TILT_DEVICE_MAP:
             entities.append(
                 MotionTiltDevice(
-                    coordinator, blind, TILT_DEVICE_MAP[blind.type], config_entry, sw_version
+                    coordinator,
+                    blind,
+                    TILT_DEVICE_MAP[blind.type],
+                    config_entry,
+                    sw_version,
                 )
             )
 
         elif blind.type in TDBU_DEVICE_MAP:
             entities.append(
                 MotionTDBUDevice(
-                    coordinator, blind, TDBU_DEVICE_MAP[blind.type], config_entry, sw_version, "Top"
+                    coordinator,
+                    blind,
+                    TDBU_DEVICE_MAP[blind.type],
+                    config_entry,
+                    sw_version,
+                    "Top",
                 )
             )
             entities.append(
@@ -120,11 +137,17 @@ async def async_setup_entry(
             )
 
         else:
-            _LOGGER.warning("Blind type '%s' not yet supported, "
-                            "assuming RollerBlind", blind.blind_type)
+            _LOGGER.warning(
+                "Blind type '%s' not yet supported, " "assuming RollerBlind",
+                blind.blind_type,
+            )
             entities.append(
                 MotionPositionDevice(
-                    coordinator, blind, POSITION_DEVICE_MAP[BlindType.RollerBlind], config_entry, sw_version
+                    coordinator,
+                    blind,
+                    POSITION_DEVICE_MAP[BlindType.RollerBlind],
+                    config_entry,
+                    sw_version,
                 )
             )
 
@@ -150,11 +173,11 @@ class MotionPositionDevice(CoordinatorEntity, CoverEntity):
 
         if blind.device_type in DEVICE_TYPES_WIFI:
             via_device = ()
-            connections={(dr.CONNECTION_NETWORK_MAC, blind.mac)}
+            connections = {(dr.CONNECTION_NETWORK_MAC, blind.mac)}
             name = blind.blind_type
         else:
-            via_device=(DOMAIN, blind._gateway.mac)
-            connections={}
+            via_device = (DOMAIN, blind._gateway.mac)
+            connections = {}
             name = f"{blind.blind_type}-{blind.mac[12:]}"
             sw_version = None
 
@@ -269,7 +292,9 @@ class MotionTiltDevice(MotionPositionDevice):
 class MotionTDBUDevice(MotionPositionDevice):
     """Representation of a Motion Top Down Bottom Up blind Device."""
 
-    def __init__(self, coordinator, blind, device_class, config_entry, sw_version, motor):
+    def __init__(
+        self, coordinator, blind, device_class, config_entry, sw_version, motor
+    ):
         """Initialize the blind."""
         super().__init__(coordinator, blind, device_class, config_entry, sw_version)
         self._motor = motor

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -3,7 +3,7 @@
   "name": "Motion Blinds",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/motion_blinds",
-  "requirements": ["motionblinds==0.5.13"],
+  "requirements": ["motionblinds==0.6.0"],
   "dependencies": ["network"],
   "codeowners": ["@starkillerOG"],
   "iot_class": "local_push",

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -3,7 +3,7 @@
   "name": "Motion Blinds",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/motion_blinds",
-  "requirements": ["motionblinds==0.6.0"],
+  "requirements": ["motionblinds==0.6.1"],
   "dependencies": ["network"],
   "codeowners": ["@starkillerOG"],
   "iot_class": "local_push",

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -1,5 +1,5 @@
 """Support for Motion Blinds sensors."""
-from motionblinds import BlindType
+from motionblinds import BlindType, DEVICE_TYPES_WIFI
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -52,9 +52,14 @@ class MotionBatterySensor(CoordinatorEntity, SensorEntity):
         """Initialize the Motion Battery Sensor."""
         super().__init__(coordinator)
 
+        if blind.device_type in DEVICE_TYPES_WIFI:
+            name = f"{blind.blind_type}-battery"
+        else:
+            name = f"{blind.blind_type}-battery-{blind.mac[12:]}"
+
         self._blind = blind
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, blind.mac)})
-        self._attr_name = f"{blind.blind_type}-battery-{blind.mac[12:]}"
+        self._attr_name = name
         self._attr_unique_id = f"{blind.mac}-battery"
 
     @property
@@ -96,9 +101,14 @@ class MotionTDBUBatterySensor(MotionBatterySensor):
         """Initialize the Motion Battery Sensor."""
         super().__init__(coordinator, blind)
 
+        if blind.device_type in DEVICE_TYPES_WIFI:
+            name = f"{blind.blind_type}-{motor}-battery"
+        else:
+            name = f"{blind.blind_type}-{motor}-battery-{blind.mac[12:]}"
+
         self._motor = motor
         self._attr_unique_id = f"{blind.mac}-{motor}-battery"
-        self._attr_name = f"{blind.blind_type}-{motor}-battery-{blind.mac[12:]}"
+        self._attr_name = name
 
     @property
     def native_value(self):
@@ -130,17 +140,18 @@ class MotionSignalStrengthSensor(CoordinatorEntity, SensorEntity):
         """Initialize the Motion Signal Strength Sensor."""
         super().__init__(coordinator)
 
+        if device_type == TYPE_GATEWAY:
+            name = "Motion gateway signal strength"
+        elif device.device_type in DEVICE_TYPES_WIFI:
+            name = f"{self._device.blind_type} signal strength"
+        else:
+            name = f"{self._device.blind_type} signal strength - {self._device.mac[12:]}"
+
         self._device = device
         self._device_type = device_type
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device.mac)})
         self._attr_unique_id = f"{device.mac}-RSSI"
-
-    @property
-    def name(self):
-        """Return the name of the blind signal strength sensor."""
-        if self._device_type == TYPE_GATEWAY:
-            return "Motion gateway signal strength"
-        return f"{self._device.blind_type} signal strength - {self._device.mac[12:]}"
+        self._attr_name = name
 
     @property
     def available(self):

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -35,9 +35,11 @@ async def async_setup_entry(
             # Only add battery powered blinds
             entities.append(MotionBatterySensor(coordinator, blind))
 
-    entities.append(
-        MotionSignalStrengthSensor(coordinator, motion_gateway, TYPE_GATEWAY)
-    )
+    # Do not add singnal sensor twice for direct WiFi blinds
+    if motion_gateway.device_type not in DEVICE_TYPES_WIFI:
+        entities.append(
+            MotionSignalStrengthSensor(coordinator, motion_gateway, TYPE_GATEWAY)
+        )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -1,5 +1,5 @@
 """Support for Motion Blinds sensors."""
-from motionblinds import BlindType, DEVICE_TYPES_WIFI
+from motionblinds import DEVICE_TYPES_WIFI, BlindType
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
         if blind.type == BlindType.TopDownBottomUp:
             entities.append(MotionTDBUBatterySensor(coordinator, blind, "Bottom"))
             entities.append(MotionTDBUBatterySensor(coordinator, blind, "Top"))
-        elif blind.battery_voltage > 0:
+        elif blind.battery_voltage is not None and blind.battery_voltage > 0:
             # Only add battery powered blinds
             entities.append(MotionBatterySensor(coordinator, blind))
 

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -143,9 +143,9 @@ class MotionSignalStrengthSensor(CoordinatorEntity, SensorEntity):
         if device_type == TYPE_GATEWAY:
             name = "Motion gateway signal strength"
         elif device.device_type in DEVICE_TYPES_WIFI:
-            name = f"{self._device.blind_type} signal strength"
+            name = f"{device.blind_type} signal strength"
         else:
-            name = f"{self._device.blind_type} signal strength - {self._device.mac[12:]}"
+            name = f"{device.blind_type} signal strength - {device.mac[12:]}"
 
         self._device = device
         self._device_type = device_type

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
             # Only add battery powered blinds
             entities.append(MotionBatterySensor(coordinator, blind))
 
-    # Do not add singnal sensor twice for direct WiFi blinds
+    # Do not add signal sensor twice for direct WiFi blinds
     if motion_gateway.device_type not in DEVICE_TYPES_WIFI:
         entities.append(
             MotionSignalStrengthSensor(coordinator, motion_gateway, TYPE_GATEWAY)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1027,7 +1027,7 @@ mitemp_bt==0.0.5
 moehlenhoff-alpha2==1.1.2
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.0
+motionblinds==0.6.1
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1027,7 +1027,7 @@ mitemp_bt==0.0.5
 moehlenhoff-alpha2==1.1.2
 
 # homeassistant.components.motion_blinds
-motionblinds==0.5.13
+motionblinds==0.6.0
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -668,7 +668,7 @@ minio==5.0.10
 moehlenhoff-alpha2==1.1.2
 
 # homeassistant.components.motion_blinds
-motionblinds==0.5.13
+motionblinds==0.6.0
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -668,7 +668,7 @@ minio==5.0.10
 moehlenhoff-alpha2==1.1.2
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.0
+motionblinds==0.6.1
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.12


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for blinds that connect directly through WiFi instead of having the blind connect to a gateway and the gateway to WiFi.
(Most models need a gateway and do not support direct WiFi, but some models support direct WiFi and it is unclear if they support connection through a 433MHz gateway).

Motionblinds version bump to 0.6.1:
https://github.com/starkillerOG/motion-blinds/compare/0.5.13...0.6.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
