### PR TITLE
Add tests for Modbus slave binary sensors, up coverage to 100%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -706,7 +706,6 @@ omit =
     homeassistant/components/mjpeg/util.py
     homeassistant/components/mochad/*
     homeassistant/components/modbus/climate.py
-    homeassistant/components/modbus/binary_sensor.py
     homeassistant/components/modem_callerid/button.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/moehlenhoff_alpha2/__init__.py

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -257,16 +257,68 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
                 {
                     CONF_NAME: TEST_ENTITY_NAME,
                     CONF_ADDRESS: 51,
-                    CONF_SLAVE_COUNT: 8,
                 }
             ]
         },
     ],
 )
 @pytest.mark.parametrize(
-    "register_words,expected, slaves",
+    "config_addon,register_words,expected, slaves",
     [
         (
+            {CONF_SLAVE_COUNT: 1},
+            [0x01],
+            STATE_ON,
+            [
+                STATE_OFF,
+            ],
+        ),
+        (
+            {CONF_SLAVE_COUNT: 1},
+            [0x02],
+            STATE_OFF,
+            [
+                STATE_ON,
+            ],
+        ),
+        (
+            {CONF_SLAVE_COUNT: 1},
+            [0x04],
+            STATE_OFF,
+            [
+                STATE_OFF,
+            ],
+        ),
+        (
+            {CONF_SLAVE_COUNT: 7},
+            [0x01],
+            STATE_ON,
+            [
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+            ],
+        ),
+        (
+            {CONF_SLAVE_COUNT: 7},
+            [0x82],
+            STATE_OFF,
+            [
+                STATE_ON,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_ON,
+            ],
+        ),
+        (
+            {CONF_SLAVE_COUNT: 10},
             [0x01, 0x00],
             STATE_ON,
             [
@@ -278,23 +330,12 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
                 STATE_OFF,
                 STATE_OFF,
                 STATE_OFF,
-            ],
-        ),
-        (
-            [0x02, 0x00],
-            STATE_OFF,
-            [
-                STATE_ON,
-                STATE_OFF,
-                STATE_OFF,
-                STATE_OFF,
-                STATE_OFF,
-                STATE_OFF,
                 STATE_OFF,
                 STATE_OFF,
             ],
         ),
         (
+            {CONF_SLAVE_COUNT: 10},
             [0x01, 0x01],
             STATE_ON,
             [
@@ -306,6 +347,25 @@ async def test_config_slave_binary_sensor(hass, mock_modbus):
                 STATE_OFF,
                 STATE_OFF,
                 STATE_ON,
+                STATE_OFF,
+                STATE_OFF,
+            ],
+        ),
+        (
+            {CONF_SLAVE_COUNT: 10},
+            [0x81, 0x01],
+            STATE_ON,
+            [
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_OFF,
+                STATE_ON,
+                STATE_ON,
+                STATE_OFF,
+                STATE_OFF,
             ],
         ),
     ],
@@ -314,6 +374,6 @@ async def test_slave_binary_sensor(hass, expected, slaves, mock_do_cycle):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 
-    for i in range(8):
+    for i in range(len(slaves)):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i+1}".replace(" ", "_")
         assert hass.states.get(entity_id).state == slaves[i]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests of different bit patterns to ensure the slaves are assigned correct values.

The side effect of this test is that coverage is again at 100% so removed from core/.coveragerc


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
