### PR TITLE
Add aurora_abb_powerone tcp support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -93,8 +93,8 @@ homeassistant/components/august/* @bdraco
 tests/components/august/* @bdraco
 homeassistant/components/aurora/* @djtimca
 tests/components/aurora/* @djtimca
-homeassistant/components/aurora_abb_powerone/* @davet2001
-tests/components/aurora_abb_powerone/* @davet2001
+homeassistant/components/aurora_abb_powerone/* @davet2001 @maugsburger
+tests/components/aurora_abb_powerone/* @davet2001 @maugsburger
 homeassistant/components/aussie_broadband/* @nickw444 @Bre77
 tests/components/aussie_broadband/* @nickw444 @Bre77
 homeassistant/components/auth/* @home-assistant/core

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -13,14 +13,11 @@ import logging
 from aurorapy.client import AuroraError, AuroraSerialClient, AuroraTCPClient
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS  # Bus address
-from homeassistant.const import CONF_HOST  # Network address
-from homeassistant.const import CONF_PORT  # RS485 Device or TCP
-from homeassistant.const import Platform
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .config_flow import validate_and_connect
+from .config_flow import CONF_TYPE_TCP, validate_and_connect
 from .const import ATTR_SERIAL_NUMBER, DOMAIN
 
 PLATFORMS = [Platform.SENSOR]
@@ -30,13 +27,15 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Aurora ABB PowerOne from a config entry."""
-    comport = entry.data[CONF_PORT]
-    address = entry.data[CONF_ADDRESS]
 
-    if entry.data[CONF_PORT] == "TCP":
-        ip, __, port = entry.data[CONF_HOST].rpartition(":")
-        client = AuroraTCPClient(ip=ip, port=int(port), address=address)
+    if entry.data[CONF_TYPE] == CONF_TYPE_TCP:
+        host = entry.data[CONF_HOST]
+        port = entry.data[CONF_PORT]
+        address = entry.data[CONF_ADDRESS]
+        client = AuroraTCPClient(ip=host, port=int(port), address=address)
     else:
+        comport = entry.data[CONF_PORT]
+        address = entry.data[CONF_ADDRESS]
         client = AuroraSerialClient(address, comport, parity="N", timeout=1)
 
     # To handle yaml import attempts in darkness, (re)try connecting only if

--- a/homeassistant/components/aurora_abb_powerone/aurora_device.py
+++ b/homeassistant/components/aurora_abb_powerone/aurora_device.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-from aurorapy.client import AuroraSerialClient
+from aurorapy.client import AuroraBaseClient
 
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 class AuroraEntity(Entity):
     """Representation of an Aurora ABB PowerOne device."""
 
-    def __init__(self, client: AuroraSerialClient, data: Mapping[str, Any]) -> None:
+    def __init__(self, client: AuroraBaseClient, data: Mapping[str, Any]) -> None:
         """Initialise the basic device."""
         self._data = data
         self.type = "device"

--- a/homeassistant/components/aurora_abb_powerone/config_flow.py
+++ b/homeassistant/components/aurora_abb_powerone/config_flow.py
@@ -1,47 +1,68 @@
 """Config flow for Aurora ABB PowerOne integration."""
-from __future__ import annotations
-
 import logging
-from typing import Any
 
 from aurorapy.client import AuroraError, AuroraSerialClient, AuroraTCPClient
 import serial.tools.list_ports
 import voluptuous as vol
 
 from homeassistant import config_entries, core
-from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT, CONF_TYPE
 
+# pylint doesn't think DOMAIN is used.  But it is used!
+# Might be this bug? https://github.com/PyCQA/pylint/issues/3445
+# pylint: disable=unused-import
 from .const import (
     ATTR_FIRMWARE,
     ATTR_MODEL,
     ATTR_SERIAL_NUMBER,
     DEFAULT_ADDRESS,
+    DEFAULT_HOST,
     DEFAULT_INTEGRATION_TITLE,
+    DEFAULT_PORT,
+    DEFAULT_TYPE,
     DOMAIN,
     MAX_ADDRESS,
     MIN_ADDRESS,
 )
 
+CONF_TYPE_SERIAL = "Direct USB Connection/Serial RS485"
+CONF_TYPE_TCP = "TCP/IP to Serial Converter"
+
 _LOGGER = logging.getLogger(__name__)
 
 
-def validate_and_connect(
-    hass: core.HomeAssistant, data: dict[str, Any]
-) -> dict[str, str]:
+def schema_serial(comportslist, comportdefault):
+    """Create a flow schema for serial mode settings."""
+    config_options = {
+        vol.Required(CONF_PORT, default=comportdefault): vol.In([comportslist]),
+        vol.Required(CONF_ADDRESS, default=DEFAULT_ADDRESS): vol.In(
+            range(MIN_ADDRESS, MAX_ADDRESS + 1)
+        ),
+    }
+    return vol.Schema(config_options)
+
+
+def schema_tcp():
+    """Create a config flow schema for TCP mode settings."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
+            vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+            vol.Required(CONF_ADDRESS, default=DEFAULT_ADDRESS): vol.In(
+                range(MIN_ADDRESS, MAX_ADDRESS + 1)
+            ),
+        }
+    )
+
+
+def validate_and_connect(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
-    if data[CONF_PORT] == "TCP":
-        return __validate_connect_tcp(data[CONF_HOST], data[CONF_ADDRESS])
-
-    return __validate_connect_serial(data[CONF_PORT], data[CONF_ADDRESS])
-
-
-def __validate_connect_serial(comport, address):
-
-    _LOGGER.debug("Initialising com port=%s", comport)
+    comport = data[CONF_PORT]
+    address = data[CONF_ADDRESS]
+    _LOGGER.debug("Intitialising com port=%s", comport)
     ret = {}
     ret["title"] = DEFAULT_INTEGRATION_TITLE
     try:
@@ -62,74 +83,107 @@ def __validate_connect_serial(comport, address):
     return ret
 
 
-def __validate_connect_tcp(host, address):
+def validate_and_connect_tcp(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
 
-    _LOGGER.debug("Initialising connection to %s", host)
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    host = data[CONF_HOST]
+    port = data[CONF_PORT]
+    address = data[CONF_ADDRESS]
+    _LOGGER.debug("Intitialising connection to %s:%s [%s]", host, port, address)
     ret = {}
     ret["title"] = DEFAULT_INTEGRATION_TITLE
     try:
-        ip, __, port = host.rpartition(":")
-        port = int(port)
-        ip = ip.strip("[]")
-        client = AuroraTCPClient(ip=ip, port=port, address=address)
+        client = AuroraTCPClient(host, port, address, timeout=1)
         client.connect()
         ret[ATTR_SERIAL_NUMBER] = client.serial_number()
         ret[ATTR_MODEL] = f"{client.version()} ({client.pn()})"
         ret[ATTR_FIRMWARE] = client.firmware(1)
         _LOGGER.info("Returning device info=%s", ret)
     except AuroraError as err:
-        _LOGGER.warning("Could not connect to %s", host)
+        _LOGGER.warning("Could not connect to device %s:%s [%s]", host, port, address)
         raise err
     finally:
-        try:
-            client.close()
-        except AuroraError:  # ignore errors on exit - there is no way to check if socket is really open
-            pass
+        client.close()
 
     # Return info we want to store in the config entry.
     return ret
-
-
-def scan_comports() -> tuple[list[str] | None, str | None]:
-    """Find and store available com ports for the GUI dropdown."""
-    com_ports = serial.tools.list_ports.comports(include_links=True)
-    com_ports_list = ["TCP"]
-    for port in com_ports:
-        com_ports_list.append(port.device)
-        _LOGGER.debug("COM port option: %s", port.device)
-    if len(com_ports_list) > 0:
-        return com_ports_list, com_ports_list[0]
-    _LOGGER.warning("No com ports found.  Need a valid RS485 device to communicate")
-    return None, None
 
 
 class AuroraABBConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Aurora ABB PowerOne."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    _comportslist = None
+    _defaultcomport = None
 
     def __init__(self):
         """Initialise the config flow."""
         self.config = None
-        self._com_ports_list = None
-        self._default_com_port = None
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_user(self, user_input=None):
         """Handle a flow initialised by the user."""
 
         errors = {}
-        if self._com_ports_list is None:
-            result = await self.hass.async_add_executor_job(scan_comports)
-            self._com_ports_list, self._default_com_port = result
+        if user_input is not None:
 
-        # Handle the initial step.
+            # print(f"user_input={user_input}")
+            if user_input.get(CONF_TYPE) == CONF_TYPE_SERIAL:
+                if self._comportslist is None:
+                    comports = serial.tools.list_ports.comports(include_links=True)
+                    comportslist = []
+                    for port in comports:
+                        comportslist.append(port.device)
+                        _LOGGER.debug("COM port option: %s", port.device)
+                    if len(comportslist) > 0:
+                        defaultcomport = comportslist[0]
+                    else:
+                        _LOGGER.warning(
+                            "No com ports found.  Need a valid RS485 device to communicate"
+                        )
+                        return self.async_abort(reason="no_serial_ports")
+                    self._comportslist = comportslist
+                    self._defaultcomport = defaultcomport
+
+                return self.async_show_form(
+                    step_id="user_serial",
+                    data_schema=schema_serial(self._defaultcomport, self._comportslist),
+                    errors=errors,
+                )
+            if user_input.get(CONF_TYPE) == CONF_TYPE_TCP:
+                return self.async_show_form(
+                    step_id="user_tcp",
+                    data_schema=schema_tcp(),
+                    errors=errors,
+                )
+        # If no user input, must be first pass through the config.  Show  initial form.
+        config_options = {
+            vol.Required(CONF_TYPE, default=DEFAULT_TYPE): vol.In(
+                [CONF_TYPE_SERIAL, CONF_TYPE_TCP]
+            ),
+        }
+        schema = vol.Schema(config_options)
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_user_serial(self, user_input=None):
+        """Handle step 2 (user has selected serial type then entered data)."""
+
+        errors = {}
         if user_input is not None:
             try:
                 info = await self.hass.async_add_executor_job(
                     validate_and_connect, self.hass, user_input
                 )
+                info.update(user_input)
+                # Bomb out early if someone has already set up this device.
+                device_unique_id = info["serial_number"]
+                await self.async_set_unique_id(device_unique_id)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(title=info["title"], data=info)
+
             except OSError as error:
                 if error.errno == 19:  # No such device.
                     errors["base"] = "invalid_serial_port"
@@ -146,24 +200,49 @@ class AuroraABBConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         error,
                     )
                     errors["base"] = "cannot_connect"
-            else:
+        # If we get to here, show the form again (could be no data so far or error).
+        return self.async_show_form(
+            step_id="user",
+            data_schema=schema_serial(self._defaultcomport, self._comportslist),
+            errors=errors,
+        )
+
+    async def async_step_user_tcp(self, user_input=None):
+        """Handle step 2 (user has selected serial type then entered data)."""
+
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await self.hass.async_add_executor_job(
+                    validate_and_connect_tcp, self.hass, user_input
+                )
                 info.update(user_input)
                 # Bomb out early if someone has already set up this device.
                 device_unique_id = info["serial_number"]
                 await self.async_set_unique_id(device_unique_id)
                 self._abort_if_unique_id_configured()
+
                 return self.async_create_entry(title=info["title"], data=info)
 
-        # If no user input, must be first pass through the config.  Show  initial form.
-        config_options = {
-            vol.Required(CONF_PORT, default=self._default_com_port): vol.In(
-                self._com_ports_list
-            ),
-            vol.Required(CONF_ADDRESS, default=DEFAULT_ADDRESS): vol.In(
-                range(MIN_ADDRESS, MAX_ADDRESS + 1)
-            ),
-            vol.Optional(CONF_HOST, default=""): str,
-        }
-        schema = vol.Schema(config_options)
-
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+            except OSError as error:
+                if error.errno == 19:  # No such device.
+                    errors["base"] = "invalid_serial_port"
+            except AuroraError as error:
+                if "could not open port" in str(error):
+                    errors["base"] = "cannot_open_serial_port"
+                elif "No response after" in str(error):
+                    errors["base"] = "cannot_connect"  # could be dark
+                else:
+                    _LOGGER.error(
+                        "Unable to communicate with Aurora ABB Inverter at %s: %s %s",
+                        user_input[CONF_PORT],
+                        type(error),
+                        error,
+                    )
+                    errors["base"] = "cannot_connect"
+        # If we get to here, show the form again (could be no data so far or error).
+        return self.async_show_form(
+            step_id="user",
+            data_schema=schema_serial(self._defaultcomport, self._comportslist),
+            errors=errors,
+        )

--- a/homeassistant/components/aurora_abb_powerone/const.py
+++ b/homeassistant/components/aurora_abb_powerone/const.py
@@ -1,5 +1,7 @@
 """Constants for the Aurora ABB PowerOne integration."""
 
+from .config_flow import CONF_TYPE_SERIAL
+
 DOMAIN = "aurora_abb_powerone"
 
 # Min max addresses and default according to here:
@@ -8,9 +10,9 @@ DOMAIN = "aurora_abb_powerone"
 MIN_ADDRESS = 2
 MAX_ADDRESS = 63
 DEFAULT_ADDRESS = 2
-DEFAULT_TYPE = "serial"
+DEFAULT_TYPE = CONF_TYPE_SERIAL
 DEFAULT_HOST = None
-DEFAULT_PORT = 1234
+DEFAULT_PORT = 2001
 
 DEFAULT_INTEGRATION_TITLE = "PhotoVoltaic Inverters"
 DEFAULT_DEVICE_NAME = "Solar Inverter"

--- a/homeassistant/components/aurora_abb_powerone/const.py
+++ b/homeassistant/components/aurora_abb_powerone/const.py
@@ -8,6 +8,9 @@ DOMAIN = "aurora_abb_powerone"
 MIN_ADDRESS = 2
 MAX_ADDRESS = 63
 DEFAULT_ADDRESS = 2
+DEFAULT_TYPE = "serial"
+DEFAULT_HOST = None
+DEFAULT_PORT = 1234
 
 DEFAULT_INTEGRATION_TITLE = "PhotoVoltaic Inverters"
 DEFAULT_DEVICE_NAME = "Solar Inverter"

--- a/homeassistant/components/aurora_abb_powerone/manifest.json
+++ b/homeassistant/components/aurora_abb_powerone/manifest.json
@@ -5,7 +5,8 @@
   "documentation": "https://www.home-assistant.io/integrations/aurora_abb_powerone",
   "requirements": ["aurorapy==0.2.6"],
   "codeowners": [
-    "@davet2001"
+    "@davet2001",
+    "@maugsburger"
   ],
   "iot_class": "local_polling",
   "loggers": ["aurorapy"]

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-from aurorapy.client import AuroraError, AuroraSerialClient
+from aurorapy.client import AuroraBaseClient, AuroraError
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -73,7 +73,7 @@ class AuroraSensor(AuroraEntity, SensorEntity):
 
     def __init__(
         self,
-        client: AuroraSerialClient,
+        client: AuroraBaseClient,
         data: Mapping[str, Any],
         entity_description: SensorEntityDescription,
     ) -> None:
@@ -127,5 +127,7 @@ class AuroraSensor(AuroraEntity, SensorEntity):
                         "Communication with %s lost",
                         self.name,
                     )
-            if self.client.serline.isOpen():
+            try:
                 self.client.close()
+            except AuroraError:  # ignore errors on exit
+                pass

--- a/homeassistant/components/aurora_abb_powerone/strings.json
+++ b/homeassistant/components/aurora_abb_powerone/strings.json
@@ -2,11 +2,24 @@
   "config": {
     "step": {
       "user": {
-        "description": "The inverter must be connected via an RS485 adaptor or TCP, please select serial port and the inverter's address as configured on the LCD panel",
+        "description": "The inverter must connected and on (in daylight), please select connection type (direct serial or TCP/IP based)",
         "data": {
-          "port": "RS485 or USB-RS485 Adaptor Port or TCP",
-          "address": "Inverter Bus Address",
-          "host": "TCP Host:Port"
+          "type": "Connection type"
+        }
+      },
+      "user_serial": {
+        "description": "The inverter must be connected via an RS485 adaptor, please select serial port and the inverter's address as configured on the LCD panel",
+        "data": {
+          "port": "RS485 or USB-RS485 Adaptor Port",
+          "address": "Inverter Address"
+        }
+      },
+      "user_tcp": {
+        "description": "The inverter must be connected via an TCP/IP to serial adaptor, please select host, port and the address number configured on the LCD panel",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "address": "Inverter Address"
         }
       }
     },

--- a/homeassistant/components/aurora_abb_powerone/strings.json
+++ b/homeassistant/components/aurora_abb_powerone/strings.json
@@ -2,10 +2,11 @@
   "config": {
     "step": {
       "user": {
-        "description": "The inverter must be connected via an RS485 adaptor, please select serial port and the inverter's address as configured on the LCD panel",
+        "description": "The inverter must be connected via an RS485 adaptor or TCP, please select serial port and the inverter's address as configured on the LCD panel",
         "data": {
-          "port": "RS485 or USB-RS485 Adaptor Port",
-          "address": "Inverter Address"
+          "port": "RS485 or USB-RS485 Adaptor Port or TCP",
+          "address": "Inverter Bus Address",
+          "host": "TCP Host:Port"
         }
       }
     },

--- a/homeassistant/components/aurora_abb_powerone/strings.json
+++ b/homeassistant/components/aurora_abb_powerone/strings.json
@@ -1,10 +1,12 @@
 {
   "config": {
     "step": {
-      "user": {
+      "user_ctype": {
         "description": "The inverter must connected and on (in daylight), please select connection type (direct serial or TCP/IP based)",
         "data": {
-          "type": "Connection type"
+          "type": "Connection type",
+          "type_tcp": "TCP/IP to Serial Converter",
+          "type_serial": "Direct USB Connection/Serial RS485"
         }
       },
       "user_serial": {


### PR DESCRIPTION
## Proposed change

The aurorapy library for PowerOne/ABB inverters has tcp support, but the aurora_abb_powerone integration did not so far.

This change enables the user to use TCP connections to the inverter as well.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Works with ser2net, e.g.:
```
$ cat /etc/ser2net.yaml
%YAML 1.1
---
connection: &abbuno
    accepter: tcp,2001
    enable: on
    options:
      kickolduser: true
    #connector: serialdev,/dev/ttyUSB0,9600n81,local
    connector: serialdev,/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A10JNDMG-if00-port0,19200n81,local
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
