### PR TITLE
IntelliFire Diagnostic Error Sensor

### DIFF
--- a/homeassistant/components/intellifire/manifest.json
+++ b/homeassistant/components/intellifire/manifest.json
@@ -3,7 +3,7 @@
   "name": "IntelliFire",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/intellifire",
-  "requirements": ["intellifire4py==0.9.9"],
+  "requirements": ["intellifire4py==0.9.10"],
   "dependencies": [],
   "codeowners": ["@jeeftor"],
   "iot_class": "local_polling",

--- a/homeassistant/components/intellifire/manifest.json
+++ b/homeassistant/components/intellifire/manifest.json
@@ -3,7 +3,7 @@
   "name": "IntelliFire",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/intellifire",
-  "requirements": ["intellifire4py==0.9.10"],
+  "requirements": ["intellifire4py==1.0.1"],
   "dependencies": [],
   "codeowners": ["@jeeftor"],
   "iot_class": "local_polling",

--- a/homeassistant/components/intellifire/manifest.json
+++ b/homeassistant/components/intellifire/manifest.json
@@ -4,7 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/intellifire",
   "requirements": ["intellifire4py==1.0.1"],
-  "dependencies": [],
   "codeowners": ["@jeeftor"],
   "iot_class": "local_polling",
   "loggers": ["intellifire4py"]

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -115,6 +115,12 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
     ),
     IntellifireSensorEntityDescription(
+        key="errors",
+        name="Errors",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: ", ".join([x.name for x in data.error_codes]),
+    ),
+    IntellifireSensorEntityDescription(
         key="ecm_latency",
         name="ECM Latency",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -118,7 +118,7 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
         key="errors",
         name="Errors",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: ", ".join([x.name for x in data.error_codes]),
+        value_fn=lambda data: data.error_codes_string,
     ),
     IntellifireSensorEntityDescription(
         key="ecm_latency",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -873,7 +873,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.9.10
+intellifire4py==1.0.1
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -873,7 +873,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.9.9
+intellifire4py==0.9.10
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -599,7 +599,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.9.10
+intellifire4py==1.0.1
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -599,7 +599,7 @@ influxdb-client==1.24.0
 influxdb==5.3.1
 
 # homeassistant.components.intellifire
-intellifire4py==0.9.9
+intellifire4py==0.9.10
 
 # homeassistant.components.iotawatt
 iotawattpy==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The fireplace offers an array of errors as part of the local passing JSON data. This PR exposes and translates the numeric error into a comma separated list of error names. The documentation has been updated with extended details on each error message as extracted from a decompiled `.apk` of the supporting mobile application. 

These changes coincide with a version bump of the backing library: https://github.com/jeeftor/intellifire4py/compare/0.9.0...1.0.1

The main changes in the backing library are the addition of the `IntellifireErrorCode` class which is based on `MultiValueEnum` from the `aenum` package. I extracted a list of error messages out of a decompiled `.apk` file for the mobile app and turned those into the multi-value error code list. The main reason is multiple error "codes" seem to map to the same error type in the app - so that is all I had to go from. 

Additionally - various folks using the IntelliFire device have had issues with the device dropping off the cloud network or the cloud network going down. The App uses a cloud-baed control protocol - however my `intellifire4py` lib also supports local control that "appears" to keep working even though the cloud control goes down. My hope is by tracking the error status inside HA it may give us some insight into why and when these cloud-based control errors are occurring. And hence the inclusion of this sensor

<img width="277" alt="image" src="https://user-images.githubusercontent.com/6491743/156068558-b8624df8-933c-41f5-968e-1b431f399f72.png">

If there is no error the sensor is blank.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.


- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/21848

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
