### PR TITLE
Restore children media class

### DIFF
--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -580,7 +580,8 @@ class DmsDeviceSource:
             children=children,
         )
 
-        media_source.calculate_children_class()
+        if media_source.children:
+            media_source.calculate_children_class()
 
         return media_source
 
@@ -650,7 +651,8 @@ class DmsDeviceSource:
             thumbnail=self._didl_thumbnail_url(item),
         )
 
-        media_source.calculate_children_class()
+        if media_source.children:
+            media_source.calculate_children_class()
 
         return media_source
 

--- a/homeassistant/components/media_player/browse_media.py
+++ b/homeassistant/components/media_player/browse_media.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+from typing import Any
 from urllib.parse import quote
 
 import yarl
@@ -74,11 +75,15 @@ class BrowseMedia:
 
     def as_dict(self, *, parent: bool = True) -> dict:
         """Convert Media class to browse media dictionary."""
-        response = {
+        if self.children_media_class is None and self.children:
+            self.calculate_children_class()
+
+        response: dict[str, Any] = {
             "title": self.title,
             "media_class": self.media_class,
             "media_content_type": self.media_content_type,
             "media_content_id": self.media_content_id,
+            "children_media_class": self.children_media_class,
             "can_play": self.can_play,
             "can_expand": self.can_expand,
             "thumbnail": self.thumbnail,
@@ -87,11 +92,7 @@ class BrowseMedia:
         if not parent:
             return response
 
-        if self.children_media_class is None:
-            self.calculate_children_class()
-
         response["not_shown"] = self.not_shown
-        response["children_media_class"] = self.children_media_class
 
         if self.children:
             response["children"] = [
@@ -104,11 +105,8 @@ class BrowseMedia:
 
     def calculate_children_class(self) -> None:
         """Count the children media classes and calculate the correct class."""
-        if self.children is None or len(self.children) == 0:
-            return
-
         self.children_media_class = MEDIA_CLASS_DIRECTORY
-
+        assert self.children is not None
         proposed_class = self.children[0].media_class
         if all(child.media_class == proposed_class for child in self.children):
             self.children_media_class = proposed_class

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -872,6 +872,7 @@ async def test_entity_browse_media(hass: HomeAssistant, hass_ws_client):
         "can_play": True,
         "can_expand": False,
         "thumbnail": None,
+        "children_media_class": None,
     }
     assert expected_child_1 in response["result"]["children"]
 
@@ -883,6 +884,7 @@ async def test_entity_browse_media(hass: HomeAssistant, hass_ws_client):
         "can_play": True,
         "can_expand": False,
         "thumbnail": None,
+        "children_media_class": None,
     }
     assert expected_child_2 in response["result"]["children"]
 
@@ -926,6 +928,7 @@ async def test_entity_browse_media_audio_only(
         "can_play": True,
         "can_expand": False,
         "thumbnail": None,
+        "children_media_class": None,
     }
     assert expected_child_1 not in response["result"]["children"]
 
@@ -937,6 +940,7 @@ async def test_entity_browse_media_audio_only(
         "can_play": True,
         "can_expand": False,
         "thumbnail": None,
+        "children_media_class": None,
     }
     assert expected_child_2 in response["result"]["children"]
 
@@ -1873,6 +1877,7 @@ async def test_cast_platform_browse_media(hass: HomeAssistant, hass_ws_client):
         "can_play": False,
         "can_expand": True,
         "thumbnail": "https://brands.home-assistant.io/_/spotify/logo.png",
+        "children_media_class": None,
     }
     assert expected_child in response["result"]["children"]
 

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -961,6 +961,7 @@ async def test_browse_media(
         "can_play": True,
         "can_expand": False,
         "thumbnail": None,
+        "children_media_class": None,
     }
     assert expected_child_video in response["result"]["children"]
 
@@ -972,6 +973,7 @@ async def test_browse_media(
         "can_play": True,
         "can_expand": False,
         "thumbnail": None,
+        "children_media_class": None,
     }
     assert expected_child_audio in response["result"]["children"]
 

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -111,6 +111,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": True,
                 "thumbnail": None,
+                "children_media_class": "directory",
             }
         ],
         "not_shown": 0,
@@ -143,6 +144,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": True,
                 "thumbnail": None,
+                "children_media_class": "directory",
             }
         ],
         "not_shown": 0,
@@ -174,6 +176,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": True,
                 "thumbnail": None,
+                "children_media_class": "video",
             },
             {
                 "title": "Images",
@@ -186,6 +189,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": True,
                 "thumbnail": None,
+                "children_media_class": "image",
             },
         ],
         "not_shown": 0,
@@ -220,6 +224,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": True,
                 "thumbnail": None,
+                "children_media_class": "directory",
             }
         ],
         "not_shown": 0,
@@ -255,6 +260,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": True,
                 "can_expand": False,
                 "thumbnail": "http://movie",
+                "children_media_class": None,
             },
             {
                 "title": "00-36-49.mp4",
@@ -268,6 +274,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": True,
                 "can_expand": False,
                 "thumbnail": "http://movie",
+                "children_media_class": None,
             },
             {
                 "title": "00-02-27.mp4",
@@ -281,6 +288,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 "can_play": True,
                 "can_expand": False,
                 "thumbnail": "http://movie",
+                "children_media_class": None,
             },
         ],
         "not_shown": 0,
@@ -331,6 +339,7 @@ async def test_async_browse_media_images_success(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": False,
                 "thumbnail": "http://image",
+                "children_media_class": None,
             }
         ],
         "not_shown": 0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Restore `children_media_class` property for children. Got accidentally deleted in #67096

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
