### PR TITLE
Suppress roku power off timeout errors

### DIFF
--- a/homeassistant/components/roku/__init__.py
+++ b/homeassistant/components/roku/__init__.py
@@ -1,14 +1,6 @@
 """Support for Roku."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Coroutine
-from functools import partial, wraps
-import logging
-from typing import Any, TypeVar
-
-from rokuecp import RokuConnectionError, RokuConnectionTimeoutError, RokuError
-from typing_extensions import Concatenate, ParamSpec
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
@@ -16,7 +8,6 @@ from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
 from .coordinator import RokuDataUpdateCoordinator
-from .entity import RokuEntity
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
@@ -27,10 +18,6 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
 ]
-_LOGGER = logging.getLogger(__name__)
-
-_T = TypeVar("_T", bound="RokuEntity")
-_P = ParamSpec("_P")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -53,30 +40,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
-
-
-def roku_exception_handler(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]] | None = None,  # type: ignore[misc]
-    *,
-    ignore_timeout: bool = False,
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
-    """Decorate Roku calls to handle Roku exceptions."""
-
-    if func is None:
-        return partial(roku_exception_handler, ignore_timeout=ignore_timeout)
-
-    @wraps(func)
-    async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
-        try:
-            await func(self, *args, **kwargs)
-        except RokuConnectionTimeoutError as error:
-            if not ignore_timeout and self.available:
-                _LOGGER.error("Error communicating with API: %s", error)
-        except RokuConnectionError as error:
-            if self.available:
-                _LOGGER.error("Error communicating with API: %s", error)
-        except RokuError as error:
-            if self.available:
-                _LOGGER.error("Invalid response from API: %s", error)
-
-    return wrapper

--- a/homeassistant/components/roku/__init__.py
+++ b/homeassistant/components/roku/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
-from functools import wraps
+from functools import partial, wraps
 import logging
 from typing import Any, TypeVar
 
@@ -56,10 +56,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 def roku_exception_handler(
-    func: Callable[Concatenate[_T, _P], Awaitable[None]],  # type: ignore[misc]
+    func: Callable[Concatenate[_T, _P], Awaitable[None]] | None = None,  # type: ignore[misc]
+    *,
     ignore_timeout: bool = False,
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:  # type: ignore[misc]
     """Decorate Roku calls to handle Roku exceptions."""
+
+    if func is None:
+        return partial(roku_exception_handler, ignore_timeout=ignore_timeout)
 
     @wraps(func)
     async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -35,7 +35,7 @@ def roku_exception_handler(ignore_timeout: bool = False) -> Callable[..., Callab
         async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
             try:
                 await func(self, *args, **kwargs)
-            except RokuConnectionTimeoutError:
+            except RokuConnectionTimeoutError as error:
                 if not ignore_timeout and self.available:
                     _LOGGER.error("Error communicating with API: %s", error)
             except RokuConnectionError as error:

--- a/homeassistant/components/roku/helpers.py
+++ b/homeassistant/components/roku/helpers.py
@@ -36,7 +36,8 @@ def roku_exception_handler(ignore_timeout: bool = False) -> Callable[..., Callab
             try:
                 await func(self, *args, **kwargs)
             except RokuConnectionTimeoutError:
-                return
+                if not ignore_timeout and self.available:
+                    _LOGGER.error("Error communicating with API: %s", error)
             except RokuConnectionError as error:
                 if self.available:
                     _LOGGER.error("Error communicating with API: %s", error)

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -2,7 +2,7 @@
   "domain": "roku",
   "name": "Roku",
   "documentation": "https://www.home-assistant.io/integrations/roku",
-  "requirements": ["rokuecp==0.14.1"],
+  "requirements": ["rokuecp==0.15.0"],
   "homekit": {
     "models": ["3810X", "4660X", "7820X", "C105X", "C135X"]
   },

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -1,11 +1,13 @@
 """Support for the Roku media player."""
 from __future__ import annotations
 
+from contextlib import suppress
 import datetime as dt
 import logging
 import mimetypes
 from typing import Any
 
+from rokuecp import RokuConnectionTimeoutError
 from rokuecp.helpers import guess_stream_format
 import voluptuous as vol
 import yarl
@@ -330,7 +332,8 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @roku_exception_handler
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
-        await self.coordinator.roku.remote("poweroff")
+        with suppress(RokuConnectionTimeoutError):
+            await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -64,11 +64,7 @@ from .const import (
 )
 from .coordinator import RokuDataUpdateCoordinator
 from .entity import RokuEntity
-from .helpers import (
-    format_channel_name,
-    roku_exception_handler,
-    roku_exception_handler_no_timeout,
-)
+from .helpers import format_channel_name, roku_exception_handler
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -292,7 +288,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             app.name for app in self.coordinator.data.apps if app.name is not None
         )
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def search(self, keyword: str) -> None:
         """Emulate opening the search screen and entering the search keyword."""
         await self.coordinator.roku.search(keyword)
@@ -324,68 +320,68 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             media_content_type,
         )
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_turn_on(self) -> None:
         """Turn on the Roku."""
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler_no_timeout
+    @roku_exception_handler(ignore_timeout=True)
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
         await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_media_pause(self) -> None:
         """Send pause command."""
         if self.state not in (STATE_STANDBY, STATE_PAUSED):
             await self.coordinator.roku.remote("play")
             await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_media_play(self) -> None:
         """Send play command."""
         if self.state not in (STATE_STANDBY, STATE_PLAYING):
             await self.coordinator.roku.remote("play")
             await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_media_play_pause(self) -> None:
         """Send play/pause command."""
         if self.state != STATE_STANDBY:
             await self.coordinator.roku.remote("play")
             await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         await self.coordinator.roku.remote("reverse")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         await self.coordinator.roku.remote("forward")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         await self.coordinator.roku.remote("volume_mute")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_volume_up(self) -> None:
         """Volume up media player."""
         await self.coordinator.roku.remote("volume_up")
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_volume_down(self) -> None:
         """Volume down media player."""
         await self.coordinator.roku.remote("volume_down")
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
     ) -> None:
@@ -490,7 +486,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         if source == "Home":

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -328,7 +328,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler(True)
+    @roku_exception_handler(ignore_timeout=True)
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
         with suppress(RokuConnectionTimeoutError):

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -1,7 +1,6 @@
 """Support for the Roku media player."""
 from __future__ import annotations
 
-from contextlib import suppress
 import datetime as dt
 import logging
 import mimetypes
@@ -329,7 +328,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler(True)
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
         with suppress(RokuConnectionTimeoutError):

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -6,7 +6,6 @@ import logging
 import mimetypes
 from typing import Any
 
-from rokuecp import RokuConnectionTimeoutError
 from rokuecp.helpers import guess_stream_format
 import voluptuous as vol
 import yarl
@@ -331,8 +330,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
     @roku_exception_handler(ignore_timeout=True)
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
-        with suppress(RokuConnectionTimeoutError):
-            await self.coordinator.roku.remote("poweroff")
+        await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -51,7 +51,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import roku_exception_handler
 from .browse_media import async_browse_media
 from .const import (
     ATTR_ARTIST_NAME,
@@ -65,7 +64,11 @@ from .const import (
 )
 from .coordinator import RokuDataUpdateCoordinator
 from .entity import RokuEntity
-from .helpers import format_channel_name
+from .helpers import (
+    format_channel_name,
+    roku_exception_handler,
+    roku_exception_handler_no_timeout,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -327,7 +330,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler(ignore_timeout=True)
+    @roku_exception_handler_no_timeout
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
         await self.coordinator.roku.remote("poweroff")

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from contextlib import suppress
 from typing import Any
 
 from rokuecp import RokuConnectionTimeoutError
@@ -53,7 +52,7 @@ class RokuRemote(RokuEntity, RemoteEntity):
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler(ignore_timeout=True)
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         with suppress(RokuConnectionTimeoutError):

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import RokuDataUpdateCoordinator
 from .entity import RokuEntity
-from .helpers import roku_exception_handler, roku_exception_handler_no_timeout
+from .helpers import roku_exception_handler
 
 
 async def async_setup_entry(
@@ -44,19 +44,19 @@ class RokuRemote(RokuEntity, RemoteEntity):
         """Return true if device is on."""
         return not self.coordinator.data.state.standby
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler_no_timeout
+    @roku_exception_handler(ignore_timeout=True)
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
         num_repeats = kwargs[ATTR_NUM_REPEATS]

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
-from rokuecp import RokuConnectionTimeoutError
-
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -55,8 +53,7 @@ class RokuRemote(RokuEntity, RemoteEntity):
     @roku_exception_handler(ignore_timeout=True)
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        with suppress(RokuConnectionTimeoutError):
-            await self.coordinator.roku.remote("poweroff")
+        await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -9,10 +9,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import roku_exception_handler
 from .const import DOMAIN
 from .coordinator import RokuDataUpdateCoordinator
 from .entity import RokuEntity
+from .helpers import roku_exception_handler, roku_exception_handler_no_timeout
 
 
 async def async_setup_entry(
@@ -50,7 +50,7 @@ class RokuRemote(RokuEntity, RemoteEntity):
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
-    @roku_exception_handler(ignore_timeout=True)
+    @roku_exception_handler_no_timeout
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.coordinator.roku.remote("poweroff")

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from contextlib import suppress
 from typing import Any
+
+from rokuecp import RokuConnectionTimeoutError
 
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.config_entries import ConfigEntry
@@ -53,7 +56,8 @@ class RokuRemote(RokuEntity, RemoteEntity):
     @roku_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        await self.coordinator.roku.remote("poweroff")
+        with suppress(RokuConnectionTimeoutError):
+            await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -162,7 +162,7 @@ class RokuSelectEntity(RokuEntity, SelectEntity):
         """Return a set of selectable options."""
         return self.entity_description.options_fn(self.coordinator.data)
 
-    @roku_exception_handler
+    @roku_exception_handler()
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         await self.entity_description.set_fn(

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -12,11 +12,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import roku_exception_handler
 from .const import DOMAIN
 from .coordinator import RokuDataUpdateCoordinator
 from .entity import RokuEntity
-from .helpers import format_channel_name
+from .helpers import format_channel_name, roku_exception_handler
 
 
 @dataclass

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2063,7 +2063,7 @@ rjpl==0.3.6
 rocketchat-API==0.6.1
 
 # homeassistant.components.roku
-rokuecp==0.14.1
+rokuecp==0.15.0
 
 # homeassistant.components.roomba
 roombapy==1.6.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1309,7 +1309,7 @@ rflink==0.0.62
 ring_doorbell==0.7.2
 
 # homeassistant.components.roku
-rokuecp==0.14.1
+rokuecp==0.15.0
 
 # homeassistant.components.roomba
 roombapy==1.6.5

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from rokuecp import RokuError
+from rokuecp import RokuConnectionError, RokuError
 
 from homeassistant.components.media_player import MediaPlayerDeviceClass
 from homeassistant.components.media_player.const import (
@@ -164,10 +164,15 @@ async def test_tv_setup(
     assert device_entry.suggested_area == "Living room"
 
 
+@pytest.mark.parametrize(
+    "error",
+    [RokuConnectionError, RokuError],
+)
 async def test_availability(
     hass: HomeAssistant,
     mock_roku: MagicMock,
     mock_config_entry: MockConfigEntry,
+    error: RokuError,
 ) -> None:
     """Test entity availability."""
     now = dt_util.utcnow()
@@ -179,7 +184,7 @@ async def test_availability(
         await hass.async_block_till_done()
 
     with patch("homeassistant.util.dt.utcnow", return_value=future):
-        mock_roku.update.side_effect = RokuError
+        mock_roku.update.side_effect = error
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
         assert hass.states.get(MAIN_ENTITY_ID).state == STATE_UNAVAILABLE

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from rokuecp import RokuConnectionError, RokuError
+from rokuecp import RokuConnectionError, RokuConnectionTimeoutError, RokuError
 
 from homeassistant.components.media_player import MediaPlayerDeviceClass
 from homeassistant.components.media_player.const import (
@@ -166,7 +166,7 @@ async def test_tv_setup(
 
 @pytest.mark.parametrize(
     "error",
-    [RokuConnectionError, RokuError],
+    [RokuConnectionTimeoutError, RokuConnectionError, RokuError],
 )
 async def test_availability(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/ctalkington/python-rokuecp/releases/tag/0.15.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65711
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
