### PR TITLE
Improve google calendar test quality and share setup

### DIFF
--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -90,7 +90,7 @@ def calendars_config_entity(
 
 @pytest.fixture
 def calendars_config(calendars_config_entity: dict[str, Any]) -> list[dict[str, Any]]:
-    """Fixture that creates the yaml configuration."""
+    """Fixture that specifies the calendar yaml configuration."""
     return [
         {
             "cal_id": CALENDAR_ID,
@@ -104,7 +104,7 @@ async def mock_calendars_yaml(
     hass: HomeAssistant,
     calendars_config: list[dict[str, Any]],
 ) -> None:
-    """Fixture that prepares the calendars.yaml file."""
+    """Fixture that prepares the google_calendars.yaml mocks."""
     mocked_open_function = mock_open(read_data=yaml.dump(calendars_config))
     with patch("homeassistant.components.google.open", mocked_open_function):
         yield

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -20,7 +20,6 @@ from homeassistant.util.dt import utcnow
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
 
-
 ApiResult = Callable[[dict[str, Any]], None]
 ComponentSetup = Callable[[], Awaitable[bool]]
 T = TypeVar("T")
@@ -49,7 +48,7 @@ TEST_API_CALENDAR = {
     "kind": "calendar#calendarListEntry",
     "backgroundColor": "#16a765",
     "description": "Test Calendar",
-    "summary": TEST_API_ENTITY_NAME,
+    "summary": "We are, we are, a... Test Calendar",
     "colorId": "8",
     "defaultReminders": [],
 }

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -1,25 +1,45 @@
 """Test configuration and mocks for the google integration."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 import datetime
 from typing import Any, Generator, TypeVar
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
 from googleapiclient import discovery as google_discovery
 from oauth2client.client import Credentials, OAuth2Credentials
 import pytest
+import yaml
 
+from homeassistant.components.google import CONF_TRACK_NEW, DOMAIN
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 from homeassistant.util.dt import utcnow
 
+ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
+
+
 ApiResult = Callable[[dict[str, Any]], None]
+ComponentSetup = Callable[[], Awaitable[bool]]
 T = TypeVar("T")
 YieldFixture = Generator[T, None, None]
 
 
 CALENDAR_ID = "qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com"
-TEST_CALENDAR = {
+
+# Entities can either be created based on data directly from the API, or from
+# the yaml config that overrides the entity name and other settings. A test
+# can use a fixture to exercise either case.
+TEST_API_ENTITY = "calendar.we_are_we_are_a_test_calendar"
+TEST_API_ENTITY_NAME = "We are, we are, a... Test Calendar"
+# Name of the entity when using yaml configuration overrides
+TEST_YAML_ENTITY = "calendar.backyard_light"
+TEST_YAML_ENTITY_NAME = "Backyard Light"
+
+# A calendar object returned from the API
+TEST_API_CALENDAR = {
     "id": CALENDAR_ID,
     "etag": '"3584134138943410"',
     "timeZone": "UTC",
@@ -29,17 +49,66 @@ TEST_CALENDAR = {
     "kind": "calendar#calendarListEntry",
     "backgroundColor": "#16a765",
     "description": "Test Calendar",
-    "summary": "We are, we are, a... Test Calendar",
+    "summary": TEST_API_ENTITY_NAME,
     "colorId": "8",
     "defaultReminders": [],
-    "track": True,
 }
 
 
 @pytest.fixture
-def test_calendar():
-    """Return a test calendar."""
-    return TEST_CALENDAR
+def test_api_calendar():
+    """Return a test calendar object used in API responses."""
+    return TEST_API_CALENDAR
+
+
+@pytest.fixture
+def calendars_config_track() -> bool:
+    """Fixture that determines the 'track' setting in yaml config."""
+    return True
+
+
+@pytest.fixture
+def calendars_config_ignore_availability() -> bool:
+    """Fixture that determines the 'ignore_availability' setting in yaml config."""
+    return None
+
+
+@pytest.fixture
+def calendars_config_entity(
+    calendars_config_track: bool, calendars_config_ignore_availability: bool | None
+) -> dict[str, Any]:
+    """Fixture that creates an entity within the yaml configuration."""
+    entity = {
+        "device_id": "backyard_light",
+        "name": "Backyard Light",
+        "search": "#Backyard",
+        "track": calendars_config_track,
+    }
+    if calendars_config_ignore_availability is not None:
+        entity["ignore_availability"] = calendars_config_ignore_availability
+    return entity
+
+
+@pytest.fixture
+def calendars_config(calendars_config_entity: dict[str, Any]) -> list[dict[str, Any]]:
+    """Fixture that creates the yaml configuration."""
+    return [
+        {
+            "cal_id": CALENDAR_ID,
+            "entities": [calendars_config_entity],
+        }
+    ]
+
+
+@pytest.fixture
+async def mock_calendars_yaml(
+    hass: HomeAssistant,
+    calendars_config: list[dict[str, Any]],
+) -> None:
+    """Fixture that prepares the calendars.yaml file."""
+    mocked_open_function = mock_open(read_data=yaml.dump(calendars_config))
+    with patch("homeassistant.components.google.open", mocked_open_function):
+        yield
 
 
 class FakeStorage:
@@ -156,3 +225,49 @@ def mock_insert_event(
     insert_mock = Mock()
     calendar_resource.return_value.events.return_value.insert = insert_mock
     return insert_mock
+
+
+@pytest.fixture(autouse=True)
+def set_time_zone(hass):
+    """Set the time zone for the tests."""
+    # Set our timezone to CST/Regina so we can check calculations
+    # This keeps UTC-6 all year round
+    hass.config.time_zone = "CST"
+    dt_util.set_default_time_zone(dt_util.get_time_zone("America/Regina"))
+    yield
+    dt_util.set_default_time_zone(ORIG_TIMEZONE)
+
+
+@pytest.fixture
+def google_config_track_new() -> None:
+    """Fixture for tests to set the 'track_new' configuration.yaml setting."""
+    return None
+
+
+@pytest.fixture
+def google_config(google_config_track_new: bool | None) -> dict[str, Any]:
+    """Fixture for overriding component config."""
+    google_config = {CONF_CLIENT_ID: "client-id", CONF_CLIENT_SECRET: "client-secret"}
+    if google_config_track_new is not None:
+        google_config[CONF_TRACK_NEW] = google_config_track_new
+    return google_config
+
+
+@pytest.fixture
+async def config(google_config: dict[str, Any]) -> dict[str, Any]:
+    """Fixture for overriding component config."""
+    return {DOMAIN: google_config}
+
+
+@pytest.fixture
+async def component_setup(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> ComponentSetup:
+    """Fixture for setting up the integration."""
+
+    async def _setup_func() -> bool:
+        result = await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+        return result
+
+    return _setup_func

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -529,7 +529,7 @@ async def test_add_event_date(
     )
 
 
-async def test_add_event_date_time(
+async def test_add_event_date(
     hass: HomeAssistant,
     mock_token_read: None,
     component_setup: ComponentSetup,

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -16,7 +16,6 @@ import pytest
 from homeassistant.components.google import DOMAIN, SERVICE_ADD_EVENT
 from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant, State
-from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from .conftest import (
@@ -529,7 +528,7 @@ async def test_add_event_date(
     )
 
 
-async def test_add_event_date(
+async def test_add_event_date_time(
     hass: HomeAssistant,
     mock_token_read: None,
     component_setup: ComponentSetup,
@@ -537,7 +536,7 @@ async def test_add_event_date(
     test_api_calendar: dict[str, Any],
     mock_insert_event: Mock,
 ) -> None:
-    """Test service call that adds an event with various time ranges."""
+    """Test service call that adds an event with a date time range."""
 
     assert await component_setup()
 

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -2,7 +2,7 @@
 from collections.abc import Awaitable, Callable
 import datetime
 from typing import Any
-from unittest.mock import Mock, call, mock_open, patch
+from unittest.mock import Mock, call, patch
 
 from oauth2client.client import (
     FlowExchangeError,
@@ -10,21 +10,27 @@ from oauth2client.client import (
     OAuth2DeviceCodeError,
 )
 import pytest
-import yaml
 
 from homeassistant.components.google import DOMAIN, SERVICE_ADD_EVENT
-from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, STATE_OFF
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import utcnow
 
-from .conftest import CALENDAR_ID, ApiResult, YieldFixture
+from .conftest import (
+    CALENDAR_ID,
+    TEST_API_ENTITY,
+    TEST_API_ENTITY_NAME,
+    TEST_YAML_ENTITY,
+    TEST_YAML_ENTITY_NAME,
+    ApiResult,
+    ComponentSetup,
+    YieldFixture,
+)
 
 from tests.common import async_fire_time_changed
 
 # Typing helpers
-ComponentSetup = Callable[[], Awaitable[bool]]
 HassApi = Callable[[], Awaitable[dict[str, Any]]]
 
 CODE_CHECK_INTERVAL = 1
@@ -60,59 +66,10 @@ async def mock_exchange(creds: OAuth2Credentials) -> YieldFixture[Mock]:
 
 
 @pytest.fixture
-async def calendars_config() -> list[dict[str, Any]]:
-    """Fixture for tests to override default calendar configuration."""
-    return [
-        {
-            "cal_id": CALENDAR_ID,
-            "entities": [
-                {
-                    "device_id": "backyard_light",
-                    "name": "Backyard Light",
-                    "search": "#Backyard",
-                    "track": True,
-                }
-            ],
-        }
-    ]
-
-
-@pytest.fixture
-async def mock_calendars_yaml(
-    hass: HomeAssistant,
-    calendars_config: list[dict[str, Any]],
-) -> None:
-    """Fixture that prepares the calendars.yaml file."""
-    mocked_open_function = mock_open(read_data=yaml.dump(calendars_config))
-    with patch("homeassistant.components.google.open", mocked_open_function):
-        yield
-
-
-@pytest.fixture
 async def mock_notification() -> YieldFixture[Mock]:
     """Fixture for capturing persistent notifications."""
     with patch("homeassistant.components.persistent_notification.create") as mock:
         yield mock
-
-
-@pytest.fixture
-async def config() -> dict[str, Any]:
-    """Fixture for overriding component config."""
-    return {DOMAIN: {CONF_CLIENT_ID: "client-id", CONF_CLIENT_SECRET: "client-ecret"}}
-
-
-@pytest.fixture
-async def component_setup(
-    hass: HomeAssistant, config: dict[str, Any]
-) -> ComponentSetup:
-    """Fixture for setting up the integration."""
-
-    async def _setup_func() -> bool:
-        result = await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
-        return result
-
-    return _setup_func
 
 
 async def fire_alarm(hass, point_in_time):
@@ -133,7 +90,7 @@ async def test_setup_config_empty(
 
     mock_notification.assert_not_called()
 
-    assert not hass.states.get("calendar.backyard_light")
+    assert not hass.states.get(TEST_YAML_ENTITY)
 
 
 async def test_init_success(
@@ -151,9 +108,9 @@ async def test_init_success(
     now = utcnow()
     await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
 
-    state = hass.states.get("calendar.backyard_light")
+    state = hass.states.get(TEST_YAML_ENTITY)
     assert state
-    assert state.name == "Backyard Light"
+    assert state.name == TEST_YAML_ENTITY_NAME
     assert state.state == STATE_OFF
 
     mock_notification.assert_called()
@@ -174,7 +131,7 @@ async def test_code_error(
     ):
         assert await component_setup()
 
-    assert not hass.states.get("calendar.backyard_light")
+    assert not hass.states.get(TEST_YAML_ENTITY)
 
     mock_notification.assert_called()
     assert "Error: Test Failure" in mock_notification.call_args[0][1]
@@ -194,7 +151,7 @@ async def test_expired_after_exchange(
     now = utcnow()
     await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
 
-    assert not hass.states.get("calendar.backyard_light")
+    assert not hass.states.get(TEST_YAML_ENTITY)
 
     mock_notification.assert_called()
     assert (
@@ -220,7 +177,7 @@ async def test_exchange_error(
         now = utcnow()
         await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
 
-    assert not hass.states.get("calendar.backyard_light")
+    assert not hass.states.get(TEST_YAML_ENTITY)
 
     mock_notification.assert_called()
     assert "In order to authorize Home-Assistant" in mock_notification.call_args[0][1]
@@ -236,9 +193,9 @@ async def test_existing_token(
     """Test setup with an existing token file."""
     assert await component_setup()
 
-    state = hass.states.get("calendar.backyard_light")
+    state = hass.states.get(TEST_YAML_ENTITY)
     assert state
-    assert state.name == "Backyard Light"
+    assert state.name == TEST_YAML_ENTITY_NAME
     assert state.state == STATE_OFF
 
     mock_notification.assert_not_called()
@@ -265,9 +222,9 @@ async def test_existing_token_missing_scope(
     await fire_alarm(hass, now + CODE_CHECK_ALARM_TIMEDELTA)
     assert len(mock_exchange.mock_calls) == 1
 
-    state = hass.states.get("calendar.backyard_light")
+    state = hass.states.get(TEST_YAML_ENTITY)
     assert state
-    assert state.name == "Backyard Light"
+    assert state.name == TEST_YAML_ENTITY_NAME
     assert state.state == STATE_OFF
 
     # No notifications on success
@@ -287,7 +244,7 @@ async def test_calendar_yaml_missing_required_fields(
     """Test setup with a missing schema fields, ignores the error and continues."""
     assert await component_setup()
 
-    assert not hass.states.get("calendar.backyard_light")
+    assert not hass.states.get(TEST_YAML_ENTITY)
 
     mock_notification.assert_not_called()
 
@@ -306,30 +263,90 @@ async def test_invalid_calendar_yaml(
     # Integration fails to setup
     assert not await component_setup()
 
-    assert not hass.states.get("calendar.backyard_light")
+    assert not hass.states.get(TEST_YAML_ENTITY)
 
     mock_notification.assert_not_called()
 
 
-async def test_found_calendar_from_api(
+@pytest.mark.parametrize(
+    "google_config_track_new,calendars_config,expect_tracked",
+    [
+        (None, [], True),  # CONF_TRACK_NEW is unset
+        (True, [], True),
+        (False, [], False),
+    ],
+    ids=["default", "True", "False"],
+)
+async def test_track_new(
     hass: HomeAssistant,
     mock_token_read: None,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
-    test_calendar: dict[str, Any],
+    test_api_calendar: dict[str, Any],
+    mock_calendars_yaml: None,
+    expect_tracked: bool,
+) -> None:
+    """Test behavior for tracking new calendars found from the API with no existing config."""
+
+    mock_calendars_list({"items": [test_api_calendar]})
+    assert await component_setup()
+
+    # The calendar does not
+    state = hass.states.get(TEST_API_ENTITY)
+    if expect_tracked:
+        assert state
+        assert state.name == TEST_API_ENTITY_NAME
+        assert state.state == STATE_OFF
+    else:
+        assert not state
+
+
+@pytest.mark.parametrize("calendars_config", [[]])
+async def test_found_calendar_from_api(
+    hass: HomeAssistant,
+    mock_token_read: None,
+    component_setup: ComponentSetup,
+    mock_calendars_yaml: None,
+    mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
 ) -> None:
     """Test finding a calendar from the API."""
 
-    mock_calendars_list({"items": [test_calendar]})
+    mock_calendars_list({"items": [test_api_calendar]})
+    assert await component_setup()
 
-    mocked_open_function = mock_open(read_data=yaml.dump([]))
-    with patch("homeassistant.components.google.open", mocked_open_function):
-        assert await component_setup()
-
-    state = hass.states.get("calendar.we_are_we_are_a_test_calendar")
+    # The calendar does not
+    state = hass.states.get(TEST_API_ENTITY)
     assert state
-    assert state.name == "We are, we are, a... Test Calendar"
+    assert state.name == TEST_API_ENTITY_NAME
     assert state.state == STATE_OFF
+
+    # No yaml config loaded that overwrites the entity name
+    assert not hass.states.get(TEST_YAML_ENTITY)
+
+
+@pytest.mark.parametrize("calendars_config_track", [True, False])
+async def test_calendar_config_track_new(
+    hass: HomeAssistant,
+    mock_token_read: None,
+    component_setup: ComponentSetup,
+    mock_calendars_yaml: None,
+    mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
+    calendars_config_track: bool,
+) -> None:
+    """Test calendar config that overrides whether or not a calendar is tracked."""
+
+    mock_calendars_list({"items": [test_api_calendar]})
+    assert await component_setup()
+
+    state = hass.states.get(TEST_YAML_ENTITY)
+    if calendars_config_track:
+        assert state
+        assert state.name == TEST_YAML_ENTITY_NAME
+        assert state.state == STATE_OFF
+    else:
+        assert not state
 
 
 async def test_add_event(
@@ -337,7 +354,7 @@ async def test_add_event(
     mock_token_read: None,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
-    test_calendar: dict[str, Any],
+    test_api_calendar: dict[str, Any],
     mock_insert_event: Mock,
 ) -> None:
     """Test service call that adds an event."""
@@ -387,7 +404,7 @@ async def test_add_event_date_in_x(
     mock_token_read: None,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
-    test_calendar: dict[str, Any],
+    test_api_calendar: dict[str, Any],
     mock_insert_event: Mock,
     date_fields: dict[str, Any],
     start_timedelta: datetime.timedelta,
@@ -425,19 +442,18 @@ async def test_add_event_date_in_x(
     )
 
 
-async def test_add_event_date_range(
+async def test_add_event_date(
     hass: HomeAssistant,
     mock_token_read: None,
     component_setup: ComponentSetup,
     mock_calendars_list: ApiResult,
-    test_calendar: dict[str, Any],
     mock_insert_event: Mock,
 ) -> None:
     """Test service call that sets a date range."""
 
     assert await component_setup()
 
-    now = dt_util.utcnow()
+    now = utcnow()
     today = now.date()
     end_date = today + datetime.timedelta(days=2)
 
@@ -462,5 +478,52 @@ async def test_add_event_date_range(
             "description": "Description",
             "start": {"date": today.isoformat()},
             "end": {"date": end_date.isoformat()},
+        },
+    )
+
+
+async def test_add_event_date_time(
+    hass: HomeAssistant,
+    mock_token_read: None,
+    component_setup: ComponentSetup,
+    mock_calendars_list: ApiResult,
+    test_api_calendar: dict[str, Any],
+    mock_insert_event: Mock,
+) -> None:
+    """Test service call that adds an event with various time ranges."""
+
+    assert await component_setup()
+
+    start_datetime = datetime.datetime.now()
+    delta = datetime.timedelta(days=3, hours=3)
+    end_datetime = start_datetime + delta
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_EVENT,
+        {
+            "calendar_id": CALENDAR_ID,
+            "summary": "Summary",
+            "description": "Description",
+            "start_date_time": start_datetime.isoformat(),
+            "end_date_time": end_datetime.isoformat(),
+        },
+        blocking=True,
+    )
+    mock_insert_event.assert_called()
+
+    assert mock_insert_event.mock_calls[0] == call(
+        calendarId=CALENDAR_ID,
+        body={
+            "summary": "Summary",
+            "description": "Description",
+            "start": {
+                "dateTime": start_datetime.isoformat(timespec="seconds"),
+                "timeZone": "CST",
+            },
+            "end": {
+                "dateTime": end_datetime.isoformat(timespec="seconds"),
+                "timeZone": "CST",
+            },
         },
     )

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -286,7 +286,7 @@ async def test_track_new(
     mock_calendars_yaml: None,
     expect_tracked: bool,
 ) -> None:
-    """Test behavior for tracking new calendars found from the API with no existing config."""
+    """Test behavior of configuration.yaml settings for tracking new calendars not in the config."""
 
     mock_calendars_list({"items": [test_api_calendar]})
     assert await component_setup()


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve google calendar test quality by exercising different combinations of
cases and new coverage. The existing test cases do achieve very high coverage,
however some of the subtle interactions between the components are not as well
exercised, which is needed when we start changing how the internal code is
structured moving to async or to config entries.

Improvement include:
- Exercising additional cases around different types of configuration parameters
  that control how calendars are tracked or not tracked. The tracking can be
  configured in google_calendars.yaml, or by defaults set in configuration.yaml
  for new calendars.
- Share even more test setup, used when exercising the above different scenarios
- Add new test cases for event creation.
- Improve test readability by making more clear the differences between tests
  exercising yaml and API test calendars. The data types are now more clearly
  separated in the two cases, as well as the entity names created in the two
  cases.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
