### PR TITLE
Add support for joaoapps_join notification categories

### DIFF
--- a/homeassistant/components/joaoapps_join/manifest.json
+++ b/homeassistant/components/joaoapps_join/manifest.json
@@ -2,7 +2,7 @@
   "domain": "joaoapps_join",
   "name": "Joaoapps Join",
   "documentation": "https://www.home-assistant.io/integrations/joaoapps_join",
-  "requirements": ["python-join-api==0.0.6"],
+  "requirements": ["python-join-api==0.0.9"],
   "codeowners": [],
   "iot_class": "cloud_push",
   "loggers": ["pyjoin"]

--- a/homeassistant/components/joaoapps_join/notify.py
+++ b/homeassistant/components/joaoapps_join/notify.py
@@ -72,6 +72,7 @@ class JoinNotificationService(BaseNotificationService):
             image=data.get("image"),
             sound=data.get("sound"),
             notification_id=data.get("notification_id"),
+            category=data.get("category"),
             url=data.get("url"),
             tts=data.get("tts"),
             tts_language=data.get("tts_language"),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1885,7 +1885,7 @@ python-hpilo==4.3
 python-izone==1.2.3
 
 # homeassistant.components.joaoapps_join
-python-join-api==0.0.6
+python-join-api==0.0.9
 
 # homeassistant.components.juicenet
 python-juicenet==1.0.2


### PR DESCRIPTION
…ty.home-assistant.io/t/add-joaoapps-join-support-for-notification-categories/393863

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**This is a second attempt at https://github.com/home-assistant/core/pull/66755 , which I bungled when attempting to clear up a CLA issue.**

Update the pyjoin library to 0.0.9, which features this change enabling notification category support:
```--- /usr/local/lib/python3.9/site-packages/pyjoin/__init__.py.orig
+++ /usr/local/lib/python3.9/site-packages/pyjoin/__init__.py
@@ -78,7 +78,7 @@
         return [(r['deviceName'], r['deviceId']) for r in response['records']]
     return False

-def send_notification(api_key, text, device_id=None, device_ids=None, device_names=None, title=None, icon=None, smallicon=None, vibration=None, image=None, url=None, tts=None, tts_language=None, sound=None, notification_id=None, actions=None):
+def send_notification(api_key, text, device_id=None, device_ids=None, device_names=None, title=None, icon=None, smallicon=None, vibration=None, image=None, url=None, tts=None, tts_language=None, sound=None, notification_id=None, category=None, actions=None):
     if device_id is None and device_ids is None and device_names is None: return False
     req_url = SEND_URL + api_key + "&text=" + text
     if title: req_url += "&title=" + title
@@ -91,6 +91,7 @@
     if tts_language: req_url += "&language=" + tts_language
     if sound: req_url += "&sound=" + sound
     if notification_id: req_url += "&notificationId=" + notification_id
+    if category: req_url += "&category=" + category
     if device_id: req_url += "&deviceId=" + device_id
     if device_ids: req_url += "&deviceIds=" + device_ids
     if device_names: req_url += "&deviceNames=" + device_names
```
Here is a link to the GitHub diff between 0.0.6 and 0.0.9: https://github.com/nkgilley/python-join-api/compare/700e59eda3b1a7d3db5a17b7e51babfe1580b5ff..a966f93609263568fbc57c48000acd85b318a4f6

Also added the related supporting code to the joaoapps_join integration component.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://community.home-assistant.io/t/add-joaoapps-join-support-for-notification-categories/393863
- This PR is related to issue:  
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21679

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
