### PR TITLE
Improve zwave_js custom triggers and services

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -60,8 +60,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+from .config_validation import BITMASK_SCHEMA
 from .const import (
-    BITMASK_SCHEMA,
     CONF_DATA_COLLECTION_OPTED_IN,
     DATA_CLIENT,
     DOMAIN,

--- a/homeassistant/components/zwave_js/config_validation.py
+++ b/homeassistant/components/zwave_js/config_validation.py
@@ -1,0 +1,41 @@
+"""Config validation for the Z-Wave JS integration."""
+from typing import Any
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+# Validates that a bitmask is provided in hex form and converts it to decimal
+# int equivalent since that's what the library uses
+BITMASK_SCHEMA = vol.All(
+    cv.string,
+    vol.Lower,
+    vol.Match(
+        r"^(0x)?[0-9a-f]+$",
+        msg="Must provide an integer (e.g. 255) or a bitmask in hex form (e.g. 0xff)",
+    ),
+    lambda value: int(value, 16),
+)
+
+
+def boolean(value: Any) -> bool:
+    """Validate and coerce a boolean value."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        value = value.lower().strip()
+        if value in ("true", "yes", "on", "enable"):
+            return True
+        if value in ("false", "no", "off", "disable"):
+            return False
+    raise vol.Invalid(f"invalid boolean value {value}")
+
+
+VALUE_SCHEMA = vol.Any(
+    boolean,
+    vol.Coerce(int),
+    vol.Coerce(float),
+    BITMASK_SCHEMA,
+    cv.string,
+    dict,
+)

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -1,5 +1,6 @@
 """Constants for the Z-Wave JS integration."""
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -132,8 +133,22 @@ BITMASK_SCHEMA = vol.All(
     lambda value: int(value, 16),
 )
 
+
+def boolean(value: Any) -> bool:
+    """Validate and coerce a boolean value."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        value = value.lower().strip()
+        if value in ("true", "yes", "on", "enable"):
+            return True
+        if value in ("false", "no", "off", "disable"):
+            return False
+    raise vol.Invalid(f"invalid boolean value {value}")
+
+
 VALUE_SCHEMA = vol.Any(
-    bool,
+    boolean,
     vol.Coerce(int),
     vol.Coerce(float),
     BITMASK_SCHEMA,

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -1,10 +1,5 @@
 """Constants for the Z-Wave JS integration."""
 import logging
-from typing import Any
-
-import voluptuous as vol
-
-import homeassistant.helpers.config_validation as cv
 
 CONF_ADDON_DEVICE = "device"
 CONF_ADDON_EMULATE_HARDWARE = "emulate_hardware"
@@ -118,40 +113,3 @@ ENTITY_DESC_KEY_TEMPERATURE = "temperature"
 ENTITY_DESC_KEY_TARGET_TEMPERATURE = "target_temperature"
 ENTITY_DESC_KEY_MEASUREMENT = "measurement"
 ENTITY_DESC_KEY_TOTAL_INCREASING = "total_increasing"
-
-# Schema Constants
-
-# Validates that a bitmask is provided in hex form and converts it to decimal
-# int equivalent since that's what the library uses
-BITMASK_SCHEMA = vol.All(
-    cv.string,
-    vol.Lower,
-    vol.Match(
-        r"^(0x)?[0-9a-f]+$",
-        msg="Must provide an integer (e.g. 255) or a bitmask in hex form (e.g. 0xff)",
-    ),
-    lambda value: int(value, 16),
-)
-
-
-def boolean(value: Any) -> bool:
-    """Validate and coerce a boolean value."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        value = value.lower().strip()
-        if value in ("true", "yes", "on", "enable"):
-            return True
-        if value in ("false", "no", "off", "disable"):
-            return False
-    raise vol.Invalid(f"invalid boolean value {value}")
-
-
-VALUE_SCHEMA = vol.Any(
-    boolean,
-    vol.Coerce(int),
-    vol.Coerce(float),
-    BITMASK_SCHEMA,
-    cv.string,
-    dict,
-)

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -29,6 +29,7 @@ from homeassistant.helpers import entity_registry
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
+from .config_validation import VALUE_SCHEMA
 from .const import (
     ATTR_COMMAND_CLASS,
     ATTR_CONFIG_PARAMETER,
@@ -48,7 +49,6 @@ from .const import (
     SERVICE_SET_CONFIG_PARAMETER,
     SERVICE_SET_LOCK_USERCODE,
     SERVICE_SET_VALUE,
-    VALUE_SCHEMA,
 )
 from .device_automation_helpers import (
     CONF_SUBTYPE,

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -16,6 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
+from .config_validation import VALUE_SCHEMA
 from .const import (
     ATTR_COMMAND_CLASS,
     ATTR_ENDPOINT,
@@ -23,7 +24,6 @@ from .const import (
     ATTR_PROPERTY_KEY,
     ATTR_VALUE,
     DOMAIN,
-    VALUE_SCHEMA,
 )
 from .device_automation_helpers import (
     CONF_SUBTYPE,

--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -32,6 +32,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.typing import ConfigType
 
 from . import trigger
+from .config_validation import VALUE_SCHEMA
 from .const import (
     ATTR_COMMAND_CLASS,
     ATTR_DATA_TYPE,
@@ -79,14 +80,6 @@ SCENE_ACTIVATION_VALUE_NOTIFICATION = "event.value_notification.scene_activation
 CONFIG_PARAMETER_VALUE_UPDATED = f"{VALUE_UPDATED_PLATFORM_TYPE}.config_parameter"
 VALUE_VALUE_UPDATED = f"{VALUE_UPDATED_PLATFORM_TYPE}.value"
 NODE_STATUS = "state.node_status"
-
-VALUE_SCHEMA = vol.Any(
-    bool,
-    vol.Coerce(int),
-    vol.Coerce(float),
-    cv.boolean,
-    cv.string,
-)
 
 
 NOTIFICATION_EVENT_CC_MAPPINGS = (

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -243,18 +243,18 @@ def async_get_nodes_from_targets(
     """
     nodes: set[ZwaveNode] = set()
     # Convert all entity IDs to nodes
-    for entity_id in expand_entity_ids(hass, val.pop(ATTR_ENTITY_ID, [])):
+    for entity_id in expand_entity_ids(hass, val.get(ATTR_ENTITY_ID, [])):
         try:
             nodes.add(async_get_node_from_entity_id(hass, entity_id, ent_reg, dev_reg))
         except ValueError as err:
             LOGGER.warning(err.args[0])
 
     # Convert all area IDs to nodes
-    for area_id in val.pop(ATTR_AREA_ID, []):
+    for area_id in val.get(ATTR_AREA_ID, []):
         nodes.update(async_get_nodes_from_area_id(hass, area_id, ent_reg, dev_reg))
 
     # Convert all device IDs to nodes
-    for device_id in val.pop(ATTR_DEVICE_ID, []):
+    for device_id in val.get(ATTR_DEVICE_ID, []):
         try:
             nodes.add(async_get_node_from_device_id(hass, device_id, dev_reg))
         except ValueError as err:

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -14,9 +14,16 @@ from zwave_js_server.model.value import (
     get_value_id,
 )
 
+from homeassistant.components.group import expand_entity_ids
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import CONF_TYPE, __version__ as HA_VERSION
+from homeassistant.const import (
+    ATTR_AREA_ID,
+    ATTR_DEVICE_ID,
+    ATTR_ENTITY_ID,
+    CONF_TYPE,
+    __version__ as HA_VERSION,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -30,6 +37,7 @@ from .const import (
     CONF_DATA_COLLECTION_OPTED_IN,
     DATA_CLIENT,
     DOMAIN,
+    LOGGER,
 )
 
 
@@ -217,6 +225,40 @@ def async_get_nodes_from_area_id(
             None,
         ):
             nodes.add(async_get_node_from_device_id(hass, device.id, dev_reg))
+
+    return nodes
+
+
+@callback
+def async_get_nodes_from_targets(
+    hass: HomeAssistant,
+    val: dict[str, Any],
+    ent_reg: er.EntityRegistry | None = None,
+    dev_reg: dr.DeviceRegistry | None = None,
+) -> set[ZwaveNode]:
+    """
+    Get nodes for all targets.
+
+    Supports entity_id with group expansion, area_id, and device_id.
+    """
+    nodes: set[ZwaveNode] = set()
+    # Convert all entity IDs to nodes
+    for entity_id in expand_entity_ids(hass, val.pop(ATTR_ENTITY_ID, [])):
+        try:
+            nodes.add(async_get_node_from_entity_id(hass, entity_id, ent_reg, dev_reg))
+        except ValueError as err:
+            LOGGER.warning(err.args[0])
+
+    # Convert all area IDs to nodes
+    for area_id in val.pop(ATTR_AREA_ID, []):
+        nodes.update(async_get_nodes_from_area_id(hass, area_id, ent_reg, dev_reg))
+
+    # Convert all device IDs to nodes
+    for device_id in val.pop(ATTR_DEVICE_ID, []):
+        try:
+            nodes.add(async_get_node_from_device_id(hass, device_id, dev_reg))
+        except ValueError as err:
+            LOGGER.warning(err.args[0])
 
     return nodes
 

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -25,6 +25,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from . import const
+from .config_validation import BITMASK_SCHEMA, VALUE_SCHEMA
 from .helpers import async_get_nodes_from_targets
 
 _LOGGER = logging.getLogger(__name__)
@@ -162,10 +163,10 @@ class ZWaveServices:
                             vol.Coerce(int), cv.string
                         ),
                         vol.Optional(const.ATTR_CONFIG_PARAMETER_BITMASK): vol.Any(
-                            vol.Coerce(int), const.BITMASK_SCHEMA
+                            vol.Coerce(int), BITMASK_SCHEMA
                         ),
                         vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
-                            vol.Coerce(int), const.BITMASK_SCHEMA, cv.string
+                            vol.Coerce(int), BITMASK_SCHEMA, cv.string
                         ),
                     },
                     cv.has_at_least_one_key(
@@ -197,10 +198,8 @@ class ZWaveServices:
                             vol.Coerce(int),
                             {
                                 vol.Any(
-                                    vol.Coerce(int), const.BITMASK_SCHEMA, cv.string
-                                ): vol.Any(
-                                    vol.Coerce(int), const.BITMASK_SCHEMA, cv.string
-                                )
+                                    vol.Coerce(int), BITMASK_SCHEMA, cv.string
+                                ): vol.Any(vol.Coerce(int), BITMASK_SCHEMA, cv.string)
                             },
                         ),
                     },
@@ -252,11 +251,9 @@ class ZWaveServices:
                             vol.Coerce(int), str
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
-                        vol.Required(const.ATTR_VALUE): const.VALUE_SCHEMA,
+                        vol.Required(const.ATTR_VALUE): VALUE_SCHEMA,
                         vol.Optional(const.ATTR_WAIT_FOR_RESULT): cv.boolean,
-                        vol.Optional(const.ATTR_OPTIONS): {
-                            cv.string: const.VALUE_SCHEMA
-                        },
+                        vol.Optional(const.ATTR_OPTIONS): {cv.string: VALUE_SCHEMA},
                     },
                     cv.has_at_least_one_key(
                         ATTR_DEVICE_ID, ATTR_ENTITY_ID, ATTR_AREA_ID
@@ -290,10 +287,8 @@ class ZWaveServices:
                             vol.Coerce(int), str
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
-                        vol.Required(const.ATTR_VALUE): const.VALUE_SCHEMA,
-                        vol.Optional(const.ATTR_OPTIONS): {
-                            cv.string: const.VALUE_SCHEMA
-                        },
+                        vol.Required(const.ATTR_VALUE): VALUE_SCHEMA,
+                        vol.Optional(const.ATTR_OPTIONS): {cv.string: VALUE_SCHEMA},
                     },
                     vol.Any(
                         cv.has_at_least_one_key(

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -20,6 +20,7 @@ from homeassistant.components.zwave_js.const import (
     ATTR_CURRENT_VALUE_RAW,
     ATTR_ENDPOINT,
     ATTR_NODE_ID,
+    ATTR_NODES,
     ATTR_PREVIOUS_VALUE,
     ATTR_PREVIOUS_VALUE_RAW,
     ATTR_PROPERTY,
@@ -29,8 +30,7 @@ from homeassistant.components.zwave_js.const import (
     DOMAIN,
 )
 from homeassistant.components.zwave_js.helpers import (
-    async_get_node_from_device_id,
-    async_get_node_from_entity_id,
+    async_get_nodes_from_targets,
     get_device_id,
 )
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, CONF_PLATFORM, MATCH_ALL
@@ -76,6 +76,20 @@ TRIGGER_SCHEMA = vol.All(
 )
 
 
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    config = TRIGGER_SCHEMA(config)
+
+    config[ATTR_NODES] = async_get_nodes_from_targets(hass, config)
+    if not config[ATTR_NODES]:
+        raise vol.Invalid(
+            f"No nodes found for given {ATTR_DEVICE_ID}s or {ATTR_ENTITY_ID}s."
+        )
+    return config
+
+
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
@@ -85,21 +99,7 @@ async def async_attach_trigger(
     platform_type: str = PLATFORM_TYPE,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
-    nodes: set[Node] = set()
-    if ATTR_DEVICE_ID in config:
-        nodes.update(
-            {
-                async_get_node_from_device_id(hass, device_id)
-                for device_id in config.get(ATTR_DEVICE_ID, [])
-            }
-        )
-    if ATTR_ENTITY_ID in config:
-        nodes.update(
-            {
-                async_get_node_from_entity_id(hass, entity_id)
-                for entity_id in config.get(ATTR_ENTITY_ID, [])
-            }
-        )
+    nodes: set[Node] = config[ATTR_NODES]
 
     from_value = config[ATTR_FROM]
     to_value = config[ATTR_TO]

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -38,19 +38,13 @@ from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
+from ..config_validation import VALUE_SCHEMA
+
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
 PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
 
 ATTR_FROM = "from"
 ATTR_TO = "to"
-
-VALUE_SCHEMA = vol.Any(
-    bool,
-    vol.Coerce(int),
-    vol.Coerce(float),
-    cv.boolean,
-    cv.string,
-)
 
 TRIGGER_SCHEMA = vol.All(
     cv.TRIGGER_BASE_SCHEMA.extend(

--- a/tests/components/zwave_js/test_config_validation.py
+++ b/tests/components/zwave_js/test_config_validation.py
@@ -7,13 +7,20 @@ from homeassistant.components.zwave_js.config_validation import boolean
 
 def test_boolean_validation():
     """Test boolean config validator."""
+    # test bool
     assert boolean(True)
     assert not boolean(False)
+    # test strings
     assert boolean("TRUE")
     assert not boolean("FALSE")
     assert boolean("ON")
     assert not boolean("NO")
+    # ensure 1's and 0's don't get converted to bool
     with pytest.raises(vol.Invalid):
         boolean("1")
     with pytest.raises(vol.Invalid):
         boolean("0")
+    with pytest.raises(vol.Invalid):
+        boolean(1)
+    with pytest.raises(vol.Invalid):
+        boolean(0)

--- a/tests/components/zwave_js/test_config_validation.py
+++ b/tests/components/zwave_js/test_config_validation.py
@@ -1,0 +1,19 @@
+"""Test the Z-Wave JS config validation helpers."""
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.zwave_js.config_validation import boolean
+
+
+def test_boolean_validation():
+    """Test boolean config validator."""
+    assert boolean(True)
+    assert not boolean(False)
+    assert boolean("TRUE")
+    assert not boolean("FALSE")
+    assert boolean("ON")
+    assert not boolean("NO")
+    with pytest.raises(vol.Invalid):
+        boolean("1")
+    with pytest.raises(vol.Invalid):
+        boolean("0")

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -498,6 +498,20 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
 
     client.async_send_command.reset_mock()
 
+    # Test setting config parameter with no valid nodes raises Exception
+    with pytest.raises(vol.MultipleInvalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_CONFIG_PARAMETER,
+            {
+                ATTR_ENTITY_ID: "sensor.fake",
+                ATTR_CONFIG_PARAMETER: 102,
+                ATTR_CONFIG_PARAMETER_BITMASK: 1,
+                ATTR_CONFIG_VALUE: 1,
+            },
+            blocking=True,
+        )
+
 
 async def test_bulk_set_config_parameters(hass, client, multisensor_6, integration):
     """Test the bulk_set_partial_config_parameters service."""
@@ -1345,8 +1359,8 @@ async def test_multicast_set_value(
     diff_network_node.client.driver.controller.home_id.return_value = "diff_home_id"
 
     with pytest.raises(vol.MultipleInvalid), patch(
-        "homeassistant.components.zwave_js.services.async_get_node_from_device_id",
-        return_value=diff_network_node,
+        "homeassistant.components.zwave_js.helpers.async_get_node_from_device_id",
+        side_effect=(climate_danfoss_lc_13, diff_network_node),
     ):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -1,6 +1,8 @@
 """The tests for Z-Wave JS automation triggers."""
 from unittest.mock import AsyncMock, patch
 
+import pytest
+import voluptuous as vol
 from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
@@ -708,3 +710,28 @@ async def test_async_validate_trigger_config(hass):
         mock_platform.async_validate_trigger_config.return_value = {}
         await async_validate_trigger_config(hass, {})
         mock_platform.async_validate_trigger_config.assert_awaited()
+
+
+async def test_invalid_trigger_configs(hass):
+    """Test invalid trigger configs."""
+    with pytest.raises(vol.Invalid):
+        await async_validate_trigger_config(
+            hass,
+            {
+                "platform": f"{DOMAIN}.event",
+                "entity_id": "fake.entity",
+                "event_source": "node",
+                "event": "value updated",
+            },
+        )
+
+    with pytest.raises(vol.Invalid):
+        await async_validate_trigger_config(
+            hass,
+            {
+                "platform": f"{DOMAIN}.value_updated",
+                "entity_id": "fake.entity",
+                "command_class": CommandClass.DOOR_LOCK.value,
+                "property": "latchStatus",
+            },
+        )


### PR DESCRIPTION
## Proposed change
Made a couple of changes to improve our custom triggers and services.

For services, we previously made a change to skip invalid entities and devices instead of raising an exception to make the services more user friendly. Now we validate that at least one valid node was provided as a target.

For the custom triggers, because we moved the entity/device/area ID logic to the helpers, we can now use it in the custom trigger validation. This means that we can perform the same check, and as a side benefit, now group entities can be targeted. In this case though we also skip invalid entities/devices - if we don't wan to support that I can revert some of these changes, as I think the group entity expansion is still worth keeping.

For anywhere we use `VALUE_SCHEMA` (services and device automations) I've made it so booleans as string will now be supported


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
