### PR TITLE
Mqtt fix issue with displaying non UTF-8 payload

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1207,11 +1207,9 @@ async def websocket_subscribe(hass, connection, msg):
     async def forward_messages(mqttmsg: ReceiveMessage):
         """Forward events to websocket."""
         try:
-            payload = (
-                mqttmsg.payload.decode(DEFAULT_ENCODING)
-                if isinstance(mqttmsg.payload, bytes)
-                else mqttmsg.payload
-            )
+            payload = cast(bytes, mqttmsg.payload).decode(
+                DEFAULT_ENCODING
+            )  # not str because encoding is set to None
         except (AttributeError, UnicodeDecodeError):
             # Convert non UTF-8 payload to a string presentation
             payload = str(mqttmsg.payload)

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1210,7 +1210,7 @@ async def websocket_subscribe(hass, connection, msg):
             payload = (
                 mqttmsg.payload.decode(DEFAULT_ENCODING)
                 if isinstance(mqttmsg.payload, bytes)
-                else None
+                else mqttmsg.payload
             )
         except (AttributeError, UnicodeDecodeError):
             # Convert non UTF-8 payload to a string presentation

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1207,11 +1207,10 @@ async def websocket_subscribe(hass, connection, msg):
     async def forward_messages(mqttmsg: ReceiveMessage):
         """Forward events to websocket."""
         try:
-
             payload = (
                 mqttmsg.payload.decode(DEFAULT_ENCODING)
                 if isinstance(mqttmsg.payload, bytes)
-                else mqttmsg.payload
+                else None
             )
         except (AttributeError, UnicodeDecodeError):
             # Convert non UTF-8 payload to a string presentation

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1647,6 +1647,7 @@ async def test_mqtt_ws_subscription(hass, hass_ws_client, mqtt_mock):
 
     async_fire_mqtt_message(hass, "test-topic", "test1")
     async_fire_mqtt_message(hass, "test-topic", "test2")
+    async_fire_mqtt_message(hass, "test-topic", b"\xDE\xAD\xBE\xEF")
 
     response = await client.receive_json()
     assert response["event"]["topic"] == "test-topic"
@@ -1655,6 +1656,10 @@ async def test_mqtt_ws_subscription(hass, hass_ws_client, mqtt_mock):
     response = await client.receive_json()
     assert response["event"]["topic"] == "test-topic"
     assert response["event"]["payload"] == "test2"
+
+    response = await client.receive_json()
+    assert response["event"]["topic"] == "test-topic"
+    assert response["event"]["payload"] == "b'\\xde\\xad\\xbe\\xef'"
 
     # Unsubscribe
     await client.send_json({"id": 8, "type": "unsubscribe_events", "subscription": 5})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When subscribing MQTT over websockets the default encoding is "UTF-8".
When listening to MQTT message using the `listen` function from the MQTT config-flow UI, an incoming payload is assumed to have the correct encoding. If this not the case there is no visible logging message in the GUI.

This fix tries to find a way to present binary payloads over web-sockets if decoding fails.
With this PR a `binary` non-`UTF8` decodable payload is presented as a string formatted `bytes` object. This makes it possible to return a bytes object as a string.

In the current situation, nothing happens and a decoding error is logged as warning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #67126
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
