### PR TITLE
Remove Ecobee homekit vendor extensions that just don't work

### DIFF
--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -48,42 +48,6 @@ NUMBER_ENTITIES: dict[str, NumberEntityDescription] = {
         icon="mdi:volume-high",
         entity_category=EntityCategory.CONFIG,
     ),
-    CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_COOL: NumberEntityDescription(
-        key=CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_COOL,
-        name="Home Cool Target",
-        icon="mdi:thermometer-minus",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_HEAT: NumberEntityDescription(
-        key=CharacteristicsTypes.VENDOR_ECOBEE_HOME_TARGET_HEAT,
-        name="Home Heat Target",
-        icon="mdi:thermometer-plus",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_COOL: NumberEntityDescription(
-        key=CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_COOL,
-        name="Sleep Cool Target",
-        icon="mdi:thermometer-minus",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_HEAT: NumberEntityDescription(
-        key=CharacteristicsTypes.VENDOR_ECOBEE_SLEEP_TARGET_HEAT,
-        name="Sleep Heat Target",
-        icon="mdi:thermometer-plus",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_COOL: NumberEntityDescription(
-        key=CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_COOL,
-        name="Away Cool Target",
-        icon="mdi:thermometer-minus",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_HEAT: NumberEntityDescription(
-        key=CharacteristicsTypes.VENDOR_ECOBEE_AWAY_TARGET_HEAT,
-        name="Away Heat Target",
-        icon="mdi:thermometer-plus",
-        entity_category=EntityCategory.CONFIG,
-    ),
 }
 
 

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -14,12 +14,10 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
-from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import EntityCategory
 
 from tests.components.homekit_controller.common import (
     HUB_TEST_ACCESSORY_ID,
@@ -122,84 +120,6 @@ async def test_ecobee3_setup(hass):
                         "max_humidity": 50,
                     },
                     state="heat",
-                ),
-                EntityTestInfo(
-                    entity_id="number.homew_home_cool_target",
-                    friendly_name="HomeW Home Cool Target",
-                    unique_id="homekit-123456789012-aid:1-sid:16-cid:35",
-                    entity_category=EntityCategory.CONFIG,
-                    capabilities={
-                        "max": 33.3,
-                        "min": 18.3,
-                        "mode": NumberMode.AUTO,
-                        "step": 0.1,
-                    },
-                    state="24.4",
-                ),
-                EntityTestInfo(
-                    entity_id="number.homew_home_heat_target",
-                    friendly_name="HomeW Home Heat Target",
-                    unique_id="homekit-123456789012-aid:1-sid:16-cid:34",
-                    entity_category=EntityCategory.CONFIG,
-                    capabilities={
-                        "max": 26.1,
-                        "min": 7.2,
-                        "mode": NumberMode.AUTO,
-                        "step": 0.1,
-                    },
-                    state="22.2",
-                ),
-                EntityTestInfo(
-                    entity_id="number.homew_sleep_cool_target",
-                    friendly_name="HomeW Sleep Cool Target",
-                    unique_id="homekit-123456789012-aid:1-sid:16-cid:37",
-                    entity_category=EntityCategory.CONFIG,
-                    capabilities={
-                        "max": 33.3,
-                        "min": 18.3,
-                        "mode": NumberMode.AUTO,
-                        "step": 0.1,
-                    },
-                    state="27.8",
-                ),
-                EntityTestInfo(
-                    entity_id="number.homew_sleep_heat_target",
-                    friendly_name="HomeW Sleep Heat Target",
-                    unique_id="homekit-123456789012-aid:1-sid:16-cid:36",
-                    entity_category=EntityCategory.CONFIG,
-                    capabilities={
-                        "max": 26.1,
-                        "min": 7.2,
-                        "mode": NumberMode.AUTO,
-                        "step": 0.1,
-                    },
-                    state="17.8",
-                ),
-                EntityTestInfo(
-                    entity_id="number.homew_away_cool_target",
-                    friendly_name="HomeW Away Cool Target",
-                    unique_id="homekit-123456789012-aid:1-sid:16-cid:39",
-                    entity_category=EntityCategory.CONFIG,
-                    capabilities={
-                        "max": 33.3,
-                        "min": 18.3,
-                        "mode": NumberMode.AUTO,
-                        "step": 0.1,
-                    },
-                    state="26.7",
-                ),
-                EntityTestInfo(
-                    entity_id="number.homew_away_heat_target",
-                    friendly_name="HomeW Away Heat Target",
-                    unique_id="homekit-123456789012-aid:1-sid:16-cid:38",
-                    entity_category=EntityCategory.CONFIG,
-                    capabilities={
-                        "max": 26.1,
-                        "min": 7.2,
-                        "mode": NumberMode.AUTO,
-                        "step": 0.1,
-                    },
-                    state="18.9",
                 ),
                 EntityTestInfo(
                     entity_id="sensor.homew_current_temperature",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I have tagged this as a breaking change, but it's only a breaking change if this misses the cut off (it removes something that hasn't been released yet). It's also removing something that unfortunately doesn't seem to work.

Remove the number entities that allow the homekit_controller Ecobee thresholds to be configured.

Unfortunately the implementation on the Ecobee side is borked:

* They show the correct values at start up (matching what the user expects)
* The device accepts new values
* Restarting HA, we see the new values still - proving it not only accepted the write, but it is parroting the new values to any read operations
* However, the device completely ignores them.

We've had a couple of reports of this, unfortunately, so it's best that they aren't released.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  https://github.com/home-assistant/core/issues/67335 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
