### PR TITLE
Improve Plex media search failure feedback

### DIFF
--- a/homeassistant/components/plex/errors.py
+++ b/homeassistant/components/plex/errors.py
@@ -16,3 +16,7 @@ class ServerNotSpecified(PlexException):
 
 class ShouldUpdateConfigEntry(PlexException):
     """Config entry data is out of date and should be updated."""
+
+
+class MediaNotFound(PlexException):
+    """Requested media was not found."""

--- a/homeassistant/components/plex/media_browser.py
+++ b/homeassistant/components/plex/media_browser.py
@@ -19,6 +19,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.components.media_player.errors import BrowseError
 
 from .const import DOMAIN, PLEX_URI_SCHEME
+from .errors import MediaNotFound
 from .helpers import pretty_title
 
 
@@ -115,9 +116,9 @@ def browse_media(  # noqa: C901
 
     def build_item_response(payload):
         """Create response payload for the provided media query."""
-        media = plex_server.lookup_media(**payload)
-
-        if media is None:
+        try:
+            media = plex_server.lookup_media(**payload)
+        except MediaNotFound:
             return None
 
         try:

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -50,6 +50,7 @@ from .const import (
     SERVERS,
     TRANSIENT_DEVICE_MODELS,
 )
+from .errors import MediaNotFound
 from .media_browser import browse_media
 
 _LOGGER = logging.getLogger(__name__)
@@ -510,7 +511,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             try:
                 playqueue = self.plex_server.get_playqueue(playqueue_id)
             except plexapi.exceptions.NotFound as err:
-                raise HomeAssistantError(
+                raise MediaNotFound(
                     f"PlayQueue '{playqueue_id}' could not be found"
                 ) from err
         else:
@@ -518,9 +519,6 @@ class PlexMediaPlayer(MediaPlayerEntity):
             offset = src.pop("offset", 0) * 1000
             resume = src.pop("resume", False)
             media = self.plex_server.lookup_media(media_type, **src)
-
-            if media is None:
-                raise HomeAssistantError(f"Media could not be found: {media_id}")
 
             if resume and not offset:
                 offset = media.viewOffset

--- a/homeassistant/components/plex/services.py
+++ b/homeassistant/components/plex/services.py
@@ -16,6 +16,7 @@ from .const import (
     SERVICE_REFRESH_LIBRARY,
     SERVICE_SCAN_CLIENTS,
 )
+from .errors import MediaNotFound
 
 REFRESH_LIBRARY_SCHEMA = vol.Schema(
     {vol.Optional("server_name"): str, vol.Required("library_name"): str}
@@ -115,15 +116,13 @@ def lookup_plex_media(hass, content_type, content_id):
         try:
             playqueue = plex_server.get_playqueue(playqueue_id)
         except NotFound as err:
-            raise HomeAssistantError(
+            raise MediaNotFound(
                 f"PlayQueue '{playqueue_id}' could not be found"
             ) from err
         return playqueue
 
     shuffle = content.pop("shuffle", 0)
     media = plex_server.lookup_media(content_type, **content)
-    if media is None:
-        raise HomeAssistantError(f"Plex media not found using payload: '{content_id}'")
 
     if shuffle:
         return plex_server.create_playqueue(media, shuffle=shuffle)

--- a/tests/components/plex/test_media_search.py
+++ b/tests/components/plex/test_media_search.py
@@ -241,7 +241,20 @@ async def test_media_lookups(hass, mock_plex_server, requests_mock, playqueue_cr
         )
         search.assert_called_with(**{"title": "Movie 1", "libtype": None})
 
-    # TV show searches
+    with pytest.raises(MediaNotFound) as excinfo:
+        payload = '{"title": "Movie 1"}'
+        assert await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: media_player_id,
+                ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_VIDEO,
+                ATTR_MEDIA_CONTENT_ID: payload,
+            },
+            True,
+        )
+    assert "Must specify 'library_name' for this search" in str(excinfo.value)
+
     with pytest.raises(MediaNotFound) as excinfo:
         payload = '{"library_name": "Movies", "title": "Not a Movie"}'
         with patch("plexapi.library.LibrarySection.search", side_effect=BadRequest):

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -43,7 +43,6 @@ async def test_media_player_playback(
     requests_mock,
     playqueue_created,
     player_plexweb_resources,
-    caplog,
 ):
     """Test playing media on a Plex media_player."""
     requests_mock.get("http://1.2.3.5:32400/resources", text=player_plexweb_resources)
@@ -68,7 +67,7 @@ async def test_media_player_playback(
                 },
                 True,
             )
-    assert f"Media could not be found: {payload}" in str(excinfo.value)
+    assert f"No {MEDIA_TYPE_MOVIE} results in 'Movies' for" in str(excinfo.value)
 
     movie1 = MockPlexMedia("Movie", "movie")
     movie2 = MockPlexMedia("Movie II", "movie")
@@ -120,8 +119,7 @@ async def test_media_player_playback(
                 },
                 True,
             )
-    assert f"Media could not be found: {payload}" in str(excinfo.value)
-    assert "Multiple matches, make content_id more specific" in caplog.text
+    assert "Multiple matches, make content_id more specific" in str(excinfo.value)
 
     # Test multiple choices with allow_multiple
     movies = [movie1, movie2, movie3]

--- a/tests/components/plex/test_services.py
+++ b/tests/components/plex/test_services.py
@@ -168,7 +168,7 @@ async def test_lookup_media_for_other_integrations(
     with patch("plexapi.library.LibrarySection.search", return_value=None):
         with pytest.raises(HomeAssistantError) as excinfo:
             lookup_plex_media(hass, MEDIA_TYPE_MUSIC, CONTENT_ID_BAD_MEDIA)
-        assert "Plex media not found" in str(excinfo.value)
+        assert f"No {MEDIA_TYPE_MUSIC} results in 'Music' for" in str(excinfo.value)
 
     # Test with playqueue
     requests_mock.get("https://1.2.3.4:32400/playQueues/1234", text=playqueue_1234)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Using `media_player.play_media` with Plex can be complex and failed media lookups are common. Previously the frontend would show a generic message saying "Media could not be found" and more detailed warnings/errors would be written to the log where the information could go unnoticed. This PR instead raises all specific errors so they are shown directly in the frontend to assist the user in fixing their query.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
