### PR TITLE
Add Hyperion device configuration URL

### DIFF
--- a/homeassistant/components/hyperion/camera.py
+++ b/homeassistant/components/hyperion/camera.py
@@ -254,7 +254,7 @@ class HyperionCamera(Camera):
             manufacturer=HYPERION_MANUFACTURER_NAME,
             model=HYPERION_MODEL_NAME,
             name=self._instance_name,
-            configuration_url=f"http://{self._client._host}:8090/#remote",
+            configuration_url=self._client.remote_url,
         )
 
 

--- a/homeassistant/components/hyperion/camera.py
+++ b/homeassistant/components/hyperion/camera.py
@@ -254,6 +254,7 @@ class HyperionCamera(Camera):
             manufacturer=HYPERION_MANUFACTURER_NAME,
             model=HYPERION_MODEL_NAME,
             name=self._instance_name,
+            configuration_url=f"http://{self._client._host}:8090/#remote",
         )
 
 

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -244,6 +244,7 @@ class HyperionBaseLight(LightEntity):
             manufacturer=HYPERION_MANUFACTURER_NAME,
             model=HYPERION_MODEL_NAME,
             name=self._instance_name,
+            configuration_url=f"http://{self._client._host}:8090/#remote",
         )
 
     def _get_option(self, key: str) -> Any:

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -244,7 +244,7 @@ class HyperionBaseLight(LightEntity):
             manufacturer=HYPERION_MANUFACTURER_NAME,
             model=HYPERION_MODEL_NAME,
             name=self._instance_name,
-            configuration_url=f"http://{self._client._host}:8090/#remote",
+            configuration_url=self._client.remote_url,
         )
 
     def _get_option(self, key: str) -> Any:

--- a/homeassistant/components/hyperion/manifest.json
+++ b/homeassistant/components/hyperion/manifest.json
@@ -5,7 +5,7 @@
   "domain": "hyperion",
   "name": "Hyperion",
   "quality_scale": "platinum",
-  "requirements": ["hyperion-py==0.7.4"],
+  "requirements": ["hyperion-py==0.7.5"],
   "ssdp": [
     {
       "manufacturer": "Hyperion Open Source Ambient Lighting",

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -191,7 +191,7 @@ class HyperionComponentSwitch(SwitchEntity):
             manufacturer=HYPERION_MANUFACTURER_NAME,
             model=HYPERION_MODEL_NAME,
             name=self._instance_name,
-            configuration_url=f"http://{self._client._host}:8090/#remote",
+            configuration_url=self._client.remote_url,
         )
 
     async def _async_send_set_component(self, value: bool) -> None:

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -191,6 +191,7 @@ class HyperionComponentSwitch(SwitchEntity):
             manufacturer=HYPERION_MANUFACTURER_NAME,
             model=HYPERION_MODEL_NAME,
             name=self._instance_name,
+            configuration_url=f"http://{self._client._host}:8090/#remote",
         )
 
     async def _async_send_set_component(self, value: bool) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -834,7 +834,7 @@ huisbaasje-client==0.1.0
 hydrawiser==0.2
 
 # homeassistant.components.hyperion
-hyperion-py==0.7.4
+hyperion-py==0.7.5
 
 # homeassistant.components.iammeter
 iammeter==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -578,7 +578,7 @@ huawei-lte-api==1.4.18
 huisbaasje-client==0.1.0
 
 # homeassistant.components.hyperion
-hyperion-py==0.7.4
+hyperion-py==0.7.5
 
 # homeassistant.components.iaqualink
 iaqualink==0.4.1


### PR DESCRIPTION
## Proposed change

This change adds a `Visit Device` link to the Hyperion integration. However, some work is probably need by maintainers of the library - as currently I'm pulling the host info out of a protected member variable. I'm hoping that the maintainers of this integration will look at what I've done and tell me there is a better way to do this.

![image](https://user-images.githubusercontent.com/6491743/156438788-fa7bbe16-ee5a-4b91-bc4f-017eaf6efe13.png)

It will link to:  `http://<HOST_IP>:8090/#remote`

**DEPENDENCY UPDATE**
https://github.com/dermotduffy/hyperion-py/compare/v0.7.4...v0.7.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
