### PR TITLE
Cleanup mac fixtures in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -82,7 +82,7 @@ def mock_now() -> datetime:
     return dt_util.utcnow()
 
 
-@pytest.fixture(name="no_mac_address")
+@pytest.fixture(name="mac_address", autouse=True)
 def mac_address_fixture() -> Mock:
     """Patch getmac.get_mac_address."""
     with patch("getmac.get_mac_address", return_value=None) as mac:

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -8,7 +8,7 @@ from samsungtvws.async_remote import SamsungTVWSAsyncRemote
 
 import homeassistant.util.dt as dt_util
 
-from .const import SAMPLE_APP_LIST
+from .const import SAMPLE_APP_LIST, SAMPLE_DEVICE_INFO_WIFI
 
 
 @pytest.fixture(autouse=True)
@@ -39,16 +39,9 @@ def rest_api_fixture() -> Mock:
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
         autospec=True,
     ) as rest_api_class:
-        rest_api_class.return_value.rest_device_info.return_value = {
-            "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
-            "device": {
-                "modelName": "82GXARRS",
-                "wifiMac": "aa:bb:cc:dd:ee:ff",
-                "name": "[TV] Living Room",
-                "type": "Samsung SmartTV",
-                "networkType": "wireless",
-            },
-        }
+        rest_api_class.return_value.rest_device_info.return_value = (
+            SAMPLE_DEVICE_INFO_WIFI
+        )
         yield rest_api_class.return_value
 
 

--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -22,3 +22,14 @@ SAMPLE_APP_LIST = [
         "name": "Spotify - Music and Podcasts",
     },
 ]
+
+SAMPLE_DEVICE_INFO_WIFI = {
+    "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+    "device": {
+        "modelName": "82GXARRS",
+        "wifiMac": "aa:bb:ww:ii:ff:ii",
+        "name": "[TV] Living Room",
+        "type": "Samsung SmartTV",
+        "networkType": "wireless",
+    },
+}

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -99,7 +99,7 @@ MOCK_SSDP_DATA_WRONGMODEL = ssdp.SsdpServiceInfo(
     },
 )
 MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
-    ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_hostname"
+    ip="fake_host", macaddress="aa:bb:dd:hh:cc:pp", hostname="fake_hostname"
 )
 EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
@@ -109,7 +109,7 @@ MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
     name="mock_name",
     port=1234,
     properties={
-        "deviceid": "aa:bb:cc:dd:ee:ff",
+        "deviceid": "aa:bb:zz:ee:rr:oo",
         "manufacturer": "fake_manufacturer",
         "model": "fake_model",
         "serialNumber": "fake_serial",
@@ -318,7 +318,7 @@ async def test_user_not_successful_2(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("remote")
 async def test_ssdp(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery."""
-    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -346,7 +346,7 @@ async def test_ssdp(hass: HomeAssistant, mac_address: Mock) -> None:
 @pytest.mark.usefixtures("remote")
 async def test_ssdp_noprefix(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery without prefixes."""
-    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO_2,
@@ -547,7 +547,7 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("remote")
 async def test_ssdp_already_in_progress(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery twice."""
-    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -571,7 +571,7 @@ async def test_ssdp_already_in_progress(hass: HomeAssistant, mac_address: Mock) 
 @pytest.mark.usefixtures("remote")
 async def test_ssdp_already_configured(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery when already configured."""
-    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -601,7 +601,7 @@ async def test_ssdp_already_configured(hass: HomeAssistant, mac_address: Mock) -
 @pytest.mark.usefixtures("remote")
 async def test_import_legacy(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test importing from yaml with hostname."""
-    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
@@ -861,7 +861,7 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
 
 async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test for send key with autodetection of protocol."""
-    mac_address.return_value = "gg:hh:ii:ll:mm:nn"
+    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
@@ -896,14 +896,14 @@ async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
         assert result["type"] == "create_entry"
         assert result["data"][CONF_METHOD] == "websocket"
         assert result["data"][CONF_TOKEN] == "123456789"
-        assert result["data"][CONF_MAC] == "gg:hh:ii:ll:mm:nn"
+        assert result["data"][CONF_MAC] == "gg:ee:tt:mm:aa:cc"
         remotews.assert_called_once_with(**AUTODETECT_WEBSOCKET_SSL)
         rest_api_class.assert_called_once_with(**DEVICEINFO_WEBSOCKET_SSL)
         await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].data[CONF_MAC] == "gg:hh:ii:ll:mm:nn"
+    assert entries[0].data[CONF_MAC] == "gg:ee:tt:mm:aa:cc"
 
 
 async def test_autodetect_auth_missing(hass: HomeAssistant) -> None:
@@ -1046,7 +1046,7 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert entry.data[CONF_MAC] == "aa:bb:dd:hh:cc:pp"
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
@@ -1074,7 +1074,7 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(
         assert len(mock_setup_entry.mock_calls) == 1
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert entry.data[CONF_MAC] == "aa:bb:zz:ee:rr:oo"
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
@@ -1135,7 +1135,7 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
         assert len(mock_setup_entry.mock_calls) == 1
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert entry.data[CONF_MAC] == "aa:bb:zz:ee:rr:oo"
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -447,7 +447,7 @@ async def test_ssdp_websocket_success_populates_mac_address(
     assert result["title"] == "Living Room (82GXARRS)"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_NAME] == "Living Room"
-    assert result["data"][CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
     assert result["data"][CONF_MODEL] == "82GXARRS"
     assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
@@ -722,7 +722,7 @@ async def test_dhcp(hass: HomeAssistant) -> None:
     assert result["title"] == "Living Room (82GXARRS)"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_NAME] == "Living Room"
-    assert result["data"][CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result["data"][CONF_MANUFACTURER] == "Samsung"
     assert result["data"][CONF_MODEL] == "82GXARRS"
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
@@ -748,7 +748,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert result["title"] == "Living Room (82GXARRS)"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_NAME] == "Living Room"
-    assert result["data"][CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result["data"][CONF_MANUFACTURER] == "Samsung"
     assert result["data"][CONF_MODEL] == "82GXARRS"
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
@@ -1103,7 +1103,7 @@ async def test_update_missing_mac_unique_id_added_from_ssdp(
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert entry.data[CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -316,9 +316,8 @@ async def test_user_not_successful_2(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp(hass: HomeAssistant, mac_address: Mock) -> None:
+async def test_ssdp(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery."""
-    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -344,9 +343,8 @@ async def test_ssdp(hass: HomeAssistant, mac_address: Mock) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_noprefix(hass: HomeAssistant, mac_address: Mock) -> None:
+async def test_ssdp_noprefix(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery without prefixes."""
-    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO_2,
@@ -545,9 +543,8 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_already_in_progress(hass: HomeAssistant, mac_address: Mock) -> None:
+async def test_ssdp_already_in_progress(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery twice."""
-    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -569,9 +566,8 @@ async def test_ssdp_already_in_progress(hass: HomeAssistant, mac_address: Mock) 
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_already_configured(hass: HomeAssistant, mac_address: Mock) -> None:
+async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery when already configured."""
-    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -599,9 +595,8 @@ async def test_ssdp_already_configured(hass: HomeAssistant, mac_address: Mock) -
 
 
 @pytest.mark.usefixtures("remote")
-async def test_import_legacy(hass: HomeAssistant, mac_address: Mock) -> None:
+async def test_import_legacy(hass: HomeAssistant) -> None:
     """Test importing from yaml with hostname."""
-    mac_address.return_value = "gg:ee:tt:mm:aa:cc"
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -316,10 +316,9 @@ async def test_user_not_successful_2(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
+async def test_ssdp(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery."""
-
-    no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -345,10 +344,9 @@ async def test_ssdp(hass: HomeAssistant, no_mac_address: Mock) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_noprefix(hass: HomeAssistant, no_mac_address: Mock) -> None:
+async def test_ssdp_noprefix(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery without prefixes."""
-
-    no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO_2,
@@ -490,7 +488,6 @@ async def test_ssdp_model_not_supported(hass: HomeAssistant) -> None:
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-@pytest.mark.usefixtures("no_mac_address")
 async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
@@ -519,7 +516,6 @@ async def test_ssdp_not_successful(hass: HomeAssistant) -> None:
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-@pytest.mark.usefixtures("no_mac_address")
 async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
@@ -549,12 +545,9 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_already_in_progress(
-    hass: HomeAssistant, no_mac_address: Mock
-) -> None:
+async def test_ssdp_already_in_progress(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery twice."""
-
-    no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -576,12 +569,9 @@ async def test_ssdp_already_in_progress(
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_already_configured(
-    hass: HomeAssistant, no_mac_address: Mock
-) -> None:
+async def test_ssdp_already_configured(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test starting a flow from discovery when already configured."""
-
-    no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
         return_value=MOCK_DEVICE_INFO,
@@ -609,10 +599,9 @@ async def test_ssdp_already_configured(
 
 
 @pytest.mark.usefixtures("remote")
-async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
+async def test_import_legacy(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test importing from yaml with hostname."""
-
-    no_mac_address.return_value = "aa:bb:cc:dd:ee:ff"
+    mac_address.return_value = "aa:bb:cc:dd:ee:ff"
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
@@ -632,7 +621,7 @@ async def test_import_legacy(hass: HomeAssistant, no_mac_address: Mock) -> None:
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-@pytest.mark.usefixtures("remote", "remotews", "no_mac_address")
+@pytest.mark.usefixtures("remote", "remotews")
 async def test_import_legacy_without_name(hass: HomeAssistant, rest_api: Mock) -> None:
     """Test importing from yaml without a name."""
     rest_api.rest_device_info.return_value = None
@@ -870,8 +859,9 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
     assert entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
-async def test_websocket_no_mac(hass: HomeAssistant) -> None:
+async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
     """Test for send key with autodetection of protocol."""
+    mac_address.return_value = "gg:hh:ii:ll:mm:nn"
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=OSError("Boom"),
@@ -879,9 +869,7 @@ async def test_websocket_no_mac(hass: HomeAssistant) -> None:
         "homeassistant.components.samsungtv.bridge.SamsungTVWSAsyncRemote"
     ) as remotews, patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVAsyncRest",
-    ) as rest_api_class, patch(
-        "getmac.get_mac_address", return_value="gg:hh:ii:ll:mm:nn"
-    ):
+    ) as rest_api_class:
         remote = Mock(SamsungTVWSAsyncRemote)
         remote.__aenter__ = AsyncMock(return_value=remote)
         remote.__aexit__ = AsyncMock(return_value=False)

--- a/tests/components/samsungtv/test_diagnostics.py
+++ b/tests/components/samsungtv/test_diagnostics.py
@@ -7,6 +7,7 @@ from homeassistant.components.samsungtv import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .const import SAMPLE_DEVICE_INFO_WIFI
 from .test_media_player import MOCK_ENTRY_WS_WITH_MAC
 
 from tests.common import MockConfigEntry
@@ -56,14 +57,5 @@ async def test_entry_diagnostics(
             "unique_id": "any",
             "version": 2,
         },
-        "device_info": {
-            "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
-            "device": {
-                "modelName": "82GXARRS",
-                "name": "[TV] Living Room",
-                "networkType": "wireless",
-                "type": "Samsung SmartTV",
-                "wifiMac": "aa:bb:cc:dd:ee:ff",
-            },
-        },
+        "device_info": SAMPLE_DEVICE_INFO_WIFI,
     }

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -102,7 +102,7 @@ async def test_setup_from_yaml_without_port_device_online(hass: HomeAssistant) -
 
     config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
     assert len(config_entries_domain) == 1
-    assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:ww:ii:ff:ii"
 
 
 @pytest.mark.usefixtures("remote")

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -55,7 +55,7 @@ REMOTE_CALL = {
 }
 
 
-@pytest.mark.usefixtures("remotews", "no_mac_address")
+@pytest.mark.usefixtures("remotews")
 async def test_setup(hass: HomeAssistant) -> None:
     """Test Samsung TV integration is setup."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
@@ -123,7 +123,7 @@ async def test_setup_duplicate_config(
     assert "duplicate host entries found" in caplog.text
 
 
-@pytest.mark.usefixtures("remote", "remotews", "no_mac_address")
+@pytest.mark.usefixtures("remote", "remotews")
 async def test_setup_duplicate_entries(hass: HomeAssistant) -> None:
     """Test duplicate setup of platform."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -124,9 +124,6 @@ MOCK_CONFIG_NOTURNON = {
     ]
 }
 
-# Fake mac address in all mediaplayer tests.
-pytestmark = pytest.mark.usefixtures("no_mac_address")
-
 
 @pytest.fixture(name="delay")
 def delay_fixture():

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -180,9 +180,7 @@ async def test_setup_websocket(hass: HomeAssistant) -> None:
         assert config_entries[0].data[CONF_MAC] == "aa:bb:ww:ii:ff:ii"
 
 
-async def test_setup_websocket_2(
-    hass: HomeAssistant, mock_now: datetime, rest_api: Mock
-) -> None:
+async def test_setup_websocket_2(hass: HomeAssistant, mock_now: datetime) -> None:
     """Test setup of platform from config entry."""
     entity_id = f"{DOMAIN}.fake"
 
@@ -197,16 +195,6 @@ async def test_setup_websocket_2(
     assert len(config_entries) == 1
     assert entry is config_entries[0]
 
-    rest_api.rest_device_info.return_value = {
-        "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
-        "device": {
-            "modelName": "82GXARRS",
-            "wifiMac": "aa:bb:cc:dd:ee:ff",
-            "name": "[TV] Living Room",
-            "type": "Samsung SmartTV",
-            "networkType": "wireless",
-        },
-    }
     with patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWSAsyncRemote"
     ) as remote_class:
@@ -219,7 +207,7 @@ async def test_setup_websocket_2(
         assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
         await hass.async_block_till_done()
 
-        assert config_entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+        assert config_entries[0].data[CONF_MAC] == "aa:bb:ww:ii:ff:ii"
 
         next_update = mock_now + timedelta(minutes=5)
         with patch("homeassistant.util.dt.utcnow", return_value=next_update):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -177,7 +177,7 @@ async def test_setup_websocket(hass: HomeAssistant) -> None:
 
         config_entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
         assert len(config_entries) == 1
-        assert config_entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+        assert config_entries[0].data[CONF_MAC] == "aa:bb:ww:ii:ff:ii"
 
 
 async def test_setup_websocket_2(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Ensure that `dhcp`, `getmac`, `wifi` and `zeroconf` all return different mac address to avoid confusion
- Move sample device info to constant file, and use it for diagnostics tests
- Make getmac fixture auto-use for all tests, to ensure that it never tries to open a socket
- Remote getmac return values when they were not used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
