### PR TITLE
Highlight in logs it is a custom component when setup fails

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -149,10 +149,17 @@ async def _async_setup_component(
 
     This method is a coroutine.
     """
+    integration: loader.Integration | None = None
 
-    def log_error(msg: str, link: str | None = None) -> None:
+    def log_error(msg: str) -> None:
         """Log helper."""
-        _LOGGER.error("Setup failed for %s: %s", domain, msg)
+        if integration is None:
+            custom = ""
+            link = None
+        else:
+            custom = "" if integration.is_built_in else "custom component "
+            link = integration.documentation
+        _LOGGER.error("Setup failed for %s%s: %s", custom, domain, msg)
         async_notify_setup_error(hass, domain, link)
 
     try:
@@ -174,7 +181,7 @@ async def _async_setup_component(
     try:
         await async_process_deps_reqs(hass, config, integration)
     except HomeAssistantError as err:
-        log_error(str(err), integration.documentation)
+        log_error(str(err))
         return False
 
     # Some integrations fail on import because they call functions incorrectly.
@@ -182,7 +189,7 @@ async def _async_setup_component(
     try:
         component = integration.get_component()
     except ImportError as err:
-        log_error(f"Unable to import component: {err}", integration.documentation)
+        log_error(f"Unable to import component: {err}")
         return False
 
     processed_config = await conf_util.async_process_component_config(
@@ -190,7 +197,7 @@ async def _async_setup_component(
     )
 
     if processed_config is None:
-        log_error("Invalid config.", integration.documentation)
+        log_error("Invalid config.")
         return False
 
     start = timer()
@@ -287,6 +294,7 @@ async def async_prepare_setup_platform(
 
     def log_error(msg: str) -> None:
         """Log helper."""
+
         _LOGGER.error("Unable to prepare setup for platform %s: %s", platform_path, msg)
         async_notify_setup_error(hass, platform_path)
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -157,7 +157,7 @@ async def _async_setup_component(
             custom = ""
             link = None
         else:
-            custom = "" if integration.is_built_in else "custom component "
+            custom = "" if integration.is_built_in else "custom integration "
             link = integration.documentation
         _LOGGER.error("Setup failed for %s%s: %s", custom, domain, msg)
         async_notify_setup_error(hass, domain, link)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant import config_entries, setup
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
 from homeassistant.helpers.config_validation import (
     PLATFORM_SCHEMA,
@@ -619,6 +620,22 @@ async def test_integration_disabled(hass, caplog):
     result = await setup.async_setup_component(hass, "test_component1", {})
     assert not result
     assert disabled_reason in caplog.text
+
+
+async def test_integration_logs_is_custom(hass, caplog):
+    """Test we highlight it's a custom component when errors happen."""
+    mock_integration(
+        hass,
+        MockModule("test_component1"),
+        built_in=False,
+    )
+    with patch(
+        "homeassistant.setup.async_process_deps_reqs",
+        side_effect=HomeAssistantError("Boom"),
+    ):
+        result = await setup.async_setup_component(hass, "test_component1", {})
+    assert not result
+    assert "Setup failed for custom component test_component1: Boom" in caplog.text
 
 
 async def test_async_get_loaded_integrations(hass):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -635,7 +635,7 @@ async def test_integration_logs_is_custom(hass, caplog):
     ):
         result = await setup.async_setup_component(hass, "test_component1", {})
     assert not result
-    assert "Setup failed for custom component test_component1: Boom" in caplog.text
+    assert "Setup failed for custom integration test_component1: Boom" in caplog.text
 
 
 async def test_async_get_loaded_integrations(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When setup fails, include in log message if it's a custom component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
