### PR TITLE
Add media source support to unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -125,19 +125,17 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
         if media_source.is_media_source_id(media_id):
             media_type = MEDIA_TYPE_MUSIC
             play_item = await media_source.async_resolve_media(self.hass, media_id)
-            media_id = play_item.url
+            media_id = async_process_play_media_url(self.hass, play_item.url)
 
         if media_type != MEDIA_TYPE_MUSIC:
-            raise ValueError("Only music media type is supported")
-
-        media_id = async_process_play_media_url(self.hass, media_id)
+            raise HomeAssistantError("Only music media type is supported")
 
         _LOGGER.debug("Playing Media %s for %s Speaker", media_id, self.device.name)
         await self.async_media_stop()
         try:
             await self.device.play_audio(media_id, blocking=False)
         except StreamError as err:
-            raise HomeAssistantError from err
+            raise HomeAssistantError(err) from err
         else:
             # update state after starting player
             self._async_updated_event()

--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -7,13 +7,19 @@ from typing import Any
 from pyunifiprotect.data import Camera
 from pyunifiprotect.exceptions import StreamError
 
+from homeassistant.components import media_source
 from homeassistant.components.media_player import (
+    BrowseMedia,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityDescription,
 )
+from homeassistant.components.media_player.browse_media import (
+    async_process_play_media_url,
+)
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
+    SUPPORT_BROWSE_MEDIA,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_STOP,
     SUPPORT_VOLUME_SET,
@@ -74,7 +80,11 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
 
         self._attr_name = f"{self.device.name} Speaker"
         self._attr_supported_features = (
-            SUPPORT_PLAY_MEDIA | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_STEP | SUPPORT_STOP
+            SUPPORT_PLAY_MEDIA
+            | SUPPORT_VOLUME_SET
+            | SUPPORT_VOLUME_STEP
+            | SUPPORT_STOP
+            | SUPPORT_BROWSE_MEDIA
         )
         self._attr_media_content_type = MEDIA_TYPE_MUSIC
 
@@ -112,9 +122,15 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
         self, media_type: str, media_id: str, **kwargs: Any
     ) -> None:
         """Play a piece of media."""
+        if media_source.is_media_source_id(media_id):
+            media_type = MEDIA_TYPE_MUSIC
+            play_item = await media_source.async_resolve_media(self.hass, media_id)
+            media_id = play_item.url
 
         if media_type != MEDIA_TYPE_MUSIC:
             raise ValueError("Only music media type is supported")
+
+        media_id = async_process_play_media_url(self.hass, media_id)
 
         _LOGGER.debug("Playing Media %s for %s Speaker", media_id, self.device.name)
         await self.async_media_stop()
@@ -129,3 +145,13 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
             await self.device.wait_until_audio_completes()
 
         self._async_updated_event()
+
+    async def async_browse_media(
+        self, media_content_type: str | None = None, media_content_id: str | None = None
+    ) -> BrowseMedia:
+        """Implement the websocket media browsing helper."""
+        return await media_source.async_browse_media(
+            self.hass,
+            media_content_id,
+            content_filter=lambda item: item.media_content_type.startswith("audio/"),
+        )

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -80,7 +80,7 @@ async def test_media_player_setup(
     assert state
     assert state.state == STATE_IDLE
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 5636
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 136708
     assert state.attributes[ATTR_MEDIA_CONTENT_TYPE] == "music"
     assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == expected_volume
 
@@ -166,7 +166,6 @@ async def test_media_player_play(
     camera: tuple[Camera, str],
 ):
     """Test media_player entity test play_media."""
-
     camera[0].__fields__["stop_audio"] = Mock()
     camera[0].__fields__["play_audio"] = Mock()
     camera[0].__fields__["wait_until_audio_completes"] = Mock()
@@ -179,13 +178,15 @@ async def test_media_player_play(
         "play_media",
         {
             ATTR_ENTITY_ID: camera[1],
-            "media_content_id": "/test.mp3",
+            "media_content_id": "http://example.com/test.mp3",
             "media_content_type": "music",
         },
         blocking=True,
     )
 
-    camera[0].play_audio.assert_called_once_with("/test.mp3", blocking=False)
+    camera[0].play_audio.assert_called_once_with(
+        "http://example.com/test.mp3", blocking=False
+    )
     camera[0].wait_until_audio_completes.assert_called_once()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add media source support to unifi protect.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68028
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
