### PR TITLE
2022.3.1

### DIFF
--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -33,6 +33,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except FRITZ_EXCEPTIONS as ex:
         raise ConfigEntryNotReady from ex
 
+    if (
+        "X_AVM-DE_UPnP1" in avm_wrapper.connection.services
+        and not (await avm_wrapper.async_get_upnp_configuration())["NewEnable"]
+    ):
+        raise ConfigEntryAuthFailed("Missing UPnP configuration")
+
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = avm_wrapper
 

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -630,6 +630,11 @@ class AvmWrapper(FritzBoxTools):
             )
         return {}
 
+    async def async_get_upnp_configuration(self) -> dict[str, Any]:
+        """Call X_AVM-DE_UPnP service."""
+
+        return await self.hass.async_add_executor_job(self.get_upnp_configuration)
+
     async def async_get_wan_link_properties(self) -> dict[str, Any]:
         """Call WANCommonInterfaceConfig service."""
 
@@ -697,6 +702,11 @@ class AvmWrapper(FritzBoxTools):
         return await self.hass.async_add_executor_job(
             partial(self.set_allow_wan_access, ip_address, turn_on)
         )
+
+    def get_upnp_configuration(self) -> dict[str, Any]:
+        """Call X_AVM-DE_UPnP service."""
+
+        return self._service_call_action("X_AVM-DE_UPnP", "1", "GetInfo")
 
     def get_ontel_num_deflections(self) -> dict[str, Any]:
         """Call GetNumberOfDeflections action from X_AVM-DE_OnTel service."""

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     ERROR_AUTH_INVALID,
     ERROR_CANNOT_CONNECT,
     ERROR_UNKNOWN,
+    ERROR_UPNP_NOT_CONFIGURED,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,6 +79,12 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             return ERROR_UNKNOWN
+
+        if (
+            "X_AVM-DE_UPnP1" in self.avm_wrapper.connection.services
+            and not (await self.avm_wrapper.async_get_upnp_configuration())["NewEnable"]
+        ):
+            return ERROR_UPNP_NOT_CONFIGURED
 
         return None
 

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -46,6 +46,7 @@ DEFAULT_USERNAME = ""
 
 ERROR_AUTH_INVALID = "invalid_auth"
 ERROR_CANNOT_CONNECT = "cannot_connect"
+ERROR_UPNP_NOT_CONFIGURED = "upnp_not_configured"
 ERROR_UNKNOWN = "unknown_error"
 
 FRITZ_SERVICES = "fritz_services"

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -36,6 +36,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "upnp_not_configured":  "Missing UPnP settings on device.",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"

--- a/homeassistant/components/fritz/translations/en.json
+++ b/homeassistant/components/fritz/translations/en.json
@@ -9,7 +9,8 @@
             "already_configured": "Device is already configured",
             "already_in_progress": "Configuration flow is already in progress",
             "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication"
+            "invalid_auth": "Invalid authentication",
+            "upnp_not_configured": "Missing UPnP settings on device."
         },
         "flow_title": "{name}",
         "step": {

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -221,12 +221,9 @@ class GrowattData:
                 # Create datetime from the latest entry
                 date_now = dt.now().date()
                 last_updated_time = dt.parse_time(str(sorted_keys[-1]))
-                combined_timestamp = datetime.datetime.combine(
+                mix_detail["lastdataupdate"] = datetime.datetime.combine(
                     date_now, last_updated_time
                 )
-                # Convert datetime to UTC
-                combined_timestamp_utc = dt.as_utc(combined_timestamp)
-                mix_detail["lastdataupdate"] = combined_timestamp_utc.isoformat()
 
                 # Dashboard data is largely inaccurate for mix system but it is the only call with the ability to return the combined
                 # imported from grid value that is the combination of charging AND load consumption

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -274,7 +274,7 @@ class HomeAccessory(Accessory):
         if self.config.get(ATTR_SW_VERSION) is not None:
             sw_version = format_version(self.config[ATTR_SW_VERSION])
         if sw_version is None:
-            sw_version = __version__
+            sw_version = format_version(__version__)
         hw_version = None
         if self.config.get(ATTR_HW_VERSION) is not None:
             hw_version = format_version(self.config[ATTR_HW_VERSION])
@@ -289,7 +289,9 @@ class HomeAccessory(Accessory):
             serv_info = self.get_service(SERV_ACCESSORY_INFO)
             char = self.driver.loader.get_char(CHAR_HARDWARE_REVISION)
             serv_info.add_characteristic(char)
-            serv_info.configure_char(CHAR_HARDWARE_REVISION, value=hw_version)
+            serv_info.configure_char(
+                CHAR_HARDWARE_REVISION, value=hw_version[:MAX_VERSION_LENGTH]
+            )
             self.iid_manager.assign(char)
             char.broker = self
 
@@ -532,7 +534,7 @@ class HomeBridge(Bridge):
         """Initialize a Bridge object."""
         super().__init__(driver, name)
         self.set_info_service(
-            firmware_revision=__version__,
+            firmware_revision=format_version(__version__),
             manufacturer=MANUFACTURER,
             model=BRIDGE_MODEL,
             serial_number=BRIDGE_SERIAL_NUMBER,

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -100,6 +100,7 @@ _LOGGER = logging.getLogger(__name__)
 
 NUMBERS_ONLY_RE = re.compile(r"[^\d.]+")
 VERSION_RE = re.compile(r"([0-9]+)(\.[0-9]+)?(\.[0-9]+)?")
+MAX_VERSION_PART = 2**32 - 1
 
 
 MAX_PORT = 65535
@@ -363,7 +364,15 @@ def convert_to_float(state):
         return None
 
 
-def cleanup_name_for_homekit(name: str | None) -> str | None:
+def coerce_int(state: str) -> int:
+    """Return int."""
+    try:
+        return int(state)
+    except (ValueError, TypeError):
+        return 0
+
+
+def cleanup_name_for_homekit(name: str | None) -> str:
     """Ensure the name of the device will not crash homekit."""
     #
     # This is not a security measure.
@@ -371,7 +380,7 @@ def cleanup_name_for_homekit(name: str | None) -> str | None:
     # UNICODE_EMOJI is also not allowed but that
     # likely isn't a problem
     if name is None:
-        return None
+        return "None"  # None crashes apple watches
     return name.translate(HOMEKIT_CHAR_TRANSLATIONS)[:MAX_NAME_LENGTH]
 
 
@@ -420,13 +429,23 @@ def get_aid_storage_fullpath_for_entry_id(hass: HomeAssistant, entry_id: str):
     )
 
 
+def _format_version_part(version_part: str) -> str:
+    return str(max(0, min(MAX_VERSION_PART, coerce_int(version_part))))
+
+
 def format_version(version):
     """Extract the version string in a format homekit can consume."""
-    split_ver = str(version).replace("-", ".")
+    split_ver = str(version).replace("-", ".").replace(" ", ".")
     num_only = NUMBERS_ONLY_RE.sub("", split_ver)
-    if match := VERSION_RE.search(num_only):
-        return match.group(0)
-    return None
+    if (match := VERSION_RE.search(num_only)) is None:
+        return None
+    value = ".".join(map(_format_version_part, match.group(0).split(".")))
+    return None if _is_zero_but_true(value) else value
+
+
+def _is_zero_but_true(value):
+    """Zero but true values can crash apple watches."""
+    return convert_to_float(value) == 0
 
 
 def remove_state_files_for_entry_id(hass: HomeAssistant, entry_id: str):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -75,11 +75,16 @@ from .const import (
     ATTR_TOPIC,
     CONF_BIRTH_MESSAGE,
     CONF_BROKER,
+    CONF_CERTIFICATE,
+    CONF_CLIENT_CERT,
+    CONF_CLIENT_KEY,
     CONF_COMMAND_TOPIC,
     CONF_ENCODING,
     CONF_QOS,
     CONF_RETAIN,
     CONF_STATE_TOPIC,
+    CONF_TLS_INSECURE,
+    CONF_TLS_VERSION,
     CONF_TOPIC,
     CONF_WILL_MESSAGE,
     DATA_MQTT_CONFIG,
@@ -94,6 +99,7 @@ from .const import (
     DOMAIN,
     MQTT_CONNECTED,
     MQTT_DISCONNECTED,
+    PROTOCOL_31,
     PROTOCOL_311,
 )
 from .discovery import LAST_DISCOVERY
@@ -118,13 +124,6 @@ SERVICE_DUMP = "dump"
 
 CONF_DISCOVERY_PREFIX = "discovery_prefix"
 CONF_KEEPALIVE = "keepalive"
-CONF_CERTIFICATE = "certificate"
-CONF_CLIENT_KEY = "client_key"
-CONF_CLIENT_CERT = "client_cert"
-CONF_TLS_INSECURE = "tls_insecure"
-CONF_TLS_VERSION = "tls_version"
-
-PROTOCOL_31 = "3.1"
 
 DEFAULT_PORT = 1883
 DEFAULT_KEEPALIVE = 60
@@ -757,6 +756,58 @@ class Subscription:
     encoding: str | None = attr.ib(default="utf-8")
 
 
+class MqttClientSetup:
+    """Helper class to setup the paho mqtt client from config."""
+
+    # We don't import on the top because some integrations
+    # should be able to optionally rely on MQTT.
+    import paho.mqtt.client as mqtt  # pylint: disable=import-outside-toplevel
+
+    def __init__(self, config: ConfigType) -> None:
+        """Initialize the MQTT client setup helper."""
+
+        if config[CONF_PROTOCOL] == PROTOCOL_31:
+            proto = self.mqtt.MQTTv31
+        else:
+            proto = self.mqtt.MQTTv311
+
+        if (client_id := config.get(CONF_CLIENT_ID)) is None:
+            # PAHO MQTT relies on the MQTT server to generate random client IDs.
+            # However, that feature is not mandatory so we generate our own.
+            client_id = self.mqtt.base62(uuid.uuid4().int, padding=22)
+        self._client = self.mqtt.Client(client_id, protocol=proto)
+
+        # Enable logging
+        self._client.enable_logger()
+
+        username = config.get(CONF_USERNAME)
+        password = config.get(CONF_PASSWORD)
+        if username is not None:
+            self._client.username_pw_set(username, password)
+
+        if (certificate := config.get(CONF_CERTIFICATE)) == "auto":
+            certificate = certifi.where()
+
+        client_key = config.get(CONF_CLIENT_KEY)
+        client_cert = config.get(CONF_CLIENT_CERT)
+        tls_insecure = config.get(CONF_TLS_INSECURE)
+        if certificate is not None:
+            self._client.tls_set(
+                certificate,
+                certfile=client_cert,
+                keyfile=client_key,
+                tls_version=ssl.PROTOCOL_TLS,
+            )
+
+            if tls_insecure is not None:
+                self._client.tls_insecure_set(tls_insecure)
+
+    @property
+    def client(self) -> mqtt.Client:
+        """Return the paho MQTT client."""
+        return self._client
+
+
 class MQTT:
     """Home Assistant MQTT client."""
 
@@ -821,46 +872,7 @@ class MQTT:
 
     def init_client(self):
         """Initialize paho client."""
-        # We don't import on the top because some integrations
-        # should be able to optionally rely on MQTT.
-        import paho.mqtt.client as mqtt  # pylint: disable=import-outside-toplevel
-
-        if self.conf[CONF_PROTOCOL] == PROTOCOL_31:
-            proto: int = mqtt.MQTTv31
-        else:
-            proto = mqtt.MQTTv311
-
-        if (client_id := self.conf.get(CONF_CLIENT_ID)) is None:
-            # PAHO MQTT relies on the MQTT server to generate random client IDs.
-            # However, that feature is not mandatory so we generate our own.
-            client_id = mqtt.base62(uuid.uuid4().int, padding=22)
-        self._mqttc = mqtt.Client(client_id, protocol=proto)
-
-        # Enable logging
-        self._mqttc.enable_logger()
-
-        username = self.conf.get(CONF_USERNAME)
-        password = self.conf.get(CONF_PASSWORD)
-        if username is not None:
-            self._mqttc.username_pw_set(username, password)
-
-        if (certificate := self.conf.get(CONF_CERTIFICATE)) == "auto":
-            certificate = certifi.where()
-
-        client_key = self.conf.get(CONF_CLIENT_KEY)
-        client_cert = self.conf.get(CONF_CLIENT_CERT)
-        tls_insecure = self.conf.get(CONF_TLS_INSECURE)
-        if certificate is not None:
-            self._mqttc.tls_set(
-                certificate,
-                certfile=client_cert,
-                keyfile=client_key,
-                tls_version=ssl.PROTOCOL_TLS,
-            )
-
-            if tls_insecure is not None:
-                self._mqttc.tls_insecure_set(tls_insecure)
-
+        self._mqttc = MqttClientSetup(self.conf).client
         self._mqttc.on_connect = self._mqtt_on_connect
         self._mqttc.on_disconnect = self._mqtt_on_disconnect
         self._mqttc.on_message = self._mqtt_on_message

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.data_entry_flow import FlowResult
 
+from . import MqttClientSetup
 from .const import (
     ATTR_PAYLOAD,
     ATTR_QOS,
@@ -62,6 +63,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             can_connect = await self.hass.async_add_executor_job(
                 try_connection,
+                self.hass,
                 user_input[CONF_BROKER],
                 user_input[CONF_PORT],
                 user_input.get(CONF_USERNAME),
@@ -102,6 +104,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data = self._hassio_discovery
             can_connect = await self.hass.async_add_executor_job(
                 try_connection,
+                self.hass,
                 data[CONF_HOST],
                 data[CONF_PORT],
                 data.get(CONF_USERNAME),
@@ -152,6 +155,7 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             can_connect = await self.hass.async_add_executor_job(
                 try_connection,
+                self.hass,
                 user_input[CONF_BROKER],
                 user_input[CONF_PORT],
                 user_input.get(CONF_USERNAME),
@@ -313,25 +317,24 @@ class MQTTOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
 
-def try_connection(broker, port, username, password, protocol="3.1"):
+def try_connection(hass, broker, port, username, password, protocol="3.1"):
     """Test if we can connect to an MQTT broker."""
-    # pylint: disable-next=import-outside-toplevel
-    import paho.mqtt.client as mqtt
-
-    if protocol == "3.1":
-        proto = mqtt.MQTTv31
-    else:
-        proto = mqtt.MQTTv311
-
-    client = mqtt.Client(protocol=proto)
-    if username and password:
-        client.username_pw_set(username, password)
+    # Get the config from configuration.yaml
+    yaml_config = hass.data.get(DATA_MQTT_CONFIG, {})
+    entry_config = {
+        CONF_BROKER: broker,
+        CONF_PORT: port,
+        CONF_USERNAME: username,
+        CONF_PASSWORD: password,
+        CONF_PROTOCOL: protocol,
+    }
+    client = MqttClientSetup({**yaml_config, **entry_config}).client
 
     result = queue.Queue(maxsize=1)
 
     def on_connect(client_, userdata, flags, result_code):
         """Handle connection result."""
-        result.put(result_code == mqtt.CONNACK_ACCEPTED)
+        result.put(result_code == MqttClientSetup.mqtt.CONNACK_ACCEPTED)
 
     client.on_connect = on_connect
 

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -22,6 +22,12 @@ CONF_STATE_VALUE_TEMPLATE = "state_value_template"
 CONF_TOPIC = "topic"
 CONF_WILL_MESSAGE = "will_message"
 
+CONF_CERTIFICATE = "certificate"
+CONF_CLIENT_KEY = "client_key"
+CONF_CLIENT_CERT = "client_cert"
+CONF_TLS_INSECURE = "tls_insecure"
+CONF_TLS_VERSION = "tls_version"
+
 DATA_MQTT_CONFIG = "mqtt_config"
 DATA_MQTT_RELOAD_NEEDED = "mqtt_reload_needed"
 
@@ -56,4 +62,5 @@ MQTT_DISCONNECTED = "mqtt_disconnected"
 PAYLOAD_EMPTY_JSON = "{}"
 PAYLOAD_NONE = "None"
 
+PROTOCOL_31 = "3.1"
 PROTOCOL_311 = "3.1.1"

--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -2,7 +2,7 @@
   "domain": "obihai",
   "name": "Obihai",
   "documentation": "https://www.home-assistant.io/integrations/obihai",
-  "requirements": ["pyobihai==1.3.1"],
+  "requirements": ["pyobihai==1.3.2"],
   "codeowners": ["@dshokouhi"],
   "iot_class": "local_polling",
   "loggers": ["pyobihai"]

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "requirements": ["soco==0.26.3"],
+  "requirements": ["soco==0.26.4"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["plex", "spotify", "zeroconf", "media_source"],
   "zeroconf": ["_sonos._tcp.local."],

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 3
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1727,7 +1727,7 @@ pynx584==0.5
 pynzbgetapi==0.2.0
 
 # homeassistant.components.obihai
-pyobihai==1.3.1
+pyobihai==1.3.2
 
 # homeassistant.components.octoprint
 pyoctoprintapi==0.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2235,7 +2235,7 @@ smhi-pkg==1.0.15
 snapcast==2.1.3
 
 # homeassistant.components.sonos
-soco==0.26.3
+soco==0.26.4
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1371,7 +1371,7 @@ smarthab==0.21
 smhi-pkg==1.0.15
 
 # homeassistant.components.sonos
-soco==0.26.3
+soco==0.26.4
 
 # homeassistant.components.solaredge
 solaredge==0.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name         = homeassistant
-version      = 2022.3.0
+version      = 2022.3.1
 author       = The Home Assistant Authors
 author_email = hello@home-assistant.io
 license      = Apache-2.0

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -42,7 +42,6 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
-    __version__,
     __version__ as hass_version,
 )
 from homeassistant.helpers.event import TRACK_STATE_CHANGE_CALLBACKS
@@ -166,7 +165,9 @@ async def test_home_accessory(hass, hk_driver):
         serv.get_characteristic(CHAR_SERIAL_NUMBER).value
         == "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum"
     )
-    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == hass_version
+    assert hass_version.startswith(
+        serv.get_characteristic(CHAR_FIRMWARE_REVISION).value
+    )
 
     hass.states.async_set(entity_id, "on")
     await hass.async_block_till_done()
@@ -216,7 +217,9 @@ async def test_accessory_with_missing_basic_service_info(hass, hk_driver):
     assert serv.get_characteristic(CHAR_MANUFACTURER).value == "Home Assistant Sensor"
     assert serv.get_characteristic(CHAR_MODEL).value == "Sensor"
     assert serv.get_characteristic(CHAR_SERIAL_NUMBER).value == entity_id
-    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == hass_version
+    assert hass_version.startswith(
+        serv.get_characteristic(CHAR_FIRMWARE_REVISION).value
+    )
     assert isinstance(acc.to_HAP(), dict)
 
 
@@ -244,7 +247,9 @@ async def test_accessory_with_hardware_revision(hass, hk_driver):
     assert serv.get_characteristic(CHAR_MANUFACTURER).value == "Home Assistant Sensor"
     assert serv.get_characteristic(CHAR_MODEL).value == "Sensor"
     assert serv.get_characteristic(CHAR_SERIAL_NUMBER).value == entity_id
-    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == hass_version
+    assert hass_version.startswith(
+        serv.get_characteristic(CHAR_FIRMWARE_REVISION).value
+    )
     assert serv.get_characteristic(CHAR_HARDWARE_REVISION).value == "1.2.3"
     assert isinstance(acc.to_HAP(), dict)
 
@@ -687,7 +692,9 @@ def test_home_bridge(hk_driver):
     serv = bridge.services[0]  # SERV_ACCESSORY_INFO
     assert serv.display_name == SERV_ACCESSORY_INFO
     assert serv.get_characteristic(CHAR_NAME).value == BRIDGE_NAME
-    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == __version__
+    assert hass_version.startswith(
+        serv.get_characteristic(CHAR_FIRMWARE_REVISION).value
+    )
     assert serv.get_characteristic(CHAR_MANUFACTURER).value == MANUFACTURER
     assert serv.get_characteristic(CHAR_MODEL).value == BRIDGE_MODEL
     assert serv.get_characteristic(CHAR_SERIAL_NUMBER).value == BRIDGE_SERIAL_NUMBER

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -399,4 +399,4 @@ async def test_empty_name(hass, hk_driver):
     assert acc.category == 10  # Sensor
 
     assert acc.char_humidity.value == 20
-    assert acc.display_name is None
+    assert acc.display_name == "None"

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -30,6 +30,7 @@ from homeassistant.components.homekit.util import (
     async_port_is_available,
     async_show_setup_message,
     cleanup_name_for_homekit,
+    coerce_int,
     convert_to_float,
     density_to_air_quality,
     format_version,
@@ -349,11 +350,21 @@ async def test_format_version():
     assert format_version("undefined-undefined-1.6.8") == "1.6.8"
     assert format_version("56.0-76060") == "56.0.76060"
     assert format_version(3.6) == "3.6"
-    assert format_version("AK001-ZJ100") == "001.100"
+    assert format_version("AK001-ZJ100") == "1.100"
     assert format_version("HF-LPB100-") == "100"
-    assert format_version("AK001-ZJ2149") == "001.2149"
+    assert format_version("AK001-ZJ2149") == "1.2149"
+    assert format_version("13216407885") == "4294967295"  # max value
+    assert format_version("000132 16407885") == "132.16407885"
     assert format_version("0.1") == "0.1"
+    assert format_version("0") is None
     assert format_version("unknown") is None
+
+
+async def test_coerce_int():
+    """Test coerce_int method."""
+    assert coerce_int("1") == 1
+    assert coerce_int("") == 0
+    assert coerce_int(0) == 0
 
 
 async def test_accessory_friendly_name():


### PR DESCRIPTION
- Bump soco to 0.26.4 ([@jjlawren] - [#67498]) ([sonos docs])
- Check if UPnP is enabled on Fritz device ([@chemelli74] - [#67512]) ([fritz docs])
- Fix MQTT config flow with advanced parameters ([@jbouwh] - [#67556]) ([mqtt docs])
- Highlight in logs it is a custom component when setup fails ([@balloob] - [#67559])
- Bump pyobihai ([@ejpenney] - [#67571]) ([obihai docs])
- Fix data type for growatt lastdataupdate (#67511) ([@muppet3000] - [#67582]) ([growatt_server docs])
- Add guards for HomeKit version/names that break apple watches ([@bdraco] - [#67585]) ([homekit docs])

[#67498]: https://github.com/home-assistant/core/pull/67498
[#67512]: https://github.com/home-assistant/core/pull/67512
[#67556]: https://github.com/home-assistant/core/pull/67556
[#67559]: https://github.com/home-assistant/core/pull/67559
[#67571]: https://github.com/home-assistant/core/pull/67571
[#67582]: https://github.com/home-assistant/core/pull/67582
[#67585]: https://github.com/home-assistant/core/pull/67585
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@chemelli74]: https://github.com/chemelli74
[@ejpenney]: https://github.com/ejpenney
[@jbouwh]: https://github.com/jbouwh
[@jjlawren]: https://github.com/jjlawren
[@muppet3000]: https://github.com/muppet3000
[fritz docs]: https://www.home-assistant.io/integrations/fritz/
[growatt_server docs]: https://www.home-assistant.io/integrations/growatt_server/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[obihai docs]: https://www.home-assistant.io/integrations/obihai/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/