### PR TITLE
Add button entities to Mazda integration

### DIFF
--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -102,7 +102,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if vehicle_id == 0 or api_client is None:
             raise HomeAssistantError("Vehicle ID not found")
 
-        if service_call.service != "send_poi":
+        if service_call.service in (
+            "start_engine",
+            "stop_engine",
+            "turn_on_hazard_lights",
+            "turn_off_hazard_lights",
+        ):
             _LOGGER.warning(
                 "The mazda.%s service is deprecated and has been replaced by a button entity; "
                 "Please use the button entity instead",

--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -37,7 +37,7 @@ from .const import DATA_CLIENT, DATA_COORDINATOR, DATA_VEHICLES, DOMAIN, SERVICE
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.DEVICE_TRACKER, Platform.LOCK, Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.LOCK, Platform.SENSOR]
 
 
 async def with_timeout(task, timeout_seconds=10):

--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -102,6 +102,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if vehicle_id == 0 or api_client is None:
             raise HomeAssistantError("Vehicle ID not found")
 
+        if service_call.service != "send_poi":
+            _LOGGER.warning(
+                "The mazda.%s service is deprecated and has been replaced by a button entity; "
+                "Please use the button entity instead",
+                service_call.service,
+            )
+
         api_method = getattr(api_client, service_call.service)
         try:
             if service_call.service == "send_poi":

--- a/homeassistant/components/mazda/button.py
+++ b/homeassistant/components/mazda/button.py
@@ -77,13 +77,13 @@ BUTTON_ENTITIES = [
     MazdaButtonEntityDescription(
         key="start_charging",
         name_suffix="Start Charging",
-        icon="mdi:engine",
+        icon="mdi:ev-station",
         is_supported=lambda data: data["isElectric"],
     ),
     MazdaButtonEntityDescription(
         key="stop_charging",
         name_suffix="Stop Charging",
-        icon="mdi:engine-off",
+        icon="mdi:ev-station",
         is_supported=lambda data: data["isElectric"],
     ),
     MazdaButtonEntityDescription(

--- a/homeassistant/components/mazda/button.py
+++ b/homeassistant/components/mazda/button.py
@@ -108,16 +108,12 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
 
-    entities: list[ButtonEntity] = []
-
-    for index, data in enumerate(coordinator.data):
-        for description in BUTTON_ENTITIES:
-            if description.is_supported(data):
-                entities.append(
-                    MazdaButtonEntity(client, coordinator, index, description)
-                )
-
-    async_add_entities(entities)
+    async_add_entities(
+        MazdaButtonEntity(client, coordinator, index, description)
+        for index, data in enumerate(coordinator.data)
+        for description in BUTTON_ENTITIES
+        if description.is_supported(data)
+    )
 
 
 class MazdaButtonEntity(MazdaEntity, ButtonEntity):

--- a/homeassistant/components/mazda/button.py
+++ b/homeassistant/components/mazda/button.py
@@ -5,17 +5,20 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from pymazda import Client as MazdaAPIClient
+
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import MazdaEntity
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 
 
-async def handle_button_press(entity: MazdaButtonEntity):
+async def handle_button_press(entity: MazdaButtonEntity) -> None:
     """Handle a press for a Mazda button entity."""
     api_client = entity.client
     api_method = getattr(api_client, entity.entity_description.key)
@@ -26,7 +29,7 @@ async def handle_button_press(entity: MazdaButtonEntity):
         raise HomeAssistantError(ex) from ex
 
 
-async def handle_refresh_vehicle_status(entity: MazdaButtonEntity):
+async def handle_refresh_vehicle_status(entity: MazdaButtonEntity) -> None:
     """Handle a request to refresh the vehicle status."""
     await handle_button_press(entity)
 
@@ -122,7 +125,13 @@ class MazdaButtonEntity(MazdaEntity, ButtonEntity):
 
     entity_description: MazdaButtonEntityDescription
 
-    def __init__(self, client, coordinator, index, description):
+    def __init__(
+        self,
+        client: MazdaAPIClient,
+        coordinator: DataUpdateCoordinator,
+        index: int,
+        description: MazdaButtonEntityDescription,
+    ) -> None:
         """Initialize Mazda button."""
         super().__init__(client, coordinator, index)
         self.entity_description = description
@@ -130,6 +139,6 @@ class MazdaButtonEntity(MazdaEntity, ButtonEntity):
         self._attr_name = f"{self.vehicle_name} {description.name_suffix}"
         self._attr_unique_id = f"{self.vin}_{description.key}"
 
-    async def async_press(self):
+    async def async_press(self) -> None:
         """Press the button."""
         await self.entity_description.async_press(self)

--- a/homeassistant/components/mazda/button.py
+++ b/homeassistant/components/mazda/button.py
@@ -104,18 +104,6 @@ BUTTON_ENTITIES = [
         icon="mdi:hazard-lights",
     ),
     MazdaButtonEntityDescription(
-        key="start_charging",
-        name_suffix="Start Charging",
-        icon="mdi:ev-station",
-        is_supported=lambda data: data["isElectric"],
-    ),
-    MazdaButtonEntityDescription(
-        key="stop_charging",
-        name_suffix="Stop Charging",
-        icon="mdi:ev-station",
-        is_supported=lambda data: data["isElectric"],
-    ),
-    MazdaButtonEntityDescription(
         key="refresh_vehicle_status",
         name_suffix="Refresh Status",
         icon="mdi:refresh",

--- a/homeassistant/components/mazda/button.py
+++ b/homeassistant/components/mazda/button.py
@@ -5,7 +5,15 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from pymazda import Client as MazdaAPIClient
+from pymazda import (
+    Client as MazdaAPIClient,
+    MazdaAccountLockedException,
+    MazdaAPIEncryptionException,
+    MazdaAuthenticationException,
+    MazdaException,
+    MazdaLoginFailedException,
+    MazdaTokenExpiredException,
+)
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +37,14 @@ async def handle_button_press(
 
     try:
         await api_method(vehicle_id)
-    except Exception as ex:
+    except (
+        MazdaException,
+        MazdaAuthenticationException,
+        MazdaAccountLockedException,
+        MazdaTokenExpiredException,
+        MazdaAPIEncryptionException,
+        MazdaLoginFailedException,
+    ) as ex:
         raise HomeAssistantError(ex) from ex
 
 
@@ -42,7 +57,7 @@ async def handle_refresh_vehicle_status(
     """Handle a request to refresh the vehicle status."""
     await handle_button_press(client, key, vehicle_id, coordinator)
 
-    await coordinator.async_refresh()
+    await coordinator.async_request_refresh()
 
 
 @dataclass

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -1,0 +1,170 @@
+"""The button tests for the Mazda Connected Services integration."""
+
+from pymazda import MazdaException
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_ICON
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.components.mazda import init_integration
+
+
+async def test_button_setup_non_electric_vehicle(hass):
+    """Test creation of button entities."""
+    await init_integration(hass)
+
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get("button.my_mazda3_start_engine")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_start_engine"
+    state = hass.states.get("button.my_mazda3_start_engine")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Start Engine"
+    assert state.attributes.get(ATTR_ICON) == "mdi:engine"
+
+    entry = entity_registry.async_get("button.my_mazda3_stop_engine")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_stop_engine"
+    state = hass.states.get("button.my_mazda3_stop_engine")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Stop Engine"
+    assert state.attributes.get(ATTR_ICON) == "mdi:engine-off"
+
+    entry = entity_registry.async_get("button.my_mazda3_turn_on_hazard_lights")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_turn_on_hazard_lights"
+    state = hass.states.get("button.my_mazda3_turn_on_hazard_lights")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Turn On Hazard Lights"
+    assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
+
+    entry = entity_registry.async_get("button.my_mazda3_turn_off_hazard_lights")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_turn_off_hazard_lights"
+    state = hass.states.get("button.my_mazda3_turn_off_hazard_lights")
+    assert state
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Turn Off Hazard Lights"
+    )
+    assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
+
+    # Since this is a non-electric vehicle, electric vehicle buttons should not be created
+    for key in ["start_charging", "stop_charging", "refresh_vehicle_status"]:
+        entry = entity_registry.async_get(f"button.my_mazda3_{key}")
+        assert entry is None
+        state = hass.states.get(f"button.my_mazda3_{key}")
+        assert state is None
+
+
+async def test_button_setup_electric_vehicle(hass):
+    """Test creation of button entities for an electric vehicle."""
+    await init_integration(hass, electric_vehicle=True)
+
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get("button.my_mazda3_start_engine")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_start_engine"
+    state = hass.states.get("button.my_mazda3_start_engine")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Start Engine"
+    assert state.attributes.get(ATTR_ICON) == "mdi:engine"
+
+    entry = entity_registry.async_get("button.my_mazda3_stop_engine")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_stop_engine"
+    state = hass.states.get("button.my_mazda3_stop_engine")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Stop Engine"
+    assert state.attributes.get(ATTR_ICON) == "mdi:engine-off"
+
+    entry = entity_registry.async_get("button.my_mazda3_turn_on_hazard_lights")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_turn_on_hazard_lights"
+    state = hass.states.get("button.my_mazda3_turn_on_hazard_lights")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Turn On Hazard Lights"
+    assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
+
+    entry = entity_registry.async_get("button.my_mazda3_turn_off_hazard_lights")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_turn_off_hazard_lights"
+    state = hass.states.get("button.my_mazda3_turn_off_hazard_lights")
+    assert state
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Turn Off Hazard Lights"
+    )
+    assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
+
+    entry = entity_registry.async_get("button.my_mazda3_start_charging")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_start_charging"
+    state = hass.states.get("button.my_mazda3_start_charging")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Start Charging"
+    assert state.attributes.get(ATTR_ICON) == "mdi:ev-station"
+
+    entry = entity_registry.async_get("button.my_mazda3_stop_charging")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_stop_charging"
+    state = hass.states.get("button.my_mazda3_stop_charging")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Stop Charging"
+    assert state.attributes.get(ATTR_ICON) == "mdi:ev-station"
+
+    entry = entity_registry.async_get("button.my_mazda3_refresh_status")
+    assert entry
+    assert entry.unique_id == "JM000000000000000_refresh_vehicle_status"
+    state = hass.states.get("button.my_mazda3_refresh_status")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Refresh Status"
+    assert state.attributes.get(ATTR_ICON) == "mdi:refresh"
+
+
+@pytest.mark.parametrize(
+    "entity_id_suffix, api_method_name",
+    [
+        ("start_engine", "start_engine"),
+        ("stop_engine", "stop_engine"),
+        ("turn_on_hazard_lights", "turn_on_hazard_lights"),
+        ("turn_off_hazard_lights", "turn_off_hazard_lights"),
+        ("start_charging", "start_charging"),
+        ("stop_charging", "stop_charging"),
+        ("refresh_status", "refresh_vehicle_status"),
+    ],
+)
+async def test_button_press(hass, entity_id_suffix, api_method_name):
+    """Test pressing the button entities."""
+    client_mock = await init_integration(hass, electric_vehicle=True)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: f"button.my_mazda3_{entity_id_suffix}"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    api_method = getattr(client_mock, api_method_name)
+    api_method.assert_called_once_with(12345)
+
+
+async def test_button_press_error(hass):
+    """Test the Mazda API raising an error when a button entity is pressed."""
+    client_mock = await init_integration(hass)
+
+    client_mock.start_engine.side_effect = MazdaException("Test error")
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.my_mazda3_start_engine"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert str(err.value) == "Test error"

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -52,11 +52,10 @@ async def test_button_setup_non_electric_vehicle(hass) -> None:
     assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
 
     # Since this is a non-electric vehicle, electric vehicle buttons should not be created
-    for key in ("start_charging", "stop_charging", "refresh_vehicle_status"):
-        entry = entity_registry.async_get(f"button.my_mazda3_{key}")
-        assert entry is None
-        state = hass.states.get(f"button.my_mazda3_{key}")
-        assert state is None
+    entry = entity_registry.async_get("button.my_mazda3_refresh_vehicle_status")
+    assert entry is None
+    state = hass.states.get("button.my_mazda3_refresh_vehicle_status")
+    assert state is None
 
 
 async def test_button_setup_electric_vehicle(hass) -> None:
@@ -99,22 +98,6 @@ async def test_button_setup_electric_vehicle(hass) -> None:
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
 
-    entry = entity_registry.async_get("button.my_mazda3_start_charging")
-    assert entry
-    assert entry.unique_id == "JM000000000000000_start_charging"
-    state = hass.states.get("button.my_mazda3_start_charging")
-    assert state
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Start Charging"
-    assert state.attributes.get(ATTR_ICON) == "mdi:ev-station"
-
-    entry = entity_registry.async_get("button.my_mazda3_stop_charging")
-    assert entry
-    assert entry.unique_id == "JM000000000000000_stop_charging"
-    state = hass.states.get("button.my_mazda3_stop_charging")
-    assert state
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Stop Charging"
-    assert state.attributes.get(ATTR_ICON) == "mdi:ev-station"
-
     entry = entity_registry.async_get("button.my_mazda3_refresh_status")
     assert entry
     assert entry.unique_id == "JM000000000000000_refresh_vehicle_status"
@@ -131,8 +114,6 @@ async def test_button_setup_electric_vehicle(hass) -> None:
         ("stop_engine", "stop_engine"),
         ("turn_on_hazard_lights", "turn_on_hazard_lights"),
         ("turn_off_hazard_lights", "turn_off_hazard_lights"),
-        ("start_charging", "start_charging"),
-        ("stop_charging", "stop_charging"),
         ("refresh_status", "refresh_vehicle_status"),
     ],
 )

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.components.mazda import init_integration
 
 
-async def test_button_setup_non_electric_vehicle(hass):
+async def test_button_setup_non_electric_vehicle(hass) -> None:
     """Test creation of button entities."""
     await init_integration(hass)
 
@@ -52,14 +52,14 @@ async def test_button_setup_non_electric_vehicle(hass):
     assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
 
     # Since this is a non-electric vehicle, electric vehicle buttons should not be created
-    for key in ["start_charging", "stop_charging", "refresh_vehicle_status"]:
+    for key in ("start_charging", "stop_charging", "refresh_vehicle_status"):
         entry = entity_registry.async_get(f"button.my_mazda3_{key}")
         assert entry is None
         state = hass.states.get(f"button.my_mazda3_{key}")
         assert state is None
 
 
-async def test_button_setup_electric_vehicle(hass):
+async def test_button_setup_electric_vehicle(hass) -> None:
     """Test creation of button entities for an electric vehicle."""
     await init_integration(hass, electric_vehicle=True)
 
@@ -136,7 +136,7 @@ async def test_button_setup_electric_vehicle(hass):
         ("refresh_status", "refresh_vehicle_status"),
     ],
 )
-async def test_button_press(hass, entity_id_suffix, api_method_name):
+async def test_button_press(hass, entity_id_suffix, api_method_name) -> None:
     """Test pressing the button entities."""
     client_mock = await init_integration(hass, electric_vehicle=True)
 
@@ -152,7 +152,7 @@ async def test_button_press(hass, entity_id_suffix, api_method_name):
     api_method.assert_called_once_with(12345)
 
 
-async def test_button_press_error(hass):
+async def test_button_press_error(hass) -> None:
     """Test the Mazda API raising an error when a button entity is pressed."""
     client_mock = await init_integration(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Mazda services `start_engine`, `stop_engine`, `turn_on_hazard_lights`, and `turn_off_hazard_lights` are deprecated and have been replaced by button entities. Please use the button entities instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace four of the Mazda services with button entities. The `send_poi` service cannot be replaced with a button entity because it takes additional arguments. The `start_charging` and `stop_charging` services will be replaced with a switch entity in a future PR. Also add a button entity to refresh vehicle status, for electric vehicles only.

![screenshot of button entities](https://user-images.githubusercontent.com/2292715/156708218-4f94cb63-1083-42b1-891b-01c1161f126a.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21894

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
