### PR TITLE
Refactor run app in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -248,17 +248,18 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
 
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send the key using legacy protocol."""
-        await self.hass.async_add_executor_job(self._send_key, key)
+        await self.hass.async_add_executor_job(self._send_keys, [key])
 
-    def _send_key(self, key: str) -> None:
-        """Send the key using legacy protocol."""
+    def _send_keys(self, keys: list[str]) -> None:
+        """Send the keys using legacy protocol."""
         try:
             # recreate connection if connection was dead
             retry_count = 1
             for _ in range(retry_count + 1):
                 try:
                     if remote := self._get_remote():
-                        remote.control(key)
+                        for key in keys:
+                            remote.control(key)
                     break
                 except (ConnectionClosed, BrokenPipeError):
                     # BrokenPipe can occur when the commands is sent to fast

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -133,7 +133,7 @@ class SamsungTVBridge(ABC):
         """Tells if the TV is on."""
 
     @abstractmethod
-    async def async_send_key(self, key: str, key_type: str | None = None) -> None:
+    async def async_send_key(self, key: str) -> None:
         """Send a key to the tv and handles exceptions."""
 
     @abstractmethod
@@ -246,7 +246,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
                 pass
         return self._remote
 
-    async def async_send_key(self, key: str, key_type: str | None = None) -> None:
+    async def async_send_key(self, key: str) -> None:
         """Send the key using legacy protocol."""
         await self.hass.async_add_executor_job(self._send_key, key)
 
@@ -406,7 +406,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         """Send the launch_app command using websocket protocol."""
         await self._async_send_command(ChannelEmitCommand.launch_app(app_id))
 
-    async def async_send_key(self, key: str, key_type: str | None = None) -> None:
+    async def async_send_key(self, key: str) -> None:
         """Send the key using websocket protocol."""
         if key == "KEY_POWEROFF":
             key = "KEY_POWER"

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -248,9 +248,9 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
 
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send the key using legacy protocol."""
-        await self.hass.async_add_executor_job(self._send_keys, [key])
+        await self.hass.async_add_executor_job(self._send_key, key)
 
-    def _send_keys(self, keys: list[str]) -> None:
+    def _send_key(self, key: str) -> None:
         """Send the keys using legacy protocol."""
         try:
             # recreate connection if connection was dead
@@ -258,8 +258,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             for _ in range(retry_count + 1):
                 try:
                     if remote := self._get_remote():
-                        for key in keys:
-                            remote.control(key)
+                        remote.control(key)
                     break
                 except (ConnectionClosed, BrokenPipeError):
                     # BrokenPipe can occur when the commands is sent to fast
@@ -405,15 +404,15 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
     async def async_launch_app(self, app_id: str) -> None:
         """Send the launch_app command using websocket protocol."""
-        await self._async_send_commands([ChannelEmitCommand.launch_app(app_id)])
+        await self._async_send_command(ChannelEmitCommand.launch_app(app_id))
 
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send the key using websocket protocol."""
         if key == "KEY_POWEROFF":
             key = "KEY_POWER"
-        await self._async_send_commands([SendRemoteKey.click(key)])
+        await self._async_send_command(SendRemoteKey.click(key))
 
-    async def _async_send_commands(self, commands: list[SamsungTVCommand]) -> None:
+    async def _async_send_command(self, command: SamsungTVCommand) -> None:
         """Send the commands using websocket protocol."""
         try:
             # recreate connection if connection was dead
@@ -421,8 +420,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             for _ in range(retry_count + 1):
                 try:
                     if remote := await self._async_get_remote():
-                        for command in commands:
-                            await remote.send_command(command)
+                        await remote.send_command(command)
                     break
                 except (
                     BrokenPipeError,

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -251,7 +251,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         await self.hass.async_add_executor_job(self._send_key, key)
 
     def _send_key(self, key: str) -> None:
-        """Send the keys using legacy protocol."""
+        """Send the key using legacy protocol."""
         try:
             # recreate connection if connection was dead
             retry_count = 1

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -403,14 +403,15 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
         return None
 
+    async def async_launch_app(self, app_id: str) -> None:
+        """Send the launch_app command using websocket protocol."""
+        await self._async_send_commands([ChannelEmitCommand.launch_app(app_id)])
+
     async def async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send the key using websocket protocol."""
-        if key_type == "run_app":
-            await self._async_send_commands([ChannelEmitCommand.launch_app(key)])
-        else:
-            if key == "KEY_POWEROFF":
-                key = "KEY_POWER"
-            await self._async_send_commands([SendRemoteKey.click(key)])
+        if key == "KEY_POWEROFF":
+            key = "KEY_POWER"
+        await self._async_send_commands([SendRemoteKey.click(key)])
 
     async def _async_send_commands(self, commands: list[SamsungTVCommand]) -> None:
         """Send the commands using websocket protocol."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -181,12 +181,12 @@ class SamsungTVDevice(MediaPlayerEntity):
         assert isinstance(self._bridge, SamsungTVWSBridge)
         await self._bridge.async_launch_app(app_id)
 
-    async def _async_send_key(self, key: str, key_type: str | None = None) -> None:
+    async def _async_send_key(self, key: str) -> None:
         """Send a key to the tv and handles exceptions."""
         if self._power_off_in_progress() and key != "KEY_POWEROFF":
             LOGGER.info("TV is powering off, not sending command: %s", key)
             return
-        await self._bridge.async_send_key(key, key_type)
+        await self._bridge.async_send_key(key)
 
     def _power_off_in_progress(self) -> bool:
         return (

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -184,7 +184,7 @@ class SamsungTVDevice(MediaPlayerEntity):
     async def _async_send_key(self, key: str) -> None:
         """Send a key to the tv and handles exceptions."""
         if self._power_off_in_progress() and key != "KEY_POWEROFF":
-            LOGGER.info("TV is powering off, not sending command: %s", key)
+            LOGGER.info("TV is powering off, not sending key: %s", key)
             return
         await self._bridge.async_send_key(key)
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -173,6 +173,14 @@ class SamsungTVDevice(MediaPlayerEntity):
         if self._app_list is not None:
             self._attr_source_list.extend(self._app_list)
 
+    async def _async_launch_app(self, app_id: str) -> None:
+        """Send launch_app to the tv."""
+        if self._power_off_in_progress():
+            LOGGER.info("TV is powering off, not sending launch_app command")
+            return
+        assert isinstance(self._bridge, SamsungTVWSBridge)
+        await self._bridge.async_launch_app(app_id)
+
     async def _async_send_key(self, key: str, key_type: str | None = None) -> None:
         """Send a key to the tv and handles exceptions."""
         if self._power_off_in_progress() and key != "KEY_POWEROFF":
@@ -248,7 +256,7 @@ class SamsungTVDevice(MediaPlayerEntity):
     ) -> None:
         """Support changing a channel."""
         if media_type == MEDIA_TYPE_APP:
-            await self._async_send_key(media_id, "run_app")
+            await self._async_launch_app(media_id)
             return
 
         if media_type != MEDIA_TYPE_CHANNEL:
@@ -284,7 +292,7 @@ class SamsungTVDevice(MediaPlayerEntity):
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         if self._app_list and source in self._app_list:
-            await self._async_send_key(self._app_list[source], "run_app")
+            await self._async_launch_app(self._app_list[source])
             return
 
         if source in SOURCES:

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -624,29 +624,41 @@ async def test_device_class(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_DEVICE_CLASS] is MediaPlayerDeviceClass.TV.value
 
 
-async def test_turn_off_websocket(hass: HomeAssistant, remotews: Mock) -> None:
+async def test_turn_off_websocket(
+    hass: HomeAssistant, remotews: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test for turn_off."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=[OSError("Boom"), DEFAULT_MOCK],
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
-        remotews.send_command.reset_mock()
 
-        assert await hass.services.async_call(
-            DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
-        )
-        # key called
-        assert remotews.send_command.call_count == 1
-        command = remotews.send_command.call_args_list[0].args[0]
-        assert isinstance(command, SendRemoteKey)
-        assert command.params["DataOfCmd"] == "KEY_POWER"
+    remotews.send_command.reset_mock()
 
-        assert await hass.services.async_call(
-            DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
-        )
-        # key not called
-        assert remotews.send_command.call_count == 1
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    # key called
+    assert remotews.send_command.call_count == 1
+    command = remotews.send_command.call_args_list[0].args[0]
+    assert isinstance(command, SendRemoteKey)
+    assert command.params["DataOfCmd"] == "KEY_POWER"
+
+    # commands not sent : power off in progress
+    remotews.send_command.reset_mock()
+    assert await hass.services.async_call(
+        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+    )
+    assert "TV is powering off, not sending command: KEY_VOLUP" in caplog.text
+    assert await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "Deezer"},
+        True,
+    )
+    assert "TV is powering off, not sending launch_app command" in caplog.text
+    remotews.send_command.assert_not_called()
 
 
 async def test_turn_off_legacy(hass: HomeAssistant, remote: Mock) -> None:

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -650,7 +650,7 @@ async def test_turn_off_websocket(
     assert await hass.services.async_call(
         DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
-    assert "TV is powering off, not sending command: KEY_VOLUP" in caplog.text
+    assert "TV is powering off, not sending key: KEY_VOLUP" in caplog.text
     assert await hass.services.async_call(
         DOMAIN,
         SERVICE_SELECT_SOURCE,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `launch_app` method to `SamsungTVWSBridge`, and drop now unnecessary `key_type` argument from `send_key` method.
Previously requested by @balloob but now easier to implement following recent refactors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
