### PR TITLE
Fix false positive MQTT climate deprecation warnings for defaults

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -433,7 +433,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
 
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
         self._send_if_off = True
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+        # AWAY and HOLD mode topics and templates are deprecated,
+        # support will be removed with release 2022.9
         self._hold_list = []
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
@@ -508,7 +509,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
         if CONF_SEND_IF_OFF in config:
             self._send_if_off = config[CONF_SEND_IF_OFF]
 
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+        # AWAY and HOLD mode topics and templates are deprecated,
+        # support will be removed with release 2022.9
         if CONF_HOLD_LIST in config:
             self._hold_list = config[CONF_HOLD_LIST]
 
@@ -819,7 +821,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
         ):
             presets.append(PRESET_AWAY)
 
-        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+        # AWAY and HOLD mode topics and templates are deprecated,
+        # support will be removed with release 2022.9
         presets.extend(self._hold_list)
 
         if presets:

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -271,7 +271,7 @@ _PLATFORM_SCHEMA_BASE = SCHEMA_BASE.extend(
         vol.Optional(CONF_HOLD_COMMAND_TOPIC): mqtt.valid_publish_topic,
         vol.Optional(CONF_HOLD_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_HOLD_STATE_TOPIC): mqtt.valid_subscribe_topic,
-        vol.Optional(CONF_HOLD_LIST, default=list): cv.ensure_list,
+        vol.Optional(CONF_HOLD_LIST): cv.ensure_list,
         vol.Optional(CONF_MODE_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
         vol.Optional(
@@ -298,7 +298,7 @@ _PLATFORM_SCHEMA_BASE = SCHEMA_BASE.extend(
         ),
         vol.Optional(CONF_RETAIN, default=mqtt.DEFAULT_RETAIN): cv.boolean,
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        vol.Optional(CONF_SEND_IF_OFF, default=True): cv.boolean,
+        vol.Optional(CONF_SEND_IF_OFF): cv.boolean,
         vol.Optional(CONF_ACTION_TEMPLATE): cv.template,
         vol.Optional(CONF_ACTION_TOPIC): mqtt.valid_subscribe_topic,
         # CONF_PRESET_MODE_COMMAND_TOPIC and CONF_PRESET_MODES_LIST must be used together
@@ -431,6 +431,11 @@ class MqttClimate(MqttEntity, ClimateEntity):
         self._feature_preset_mode = False
         self._optimistic_preset_mode = None
 
+        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+        self._send_if_off = True
+        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+        self._hold_list = []
+
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     @staticmethod
@@ -498,6 +503,14 @@ class MqttClimate(MqttEntity, ClimateEntity):
             ).async_render
 
         self._command_templates = command_templates
+
+        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+        if CONF_SEND_IF_OFF in config:
+            self._send_if_off = config[CONF_SEND_IF_OFF]
+
+        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+        if CONF_HOLD_LIST in config:
+            self._hold_list = config[CONF_HOLD_LIST]
 
     def _prepare_subscribe_topics(self):  # noqa: C901
         """(Re)Subscribe to topics."""
@@ -806,7 +819,8 @@ class MqttClimate(MqttEntity, ClimateEntity):
         ):
             presets.append(PRESET_AWAY)
 
-        presets.extend(self._config[CONF_HOLD_LIST])
+        # AWAY and HOLD mode topics and templates are deprecated, support will be removed with release 2022.9
+        presets.extend(self._hold_list)
 
         if presets:
             presets.insert(0, PRESET_NONE)
@@ -847,10 +861,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
                 setattr(self, attr, temp)
 
             # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-            if (
-                self._config[CONF_SEND_IF_OFF]
-                or self._current_operation != HVAC_MODE_OFF
-            ):
+            if self._send_if_off or self._current_operation != HVAC_MODE_OFF:
                 payload = self._command_templates[cmnd_template](temp)
                 await self._publish(cmnd_topic, payload)
 
@@ -890,7 +901,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
+        if self._send_if_off or self._current_operation != HVAC_MODE_OFF:
             payload = self._command_templates[CONF_SWING_MODE_COMMAND_TEMPLATE](
                 swing_mode
             )
@@ -903,7 +914,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode):
         """Set new target temperature."""
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
+        if self._send_if_off or self._current_operation != HVAC_MODE_OFF:
             payload = self._command_templates[CONF_FAN_MODE_COMMAND_TEMPLATE](fan_mode)
             await self._publish(CONF_FAN_MODE_COMMAND_TOPIC, payload)
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -337,9 +337,9 @@ async def test_set_fan_mode(hass, mqtt_mock):
 @pytest.mark.parametrize(
     "send_if_off,assert_async_publish",
     [
-        (None, [call("fan-mode-topic", "low", 0, False)]),
-        (True, [call("fan-mode-topic", "low", 0, False)]),
-        (False, []),
+        ({}, [call("fan-mode-topic", "low", 0, False)]),
+        ({"send_if_off": True}, [call("fan-mode-topic", "low", 0, False)]),
+        ({"send_if_off": False}, []),
     ],
 )
 async def test_set_fan_mode_send_if_off(
@@ -347,8 +347,7 @@ async def test_set_fan_mode_send_if_off(
 ):
     """Test setting of fan mode if the hvac is off."""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    if send_if_off is not None:
-        config[CLIMATE_DOMAIN]["send_if_off"] = send_if_off
+    config[CLIMATE_DOMAIN].update(send_if_off)
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_CLIMATE) is not None
@@ -427,9 +426,9 @@ async def test_set_swing(hass, mqtt_mock):
 @pytest.mark.parametrize(
     "send_if_off,assert_async_publish",
     [
-        (None, [call("swing-mode-topic", "on", 0, False)]),
-        (True, [call("swing-mode-topic", "on", 0, False)]),
-        (False, []),
+        ({}, [call("swing-mode-topic", "on", 0, False)]),
+        ({"send_if_off": True}, [call("swing-mode-topic", "on", 0, False)]),
+        ({"send_if_off": False}, []),
     ],
 )
 async def test_set_swing_mode_send_if_off(
@@ -437,8 +436,7 @@ async def test_set_swing_mode_send_if_off(
 ):
     """Test setting of swing mode if the hvac is off."""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    if send_if_off is not None:
-        config[CLIMATE_DOMAIN]["send_if_off"] = send_if_off
+    config[CLIMATE_DOMAIN].update(send_if_off)
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_CLIMATE) is not None
@@ -501,9 +499,9 @@ async def test_set_target_temperature(hass, mqtt_mock):
 @pytest.mark.parametrize(
     "send_if_off,assert_async_publish",
     [
-        (None, [call("temperature-topic", "21.0", 0, False)]),
-        (True, [call("temperature-topic", "21.0", 0, False)]),
-        (False, []),
+        ({}, [call("temperature-topic", "21.0", 0, False)]),
+        ({"send_if_off": True}, [call("temperature-topic", "21.0", 0, False)]),
+        ({"send_if_off": False}, []),
     ],
 )
 async def test_set_target_temperature_send_if_off(
@@ -511,8 +509,7 @@ async def test_set_target_temperature_send_if_off(
 ):
     """Test setting of target temperature if the hvac is off."""
     config = copy.deepcopy(DEFAULT_CONFIG)
-    if send_if_off is not None:
-        config[CLIMATE_DOMAIN]["send_if_off"] = send_if_off
+    config[CLIMATE_DOMAIN].update(send_if_off)
     assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_CLIMATE) is not None

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -446,7 +446,7 @@ async def test_set_swing_mode_send_if_off(
     # Turn on HVAC
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     mqtt_mock.async_publish.reset_mock()
-    # Updates for fan_mode should be sent when the device is turned on
+    # Updates for swing_mode should be sent when the device is turned on
     await common.async_set_swing_mode(hass, "off", ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with("swing-mode-topic", "off", 0, False)
 
@@ -520,7 +520,7 @@ async def test_set_target_temperature_send_if_off(
     # Turn on HVAC
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     mqtt_mock.async_publish.reset_mock()
-    # Updates for fan_mode should be sent when the device is turned on
+    # Updates for target temperature should be sent when the device is turned on
     await common.async_set_temperature(hass, 16.0, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         "temperature-topic", "16.0", 0, False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT climate config parameters `SEND_IF_OFF` and `HOLD_MODES` were deprecated, deprecated with the HA 2022.3.0 release. There config parameters had default values in the schema causing deprecation warnings even when they were not configured. This PR removes the defaults from the schema and respects them later.

The issue was reported here:
https://community.home-assistant.io/t/2022-3-select-and-play-media/398201/218

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/adorobis/hacomfoairmqtt/issues/37
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
