### PR TITLE
Remove rfxtrx signal repetition

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -48,7 +48,6 @@ from .const import (
 
 DOMAIN = "rfxtrx"
 
-DEFAULT_SIGNAL_REPETITIONS = 1
 DEFAULT_OFF_DELAY = 2.0
 
 SIGNAL_EVENT = f"{DOMAIN}_event"
@@ -562,15 +561,12 @@ class RfxtrxCommandEntity(RfxtrxEntity):
         self,
         device: rfxtrxmod.RFXtrxDevice,
         device_id: DeviceTuple,
-        signal_repetitions: int = 1,
         event: rfxtrxmod.RFXtrxEvent | None = None,
     ) -> None:
         """Initialzie a switch or light device."""
         super().__init__(device, device_id, event=event)
-        self.signal_repetitions = signal_repetitions
         self._state: bool | None = None
 
     async def _async_send(self, fun, *args):
         rfx_object = self.hass.data[DOMAIN][DATA_RFXOBJECT]
-        for _ in range(self.signal_repetitions):
-            await self.hass.async_add_executor_job(fun, rfx_object.transport, *args)
+        await self.hass.async_add_executor_job(fun, rfx_object.transport, *args)

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -50,16 +50,12 @@ from .const import (
     CONF_OFF_DELAY,
     CONF_PROTOCOLS,
     CONF_REPLACE_DEVICE,
-    CONF_SIGNAL_REPETITIONS,
     CONF_VENETIAN_BLIND_MODE,
     CONST_VENETIAN_BLIND_MODE_DEFAULT,
     CONST_VENETIAN_BLIND_MODE_EU,
     CONST_VENETIAN_BLIND_MODE_US,
     DEVICE_PACKET_TYPE_LIGHTING4,
 )
-from .cover import supported as cover_supported
-from .light import supported as light_supported
-from .switch import supported as switch_supported
 
 CONF_EVENT_CODE = "event_code"
 CONF_MANUAL_PATH = "Enter Manually"
@@ -210,7 +206,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 devices = {}
                 device = {
                     CONF_DEVICE_ID: device_id,
-                    CONF_SIGNAL_REPETITIONS: user_input.get(CONF_SIGNAL_REPETITIONS, 1),
                 }
 
                 devices[self._selected_device_event_code] = device
@@ -251,21 +246,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(CONF_OFF_DELAY): str,
                 }
             data_schema.update(off_delay_schema)
-
-        if (
-            binary_supported(self._selected_device_object)
-            or cover_supported(self._selected_device_object)
-            or light_supported(self._selected_device_object)
-            or switch_supported(self._selected_device_object)
-        ):
-            data_schema.update(
-                {
-                    vol.Optional(
-                        CONF_SIGNAL_REPETITIONS,
-                        default=device_data.get(CONF_SIGNAL_REPETITIONS, 1),
-                    ): int,
-                }
-            )
 
         if (
             self._selected_device_object.device.packettype

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -2,7 +2,6 @@
 
 CONF_DATA_BITS = "data_bits"
 CONF_AUTOMATIC_ADD = "automatic_add"
-CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 CONF_OFF_DELAY = "off_delay"
 CONF_VENETIAN_BLIND_MODE = "venetian_blind_mode"
 CONF_PROTOCOLS = "protocols"

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -19,16 +19,10 @@ from homeassistant.const import STATE_OPEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import (
-    DEFAULT_SIGNAL_REPETITIONS,
-    DeviceTuple,
-    RfxtrxCommandEntity,
-    async_setup_platform_entry,
-)
+from . import DeviceTuple, RfxtrxCommandEntity, async_setup_platform_entry
 from .const import (
     COMMAND_OFF_LIST,
     COMMAND_ON_LIST,
-    CONF_SIGNAL_REPETITIONS,
     CONF_VENETIAN_BLIND_MODE,
     CONST_VENETIAN_BLIND_MODE_EU,
     CONST_VENETIAN_BLIND_MODE_US,
@@ -59,7 +53,6 @@ async def async_setup_entry(
             RfxtrxCover(
                 event.device,
                 device_id,
-                entity_info.get(CONF_SIGNAL_REPETITIONS, DEFAULT_SIGNAL_REPETITIONS),
                 venetian_blind_mode=entity_info.get(CONF_VENETIAN_BLIND_MODE),
                 event=event if auto else None,
             )
@@ -79,12 +72,11 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         self,
         device: rfxtrxmod.RFXtrxDevice,
         device_id: DeviceTuple,
-        signal_repetitions: int,
         event: rfxtrxmod.RFXtrxEvent = None,
         venetian_blind_mode: bool | None = None,
     ) -> None:
         """Initialize the RFXtrx cover device."""
-        super().__init__(device, device_id, signal_repetitions, event)
+        super().__init__(device, device_id, event)
         self._venetian_blind_mode = venetian_blind_mode
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -15,13 +15,8 @@ from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import (
-    DEFAULT_SIGNAL_REPETITIONS,
-    DeviceTuple,
-    RfxtrxCommandEntity,
-    async_setup_platform_entry,
-)
-from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST, CONF_SIGNAL_REPETITIONS
+from . import DeviceTuple, RfxtrxCommandEntity, async_setup_platform_entry
+from .const import COMMAND_OFF_LIST, COMMAND_ON_LIST
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +48,6 @@ async def async_setup_entry(
             RfxtrxLight(
                 event.device,
                 device_id,
-                entity_info.get(CONF_SIGNAL_REPETITIONS, DEFAULT_SIGNAL_REPETITIONS),
                 event=event if auto else None,
             )
         ]

--- a/homeassistant/components/rfxtrx/siren.py
+++ b/homeassistant/components/rfxtrx/siren.py
@@ -20,12 +20,11 @@ from homeassistant.helpers.event import async_call_later
 
 from . import (
     DEFAULT_OFF_DELAY,
-    DEFAULT_SIGNAL_REPETITIONS,
     DeviceTuple,
     RfxtrxCommandEntity,
     async_setup_platform_entry,
 )
-from .const import CONF_OFF_DELAY, CONF_SIGNAL_REPETITIONS
+from .const import CONF_OFF_DELAY
 
 SUPPORT_RFXTRX = SUPPORT_TURN_ON | SUPPORT_TONES
 
@@ -76,9 +75,6 @@ async def async_setup_entry(
                 RfxtrxChime(
                     event.device,
                     device_id,
-                    entity_info.get(
-                        CONF_SIGNAL_REPETITIONS, DEFAULT_SIGNAL_REPETITIONS
-                    ),
                     entity_info.get(CONF_OFF_DELAY, DEFAULT_OFF_DELAY),
                     auto,
                 )
@@ -92,9 +88,6 @@ async def async_setup_entry(
                     RfxtrxSecurityPanic(
                         event.device,
                         device_id,
-                        entity_info.get(
-                            CONF_SIGNAL_REPETITIONS, DEFAULT_SIGNAL_REPETITIONS
-                        ),
                         entity_info.get(CONF_OFF_DELAY, DEFAULT_OFF_DELAY),
                         auto,
                     )
@@ -138,11 +131,9 @@ class RfxtrxChime(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin):
 
     _device: rfxtrxmod.ChimeDevice
 
-    def __init__(
-        self, device, device_id, signal_repetitions=1, off_delay=None, event=None
-    ):
+    def __init__(self, device, device_id, off_delay=None, event=None):
         """Initialize the entity."""
-        super().__init__(device, device_id, signal_repetitions, event)
+        super().__init__(device, device_id, event)
         self._attr_available_tones = list(self._device.COMMANDS.values())
         self._attr_supported_features = SUPPORT_TURN_ON | SUPPORT_TONES
         self._default_tone = next(iter(self._device.COMMANDS))
@@ -191,11 +182,9 @@ class RfxtrxSecurityPanic(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin)
 
     _device: rfxtrxmod.SecurityDevice
 
-    def __init__(
-        self, device, device_id, signal_repetitions=1, off_delay=None, event=None
-    ):
+    def __init__(self, device, device_id, off_delay=None, event=None):
         """Initialize the entity."""
-        super().__init__(device, device_id, signal_repetitions, event)
+        super().__init__(device, device_id, event)
         self._attr_supported_features = SUPPORT_TURN_ON | SUPPORT_TURN_OFF
         self._on_value = get_first_key(self._device.STATUS, SECURITY_PANIC_ON)
         self._off_value = get_first_key(self._device.STATUS, SECURITY_PANIC_OFF)

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -54,7 +54,6 @@
           "data_bit": "Number of data bits",
           "command_on": "Data bits value for command on",
           "command_off": "Data bits value for command off",
-          "signal_repetitions": "Number of signal repetitions",
           "venetian_blind_mode": "Venetian blind mode",
           "replace_device": "Select device to replace"
         },

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -12,7 +12,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
-    DEFAULT_SIGNAL_REPETITIONS,
     DOMAIN,
     DeviceTuple,
     RfxtrxCommandEntity,
@@ -23,7 +22,6 @@ from .const import (
     COMMAND_OFF_LIST,
     COMMAND_ON_LIST,
     CONF_DATA_BITS,
-    CONF_SIGNAL_REPETITIONS,
     DEVICE_PACKET_TYPE_LIGHTING4,
 )
 
@@ -59,7 +57,6 @@ async def async_setup_entry(
             RfxtrxSwitch(
                 event.device,
                 device_id,
-                entity_info.get(CONF_SIGNAL_REPETITIONS, DEFAULT_SIGNAL_REPETITIONS),
                 entity_info.get(CONF_DATA_BITS),
                 entity_info.get(CONF_COMMAND_ON),
                 entity_info.get(CONF_COMMAND_OFF),
@@ -79,14 +76,13 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
         self,
         device: rfxtrxmod.RFXtrxDevice,
         device_id: DeviceTuple,
-        signal_repetitions: int = 1,
         data_bits: int | None = None,
         cmd_on: int | None = None,
         cmd_off: int | None = None,
         event: rfxtrxmod.RFXtrxEvent | None = None,
     ) -> None:
         """Initialize the RFXtrx switch."""
-        super().__init__(device, device_id, signal_repetitions, event=event)
+        super().__init__(device, device_id, event=event)
         self._data_bits = data_bits
         self._cmd_on = cmd_on
         self._cmd_off = cmd_off

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -401,7 +401,7 @@ async def test_options_add_device(hass):
     assert result["step_id"] == "set_device_options"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"signal_repetitions": 5}
+        result["flow_id"], user_input={}
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -411,7 +411,6 @@ async def test_options_add_device(hass):
     assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0b1100cd0213c7f230010f71"]
-    assert entry.data["devices"]["0b1100cd0213c7f230010f71"]["signal_repetitions"] == 5
     assert "delay_off" not in entry.data["devices"]["0b1100cd0213c7f230010f71"]
 
     state = hass.states.get("binary_sensor.ac_213c7f2_48")
@@ -431,7 +430,7 @@ async def test_options_add_duplicate_device(hass):
             "device": "/dev/tty123",
             "debug": False,
             "automatic_add": False,
-            "devices": {"0b1100cd0213c7f230010f71": {"signal_repetitions": 1}},
+            "devices": {"0b1100cd0213c7f230010f71": {}},
         },
         unique_id=DOMAIN,
     )
@@ -626,11 +625,9 @@ async def test_options_replace_control_device(hass):
             "devices": {
                 "0b1100100118cdea02010f70": {
                     "device_id": ["11", "0", "118cdea:2"],
-                    "signal_repetitions": 1,
                 },
                 "0b1100101118cdea02010f70": {
                     "device_id": ["11", "0", "1118cdea:2"],
-                    "signal_repetitions": 1,
                 },
             },
         },
@@ -751,7 +748,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "signal_repetitions": 5,
             "data_bits": 4,
             "off_delay": "abcdef",
             "command_on": "xyz",
@@ -769,7 +765,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "signal_repetitions": 5,
             "data_bits": 4,
             "command_on": "0xE",
             "command_off": "0x7",
@@ -784,7 +779,6 @@ async def test_options_add_and_configure_device(hass):
     assert entry.data["automatic_add"]
 
     assert entry.data["devices"]["0913000022670e013970"]
-    assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
     assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
 
     state = hass.states.get("binary_sensor.pt2262_22670e")
@@ -816,7 +810,6 @@ async def test_options_add_and_configure_device(hass):
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "signal_repetitions": 5,
             "data_bits": 4,
             "command_on": "0xE",
             "command_off": "0x7",
@@ -828,7 +821,6 @@ async def test_options_add_and_configure_device(hass):
     await hass.async_block_till_done()
 
     assert entry.data["devices"]["0913000022670e013970"]
-    assert entry.data["devices"]["0913000022670e013970"]["signal_repetitions"] == 5
     assert "delay_off" not in entry.data["devices"]["0913000022670e013970"]
 
 

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -12,9 +12,7 @@ from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 async def test_one_cover(hass, rfxtrx):
     """Test with 1 cover."""
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1400cd0213c7f20d010f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -61,9 +59,7 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1400cd0213c7f20d010f51": {"signal_repetitions": 1}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1400cd0213c7f20d010f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -78,9 +74,9 @@ async def test_several_covers(hass, rfxtrx):
     """Test with 3 covers."""
     entry_data = create_rfx_test_cfg(
         devices={
-            "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
-            "0A1400ADF394AB010D0060": {"signal_repetitions": 1},
-            "09190000009ba8010100": {"signal_repetitions": 1},
+            "0b1400cd0213c7f20d010f51": {},
+            "0A1400ADF394AB010D0060": {},
+            "09190000009ba8010100": {},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -125,8 +121,8 @@ async def test_duplicate_cover(hass, rfxtrx):
     """Test with 2 duplicate covers."""
     entry_data = create_rfx_test_cfg(
         devices={
-            "0b1400cd0213c7f20d010f51": {"signal_repetitions": 1},
-            "0b1400cd0213c7f20d010f50": {"signal_repetitions": 1},
+            "0b1400cd0213c7f20d010f51": {},
+            "0b1400cd0213c7f20d010f50": {},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -147,11 +143,10 @@ async def test_rfy_cover(hass, rfxtrx):
     entry_data = create_rfx_test_cfg(
         devices={
             "071a000001020301": {
-                "signal_repetitions": 1,
                 "venetian_blind_mode": "Unknown",
             },
-            "071a000001020302": {"signal_repetitions": 1, "venetian_blind_mode": "US"},
-            "071a000001020303": {"signal_repetitions": 1, "venetian_blind_mode": "EU"},
+            "071a000001020302": {"venetian_blind_mode": "US"},
+            "071a000001020303": {"venetian_blind_mode": "EU"},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -94,7 +94,7 @@ def _get_expected_actions(data):
 )
 async def test_get_actions(hass, device_reg: DeviceRegistry, device, expected):
     """Test we get the expected actions from a rfxtrx."""
-    await setup_entry(hass, {device.code: {"signal_repetitions": 1}})
+    await setup_entry(hass, {device.code: {}})
 
     device_entry = device_reg.async_get_device(device.device_identifiers, set())
     assert device_entry
@@ -137,7 +137,7 @@ async def test_action(
 ):
     """Test for actions."""
 
-    await setup_entry(hass, {device.code: {"signal_repetitions": 1}})
+    await setup_entry(hass, {device.code: {}})
 
     device_entry = device_reg.async_get_device(device.device_identifiers, set())
     assert device_entry
@@ -172,7 +172,7 @@ async def test_invalid_action(hass, device_reg: DeviceRegistry):
     """Test for invalid actions."""
     device = DEVICE_LIGHTING_1
 
-    await setup_entry(hass, {device.code: {"signal_repetitions": 1}})
+    await setup_entry(hass, {device.code: {}})
 
     device_identifers: Any = device.device_identifiers
     device_entry = device_reg.async_get_device(device_identifers, set())

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -85,7 +85,7 @@ async def setup_entry(hass, devices):
 )
 async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
     """Test we get the expected triggers from a rfxtrx."""
-    await setup_entry(hass, {event.code: {"signal_repetitions": 1}})
+    await setup_entry(hass, {event.code: {}})
 
     device_entry = device_reg.async_get_device(event.device_identifiers, set())
 
@@ -112,7 +112,7 @@ async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
 async def test_firing_event(hass, device_reg: DeviceRegistry, rfxtrx, event):
     """Test for turn_on and turn_off triggers firing."""
 
-    await setup_entry(hass, {event.code: {"fire_event": True, "signal_repetitions": 1}})
+    await setup_entry(hass, {event.code: {"fire_event": True}})
 
     device_entry = device_reg.async_get_device(event.device_identifiers, set())
     assert device_entry
@@ -152,7 +152,7 @@ async def test_invalid_trigger(hass, device_reg: DeviceRegistry):
     """Test for invalid actions."""
     event = EVENT_LIGHTING_1
 
-    await setup_entry(hass, {event.code: {"fire_event": True, "signal_repetitions": 1}})
+    await setup_entry(hass, {event.code: {"fire_event": True}})
 
     device_identifers: Any = event.device_identifiers
     device_entry = device_reg.async_get_device(device_identifers, set())

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -14,9 +14,7 @@ from tests.components.rfxtrx.conftest import create_rfx_test_cfg
 
 async def test_one_light(hass, rfxtrx):
     """Test with 1 light."""
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210020f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -100,9 +98,7 @@ async def test_state_restore(hass, rfxtrx, state, brightness):
         hass, [State(entity_id, state, attributes={ATTR_BRIGHTNESS: brightness})]
     )
 
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1100cd0213c7f210020f51": {"signal_repetitions": 1}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210020f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -118,9 +114,9 @@ async def test_several_lights(hass, rfxtrx):
     """Test with 3 lights."""
     entry_data = create_rfx_test_cfg(
         devices={
-            "0b1100cd0213c7f230020f71": {"signal_repetitions": 1},
-            "0b1100100118cdea02020f70": {"signal_repetitions": 1},
-            "0b1100101118cdea02050f70": {"signal_repetitions": 1},
+            "0b1100cd0213c7f230020f71": {},
+            "0b1100100118cdea02020f70": {},
+            "0b1100101118cdea02050f70": {},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -161,27 +157,6 @@ async def test_several_lights(hass, rfxtrx):
     assert state
     assert state.state == "on"
     assert state.attributes.get("brightness") == 255
-
-
-@pytest.mark.parametrize("repetitions", [1, 3])
-async def test_repetitions(hass, rfxtrx, repetitions):
-    """Test signal repetitions."""
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1100cd0213c7f230020f71": {"signal_repetitions": repetitions}}
-    )
-    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
-
-    mock_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        "light", "turn_on", {"entity_id": "light.ac_213c7f2_48"}, blocking=True
-    )
-    await hass.async_block_till_done()
-
-    assert rfxtrx.transport.send.call_count == repetitions
 
 
 async def test_discover_light(hass, rfxtrx_automatic):

--- a/tests/components/rfxtrx/test_siren.py
+++ b/tests/components/rfxtrx/test_siren.py
@@ -11,7 +11,7 @@ from tests.common import MockConfigEntry
 async def test_one_chime(hass, rfxtrx, timestep):
     """Test with 1 entity."""
     entry_data = create_rfx_test_cfg(
-        devices={"0a16000000000000000000": {"signal_repetitions": 1, "off_delay": 2.0}}
+        devices={"0a16000000000000000000": {"off_delay": 2.0}}
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
@@ -66,9 +66,7 @@ async def test_one_chime(hass, rfxtrx, timestep):
 
 async def test_one_security1(hass, rfxtrx, timestep):
     """Test with 1 entity."""
-    entry_data = create_rfx_test_cfg(
-        devices={"08200300a109000670": {"signal_repetitions": 1, "off_delay": 2.0}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"08200300a109000670": {"off_delay": 2.0}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -17,9 +17,7 @@ EVENT_RFY_DISABLE_SUN_AUTO = "081a00000301010114"
 
 async def test_one_switch(hass, rfxtrx):
     """Test with 1 switch."""
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210010f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -57,7 +55,6 @@ async def test_one_pt2262_switch(hass, rfxtrx):
     entry_data = create_rfx_test_cfg(
         devices={
             "0913000022670e013970": {
-                "signal_repetitions": 1,
                 "data_bits": 4,
                 "command_on": 0xE,
                 "command_off": 0x7,
@@ -104,9 +101,7 @@ async def test_state_restore(hass, rfxtrx, state):
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1100cd0213c7f210010f51": {"signal_repetitions": 1}}
-    )
+    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210010f51": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)
@@ -121,9 +116,9 @@ async def test_several_switches(hass, rfxtrx):
     """Test with 3 switches."""
     entry_data = create_rfx_test_cfg(
         devices={
-            "0b1100cd0213c7f230010f71": {"signal_repetitions": 1},
-            "0b1100100118cdea02010f70": {"signal_repetitions": 1},
-            "0b1100101118cdea02010f70": {"signal_repetitions": 1},
+            "0b1100cd0213c7f230010f71": {},
+            "0b1100100118cdea02010f70": {},
+            "0b1100101118cdea02010f70": {},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -149,33 +144,12 @@ async def test_several_switches(hass, rfxtrx):
     assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
 
 
-@pytest.mark.parametrize("repetitions", [1, 3])
-async def test_repetitions(hass, rfxtrx, repetitions):
-    """Test signal repetitions."""
-    entry_data = create_rfx_test_cfg(
-        devices={"0b1100cd0213c7f230010f71": {"signal_repetitions": repetitions}}
-    )
-    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
-
-    mock_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.ac_213c7f2_48"}, blocking=True
-    )
-    await hass.async_block_till_done()
-
-    assert rfxtrx.transport.send.call_count == repetitions
-
-
 async def test_switch_events(hass, rfxtrx):
     """Event test with 2 switches."""
     entry_data = create_rfx_test_cfg(
         devices={
-            "0b1100cd0213c7f205010f51": {"signal_repetitions": 1},
-            "0b1100cd0213c7f210010f51": {"signal_repetitions": 1},
+            "0b1100cd0213c7f205010f51": {},
+            "0b1100cd0213c7f210010f51": {},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -231,7 +205,6 @@ async def test_pt2262_switch_events(hass, rfxtrx):
     entry_data = create_rfx_test_cfg(
         devices={
             "0913000022670e013970": {
-                "signal_repetitions": 1,
                 "data_bits": 4,
                 "command_on": 0xE,
                 "command_off": 0x7,
@@ -299,7 +272,7 @@ async def test_discover_rfy_sun_switch(hass, rfxtrx_automatic):
 
 async def test_unknown_event_code(hass, rfxtrx):
     """Test with 3 switches."""
-    entry_data = create_rfx_test_cfg(devices={"1234567890": {"signal_repetitions": 1}})
+    entry_data = create_rfx_test_cfg(devices={"1234567890": {}})
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
     mock_entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

* Support for signal repetition for devices have been removed. RFXCOM internally repeat packets as needed per protocol.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove support for explicit per device signal repetition. RFXCOM devices will repeat each RF message by default around 7 times for most protocols. By doing repeats in HA we send X times 7 RF packets on a already polluted 433 band.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21906

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
