### PR TITLE
Fix error handling for expired html5 registration

### DIFF
--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -533,7 +533,9 @@ class HTML5NotificationService(BaseNotificationService):
             if response.status_code == 410:
                 _LOGGER.info("Notification channel has expired")
                 reg = self.registrations.pop(target)
-                if not save_json(self.registrations_json_path, self.registrations):
+                try:
+                    save_json(self.registrations_json_path, self.registrations)
+                except HomeAssistantError:
                     self.registrations[target] = reg
                     _LOGGER.error("Error saving registration")
                 else:

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -550,7 +550,7 @@ async def test_send_fcm_expired(hass, hass_client):
 
 
 async def test_send_fcm_expired_save_fails(hass, hass_client):
-    """Test that the FCM target is removed when expired."""
+    """Test that the FCM target remains after expiry if save_json fails."""
     registrations = {"device": SUBSCRIPTION_5}
     await mock_client(hass, hass_client, registrations)
 

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -527,3 +527,46 @@ async def test_send_fcm_without_targets(hass, hass_client):
     assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_5["subscription"]
     # Third mock_call checks the status_code of the response.
     assert mock_wp.mock_calls[2][0] == "().send().status_code.__eq__"
+
+
+async def test_send_fcm_expired(hass, hass_client):
+    """Test that the FCM target is removed when expired."""
+    registrations = {"device": SUBSCRIPTION_5}
+    await mock_client(hass, hass_client, registrations)
+
+    with (
+        patch("homeassistant.components.html5.notify.WebPusher") as mock_wp,
+        patch("homeassistant.components.html5.notify.save_json"),
+    ):
+        mock_wp().send().status_code = 410
+        await hass.services.async_call(
+            "notify",
+            "notify",
+            {"message": "Hello", "target": ["device"], "data": {"icon": "beer.png"}},
+            blocking=True,
+        )
+    # "device" should be removed when expired.
+    assert "device" not in registrations
+
+
+async def test_send_fcm_expired_save_fails(hass, hass_client):
+    """Test that the FCM target is removed when expired."""
+    registrations = {"device": SUBSCRIPTION_5}
+    await mock_client(hass, hass_client, registrations)
+
+    with (
+        patch("homeassistant.components.html5.notify.WebPusher") as mock_wp,
+        patch(
+            "homeassistant.components.html5.notify.save_json",
+            side_effect=HomeAssistantError(),
+        ),
+    ):
+        mock_wp().send().status_code = 410
+        await hass.services.async_call(
+            "notify",
+            "notify",
+            {"message": "Hello", "target": ["device"], "data": {"icon": "beer.png"}},
+            blocking=True,
+        )
+    # "device" should still exist if save fails.
+    assert "device" in registrations


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

[`save_json`](https://github.com/home-assistant/core/blob/c5f7e7d1b07d3a017eff521986f8bfa4fac8e151/homeassistant/util/json.py#L46) does not return a value. Use exceptions for error handling instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
