### PR TITLE
Fix Jellyfin erroring on media items without a source

### DIFF
--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -324,11 +324,14 @@ class JellyfinSource(MediaSource):
 
 def _media_mime_type(media_item: dict[str, Any]) -> str:
     """Return the mime type of a media item."""
-    media_source = media_item[ITEM_KEY_MEDIA_SOURCES][0]
-    path = media_source[MEDIA_SOURCE_KEY_PATH]
-    mime_type, _ = mimetypes.guess_type(path)
+    if media_item[ITEM_KEY_MEDIA_SOURCES]:
+        media_source = media_item[ITEM_KEY_MEDIA_SOURCES][0]
+        path = media_source[MEDIA_SOURCE_KEY_PATH]
+        mime_type, _ = mimetypes.guess_type(path)
 
-    if mime_type is not None:
-        return mime_type
+        if mime_type is not None:
+            return mime_type
 
-    raise BrowseError(f"Unable to determine mime type for path {path}")
+        raise BrowseError(f"Unable to determine mime type for path {path}")
+
+    raise BrowseError("Unable to determine mime type for item without media source")

--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -324,14 +324,14 @@ class JellyfinSource(MediaSource):
 
 def _media_mime_type(media_item: dict[str, Any]) -> str:
     """Return the mime type of a media item."""
-    if media_item[ITEM_KEY_MEDIA_SOURCES]:
-        media_source = media_item[ITEM_KEY_MEDIA_SOURCES][0]
-        path = media_source[MEDIA_SOURCE_KEY_PATH]
-        mime_type, _ = mimetypes.guess_type(path)
+    if not media_item[ITEM_KEY_MEDIA_SOURCES]:
+        raise BrowseError("Unable to determine mime type for item without media source")
 
-        if mime_type is not None:
-            return mime_type
+    media_source = media_item[ITEM_KEY_MEDIA_SOURCES][0]
+    path = media_source[MEDIA_SOURCE_KEY_PATH]
+    mime_type, _ = mimetypes.guess_type(path)
 
-        raise BrowseError(f"Unable to determine mime type for path {path}")
+    if mime_type is not None:
+        return mime_type
 
-    raise BrowseError("Unable to determine mime type for item without media source")
+    raise BrowseError(f"Unable to determine mime type for path {path}")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a small fix that prevents the Jellyfin integration from throwing an exception when it encounters a media item without an associated source. This issue was found while implementing full test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR is a prerequisite of https://github.com/home-assistant/core/pull/65262
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
