### PR TITLE
Improve `nmap_tracker` default options

### DIFF
--- a/homeassistant/components/nmap_tracker/const.py
+++ b/homeassistant/components/nmap_tracker/const.py
@@ -12,6 +12,6 @@ NMAP_TRACKED_DEVICES: Final = "nmap_tracked_devices"
 # Interval in minutes to exclude devices from a scan while they are home
 CONF_HOME_INTERVAL: Final = "home_interval"
 CONF_OPTIONS: Final = "scan_options"
-DEFAULT_OPTIONS: Final = "-F -T4 --min-rate 10 --host-timeout 5s"
+DEFAULT_OPTIONS: Final = "-n -sn --disable-arp-ping --host-timeout 5s"
 
 TRACKER_SCAN_INTERVAL: Final = 120

--- a/tests/components/nmap_tracker/test_config_flow.py
+++ b/tests/components/nmap_tracker/test_config_flow.py
@@ -211,7 +211,7 @@ async def test_options_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
         CONF_HOSTS: "192.168.1.0/24",
         CONF_CONSIDER_HOME: 180,
         CONF_SCAN_INTERVAL: 120,
-        CONF_OPTIONS: "-F -T4 --min-rate 10 --host-timeout 5s",
+        CONF_OPTIONS: "-n -sn --disable-arp-ping --host-timeout 5s",
     }
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve the reliability and speed of the default `nmap_tracker` scan options.

I'm using the nmap integration to monitor two phones for home/away status:
- CAT S61
- Samsung S10e

The S61 has been working great with the default options, always continuous blocks of "Home" or "Away", no weird flopping.

The S10e on the other hand... too bad I don't have any screenshots from before, but it was randomly flopping between "Home" and "Away".

For a long time I thought it must be some power saving thing on the phone itself, but it's not.

After adding `--disable-arp-ping`, all the flopping went away and it's working reliably now. The S61 still works as before.

The rest of the options are just for reducing the scan speed dramatically:
- `-n`: do not resolve hostnames
- `-sn`: don't do any port scan (since AFAIK home-assistant only cares about up/down)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
