### PR TITLE
Ensure elkm1 can be manually configured when discovered instance is not used

### DIFF
--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -289,7 +289,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     dr.format_mac(device.mac_address), raise_on_progress=False
                 )
                 self._abort_if_unique_id_configured()
-                user_input[CONF_ADDRESS] = f"{device.ip_address}:{device.port}"
+                # Ignore the port from discovery since its always going to be
+                # 2601 if secure is turned on even though they may want insecure
+                user_input[CONF_ADDRESS] = device.ip_address
             errors, result = await self._async_create_or_error(user_input, False)
             if not errors:
                 return result

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -225,7 +225,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             info = await validate_input(user_input, self.unique_id)
         except asyncio.TimeoutError:
-            return {CONF_HOST: "cannot_connect"}, None
+            return {"base": "cannot_connect"}, None
         except InvalidAuth:
             return {CONF_PASSWORD: "invalid_auth"}, None
         except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -285,7 +285,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if device := await async_discover_device(
                 self.hass, user_input[CONF_ADDRESS]
             ):
-                await self.async_set_unique_id(dr.format_mac(device.mac_address))
+                await self.async_set_unique_id(
+                    dr.format_mac(device.mac_address), raise_on_progress=False
+                )
                 self._abort_if_unique_id_configured()
                 user_input[CONF_ADDRESS] = f"{device.ip_address}:{device.port}"
             errors, result = await self._async_create_or_error(user_input, False)

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -324,7 +324,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if is_ip_address(host) and (
             device := await async_discover_device(self.hass, host)
         ):
-            await self.async_set_unique_id(dr.format_mac(device.mac_address))
+            await self.async_set_unique_id(
+                dr.format_mac(device.mac_address), raise_on_progress=False
+            )
             self._abort_if_unique_id_configured()
 
         return (await self._async_create_or_error(user_input, True))[1]

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -73,6 +73,58 @@ async def test_form_user_with_secure_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_form_user_with_insecure_elk_skip_discovery(hass):
+    """Test we can setup a insecure elk with skipping discovery."""
+
+    with _patch_discovery(), _patch_elk():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DHCP_DISCOVERY
+        )
+        await hass.async_block_till_done()
+
+    with _patch_discovery(no_device=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+    assert result["step_id"] == "manual_connection"
+
+    mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
+
+    with _patch_discovery(), _patch_elk(elk=mocked_elk), patch(
+        "homeassistant.components.elkm1.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.elkm1.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "protocol": "non-secure",
+                "address": "1.2.3.4",
+                "username": "test-username",
+                "password": "test-password",
+                "prefix": "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "ElkM1"
+    assert result2["data"] == {
+        "auto_configure": True,
+        "host": "elk://1.2.3.4",
+        "password": "test-password",
+        "prefix": "",
+        "username": "test-username",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_form_user_with_insecure_elk_no_discovery(hass):
     """Test we can setup a insecure elk."""
 
@@ -94,7 +146,7 @@ async def test_form_user_with_insecure_elk_no_discovery(hass):
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
 
-    with _patch_discovery(), _patch_elk(elk=mocked_elk), patch(
+    with _patch_discovery(no_device=True), _patch_elk(elk=mocked_elk), patch(
         "homeassistant.components.elkm1.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.elkm1.async_setup_entry",
@@ -359,7 +411,7 @@ async def test_form_user_with_secure_elk_with_discovery_pick_manual_direct_disco
     assert result3["title"] == "ElkM1 ddeeff"
     assert result3["data"] == {
         "auto_configure": True,
-        "host": "elks://127.0.0.1:2601",
+        "host": "elks://127.0.0.1",
         "password": "test-password",
         "prefix": "",
         "username": "test-username",

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -73,6 +73,58 @@ async def test_form_user_with_secure_elk_no_discovery(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_form_user_with_insecure_elk_no_discovery(hass):
+    """Test we can setup a insecure elk."""
+
+    with _patch_discovery(), _patch_elk():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DHCP_DISCOVERY
+        )
+        await hass.async_block_till_done()
+
+    with _patch_discovery(no_device=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+    assert result["step_id"] == "manual_connection"
+
+    mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
+
+    with _patch_discovery(), _patch_elk(elk=mocked_elk), patch(
+        "homeassistant.components.elkm1.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.elkm1.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "protocol": "non-secure",
+                "address": "1.2.3.4",
+                "username": "test-username",
+                "password": "test-password",
+                "prefix": "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "ElkM1"
+    assert result2["data"] == {
+        "auto_configure": True,
+        "host": "elk://1.2.3.4",
+        "password": "test-password",
+        "prefix": "",
+        "username": "test-username",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_form_user_with_secure_elk_no_discovery_ip_already_configured(hass):
     """Test we abort when we try to configure the same ip."""
     config_entry = MockConfigEntry(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure elkm1 can be manually configured when discovered instance is not used


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #67707
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
