### PR TITLE
Make google calendar loading API centric, not loading from yaml

### DIFF
--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -99,7 +99,7 @@ def calendars_config(calendars_config_entity: dict[str, Any]) -> list[dict[str, 
     ]
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def mock_calendars_yaml(
     hass: HomeAssistant,
     calendars_config: list[dict[str, Any]],

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -16,6 +16,8 @@ import homeassistant.util.dt as dt_util
 
 from .conftest import TEST_YAML_ENTITY, TEST_YAML_ENTITY_NAME
 
+from tests.common import async_fire_time_changed
+
 TEST_ENTITY = TEST_YAML_ENTITY
 TEST_ENTITY_NAME = TEST_YAML_ENTITY_NAME
 
@@ -290,7 +292,8 @@ async def test_update_error(
         "homeassistant.components.google.api.google_discovery.build",
         side_effect=httplib2.ServerNotFoundError("unit test"),
     ), patch("homeassistant.util.utcnow", return_value=now):
-        await hass.helpers.entity_component.async_update_entity(TEST_ENTITY)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
 
     # No change
     state = hass.states.get(TEST_ENTITY)
@@ -316,7 +319,8 @@ async def test_update_error(
                 }
             ]
         }
-        await hass.helpers.entity_component.async_update_entity(TEST_ENTITY)
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
 
     # State updated
     state = hass.states.get(TEST_ENTITY)

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import patch
 
 import httplib2
 import pytest
@@ -50,8 +50,11 @@ TEST_EVENT = {
 
 
 @pytest.fixture(autouse=True)
-def mock_test_setup(mock_calendars_yaml, mock_token_read):
+def mock_test_setup(
+    mock_calendars_yaml, test_api_calendar, mock_calendars_list, mock_token_read
+):
     """Fixture that pulls in the default fixtures for tests in this file."""
+    mock_calendars_list({"items": [test_api_calendar]})
     return
 
 
@@ -252,13 +255,70 @@ async def test_all_day_offset_event(hass, mock_events_list_items, component_setu
     }
 
 
-async def test_update_error(hass, calendar_resource, component_setup):
-    """Test that the calendar handles a server error."""
-    calendar_resource.return_value.get = Mock(
-        side_effect=httplib2.ServerNotFoundError("unit test")
-    )
-    assert await component_setup()
+async def test_update_error(
+    hass, calendar_resource, component_setup, test_api_calendar
+):
+    """Test that the calendar update handles a server error."""
 
+    now = dt_util.now()
+    with patch("homeassistant.components.google.api.google_discovery.build") as mock:
+        mock.return_value.calendarList.return_value.list.return_value.execute.return_value = {
+            "items": [test_api_calendar]
+        }
+        mock.return_value.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    **TEST_EVENT,
+                    "start": {
+                        "dateTime": (now + datetime.timedelta(minutes=-30)).isoformat()
+                    },
+                    "end": {
+                        "dateTime": (now + datetime.timedelta(minutes=30)).isoformat()
+                    },
+                }
+            ]
+        }
+        assert await component_setup()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state.name == TEST_ENTITY_NAME
+    assert state.state == "on"
+
+    # Advance time to avoid throttling
+    now += datetime.timedelta(minutes=30)
+    with patch(
+        "homeassistant.components.google.api.google_discovery.build",
+        side_effect=httplib2.ServerNotFoundError("unit test"),
+    ), patch("homeassistant.util.utcnow", return_value=now):
+        await hass.helpers.entity_component.async_update_entity(TEST_ENTITY)
+
+    # No change
+    state = hass.states.get(TEST_ENTITY)
+    assert state.name == TEST_ENTITY_NAME
+    assert state.state == "on"
+
+    # Advance time to avoid throttling
+    now += datetime.timedelta(minutes=30)
+    with patch(
+        "homeassistant.components.google.api.google_discovery.build"
+    ) as mock, patch("homeassistant.util.utcnow", return_value=now):
+
+        mock.return_value.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    **TEST_EVENT,
+                    "start": {
+                        "dateTime": (now + datetime.timedelta(minutes=30)).isoformat()
+                    },
+                    "end": {
+                        "dateTime": (now + datetime.timedelta(minutes=60)).isoformat()
+                    },
+                }
+            ]
+        }
+        await hass.helpers.entity_component.async_update_entity(TEST_ENTITY)
+
+    # State updated
     state = hass.states.get(TEST_ENTITY)
     assert state.name == TEST_ENTITY_NAME
     assert state.state == "off"
@@ -284,11 +344,12 @@ async def test_http_event_api_failure(
     hass, hass_client, calendar_resource, component_setup
 ):
     """Test the Rest API response during a calendar failure."""
-    calendar_resource.side_effect = httplib2.ServerNotFoundError("unit test")
-
     assert await component_setup()
 
     client = await hass_client()
+
+    calendar_resource.side_effect = httplib2.ServerNotFoundError("unit test")
+
     response = await client.get(upcoming_event_url())
     assert response.status == HTTPStatus.OK
     # A failure to talk to the server results in an empty list of events


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the behavior for google calendar to focus on loading calendars based on the API and using the yaml configuration to override behavior. The old behavior was to first load from yaml, then also load from the API, which is atypical. I am not considering this a breaking change since any calendars that are in the .yaml file but not found in the API should already effectively be broken.

More background on changes:  The behavior for updating yaml file itself is adjusted. Now there is a separate `set` tracking source of truth for whether or not an entity was loaded since items are no longer loaded from yaml on startup. Tests needed to be updated to reflect the new API centric behavior, and changing the API call ordering required changing tests that exercise failures.

This is pulled out from a larger change to rewrite calendar using async and config.  Remaining work in `google` overhaul:
- [X] Simplify API + yaml interactions (this PR)
- [ ] async APIs (e.g. aiogoogle)
- [ ] async setup, config entries, platform (will move some logic in this PR to the platform)
- [ ] config flow for device auth
- [ ] yaml configuration alternatives
- [ ] other robustness fixes (platinum quality scale)
- [ ] trigger platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
