### PR TITLE
Skip unsupported LIFX Switches during discovery

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -401,12 +401,12 @@ class LIFXManager:
             # can be ignored.
             version_resp = await ack(bulb.get_version)
             if version_resp and bulb.product in SWITCH_PRODUCT_IDS:
-                    _LOGGER.warning(
-                        "(Switch) action=skip_discovery, reason=unsupported, serial=%s, ip_addr=%s, type='LIFX Switch'",
-                        str(bulb.mac_addr).replace(":", ""),
-                        bulb.ip_addr,
-                    )
-                    return False
+                _LOGGER.warning(
+                    "(Switch) action=skip_discovery, reason=unsupported, serial=%s, ip_addr=%s, type='LIFX Switch'",
+                    str(bulb.mac_addr).replace(":", ""),
+                    bulb.ip_addr,
+                )
+                return False
 
             color_resp = await ack(bulb.get_color)
 

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -400,8 +400,7 @@ class LIFXManager:
             # Get the product info first so that LIFX Switches
             # can be ignored.
             version_resp = await ack(bulb.get_version)
-            if version_resp:
-                if bulb.product in SWITCH_PRODUCT_IDS:
+            if version_resp and bulb.product in SWITCH_PRODUCT_IDS:
                     _LOGGER.warning(
                         "(Switch) action=skip_discovery, reason=unsupported, serial=%s, ip_addr=%s, type='LIFX Switch'",
                         str(bulb.mac_addr).replace(":", ""),

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -74,6 +74,7 @@ MESSAGE_RETRIES = 8
 UNAVAILABLE_GRACE = 90
 
 FIX_MAC_FW = AwesomeVersion("3.70")
+SWITCH_PRODUCT_IDS = [70, 71, 89]
 
 SERVICE_LIFX_SET_STATE = "set_state"
 
@@ -396,14 +397,19 @@ class LIFXManager:
             # Read initial state
             ack = AwaitAioLIFX().wait
 
-            # Used to populate sw_version
-            # no need to wait as we do not
-            # need it until later
-            bulb.get_hostfirmware()
+            # Get the product info first so that LIFX Switches
+            # can be ignored.
+            version_resp = await ack(bulb.get_version)
+            if version_resp:
+                if bulb.product in SWITCH_PRODUCT_IDS:
+                    _LOGGER.warning(
+                        "(Switch) action=skip_discovery, reason=unsupported, serial=%s, ip_addr=%s, type='LIFX Switch'",
+                        str(bulb.mac_addr).replace(":", ""),
+                        bulb.ip_addr,
+                    )
+                    return False
 
             color_resp = await ack(bulb.get_color)
-            if color_resp:
-                version_resp = await ack(bulb.get_version)
 
             if color_resp is None or version_resp is None:
                 _LOGGER.error("Failed to initialize %s", bulb.ip_addr)


### PR DESCRIPTION
This resolves an issue with the underlying library waiting for
a response from the switches that will never arrive.

Signed-off-by: Avi Miller <me@dje.li>

## Proposed change

This change adjusts the discovery of LIFX devices so that switches are skipped. This is due to the underlying `aiolifx` library's lack of support for switches and the core integration's assumption that all LIFX devices are bulbs. The `bulb.get_color` call will hang for about 2-3 minutes for each switch discovered without this fix.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #57195
- This PR is related to issue: #54440 (possibly)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [-] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [-] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [-] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [-] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [-] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [-] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
