### PR TITLE
Prevent polling from recreating an entity after removal

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -296,7 +296,7 @@ class Entity(ABC):
     # If entity is added to an entity platform
     _added = False
     # If entity was removed from an entity platform
-    _removed = False
+    _entity_removed = False  # Named _entity_removed since _removed is already used
 
     # Entity Properties
     _attr_assumed_state: bool = False
@@ -555,7 +555,7 @@ class Entity(ABC):
     @callback
     def _async_write_ha_state(self) -> None:
         """Write the state to the state machine."""
-        if self._removed:
+        if self._entity_removed:
             # Polling returned after the entity has already been removed
             return
 
@@ -773,7 +773,7 @@ class Entity(ABC):
         self.platform = platform
         self.parallel_updates = parallel_updates
         self._added = True
-        self._removed = False
+        self._entity_removed = False
 
     @callback
     def add_to_platform_abort(self) -> None:
@@ -805,7 +805,7 @@ class Entity(ABC):
             )
 
         self._added = False
-        self._removed = True
+        self._entity_removed = True
 
         if self._on_remove is not None:
             while self._on_remove:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -295,7 +295,7 @@ class Entity(ABC):
 
     # If entity is added to an entity platform
     _added = False
-    # If entity was removed to an entity platform
+    # If entity was removed from an entity platform
     _removed = False
 
     # Entity Properties

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -295,6 +295,8 @@ class Entity(ABC):
 
     # If entity is added to an entity platform
     _added = False
+    # If entity was removed to an entity platform
+    _removed = False
 
     # Entity Properties
     _attr_assumed_state: bool = False
@@ -553,6 +555,10 @@ class Entity(ABC):
     @callback
     def _async_write_ha_state(self) -> None:
         """Write the state to the state machine."""
+        if self._removed:
+            # Polling returned after the entity has already been removed
+            return
+
         if self.registry_entry and self.registry_entry.disabled_by:
             if not self._disabled_reported:
                 self._disabled_reported = True
@@ -767,6 +773,7 @@ class Entity(ABC):
         self.platform = platform
         self.parallel_updates = parallel_updates
         self._added = True
+        self._removed = False
 
     @callback
     def add_to_platform_abort(self) -> None:
@@ -798,6 +805,7 @@ class Entity(ABC):
             )
 
         self._added = False
+        self._removed = True
 
         if self._on_remove is not None:
             while self._on_remove:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -810,7 +810,7 @@ class Entity(ABC):
         If the entity doesn't have a non disabled entry in the entity registry,
         or if force_remove=True, its state will be removed.
         """
-        if self.platform and not self._platform_state == EntityPlatformState.ADDED:
+        if self.platform and self._platform_state != EntityPlatformState.ADDED:
             raise HomeAssistantError(
                 f"Entity {self.entity_id} async_remove called twice"
             )

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import Enum, auto
 import functools as ft
 import logging
 import math
@@ -212,13 +212,13 @@ class EntityPlatformState(Enum):
     """The platform state of an entity."""
 
     # Not Added: Not yet added to a platform, polling updates are written to the state machine
-    NOT_ADDED = "not_added"
+    NOT_ADDED = auto()
 
     # Added: Added to a platform, polling updates are written to the state machine
-    ADDED = "added"
+    ADDED = auto()
 
     # Removed: Removed from a platform, polling updates are not written to the state machine
-    REMOVED = "removed"
+    REMOVED = auto()
 
 
 def convert_to_entity_category(

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 import functools as ft
 import logging
 import math
@@ -207,6 +208,19 @@ class EntityCategory(StrEnum):
     SYSTEM = "system"
 
 
+class EntityPlatformState(Enum):
+    """The platform state of an entity."""
+
+    # New: Not yet added to a platform, polling updates are written to the state machine
+    NEW = "new"
+
+    # Added: Added to a platform, polling updates are written to the state machine
+    ADDED = "added"
+
+    # Removed: Removed from a platform, polling updates are not written to the state machine
+    REMOVED = "removed"
+
+
 def convert_to_entity_category(
     value: EntityCategory | str | None, raise_report: bool = True
 ) -> EntityCategory | None:
@@ -294,9 +308,7 @@ class Entity(ABC):
     _context_set: datetime | None = None
 
     # If entity is added to an entity platform
-    _added = False
-    # If entity was removed from an entity platform
-    _entity_removed = False  # Named _entity_removed since _removed is already used
+    _platform_state = EntityPlatformState.NEW
 
     # Entity Properties
     _attr_assumed_state: bool = False
@@ -555,7 +567,7 @@ class Entity(ABC):
     @callback
     def _async_write_ha_state(self) -> None:
         """Write the state to the state machine."""
-        if self._entity_removed:
+        if self._platform_state == EntityPlatformState.REMOVED:
             # Polling returned after the entity has already been removed
             return
 
@@ -764,7 +776,7 @@ class Entity(ABC):
         parallel_updates: asyncio.Semaphore | None,
     ) -> None:
         """Start adding an entity to a platform."""
-        if self._added:
+        if self._platform_state == EntityPlatformState.ADDED:
             raise HomeAssistantError(
                 f"Entity {self.entity_id} cannot be added a second time to an entity platform"
             )
@@ -772,8 +784,7 @@ class Entity(ABC):
         self.hass = hass
         self.platform = platform
         self.parallel_updates = parallel_updates
-        self._added = True
-        self._entity_removed = False
+        self._platform_state = EntityPlatformState.ADDED
 
     @callback
     def add_to_platform_abort(self) -> None:
@@ -781,7 +792,7 @@ class Entity(ABC):
         self.hass = None  # type: ignore[assignment]
         self.platform = None
         self.parallel_updates = None
-        self._added = False
+        self._platform_state = EntityPlatformState.NEW
 
     async def add_to_platform_finish(self) -> None:
         """Finish adding an entity to a platform."""
@@ -799,13 +810,12 @@ class Entity(ABC):
         If the entity doesn't have a non disabled entry in the entity registry,
         or if force_remove=True, its state will be removed.
         """
-        if self.platform and not self._added:
+        if self.platform and not self._platform_state == EntityPlatformState.ADDED:
             raise HomeAssistantError(
                 f"Entity {self.entity_id} async_remove called twice"
             )
 
-        self._added = False
-        self._entity_removed = True
+        self._platform_state = EntityPlatformState.REMOVED
 
         if self._on_remove is not None:
             while self._on_remove:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -211,8 +211,8 @@ class EntityCategory(StrEnum):
 class EntityPlatformState(Enum):
     """The platform state of an entity."""
 
-    # New: Not yet added to a platform, polling updates are written to the state machine
-    NEW = "new"
+    # Not Added: Not yet added to a platform, polling updates are written to the state machine
+    NOT_ADDED = "not_added"
 
     # Added: Added to a platform, polling updates are written to the state machine
     ADDED = "added"
@@ -308,7 +308,7 @@ class Entity(ABC):
     _context_set: datetime | None = None
 
     # If entity is added to an entity platform
-    _platform_state = EntityPlatformState.NEW
+    _platform_state = EntityPlatformState.NOT_ADDED
 
     # Entity Properties
     _attr_assumed_state: bool = False
@@ -792,7 +792,7 @@ class Entity(ABC):
         self.hass = None  # type: ignore[assignment]
         self.platform = None
         self.parallel_updates = None
-        self._platform_state = EntityPlatformState.NEW
+        self._platform_state = EntityPlatformState.NOT_ADDED
 
     async def add_to_platform_finish(self) -> None:
         """Finish adding an entity to a platform."""

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -559,7 +559,6 @@ async def test_async_remove_ignores_in_flight_polling(hass):
     assert len(result) == 1
     assert hass.states.get("test.test") is None
     ent.async_write_ha_state()
-    assert hass.states.get("test.test") is None
 
 
 async def test_set_context(hass):

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -545,6 +545,23 @@ async def test_async_remove_runs_callbacks(hass):
     assert len(result) == 1
 
 
+async def test_async_remove_ignores_in_flight_polling(hass):
+    """Test in flight polling is ignored after removing."""
+    result = []
+
+    ent = entity.Entity()
+    ent.hass = hass
+    ent.entity_id = "test.test"
+    ent.async_on_remove(lambda: result.append(1))
+    ent.async_write_ha_state()
+    assert hass.states.get("test.test").state == STATE_UNKNOWN
+    await ent.async_remove()
+    assert len(result) == 1
+    assert hass.states.get("test.test") is None
+    ent.async_write_ha_state()
+    assert hass.states.get("test.test") is None
+
+
 async def test_set_context(hass):
     """Test setting context."""
     context = Context()

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -390,6 +390,30 @@ async def test_async_remove_with_platform(hass):
     assert len(hass.states.async_entity_ids()) == 0
 
 
+async def test_async_remove_with_platform_update_finishes(hass):
+    """Remove an entity when an update finishes after its been removed."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    entity1 = MockEntity(name="test_1")
+
+    async def _delayed_update(*args, **kwargs):
+        await asyncio.sleep(0.01)
+
+    entity1.async_update = _delayed_update
+
+    # Add, remove, add, remove and make sure no updates
+    # cause the entity to reappear after removal
+    for i in range(2):
+        await component.async_add_entities([entity1])
+        assert len(hass.states.async_entity_ids()) == 1
+        entity1.async_write_ha_state()
+        assert hass.states.get(entity1.entity_id) is not None
+        task = asyncio.create_task(entity1.async_update_ha_state(True))
+        await entity1.async_remove()
+        assert len(hass.states.async_entity_ids()) == 0
+        await task
+        assert len(hass.states.async_entity_ids()) == 0
+
+
 async def test_not_adding_duplicate_entities_with_unique_id(hass, caplog):
     """Test for not adding duplicate entities."""
     caplog.set_level(logging.ERROR)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- There was a race where the polling could finish after the entity
  had been removed which would cause it to be unexpectedly recreated


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66450
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
