### PR TITLE
Modify diagnostics for yale_smart_alarm

### DIFF
--- a/homeassistant/components/yale_smart_alarm/diagnostics.py
+++ b/homeassistant/components/yale_smart_alarm/diagnostics.py
@@ -15,8 +15,10 @@ TO_REDACT = {
     "name",
     "mac",
     "device_id",
-    "sensor_map",
-    "lock_map",
+    "user_id",
+    "id",
+    "mail_address",
+    "report_account",
 }
 
 
@@ -27,4 +29,7 @@ async def async_get_config_entry_diagnostics(
     coordinator: YaleDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
         COORDINATOR
     ]
-    return async_redact_data(coordinator.data, TO_REDACT)
+
+    assert coordinator.yale
+    get_all_data = coordinator.yale.get_all()
+    return async_redact_data(get_all_data, TO_REDACT)

--- a/homeassistant/components/yale_smart_alarm/diagnostics.py
+++ b/homeassistant/components/yale_smart_alarm/diagnostics.py
@@ -31,5 +31,5 @@ async def async_get_config_entry_diagnostics(
     ]
 
     assert coordinator.yale
-    get_all_data = coordinator.yale.get_all()
+    get_all_data = await hass.async_add_executor_job(coordinator.yale.get_all)
     return async_redact_data(get_all_data, TO_REDACT)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modify diagnostics for yale_smart_alarm to provide more information

Example:
```json
{
  "data": {
    "DEVICES": [
      {
        "area": "1",
        "no": "1",
        "rf": null,
        "address": "**REDACTED**",
        "type": "device_type.door_lock",
        "name": "**REDACTED**",
        "status1": "device_status.lock",
        "status2": null,
        "status_switch": null,
        "status_power": null,
        "status_temp": null,
        "status_humi": null,
        "status_dim_level": null,
        "status_lux": "",
        "status_hue": null,
        "status_saturation": null,
        "rssi": "9",
        "mac": "**REDACTED**",
        "scene_trigger": "0",
        "status_total_energy": null,
        "device_id2": "",
        "extension": null,
        "minigw_protocol": "DM",
        "minigw_syncing": "0",
        "minigw_configuration_data": "03FF000001000000000000000000001E000100",
        "minigw_product_data": "21020120",
        "minigw_lock_status": "35",
        "minigw_number_of_credentials_supported": "10",
        "sresp_button_3": null,
        "sresp_button_1": null,
        "sresp_button_2": null,
        "sresp_button_4": null,
        "ipcam_trigger_by_zone1": null,
        "ipcam_trigger_by_zone2": null,
        "ipcam_trigger_by_zone3": null,
        "ipcam_trigger_by_zone4": null,
        "scene_restore": null,
        "thermo_mode": null,
        "thermo_setpoint": null,
        "thermo_c_setpoint": null,
        "thermo_setpoint_away": null,
        "thermo_c_setpoint_away": null,
        "thermo_fan_mode": null,
        "thermo_schd_setting": null,
        "group_id": null,
        "group_name": null,
        "bypass": "0",
        "device_id": "**REDACTED**",
        "status_temp_format": "C",
        "type_no": "72",
        "device_group": "002",
        "status_fault": [],
        "status_open": [
          "device_status.lock"
        ],
        "trigger_by_zone": []
      }
    ],
    "MODE": [
      {
        "area": "1",
        "mode": "disarm"
      }
    ],
    "STATUS": {
      "acfail": "main.normal",
      "battery": "main.normal",
      "tamper": "main.normal",
      "jam": "main.normal",
      "rssi": "3",
      "gsm_rssi": "0",
      "imei": "",
      "imsi": ""
    },
    "CYCLE": {
      "model": [
        {
          "area": "1",
          "mode": "disarm"
        }
      ],
      "panel_status": {
        "warning_snd_mute": "0"
      },
      "device_status": [
        {
          "area": "1",
          "no": "1",
          "rf": null,
          "address": "**REDACTED**",
          "type": "device_type.door_lock",
          "name": "**REDACTED**",
          "status1": "device_status.lock",
          "status2": null,
          "status_switch": null,
          "status_power": null,
          "status_temp": null,
          "status_humi": null,
          "status_dim_level": null,
          "status_lux": "",
          "status_hue": null,
          "status_saturation": null,
          "rssi": "9",
          "mac": "**REDACTED**",
          "scene_trigger": "0",
          "status_total_energy": null,
          "device_id2": "",
          "extension": null,
          "minigw_protocol": "DM",
          "minigw_syncing": "0",
          "minigw_configuration_data": "03FF000001000000000000000000001E000100",
          "minigw_product_data": "21020120",
          "minigw_lock_status": "35",
          "minigw_number_of_credentials_supported": "10",
          "sresp_button_3": null,
          "sresp_button_1": null,
          "sresp_button_2": null,
          "sresp_button_4": null,
          "ipcam_trigger_by_zone1": null,
          "ipcam_trigger_by_zone2": null,
          "ipcam_trigger_by_zone3": null,
          "ipcam_trigger_by_zone4": null,
          "scene_restore": null,
          "thermo_mode": null,
          "thermo_setpoint": null,
          "thermo_c_setpoint": null,
          "thermo_setpoint_away": null,
          "thermo_c_setpoint_away": null,
          "thermo_fan_mode": null,
          "thermo_schd_setting": null,
          "group_id": null,
          "group_name": null,
          "bypass": "0",
          "device_id": "**REDACTED**",
          "status_temp_format": "C",
          "type_no": "72",
          "device_group": "002",
          "status_fault": [],
          "status_open": [
            "device_status.lock"
          ],
          "trigger_by_zone": []
        }
      ],
      "capture_latest": null,
      "report_event_latest": {
        "utc_event_time": null,
        "time": "1646594475",
        "report_id": "662262974",
        "id": "**REDACTED**",
        "event_time": null,
        "cid_code": "1602"
      },
      "alarm_event_latest": null
    },
    "ONLINE": "online",
    "HISTORY": [
      {
        "report_id": "662262974",
        "cid": "18160200000",
        "event_type": "1602",
        "user": "",
        "area": 0,
        "zone": 0,
        "name": "**REDACTED**",
        "type": "",
        "event_time": null,
        "time": "2022/03/06 19:21:15",
        "status_temp_format": "C",
        "cid_source": "SYSTEM"
      },
      {
        "report_id": "662245794",
        "cid": "18180701000",
        "event_type": "1807",
        "user": 0,
        "area": 1,
        "zone": 1,
        "name": "**REDACTED**",
        "type": "device_type.door_lock",
        "event_time": null,
        "time": "2022/03/06 18:42:30",
        "status_temp_format": "C",
        "cid_source": "DEVICE"
      }
    ],
    "PANEL INFO": {
      "mac": "**REDACTED**",
      "report_account": "**REDACTED**",
      "xml_version": "2",
      "version": "MINIGW-MZ-1_G 1.0.1.29A,,4.1.2.6.2,00:1D:94:0B:5E:A7,4496468,ML_yamga",
      "net_version": "MINIGW-MZ-1_G 1.0.1.29A",
      "rf51_version": "",
      "zb_version": "4.1.2.6.2",
      "zw_version": "",
      "SMS_Balance": "50",
      "voice_balance": "0",
      "name": "**REDACTED**",
      "contact": "",
      "mail_address": "**REDACTED**",
      "phone": "UK-01902364606 / Sweden-0770373710 / Demark-89887818 / Norway-81569036",
      "service_time": "UK - Mon to Fri 8:30 til 17:30 / Scandinavia - Mon to Fri 8:00 til 20:00, Sat to Sun 10:00 til 15:00",
      "dealer_name": "Poland"
    },
    "AUTH CHECK": {
      "user_id": "**REDACTED**",
      "id": "**REDACTED**",
      "mail_address": "**REDACTED**",
      "mac": "**REDACTED**",
      "is_auth": "1",
      "master": "1",
      "first_login": "1",
      "name": "**REDACTED**",
      "token_time": "2022-03-06 19:20:35",
      "agent": false,
      "xml_version": "2",
      "dealer_id": "605",
      "dealer_group": "yale"
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
