### PR TITLE
Move key sequences to bridge in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -133,7 +133,7 @@ class SamsungTVBridge(ABC):
 
     @abstractmethod
     async def async_send_keys(self, keys: list[str]) -> None:
-        """Send a key to the tv and handles exceptions."""
+        """Send a list of keys to the tv."""
 
     @abstractmethod
     async def async_close_remote(self) -> None:
@@ -242,11 +242,11 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         return self._remote
 
     async def async_send_keys(self, keys: list[str]) -> None:
-        """Send the key using legacy protocol."""
+        """Send a list of keys using legacy protocol."""
         await self.hass.async_add_executor_job(self._send_keys, keys)
 
     def _send_keys(self, keys: list[str]) -> None:
-        """Send the keys using legacy protocol."""
+        """Send a list of keys using legacy protocol."""
         try:  # pylint: disable=[too-many-nested-blocks]
             # recreate connection if connection was dead
             retry_count = 1
@@ -403,7 +403,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         await self._async_send_commands([ChannelEmitCommand.launch_app(app_id)])
 
     async def async_send_keys(self, keys: list[str]) -> None:
-        """Send the key using websocket protocol."""
+        """Send a list of keys using websocket protocol."""
         commands: list[SamsungTVCommand] = []
         for key in keys:
             if key == "KEY_POWEROFF":

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -413,18 +413,13 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
     async def _async_send_commands(self, commands: list[SamsungTVCommand]) -> None:
         """Send the commands using websocket protocol."""
-        try:  # pylint: disable=[too-many-nested-blocks]
+        try:
             # recreate connection if connection was dead
             retry_count = 1
             for _ in range(retry_count + 1):
                 try:
                     if remote := await self._async_get_remote():
-                        first_key = True
                         for command in commands:
-                            if first_key:
-                                first_key = False
-                            else:
-                                await asyncio.sleep(KEY_PRESS_TIMEOUT)
                             await remote.send_command(command)
                     break
                 except (

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -179,11 +179,9 @@ class SamsungTVDevice(MediaPlayerEntity):
         assert isinstance(self._bridge, SamsungTVWSBridge)
         await self._bridge.async_launch_app(app_id)
 
-    async def _async_send_keys(self, keys: list[str] | str) -> None:
+    async def _async_send_keys(self, keys: list[str]) -> None:
         """Send a key to the tv and handles exceptions."""
         assert keys
-        if not isinstance(keys, list):
-            keys = [keys]
         if self._power_off_in_progress() and keys[0] != "KEY_POWEROFF":
             LOGGER.info("TV is powering off, not sending keys: %s", keys)
             return
@@ -211,21 +209,21 @@ class SamsungTVDevice(MediaPlayerEntity):
         """Turn off media player."""
         self._end_of_power_off = dt_util.utcnow() + SCAN_INTERVAL_PLUS_OFF_TIME
 
-        await self._async_send_keys("KEY_POWEROFF")
+        await self._async_send_keys(["KEY_POWEROFF"])
         # Force closing of remote session to provide instant UI feedback
         await self._bridge.async_close_remote()
 
     async def async_volume_up(self) -> None:
         """Volume up the media player."""
-        await self._async_send_keys("KEY_VOLUP")
+        await self._async_send_keys(["KEY_VOLUP"])
 
     async def async_volume_down(self) -> None:
         """Volume down media player."""
-        await self._async_send_keys("KEY_VOLDOWN")
+        await self._async_send_keys(["KEY_VOLDOWN"])
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
-        await self._async_send_keys("KEY_MUTE")
+        await self._async_send_keys(["KEY_MUTE"])
 
     async def async_media_play_pause(self) -> None:
         """Simulate play pause media player."""
@@ -237,20 +235,20 @@ class SamsungTVDevice(MediaPlayerEntity):
     async def async_media_play(self) -> None:
         """Send play command."""
         self._playing = True
-        await self._async_send_keys("KEY_PLAY")
+        await self._async_send_keys(["KEY_PLAY"])
 
     async def async_media_pause(self) -> None:
         """Send media pause command to media player."""
         self._playing = False
-        await self._async_send_keys("KEY_PAUSE")
+        await self._async_send_keys(["KEY_PAUSE"])
 
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        await self._async_send_keys("KEY_CHUP")
+        await self._async_send_keys(["KEY_CHUP"])
 
     async def async_media_previous_track(self) -> None:
         """Send the previous track command."""
-        await self._async_send_keys("KEY_CHDOWN")
+        await self._async_send_keys(["KEY_CHDOWN"])
 
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
@@ -271,9 +269,9 @@ class SamsungTVDevice(MediaPlayerEntity):
             LOGGER.error("Media ID must be positive integer")
             return
 
-        keys = [f"KEY_{digit}" for digit in media_id]
-        keys.append("KEY_ENTER")
-        await self._async_send_keys(keys)
+        await self._async_send_keys(
+            keys=[f"KEY_{digit}" for digit in media_id] + ["KEY_ENTER"]
+        )
 
     def _wake_on_lan(self) -> None:
         """Wake the device via wake on lan."""

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -1,7 +1,6 @@
 """Support for interface with an Samsung TV."""
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -47,7 +46,6 @@ from .const import (
     LOGGER,
 )
 
-KEY_PRESS_TIMEOUT = 1.2
 SOURCES = {"TV": "KEY_TV", "HDMI": "KEY_HDMI"}
 
 SUPPORT_SAMSUNGTV = (
@@ -181,12 +179,15 @@ class SamsungTVDevice(MediaPlayerEntity):
         assert isinstance(self._bridge, SamsungTVWSBridge)
         await self._bridge.async_launch_app(app_id)
 
-    async def _async_send_key(self, key: str) -> None:
+    async def _async_send_keys(self, keys: list[str] | str) -> None:
         """Send a key to the tv and handles exceptions."""
-        if self._power_off_in_progress() and key != "KEY_POWEROFF":
-            LOGGER.info("TV is powering off, not sending key: %s", key)
+        assert keys
+        if not isinstance(keys, list):
+            keys = [keys]
+        if self._power_off_in_progress() and keys[0] != "KEY_POWEROFF":
+            LOGGER.info("TV is powering off, not sending keys: %s", keys)
             return
-        await self._bridge.async_send_key(key)
+        await self._bridge.async_send_keys(keys)
 
     def _power_off_in_progress(self) -> bool:
         return (
@@ -210,21 +211,21 @@ class SamsungTVDevice(MediaPlayerEntity):
         """Turn off media player."""
         self._end_of_power_off = dt_util.utcnow() + SCAN_INTERVAL_PLUS_OFF_TIME
 
-        await self._async_send_key("KEY_POWEROFF")
+        await self._async_send_keys("KEY_POWEROFF")
         # Force closing of remote session to provide instant UI feedback
         await self._bridge.async_close_remote()
 
     async def async_volume_up(self) -> None:
         """Volume up the media player."""
-        await self._async_send_key("KEY_VOLUP")
+        await self._async_send_keys("KEY_VOLUP")
 
     async def async_volume_down(self) -> None:
         """Volume down media player."""
-        await self._async_send_key("KEY_VOLDOWN")
+        await self._async_send_keys("KEY_VOLDOWN")
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
-        await self._async_send_key("KEY_MUTE")
+        await self._async_send_keys("KEY_MUTE")
 
     async def async_media_play_pause(self) -> None:
         """Simulate play pause media player."""
@@ -236,20 +237,20 @@ class SamsungTVDevice(MediaPlayerEntity):
     async def async_media_play(self) -> None:
         """Send play command."""
         self._playing = True
-        await self._async_send_key("KEY_PLAY")
+        await self._async_send_keys("KEY_PLAY")
 
     async def async_media_pause(self) -> None:
         """Send media pause command to media player."""
         self._playing = False
-        await self._async_send_key("KEY_PAUSE")
+        await self._async_send_keys("KEY_PAUSE")
 
     async def async_media_next_track(self) -> None:
         """Send next track command."""
-        await self._async_send_key("KEY_CHUP")
+        await self._async_send_keys("KEY_CHUP")
 
     async def async_media_previous_track(self) -> None:
         """Send the previous track command."""
-        await self._async_send_key("KEY_CHDOWN")
+        await self._async_send_keys("KEY_CHDOWN")
 
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
@@ -270,10 +271,9 @@ class SamsungTVDevice(MediaPlayerEntity):
             LOGGER.error("Media ID must be positive integer")
             return
 
-        for digit in media_id:
-            await self._async_send_key(f"KEY_{digit}")
-            await asyncio.sleep(KEY_PRESS_TIMEOUT)
-        await self._async_send_key("KEY_ENTER")
+        keys = [f"KEY_{digit}" for digit in media_id]
+        keys.append("KEY_ENTER")
+        await self._async_send_keys(keys)
 
     def _wake_on_lan(self) -> None:
         """Wake the device via wake on lan."""
@@ -296,7 +296,7 @@ class SamsungTVDevice(MediaPlayerEntity):
             return
 
         if source in SOURCES:
-            await self._async_send_key(SOURCES[source])
+            await self._async_send_keys([SOURCES[source]])
             return
 
         LOGGER.error("Unsupported source")

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -853,7 +853,7 @@ async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Mock) -> None
 async def test_play_media(hass: HomeAssistant, remote: Mock) -> None:
     """Test for play_media."""
     await setup_samsungtv(hass, MOCK_CONFIG)
-    with patch("homeassistant.components.samsungtv.bridge.time.sleep") as sleep:
+    with patch("homeassistant.components.samsungtv.bridge.asyncio.sleep") as sleep:
         assert await hass.services.async_call(
             DOMAIN,
             SERVICE_PLAY_MEDIA,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, key sequences are handled inside media_player, with a sleep in between each key.
However, this timer is also already part of the websocket library, so it should be kept only for the legacy bridge.

Note: currently, only `async_play_media` uses key sequences (eg. 5 + 7 + 6 + ENTER to set channel 576) but new sequences will be added in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
