### PR TITLE
Add tests for Fritz!Tools sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -388,7 +388,6 @@ omit =
     homeassistant/components/fritz/common.py
     homeassistant/components/fritz/const.py
     homeassistant/components/fritz/device_tracker.py
-    homeassistant/components/fritz/sensor.py
     homeassistant/components/fritz/services.py
     homeassistant/components/fritz/switch.py
     homeassistant/components/fritzbox_callmonitor/__init__.py

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -308,14 +308,13 @@ class FritzBoxSensor(FritzBoxBaseEntity, SensorEntity):
         """Update data."""
         _LOGGER.debug("Updating FRITZ!Box sensors")
 
+        status: FritzStatus = self._avm_wrapper.fritz_status
         try:
-            status: FritzStatus = self._avm_wrapper.fritz_status
-            self._attr_available = True
+            self._attr_native_value = (
+                self._last_device_value
+            ) = self.entity_description.value_fn(status, self._last_device_value)
         except FritzConnectionException:
             _LOGGER.error("Error getting the state from the FRITZ!Box", exc_info=True)
             self._attr_available = False
             return
-
-        self._attr_native_value = (
-            self._last_device_value
-        ) = self.entity_description.value_fn(status, self._last_device_value)
+        self._attr_available = True

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -1,6 +1,6 @@
 """Common stuff for AVM Fritz!Box tests."""
 import logging
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fritzconnection.core.processor import Service
 from fritzconnection.lib.fritzhosts import FritzHosts
@@ -25,7 +25,7 @@ class FritzConnectionMock:  # pylint: disable=too-few-public-methods
     """FritzConnection mocking."""
 
     def __init__(self, services):
-        """Inint Mocking class."""
+        """Init Mocking class."""
         self.modelname = MOCK_MODELNAME
         self.call_action = self._call_action
         self._services = services
@@ -35,6 +35,13 @@ class FritzConnectionMock:  # pylint: disable=too-few-public-methods
         }
         LOGGER.debug("-" * 80)
         LOGGER.debug("FritzConnectionMock - services: %s", self.services)
+
+    def call_action_side_effect(self, side_effect=None) -> None:
+        """Set or unset a side_effect for call_action."""
+        if side_effect is not None:
+            self.call_action = MagicMock(side_effect=side_effect)
+        else:
+            self.call_action = self._call_action
 
     def _call_action(self, service: str, action: str, **kwargs):
         LOGGER.debug(

--- a/tests/components/fritz/test_sensor.py
+++ b/tests/components/fritz/test_sensor.py
@@ -1,0 +1,151 @@
+"""Tests for Shelly button platform."""
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from fritzconnection.core.exceptions import FritzConnectionException
+
+from homeassistant.components.fritz.const import DOMAIN
+from homeassistant.components.fritz.sensor import SENSOR_TYPES
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    DEVICE_CLASS_TIMESTAMP,
+    DOMAIN as SENSOR_DOMAIN,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+    ATTR_STATE,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from .const import MOCK_USER_DATA
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+SENSOR_STATES: dict[str, dict[str, Any]] = {
+    "sensor.mock_title_external_ip": {
+        ATTR_STATE: "1.2.3.4",
+        ATTR_ICON: "mdi:earth",
+    },
+    "sensor.mock_title_device_uptime": {
+        # ATTR_STATE: "2022-02-05T17:46:04+00:00",
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
+    },
+    "sensor.mock_title_connection_uptime": {
+        # ATTR_STATE: "2022-03-06T11:27:16+00:00",
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
+    },
+    "sensor.mock_title_upload_throughput": {
+        ATTR_STATE: "3.4",
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+        ATTR_UNIT_OF_MEASUREMENT: "kB/s",
+        ATTR_ICON: "mdi:upload",
+    },
+    "sensor.mock_title_download_throughput": {
+        ATTR_STATE: "67.6",
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+        ATTR_UNIT_OF_MEASUREMENT: "kB/s",
+        ATTR_ICON: "mdi:download",
+    },
+    "sensor.mock_title_max_connection_upload_throughput": {
+        ATTR_STATE: "2105.0",
+        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
+        ATTR_ICON: "mdi:upload",
+    },
+    "sensor.mock_title_max_connection_download_throughput": {
+        ATTR_STATE: "10087.0",
+        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
+        ATTR_ICON: "mdi:download",
+    },
+    "sensor.mock_title_gb_sent": {
+        ATTR_STATE: "1.7",
+        ATTR_STATE_CLASS: STATE_CLASS_TOTAL_INCREASING,
+        ATTR_UNIT_OF_MEASUREMENT: "GB",
+        ATTR_ICON: "mdi:upload",
+    },
+    "sensor.mock_title_gb_received": {
+        ATTR_STATE: "5.2",
+        ATTR_STATE_CLASS: STATE_CLASS_TOTAL_INCREASING,
+        ATTR_UNIT_OF_MEASUREMENT: "GB",
+        ATTR_ICON: "mdi:download",
+    },
+    "sensor.mock_title_link_upload_throughput": {
+        ATTR_STATE: "51805.0",
+        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
+        ATTR_ICON: "mdi:upload",
+    },
+    "sensor.mock_title_link_download_throughput": {
+        ATTR_STATE: "318557.0",
+        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
+        ATTR_ICON: "mdi:download",
+    },
+    "sensor.mock_title_link_upload_noise_margin": {
+        ATTR_STATE: "9.0",
+        ATTR_UNIT_OF_MEASUREMENT: "dB",
+        ATTR_ICON: "mdi:upload",
+    },
+    "sensor.mock_title_link_download_noise_margin": {
+        ATTR_STATE: "8.0",
+        ATTR_UNIT_OF_MEASUREMENT: "dB",
+        ATTR_ICON: "mdi:download",
+    },
+    "sensor.mock_title_link_upload_power_attenuation": {
+        ATTR_STATE: "7.0",
+        ATTR_UNIT_OF_MEASUREMENT: "dB",
+        ATTR_ICON: "mdi:upload",
+    },
+    "sensor.mock_title_link_download_power_attenuation": {
+        ATTR_STATE: "12.0",
+        ATTR_UNIT_OF_MEASUREMENT: "dB",
+        ATTR_ICON: "mdi:download",
+    },
+}
+
+
+async def test_sensor_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+    """Test setup of Fritz!Tools sesnors."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.LOADED
+
+    sensors = hass.states.async_all(SENSOR_DOMAIN)
+    assert len(sensors) == len(SENSOR_TYPES)
+
+    for sensor in sensors:
+        assert SENSOR_STATES.get(sensor.entity_id) is not None
+        for key, val in SENSOR_STATES[sensor.entity_id].items():
+            if key == ATTR_STATE:
+                assert sensor.state == val
+            else:
+                assert sensor.attributes.get(key) == val
+
+
+async def test_sensor_update_fail(hass: HomeAssistant, fc_class_mock, fh_class_mock):
+    """Test failed update of Fritz!Tools sesnors."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    fc_class_mock().call_action_side_effect(FritzConnectionException)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=300))
+    await hass.async_block_till_done()
+
+    sensors = hass.states.async_all(SENSOR_DOMAIN)
+    for sensor in sensors:
+        assert sensor.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds tests for sensor entities.
Further this fixes the exception handling in update method of those.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
