### PR TITLE
Adjust get_mac routine in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -47,9 +47,8 @@ from .const import (
 
 def mac_from_device_info(info: dict[str, Any]) -> str | None:
     """Extract the mac address from the device info."""
-    dev_info = info.get("device", {})
-    if dev_info.get("networkType") == "wireless" and dev_info.get("wifiMac"):
-        return format_mac(dev_info["wifiMac"])
+    if wifi_mac := info.get("device", {}).get("wifiMac"):
+        return format_mac(wifi_mac)
     return None
 
 

--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -33,3 +33,43 @@ SAMPLE_DEVICE_INFO_WIFI = {
         "networkType": "wireless",
     },
 }
+
+SAMPLE_DEVICE_INFO_FRAME = {
+    "device": {
+        "FrameTVSupport": "true",
+        "GamePadSupport": "true",
+        "ImeSyncedSupport": "true",
+        "OS": "Tizen",
+        "TokenAuthSupport": "true",
+        "VoiceSupport": "true",
+        "countryCode": "FR",
+        "description": "Samsung DTV RCR",
+        "developerIP": "0.0.0.0",
+        "developerMode": "0",
+        "duid": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+        "firmwareVersion": "Unknown",
+        "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+        "ip": "1.2.3.4",
+        "model": "17_KANTM_UHD",
+        "modelName": "UE43LS003",
+        "name": "[TV] Samsung Frame (43)",
+        "networkType": "wired",
+        "resolution": "3840x2160",
+        "smartHubAgreement": "true",
+        "type": "Samsung SmartTV",
+        "udn": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+        "wifiMac": "aa:bb:ww:ii:ff:ii",
+    },
+    "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+    "isSupport": (
+        '{"DMP_DRM_PLAYREADY":"false","DMP_DRM_WIDEVINE":"false","DMP_available":"true",'
+        '"EDEN_available":"true","FrameTVSupport":"true","ImeSyncedSupport":"true",'
+        '"TokenAuthSupport":"true","remote_available":"true","remote_fourDirections":"true",'
+        '"remote_touchPad":"true","remote_voiceControl":"true"}\n'
+    ),
+    "name": "[TV] Samsung Frame (43)",
+    "remote": "1.0",
+    "type": "Samsung SmartTV",
+    "uri": "https://1.2.3.4:8002/api/v2/",
+    "version": "2.0.25",
+}

--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -58,7 +58,7 @@ SAMPLE_DEVICE_INFO_FRAME = {
         "smartHubAgreement": "true",
         "type": "Samsung SmartTV",
         "udn": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
-        "wifiMac": "aa:bb:ww:ii:ff:ii",
+        "wifiMac": "aa:ee:tt:hh:ee:rr",
     },
     "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
     "isSupport": (

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -746,7 +746,7 @@ async def test_dhcp_wired(hass: HomeAssistant, rest_api: Mock) -> None:
     assert result["title"] == "Samsung Frame (43) (UE43LS003)"
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_NAME] == "Samsung Frame (43)"
-    assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
+    assert result["data"][CONF_MAC] == "aa:ee:tt:hh:ee:rr"
     assert result["data"][CONF_MANUFACTURER] == "Samsung"
     assert result["data"][CONF_MODEL] == "UE43LS003"
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We are currently checking the `networkType` and only populating the mac address if it is set to `wireless`.
However (at least in my case) the mac address specified in `wifiMac` matches the mac address on the router.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
