### PR TITLE
Fix SSDP unique id in SamsungTV config flow

### DIFF
--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -214,14 +214,20 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
     @callback
+    def _async_get_existing_host_entry(self) -> config_entries.ConfigEntry | None:
+        """Get first matching entry with the same host."""
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data[CONF_HOST] == self._host:
+                return entry
+        return None
+
+    @callback
     def _async_update_existing_host_entry(self) -> config_entries.ConfigEntry | None:
         """Check existing entries and update them.
 
         Returns the existing entry if it was updated.
         """
-        for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] != self._host:
-                continue
+        if entry := self._async_get_existing_host_entry():
             entry_kw_args: dict = {}
             if self.unique_id and entry.unique_id is None:
                 entry_kw_args["unique_id"] = self.unique_id

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -267,13 +267,13 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._udn = _strip_uuid(discovery_info.upnp[ssdp.ATTR_UPNP_UDN])
         if hostname := urlparse(discovery_info.ssdp_location or "").hostname:
             self._host = hostname
-        await self._async_set_unique_id_from_udn()
         self._manufacturer = discovery_info.upnp[ssdp.ATTR_UPNP_MANUFACTURER]
         self._abort_if_manufacturer_is_not_samsung()
         if not await self._async_get_and_check_device_info():
             # If we cannot get device info for an SSDP discovery
             # its likely a legacy tv.
             self._name = self._title = self._model = model_name
+        await self._async_set_unique_id_from_udn()
         self._async_update_and_abort_for_matching_unique_id()
         self._async_abort_if_host_already_in_progress()
         self.context["title_placeholders"] = {"device": self._title}

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -273,6 +273,10 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # If we cannot get device info for an SSDP discovery
             # its likely a legacy tv.
             self._name = self._title = self._model = model_name
+
+        # The UDN provided by the ssdp discovery doesn't always match the UDN
+        # from the device_info, used by the the other methods so we need to
+        # ensure the device_info is loaded before setting the unique_id
         await self._async_set_unique_id_from_udn()
         self._async_update_and_abort_for_matching_unique_id()
         self._async_abort_if_host_already_in_progress()

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -214,20 +214,14 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
     @callback
-    def _async_get_existing_host_entry(self) -> config_entries.ConfigEntry | None:
-        """Get first matching entry with the same host."""
-        for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] == self._host:
-                return entry
-        return None
-
-    @callback
     def _async_update_existing_host_entry(self) -> config_entries.ConfigEntry | None:
         """Check existing entries and update them.
 
         Returns the existing entry if it was updated.
         """
-        if entry := self._async_get_existing_host_entry():
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data[CONF_HOST] != self._host:
+                continue
             entry_kw_args: dict = {}
             if self.unique_id and entry.unique_id is None:
                 entry_kw_args["unique_id"] = self.unique_id

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -339,7 +339,7 @@ async def test_ssdp(hass: HomeAssistant) -> None:
         assert result["data"][CONF_NAME] == "fake_name"
         assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
         assert result["data"][CONF_MODEL] == "fake_model"
-        assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+        assert result["result"].unique_id == "123"
 
 
 @pytest.mark.usefixtures("remote")
@@ -373,7 +373,7 @@ async def test_ssdp_noprefix(hass: HomeAssistant) -> None:
             assert result["data"][CONF_NAME] == "fake2_name"
             assert result["data"][CONF_MANUFACTURER] == "Samsung fake2_manufacturer"
             assert result["data"][CONF_MODEL] == "fake2_model"
-            assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
+            assert result["result"].unique_id == "345"
 
 
 @pytest.mark.usefixtures("remotews")
@@ -448,7 +448,7 @@ async def test_ssdp_websocket_success_populates_mac_address(
     assert result["data"][CONF_MAC] == "aa:bb:ww:ii:ff:ii"
     assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
     assert result["data"][CONF_MODEL] == "82GXARRS"
-    assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+    assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
 async def test_ssdp_websocket_not_supported(
@@ -591,7 +591,7 @@ async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
         assert result2["reason"] == RESULT_ALREADY_CONFIGURED
 
         # check updated device info
-        assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+        assert entry.unique_id == "123"
 
 
 @pytest.mark.usefixtures("remote")
@@ -1013,7 +1013,7 @@ async def test_update_old_entry(hass: HomeAssistant) -> None:
         # check updated device info
         assert entry2.data.get(CONF_ID) is not None
         assert entry2.data.get(CONF_IP_ADDRESS) is not None
-        assert entry2.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+        assert entry2.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
 @pytest.mark.usefixtures("remotews")
@@ -1099,7 +1099,7 @@ async def test_update_missing_mac_unique_id_added_from_ssdp(
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_MAC] == "aa:bb:ww:ii:ff:ii"
-    assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+    assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
 @pytest.mark.usefixtures("remotews")

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -343,34 +343,6 @@ async def test_ssdp(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_ssdp_no_device_info(hass: HomeAssistant) -> None:
-    """Test starting a flow from SSDP discovery, with device_info failing."""
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.async_device_info",
-        return_value=None,
-    ):
-        # confirm to add the entry
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
-        )
-        assert result["type"] == "form"
-        assert result["step_id"] == "confirm"
-
-        # entry was added
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input="whatever"
-        )
-        assert result["type"] == "create_entry"
-        assert result["title"] == "fake_model"
-        assert result["data"][CONF_METHOD] == "legacy"
-        assert result["data"][CONF_HOST] == "fake_host"
-        assert result["data"][CONF_NAME] == "fake_model"
-        assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
-        assert result["data"][CONF_MODEL] == "fake_model"
-        assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
-
-
-@pytest.mark.usefixtures("remote")
 async def test_ssdp_noprefix(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery without prefixes."""
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
## Breaking change
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix SSDP unique id in SamsungTV config flow.

The UDN provided by the ssdp discovery doesn't match the UDN provided by the rest api (using in dhcp/zeroconf discovery and used in user entry) We should therefore wait until the call to the rest api has been made before we set the unique-id.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #64465
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
