### PR TITLE
Compatibility for "device_state_attributes" which was deprecated in 2021.4 has been removed

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -573,25 +573,7 @@ class Entity(ABC):
         state = self._stringify_state(available)
         if available:
             attr.update(self.state_attributes or {})
-            extra_state_attributes = self.extra_state_attributes
-            if extra_state_attributes is None:
-                device_state_attributes = self.device_state_attributes
-                # Backwards compatibility for "device_state_attributes" deprecated in 2021.4
-                # Warning added in 2021.12, will be removed in 2022.4
-                if (
-                    device_state_attributes is not None
-                    and not self._deprecated_device_state_attributes_reported
-                ):
-                    report_issue = self._suggest_report_issue()
-                    _LOGGER.warning(
-                        "Entity %s (%s) implements device_state_attributes. Please %s",
-                        self.entity_id,
-                        type(self),
-                        report_issue,
-                    )
-                    self._deprecated_device_state_attributes_reported = True
-                    extra_state_attributes = device_state_attributes
-            attr.update(extra_state_attributes or {})
+            attr.update(self.extra_state_attributes or {})
 
         if (unit_of_measurement := self.unit_of_measurement) is not None:
             attr[ATTR_UNIT_OF_MEASUREMENT] = unit_of_measurement

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -274,9 +274,6 @@ class Entity(ABC):
     # If we reported this entity is updated while disabled
     _disabled_reported = False
 
-    # If we reported this entity is using deprecated device_state_attributes
-    _deprecated_device_state_attributes_reported = False
-
     # Protect for multiple updates
     _update_staged = False
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -538,9 +538,9 @@ class Entity(ABC):
 
         self._async_write_ha_state()
 
-    def _stringify_state(self) -> str:
+    def _stringify_state(self, available: bool) -> str:
         """Convert state to string."""
-        if not self.available:
+        if not available:
             return STATE_UNAVAILABLE
         if (state := self.state) is None:
             return STATE_UNKNOWN
@@ -569,30 +569,31 @@ class Entity(ABC):
         attr = self.capability_attributes
         attr = dict(attr) if attr else {}
 
-        state = self._stringify_state()
-        if self.available:
+        available = self.available  # only call self.available once per update cycle
+        state = self._stringify_state(available)
+        if available:
             attr.update(self.state_attributes or {})
             extra_state_attributes = self.extra_state_attributes
-            # Backwards compatibility for "device_state_attributes" deprecated in 2021.4
-            # Warning added in 2021.12, will be removed in 2022.4
-            if (
-                self.device_state_attributes is not None
-                and not self._deprecated_device_state_attributes_reported
-            ):
-                report_issue = self._suggest_report_issue()
-                _LOGGER.warning(
-                    "Entity %s (%s) implements device_state_attributes. Please %s",
-                    self.entity_id,
-                    type(self),
-                    report_issue,
-                )
-                self._deprecated_device_state_attributes_reported = True
             if extra_state_attributes is None:
-                extra_state_attributes = self.device_state_attributes
+                device_state_attributes = self.device_state_attributes
+                # Backwards compatibility for "device_state_attributes" deprecated in 2021.4
+                # Warning added in 2021.12, will be removed in 2022.4
+                if (
+                    device_state_attributes is not None
+                    and not self._deprecated_device_state_attributes_reported
+                ):
+                    report_issue = self._suggest_report_issue()
+                    _LOGGER.warning(
+                        "Entity %s (%s) implements device_state_attributes. Please %s",
+                        self.entity_id,
+                        type(self),
+                        report_issue,
+                    )
+                    self._deprecated_device_state_attributes_reported = True
+                    extra_state_attributes = device_state_attributes
             attr.update(extra_state_attributes or {})
 
-        unit_of_measurement = self.unit_of_measurement
-        if unit_of_measurement is not None:
+        if (unit_of_measurement := self.unit_of_measurement) is not None:
             attr[ATTR_UNIT_OF_MEASUREMENT] = unit_of_measurement
 
         entry = self.registry_entry


### PR DESCRIPTION
## Breaking change

Compatibility for "device_state_attributes" which was deprecated in 2021.4 has been removed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Small performance tweaks to _async_write_ha_state

Noticed that self.available was called 2x per write when debugging for #67836. 

- Only call self.available once per cycle

- Only call self.device_state_attributes once per update cycle

- Do not check for device_state_attributes if extra_state_attributes is not None


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
