### PR TITLE
2022.3.3

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -392,6 +392,8 @@ class FritzBoxTools(update_coordinator.DataUpdateCoordinator):
             )
             self.mesh_role = MeshRoles.NONE
             for mac, info in hosts.items():
+                if info.ip_address:
+                    info.wan_access = self._get_wan_access(info.ip_address)
                 if self.manage_device_info(info, mac, consider_home):
                     new_device = True
             self.send_signal_device_update(new_device)

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20220301.0"
+    "home-assistant-frontend==20220301.1"
   ],
   "dependencies": [
     "api",
@@ -13,7 +13,8 @@
     "diagnostics",
     "http",
     "lovelace",
-    "onboarding",    "search",
+    "onboarding",
+    "search",
     "system_log",
     "websocket_api"
   ],

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -222,7 +222,7 @@ class GrowattData:
                 date_now = dt.now().date()
                 last_updated_time = dt.parse_time(str(sorted_keys[-1]))
                 mix_detail["lastdataupdate"] = datetime.datetime.combine(
-                    date_now, last_updated_time
+                    date_now, last_updated_time, dt.DEFAULT_TIME_ZONE
                 )
 
                 # Dashboard data is largely inaccurate for mix system but it is the only call with the ability to return the combined

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -285,20 +285,19 @@ class Thermostat(HomeAccessory):
                 CHAR_CURRENT_HUMIDITY, value=50
             )
 
-        fan_modes = self.fan_modes = {
-            fan_mode.lower(): fan_mode
-            for fan_mode in attributes.get(ATTR_FAN_MODES, [])
-        }
+        fan_modes = {}
         self.ordered_fan_speeds = []
-        if (
-            features & SUPPORT_FAN_MODE
-            and fan_modes
-            and PRE_DEFINED_FAN_MODES.intersection(fan_modes)
-        ):
-            self.ordered_fan_speeds = [
-                speed for speed in ORDERED_FAN_SPEEDS if speed in fan_modes
-            ]
-            self.fan_chars.append(CHAR_ROTATION_SPEED)
+
+        if features & SUPPORT_FAN_MODE:
+            fan_modes = {
+                fan_mode.lower(): fan_mode
+                for fan_mode in attributes.get(ATTR_FAN_MODES) or []
+            }
+            if fan_modes and PRE_DEFINED_FAN_MODES.intersection(fan_modes):
+                self.ordered_fan_speeds = [
+                    speed for speed in ORDERED_FAN_SPEEDS if speed in fan_modes
+                ]
+                self.fan_chars.append(CHAR_ROTATION_SPEED)
 
         if FAN_AUTO in fan_modes and (FAN_ON in fan_modes or self.ordered_fan_speeds):
             self.fan_chars.append(CHAR_TARGET_FAN_STATE)

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -271,7 +271,7 @@ _PLATFORM_SCHEMA_BASE = SCHEMA_BASE.extend(
         vol.Optional(CONF_HOLD_COMMAND_TOPIC): mqtt.valid_publish_topic,
         vol.Optional(CONF_HOLD_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_HOLD_STATE_TOPIC): mqtt.valid_subscribe_topic,
-        vol.Optional(CONF_HOLD_LIST, default=list): cv.ensure_list,
+        vol.Optional(CONF_HOLD_LIST): cv.ensure_list,
         vol.Optional(CONF_MODE_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
         vol.Optional(
@@ -298,7 +298,7 @@ _PLATFORM_SCHEMA_BASE = SCHEMA_BASE.extend(
         ),
         vol.Optional(CONF_RETAIN, default=mqtt.DEFAULT_RETAIN): cv.boolean,
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        vol.Optional(CONF_SEND_IF_OFF, default=True): cv.boolean,
+        vol.Optional(CONF_SEND_IF_OFF): cv.boolean,
         vol.Optional(CONF_ACTION_TEMPLATE): cv.template,
         vol.Optional(CONF_ACTION_TOPIC): mqtt.valid_subscribe_topic,
         # CONF_PRESET_MODE_COMMAND_TOPIC and CONF_PRESET_MODES_LIST must be used together
@@ -431,6 +431,12 @@ class MqttClimate(MqttEntity, ClimateEntity):
         self._feature_preset_mode = False
         self._optimistic_preset_mode = None
 
+        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+        self._send_if_off = True
+        # AWAY and HOLD mode topics and templates are deprecated,
+        # support will be removed with release 2022.9
+        self._hold_list = []
+
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     @staticmethod
@@ -498,6 +504,15 @@ class MqttClimate(MqttEntity, ClimateEntity):
             ).async_render
 
         self._command_templates = command_templates
+
+        # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+        if CONF_SEND_IF_OFF in config:
+            self._send_if_off = config[CONF_SEND_IF_OFF]
+
+        # AWAY and HOLD mode topics and templates are deprecated,
+        # support will be removed with release 2022.9
+        if CONF_HOLD_LIST in config:
+            self._hold_list = config[CONF_HOLD_LIST]
 
     def _prepare_subscribe_topics(self):  # noqa: C901
         """(Re)Subscribe to topics."""
@@ -806,7 +821,9 @@ class MqttClimate(MqttEntity, ClimateEntity):
         ):
             presets.append(PRESET_AWAY)
 
-        presets.extend(self._config[CONF_HOLD_LIST])
+        # AWAY and HOLD mode topics and templates are deprecated,
+        # support will be removed with release 2022.9
+        presets.extend(self._hold_list)
 
         if presets:
             presets.insert(0, PRESET_NONE)
@@ -847,10 +864,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
                 setattr(self, attr, temp)
 
             # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-            if (
-                self._config[CONF_SEND_IF_OFF]
-                or self._current_operation != HVAC_MODE_OFF
-            ):
+            if self._send_if_off or self._current_operation != HVAC_MODE_OFF:
                 payload = self._command_templates[cmnd_template](temp)
                 await self._publish(cmnd_topic, payload)
 
@@ -890,7 +904,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
+        if self._send_if_off or self._current_operation != HVAC_MODE_OFF:
             payload = self._command_templates[CONF_SWING_MODE_COMMAND_TEMPLATE](
                 swing_mode
             )
@@ -903,7 +917,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode):
         """Set new target temperature."""
         # CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
-        if self._config[CONF_SEND_IF_OFF] or self._current_operation != HVAC_MODE_OFF:
+        if self._send_if_off or self._current_operation != HVAC_MODE_OFF:
             payload = self._command_templates[CONF_FAN_MODE_COMMAND_TEMPLATE](fan_mode)
             await self._publish(CONF_FAN_MODE_COMMAND_TOPIC, payload)
 

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.light import ATTR_TRANSITION
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PLATFORM, SERVICE_TURN_ON
+from homeassistant.const import CONF_PLATFORM, SERVICE_TURN_ON, STATE_UNAVAILABLE
 from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -117,7 +117,11 @@ class Scene(RestoreEntity):
         """Call when the scene is added to hass."""
         await super().async_internal_added_to_hass()
         state = await self.async_get_last_state()
-        if state is not None and state.state is not None:
+        if (
+            state is not None
+            and state.state is not None
+            and state.state != STATE_UNAVAILABLE
+        ):
             self.__last_activated = state.state
 
     def activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/sensibo/coordinator.py
+++ b/homeassistant/components/sensibo/coordinator.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, TIMEOUT
 
+MAX_POSSIBLE_STEP = 1000
+
 
 class SensiboDataUpdateCoordinator(DataUpdateCoordinator):
     """A Sensibo Data Update Coordinator."""
@@ -74,7 +76,11 @@ class SensiboDataUpdateCoordinator(DataUpdateCoordinator):
                 .get("values", [0, 1])
             )
             if temperatures_list:
-                temperature_step = temperatures_list[1] - temperatures_list[0]
+                diff = MAX_POSSIBLE_STEP
+                for i in range(len(temperatures_list) - 1):
+                    if temperatures_list[i + 1] - temperatures_list[i] < diff:
+                        diff = temperatures_list[i + 1] - temperatures_list[i]
+                temperature_step = diff
 
             active_features = list(ac_states)
             full_features = set()

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -317,4 +317,14 @@ class BlockSleepingClimate(
 
         if self.device_block and self.block:
             _LOGGER.debug("Entity %s attached to blocks", self.name)
+
+            assert self.block.channel
+
+            self._preset_modes = [
+                PRESET_NONE,
+                *self.wrapper.device.settings["thermostats"][int(self.block.channel)][
+                    "schedule_profile_names"
+                ],
+            ]
+
             self.async_write_ha_state()

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.10.56", "micloud==0.5", "python-miio==0.5.10"],
+  "requirements": ["construct==2.10.56", "micloud==0.5", "python-miio==0.5.11"],
   "codeowners": ["@rytilahti", "@syssi", "@starkillerOG", "@bieniu"],
   "zeroconf": ["_miio._udp.local."],
   "iot_class": "local_polling",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 3
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -14,7 +14,7 @@ certifi>=2021.5.30
 ciso8601==2.2.0
 cryptography==35.0.0
 hass-nabucasa==0.54.0
-home-assistant-frontend==20220301.0
+home-assistant-frontend==20220301.1
 httpx==0.21.3
 ifaddr==0.1.7
 jinja2==3.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -843,7 +843,7 @@ hole==0.7.0
 holidays==0.13
 
 # homeassistant.components.frontend
-home-assistant-frontend==20220301.0
+home-assistant-frontend==20220301.1
 
 # homeassistant.components.zwave
 # homeassistant-pyozw==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1952,7 +1952,7 @@ python-kasa==0.4.1
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.10
+python-miio==0.5.11
 
 # homeassistant.components.mpd
 python-mpd2==3.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -553,7 +553,7 @@ hole==0.7.0
 holidays==0.13
 
 # homeassistant.components.frontend
-home-assistant-frontend==20220301.0
+home-assistant-frontend==20220301.1
 
 # homeassistant.components.zwave
 # homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1219,7 +1219,7 @@ python-juicenet==1.0.2
 python-kasa==0.4.1
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.10
+python-miio==0.5.11
 
 # homeassistant.components.nest
 python-nest==4.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name         = homeassistant
-version      = 2022.3.2
+version      = 2022.3.3
 author       = The Home Assistant Authors
 author_email = hello@home-assistant.io
 license      = Apache-2.0

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -333,6 +333,43 @@ async def test_set_fan_mode(hass, mqtt_mock):
     assert state.attributes.get("fan_mode") == "high"
 
 
+# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+@pytest.mark.parametrize(
+    "send_if_off,assert_async_publish",
+    [
+        ({}, [call("fan-mode-topic", "low", 0, False)]),
+        ({"send_if_off": True}, [call("fan-mode-topic", "low", 0, False)]),
+        ({"send_if_off": False}, []),
+    ],
+)
+async def test_set_fan_mode_send_if_off(
+    hass, mqtt_mock, send_if_off, assert_async_publish
+):
+    """Test setting of fan mode if the hvac is off."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config[CLIMATE_DOMAIN].update(send_if_off)
+    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_CLIMATE) is not None
+
+    # Turn on HVAC
+    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.reset_mock()
+    # Updates for fan_mode should be sent when the device is turned on
+    await common.async_set_fan_mode(hass, "high", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_called_once_with("fan-mode-topic", "high", 0, False)
+
+    # Turn off HVAC
+    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    # Updates for fan_mode should be sent if SEND_IF_OFF is not set or is True
+    mqtt_mock.async_publish.reset_mock()
+    await common.async_set_fan_mode(hass, "low", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_has_calls(assert_async_publish)
+
+
 async def test_set_swing_mode_bad_attr(hass, mqtt_mock, caplog):
     """Test setting swing mode without required attribute."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
@@ -385,6 +422,43 @@ async def test_set_swing(hass, mqtt_mock):
     assert state.attributes.get("swing_mode") == "on"
 
 
+# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+@pytest.mark.parametrize(
+    "send_if_off,assert_async_publish",
+    [
+        ({}, [call("swing-mode-topic", "on", 0, False)]),
+        ({"send_if_off": True}, [call("swing-mode-topic", "on", 0, False)]),
+        ({"send_if_off": False}, []),
+    ],
+)
+async def test_set_swing_mode_send_if_off(
+    hass, mqtt_mock, send_if_off, assert_async_publish
+):
+    """Test setting of swing mode if the hvac is off."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config[CLIMATE_DOMAIN].update(send_if_off)
+    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_CLIMATE) is not None
+
+    # Turn on HVAC
+    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.reset_mock()
+    # Updates for swing_mode should be sent when the device is turned on
+    await common.async_set_swing_mode(hass, "off", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_called_once_with("swing-mode-topic", "off", 0, False)
+
+    # Turn off HVAC
+    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    # Updates for swing_mode should be sent if SEND_IF_OFF is not set or is True
+    mqtt_mock.async_publish.reset_mock()
+    await common.async_set_swing_mode(hass, "on", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_has_calls(assert_async_publish)
+
+
 async def test_set_target_temperature(hass, mqtt_mock):
     """Test setting the target temperature."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
@@ -419,6 +493,45 @@ async def test_set_target_temperature(hass, mqtt_mock):
         ]
     )
     mqtt_mock.async_publish.reset_mock()
+
+
+# CONF_SEND_IF_OFF is deprecated, support will be removed with release 2022.9
+@pytest.mark.parametrize(
+    "send_if_off,assert_async_publish",
+    [
+        ({}, [call("temperature-topic", "21.0", 0, False)]),
+        ({"send_if_off": True}, [call("temperature-topic", "21.0", 0, False)]),
+        ({"send_if_off": False}, []),
+    ],
+)
+async def test_set_target_temperature_send_if_off(
+    hass, mqtt_mock, send_if_off, assert_async_publish
+):
+    """Test setting of target temperature if the hvac is off."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config[CLIMATE_DOMAIN].update(send_if_off)
+    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_CLIMATE) is not None
+
+    # Turn on HVAC
+    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.reset_mock()
+    # Updates for target temperature should be sent when the device is turned on
+    await common.async_set_temperature(hass, 16.0, ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "temperature-topic", "16.0", 0, False
+    )
+
+    # Turn off HVAC
+    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    # Updates for target temperature sent should be if SEND_IF_OFF is not set or is True
+    mqtt_mock.async_publish.reset_mock()
+    await common.async_set_temperature(hass, 21.0, ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_has_calls(assert_async_publish)
 
 
 async def test_set_target_temperature_pessimistic(hass, mqtt_mock):

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -545,6 +545,22 @@ async def test_async_remove_runs_callbacks(hass):
     assert len(result) == 1
 
 
+async def test_async_remove_ignores_in_flight_polling(hass):
+    """Test in flight polling is ignored after removing."""
+    result = []
+
+    ent = entity.Entity()
+    ent.hass = hass
+    ent.entity_id = "test.test"
+    ent.async_on_remove(lambda: result.append(1))
+    ent.async_write_ha_state()
+    assert hass.states.get("test.test").state == STATE_UNKNOWN
+    await ent.async_remove()
+    assert len(result) == 1
+    assert hass.states.get("test.test") is None
+    ent.async_write_ha_state()
+
+
 async def test_set_context(hass):
     """Test setting context."""
     context = Context()

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -390,6 +390,30 @@ async def test_async_remove_with_platform(hass):
     assert len(hass.states.async_entity_ids()) == 0
 
 
+async def test_async_remove_with_platform_update_finishes(hass):
+    """Remove an entity when an update finishes after its been removed."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    entity1 = MockEntity(name="test_1")
+
+    async def _delayed_update(*args, **kwargs):
+        await asyncio.sleep(0.01)
+
+    entity1.async_update = _delayed_update
+
+    # Add, remove, add, remove and make sure no updates
+    # cause the entity to reappear after removal
+    for i in range(2):
+        await component.async_add_entities([entity1])
+        assert len(hass.states.async_entity_ids()) == 1
+        entity1.async_write_ha_state()
+        assert hass.states.get(entity1.entity_id) is not None
+        task = asyncio.create_task(entity1.async_update_ha_state(True))
+        await entity1.async_remove()
+        assert len(hass.states.async_entity_ids()) == 0
+        await task
+        assert len(hass.states.async_entity_ids()) == 0
+
+
 async def test_not_adding_duplicate_entities_with_unique_id(hass, caplog):
     """Test for not adding duplicate entities."""
     caplog.set_level(logging.ERROR)


### PR DESCRIPTION
- Fix false positive MQTT climate deprecation warnings for defaults ([@jbouwh] - [#67661]) ([mqtt docs])
- Fix timezone for growatt lastdataupdate ([@muppet3000] - [#67684]) ([growatt_server docs])
- Fix temperature stepping in Sensibo ([@gjohansson-ST] - [#67737]) ([sensibo docs])
- Prevent polling from recreating an entity after removal ([@bdraco] - [#67750])
- Fix internet access switch for old discovery ([@chemelli74] - [#67777]) ([fritz docs])
- Fix profile name update for Shelly Valve ([@chemelli74] - [#67778]) ([shelly docs])
- Handle fan_modes being set to None in homekit ([@bdraco] - [#67790]) ([homekit docs])
- Catch Elgato connection errors ([@frenck] - [#67799]) ([elgato docs])
- Update frontend to 20220301.1 ([@bramkragten] - [#67812]) ([frontend docs])
- Bump python-miio version to 0.5.11 ([@rytilahti] - [#67824]) ([xiaomi_miio docs])
- Prevent scene from restoring unavailable states ([@bdraco] - [#67836]) ([scene docs])

[#67661]: https://github.com/home-assistant/core/pull/67661
[#67684]: https://github.com/home-assistant/core/pull/67684
[#67737]: https://github.com/home-assistant/core/pull/67737
[#67750]: https://github.com/home-assistant/core/pull/67750
[#67777]: https://github.com/home-assistant/core/pull/67777
[#67778]: https://github.com/home-assistant/core/pull/67778
[#67790]: https://github.com/home-assistant/core/pull/67790
[#67799]: https://github.com/home-assistant/core/pull/67799
[#67812]: https://github.com/home-assistant/core/pull/67812
[#67824]: https://github.com/home-assistant/core/pull/67824
[#67836]: https://github.com/home-assistant/core/pull/67836
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@chemelli74]: https://github.com/chemelli74
[@frenck]: https://github.com/frenck
[@gjohansson-ST]: https://github.com/gjohansson-ST
[@jbouwh]: https://github.com/jbouwh
[@muppet3000]: https://github.com/muppet3000
[@rytilahti]: https://github.com/rytilahti
[elgato docs]: https://www.home-assistant.io/integrations/elgato/
[fritz docs]: https://www.home-assistant.io/integrations/fritz/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[growatt_server docs]: https://www.home-assistant.io/integrations/growatt_server/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[scene docs]: https://www.home-assistant.io/integrations/scene/
[sensibo docs]: https://www.home-assistant.io/integrations/sensibo/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[xiaomi_miio docs]: https://www.home-assistant.io/integrations/xiaomi_miio/