### PR TITLE
Batch send commands in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -422,8 +422,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             for _ in range(retry_count + 1):
                 try:
                     if remote := await self._async_get_remote():
-                        for command in commands:
-                            await remote.send_command(command)
+                        await remote.send_command(commands)
                     break
                 except (
                     BrokenPipeError,

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -641,9 +641,10 @@ async def test_turn_off_websocket(
     )
     # key called
     assert remotews.send_command.call_count == 1
-    command = remotews.send_command.call_args_list[0].args[0]
-    assert isinstance(command, SendRemoteKey)
-    assert command.params["DataOfCmd"] == "KEY_POWER"
+    commands = remotews.send_command.call_args_list[0].args[0]
+    assert len(commands) == 1
+    assert isinstance(commands[0], SendRemoteKey)
+    assert commands[0].params["DataOfCmd"] == "KEY_POWER"
 
     # commands not sent : power off in progress
     remotews.send_command.reset_mock()
@@ -678,18 +679,17 @@ async def test_turn_off_websocket_frame(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
-    assert remotews.send_command.call_count == 3
-    command = remotews.send_command.call_args_list[0].args[0]
-    assert isinstance(command, SendRemoteKey)
-    assert command.params["Cmd"] == "Press"
-    assert command.params["DataOfCmd"] == "KEY_POWER"
-    command = remotews.send_command.call_args_list[1].args[0]
-    assert isinstance(command, SamsungTVSleepCommand)
-    assert command.delay == 3
-    command = remotews.send_command.call_args_list[2].args[0]
-    assert isinstance(command, SendRemoteKey)
-    assert command.params["Cmd"] == "Release"
-    assert command.params["DataOfCmd"] == "KEY_POWER"
+    assert remotews.send_command.call_count == 1
+    commands = remotews.send_command.call_args_list[0].args[0]
+    assert len(commands) == 3
+    assert isinstance(commands[0], SendRemoteKey)
+    assert commands[0].params["Cmd"] == "Press"
+    assert commands[0].params["DataOfCmd"] == "KEY_POWER"
+    assert isinstance(commands[1], SamsungTVSleepCommand)
+    assert commands[1].delay == 3
+    assert isinstance(commands[2], SendRemoteKey)
+    assert commands[2].params["Cmd"] == "Release"
+    assert commands[2].params["DataOfCmd"] == "KEY_POWER"
 
 
 async def test_turn_off_legacy(hass: HomeAssistant, remote: Mock) -> None:
@@ -1023,9 +1023,10 @@ async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
         True,
     )
     assert remotews.send_command.call_count == 1
-    command = remotews.send_command.call_args_list[0].args[0]
-    assert isinstance(command, ChannelEmitCommand)
-    assert command.params["data"]["appId"] == "3201608010191"
+    commands = remotews.send_command.call_args_list[0].args[0]
+    assert len(commands) == 1
+    assert isinstance(commands[0], ChannelEmitCommand)
+    assert commands[0].params["data"]["appId"] == "3201608010191"
 
 
 async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
@@ -1040,6 +1041,7 @@ async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
         True,
     )
     assert remotews.send_command.call_count == 1
-    command = remotews.send_command.call_args_list[0].args[0]
-    assert isinstance(command, ChannelEmitCommand)
-    assert command.params["data"]["appId"] == "3201608010191"
+    commands = remotews.send_command.call_args_list[0].args[0]
+    assert len(commands) == 1
+    assert isinstance(commands[0], ChannelEmitCommand)
+    assert commands[0].params["data"]["appId"] == "3201608010191"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As part of #67771, the library was updated to be able to send commands in batch (see https://github.com/xchwarze/samsung-tv-ws-api/pull/66).

This makes the corresponding adjustment in HomeAssistant

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
