### PR TITLE
Trigger Alexa routines from toggles and buttons

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components import (
+    button,
     cover,
     fan,
     image_processing,
+    input_button,
     input_number,
     light,
     timer,
@@ -1891,7 +1893,10 @@ class AlexaEventDetectionSensor(AlexaCapability):
         if self.entity.domain == image_processing.DOMAIN:
             if int(state):
                 human_presence = "DETECTED"
-        elif state == STATE_ON:
+        elif state == STATE_ON or self.entity.domain in [
+            input_button.DOMAIN,
+            button.DOMAIN,
+        ]:
             human_presence = "DETECTED"
 
         return {"value": human_presence}
@@ -1903,7 +1908,8 @@ class AlexaEventDetectionSensor(AlexaCapability):
             "detectionModes": {
                 "humanPresence": {
                     "featureAvailability": "ENABLED",
-                    "supportsNotDetected": True,
+                    "supportsNotDetected": self.entity.domain
+                    not in [input_button.DOMAIN, button.DOMAIN],
                 }
             },
         }

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -382,7 +382,6 @@ def async_get_entities(hass, config) -> list[AlexaEntity]:
 @ENTITY_ADAPTERS.register(alert.DOMAIN)
 @ENTITY_ADAPTERS.register(automation.DOMAIN)
 @ENTITY_ADAPTERS.register(group.DOMAIN)
-@ENTITY_ADAPTERS.register(input_boolean.DOMAIN)
 class GenericCapabilities(AlexaEntity):
     """A generic, on/off device.
 
@@ -405,12 +404,16 @@ class GenericCapabilities(AlexaEntity):
         ]
 
 
+@ENTITY_ADAPTERS.register(input_boolean.DOMAIN)
 @ENTITY_ADAPTERS.register(switch.DOMAIN)
 class SwitchCapabilities(AlexaEntity):
     """Class to represent Switch capabilities."""
 
     def default_display_categories(self):
         """Return the display categories for this entity."""
+        if self.entity.domain == input_boolean.DOMAIN:
+            return [DisplayCategory.OTHER]
+
         device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
         if device_class == switch.SwitchDeviceClass.OUTLET:
             return [DisplayCategory.SMARTPLUG]
@@ -421,6 +424,7 @@ class SwitchCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         return [
             AlexaPowerController(self.entity),
+            AlexaContactSensor(self.hass, self.entity),
             AlexaEndpointHealth(self.hass, self.entity),
             Alexa(self.hass),
         ]
@@ -439,6 +443,8 @@ class ButtonCapabilities(AlexaEntity):
         """Yield the supported interfaces."""
         return [
             AlexaSceneController(self.entity, supports_deactivation=False),
+            AlexaEventDetectionSensor(self.hass, self.entity),
+            AlexaEndpointHealth(self.hass, self.entity),
             Alexa(self.hass),
         ]
 

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -846,6 +846,57 @@ async def test_report_image_processing(hass):
     )
 
 
+@pytest.mark.parametrize("domain", ["button", "input_button"])
+async def test_report_button_pressed(hass, domain):
+    """Test button presses report human presence detection events to trigger routines."""
+    hass.states.async_set(
+        f"{domain}.test_button", "now", {"friendly_name": "Test button"}
+    )
+
+    properties = await reported_properties(hass, f"{domain}#test_button")
+    properties.assert_equal(
+        "Alexa.EventDetectionSensor",
+        "humanPresenceDetectionState",
+        {"value": "DETECTED"},
+    )
+
+
+@pytest.mark.parametrize("domain", ["switch", "input_boolean"])
+async def test_toggle_entities_report_contact_events(hass, domain):
+    """Test toggles and switches report contact sensor events to trigger routines."""
+    hass.states.async_set(
+        f"{domain}.test_toggle", "on", {"friendly_name": "Test toggle"}
+    )
+
+    properties = await reported_properties(hass, f"{domain}#test_toggle")
+    properties.assert_equal(
+        "Alexa.PowerController",
+        "powerState",
+        "ON",
+    )
+    properties.assert_equal(
+        "Alexa.ContactSensor",
+        "detectionState",
+        "DETECTED",
+    )
+
+    hass.states.async_set(
+        f"{domain}.test_toggle", "off", {"friendly_name": "Test toggle"}
+    )
+
+    properties = await reported_properties(hass, f"{domain}#test_toggle")
+    properties.assert_equal(
+        "Alexa.PowerController",
+        "powerState",
+        "OFF",
+    )
+    properties.assert_equal(
+        "Alexa.ContactSensor",
+        "detectionState",
+        "NOT_DETECTED",
+    )
+
+
 async def test_get_property_blowup(hass, caplog):
     """Test we handle a property blowing up."""
     hass.states.async_set(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -182,8 +182,12 @@ async def test_switch(hass, events):
     assert appliance["endpointId"] == "switch#test"
     assert appliance["displayCategories"][0] == "SWITCH"
     assert appliance["friendlyName"] == "Test switch"
-    assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.ContactSensor",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     await assert_power_controller_works(
@@ -192,6 +196,14 @@ async def test_switch(hass, events):
 
     properties = await reported_properties(hass, "switch#test")
     properties.assert_equal("Alexa.PowerController", "powerState", "ON")
+    properties.assert_equal("Alexa.ContactSensor", "detectionState", "DETECTED")
+    properties.assert_equal("Alexa.EndpointHealth", "connectivity", {"value": "OK"})
+
+    contact_sensor_capability = get_capability(capabilities, "Alexa.ContactSensor")
+    assert contact_sensor_capability is not None
+    properties = contact_sensor_capability["properties"]
+    assert properties["retrievable"] is True
+    assert {"name": "detectionState"} in properties["supported"]
 
 
 async def test_outlet(hass, events):
@@ -207,7 +219,11 @@ async def test_outlet(hass, events):
     assert appliance["displayCategories"][0] == "SMARTPLUG"
     assert appliance["friendlyName"] == "Test switch"
     assert_endpoint_capabilities(
-        appliance, "Alexa", "Alexa.PowerController", "Alexa.EndpointHealth"
+        appliance,
+        "Alexa",
+        "Alexa.PowerController",
+        "Alexa.EndpointHealth",
+        "Alexa.ContactSensor",
     )
 
 
@@ -335,8 +351,12 @@ async def test_input_boolean(hass):
     assert appliance["endpointId"] == "input_boolean#test"
     assert appliance["displayCategories"][0] == "OTHER"
     assert appliance["friendlyName"] == "Test input boolean"
-    assert_endpoint_capabilities(
-        appliance, "Alexa.PowerController", "Alexa.EndpointHealth", "Alexa"
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.PowerController",
+        "Alexa.ContactSensor",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
 
     await assert_power_controller_works(
@@ -346,6 +366,17 @@ async def test_input_boolean(hass):
         hass,
         "2022-04-19T07:53:05Z",
     )
+
+    properties = await reported_properties(hass, "input_boolean#test")
+    properties.assert_equal("Alexa.PowerController", "powerState", "OFF")
+    properties.assert_equal("Alexa.ContactSensor", "detectionState", "NOT_DETECTED")
+    properties.assert_equal("Alexa.EndpointHealth", "connectivity", {"value": "OK"})
+
+    contact_sensor_capability = get_capability(capabilities, "Alexa.ContactSensor")
+    assert contact_sensor_capability is not None
+    properties = contact_sensor_capability["properties"]
+    assert properties["retrievable"] is True
+    assert {"name": "detectionState"} in properties["supported"]
 
 
 @freeze_time("2022-04-19 07:53:05")
@@ -4003,7 +4034,11 @@ async def test_button(hass, domain):
     assert appliance["friendlyName"] == "Ring Doorbell"
 
     capabilities = assert_endpoint_capabilities(
-        appliance, "Alexa.SceneController", "Alexa"
+        appliance,
+        "Alexa.SceneController",
+        "Alexa.EventDetectionSensor",
+        "Alexa.EndpointHealth",
+        "Alexa",
     )
     scene_capability = get_capability(capabilities, "Alexa.SceneController")
     assert scene_capability["supportsDeactivation"] is False
@@ -4014,6 +4049,21 @@ async def test_button(hass, domain):
         False,
         hass,
         "2022-04-19T07:53:05Z",
+    )
+
+    event_detection_capability = get_capability(
+        capabilities, "Alexa.EventDetectionSensor"
+    )
+    assert event_detection_capability is not None
+    properties = event_detection_capability["properties"]
+    assert properties["proactivelyReported"] is True
+    assert not properties["retrievable"]
+    assert {"name": "humanPresenceDetectionState"} in properties["supported"]
+    assert (
+        event_detection_capability["configuration"]["detectionModes"]["humanPresence"][
+            "supportsNotDetected"
+        ]
+        is False
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switches and input booleans are double listed as both `Alexa.PowerController` and `Alexa.ContactSensor` interfaces. This enables users to trigger routines from their state changes using the smart home option. Buttons and input buttons are also double listed as `Alexa.SceneController` and `Alexa.EventDetectionSensor`, the latter specifically with `supportsNotDetected` set to `false`. This enables users to make routines which trigger when the button is pressed.

This change really has no impact on existing use cases with Alexa. I specifically did not change the display categories so devices appear exactly as they did before and work in the same use cases they did before (alexa can press buttons and change switches/toggles from routines). They just now also appear as routine starter options under "smart home".

It's a bit unintuitive in this particular menu since you see this UI for buttons:
<details>
<summary>Button pretending its a presence detector</summary>

![image](https://user-images.githubusercontent.com/2037026/157353305-d21673d2-13ea-4b75-b362-8db3beb315d0.png)

</details>
And this for switches and toggles:
<details>
<summary>Switch pretending its a contact sensor</summary>

![image](https://user-images.githubusercontent.com/2037026/157353356-8334ea90-bfd7-4f42-a141-40b2069af518.png)

</details>

But it is in line with what users were already doing to solve this use case, it just makes it easier (no YAML/template knowledge required). And we can guide them through it with a bit of documentation.

This will help users interested in HA but invested in Alexa able to transition more slowly by leveraging their existing routines. It also gives all users a way to leverage devices and services which can be integrated with Alexa but not with HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
