### PR TITLE
Use import instead of hass in Shelly tests

### DIFF
--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -13,6 +13,7 @@ from homeassistant.components.cover import (
     STATE_OPENING,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.helpers.entity_component import async_update_entity
 
 ROLLER_BLOCK_ID = 1
 
@@ -71,12 +72,12 @@ async def test_block_device_update(hass, coap_wrapper, monkeypatch):
     await hass.async_block_till_done()
 
     monkeypatch.setattr(coap_wrapper.device.blocks[ROLLER_BLOCK_ID], "rollerPos", 0)
-    await hass.helpers.entity_component.async_update_entity("cover.test_name")
+    await async_update_entity(hass, "cover.test_name")
     await hass.async_block_till_done()
     assert hass.states.get("cover.test_name").state == STATE_CLOSED
 
     monkeypatch.setattr(coap_wrapper.device.blocks[ROLLER_BLOCK_ID], "rollerPos", 100)
-    await hass.helpers.entity_component.async_update_entity("cover.test_name")
+    await async_update_entity(hass, "cover.test_name")
     await hass.async_block_till_done()
     assert hass.states.get("cover.test_name").state == STATE_OPEN
 
@@ -165,12 +166,12 @@ async def test_rpc_device_update(hass, rpc_wrapper, monkeypatch):
     await hass.async_block_till_done()
 
     monkeypatch.setitem(rpc_wrapper.device.status["cover:0"], "state", "closed")
-    await hass.helpers.entity_component.async_update_entity("cover.test_cover_0")
+    await async_update_entity(hass, "cover.test_cover_0")
     await hass.async_block_till_done()
     assert hass.states.get("cover.test_cover_0").state == STATE_CLOSED
 
     monkeypatch.setitem(rpc_wrapper.device.status["cover:0"], "state", "open")
-    await hass.helpers.entity_component.async_update_entity("cover.test_cover_0")
+    await async_update_entity(hass, "cover.test_cover_0")
     await hass.async_block_till_done()
     assert hass.states.get("cover.test_cover_0").state == STATE_OPEN
 
@@ -186,6 +187,6 @@ async def test_rpc_device_no_position_control(hass, rpc_wrapper, monkeypatch):
     )
     await hass.async_block_till_done()
 
-    await hass.helpers.entity_component.async_update_entity("cover.test_cover_0")
+    await async_update_entity(hass, "cover.test_cover_0")
     await hass.async_block_till_done()
     assert hass.states.get("cover.test_cover_0").state == STATE_UNKNOWN

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers.entity_component import async_update_entity
 
 RELAY_BLOCK_ID = 0
 
@@ -47,16 +48,12 @@ async def test_block_device_update(hass, coap_wrapper, monkeypatch):
     await hass.async_block_till_done()
 
     monkeypatch.setattr(coap_wrapper.device.blocks[RELAY_BLOCK_ID], "output", False)
-    await hass.helpers.entity_component.async_update_entity(
-        "switch.test_name_channel_1"
-    )
+    await async_update_entity(hass, "switch.test_name_channel_1")
     await hass.async_block_till_done()
     assert hass.states.get("switch.test_name_channel_1").state == STATE_OFF
 
     monkeypatch.setattr(coap_wrapper.device.blocks[RELAY_BLOCK_ID], "output", True)
-    await hass.helpers.entity_component.async_update_entity(
-        "switch.test_name_channel_1"
-    )
+    await async_update_entity(hass, "switch.test_name_channel_1")
     await hass.async_block_till_done()
     assert hass.states.get("switch.test_name_channel_1").state == STATE_ON
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use imports from helpers instead of `hass.helpers.` in tests - follow up of https://github.com/home-assistant/core/pull/67705#discussion_r822552660

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
