### PR TITLE
WIP: Mqtt discovery updates rework

### DIFF
--- a/homeassistant/components/mqtt/notify.py
+++ b/homeassistant/components/mqtt/notify.py
@@ -153,7 +153,7 @@ async def _async_setup_notify(
         config,
         config_entry,
         device_id,
-        discovery_hash,
+        discovery_data,
     )
     hass.data[MQTT_NOTIFY_SERVICES_SETUP][service_name] = service
 
@@ -193,7 +193,7 @@ class MqttNotificationService(
         service_config: MqttNotificationConfig,
         config_entry: ConfigEntry | None = None,
         device_id: str | None = None,
-        discovery_hash: tuple | None = None,
+        discovery_data: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the service."""
         self.hass = hass
@@ -205,7 +205,7 @@ class MqttNotificationService(
         self._device_id = device_id
         self._service_name = slugify(service_config[CONF_NAME])
         MqttDiscoveryDeviceUpdateService.__init__(
-            self, hass, LOG_NAME, discovery_hash, device_id, config_entry
+            self, hass, LOG_NAME, discovery_data, device_id, config_entry
         )
 
     @property
@@ -223,7 +223,7 @@ class MqttNotificationService(
         """Return a dictionary of registered targets."""
         return {target: target for target in self._config[CONF_TARGETS]}
 
-    async def async_update_service(
+    async def async_discovery_update(
         self,
         discovery_payload: DiscoveryInfoType,
     ) -> None:

--- a/tests/components/mqtt/test_notify.py
+++ b/tests/components/mqtt/test_notify.py
@@ -704,6 +704,12 @@ async def test_discovery_with_device_removal(hass, mqtt_mock, caplog, device_reg
         in caplog.text
     )
 
+    # Test if discovery topic is cleared with retained flag
+    mqtt_mock.async_publish.assert_called_once_with(
+        f"homeassistant/{notify.DOMAIN}/{service_name1}/config", "", 0, True
+    )
+    mqtt_mock.async_publish.reset_mock()
+
 
 async def test_publishing_with_custom_encoding(hass, mqtt_mock, caplog):
     """Test publishing MQTT payload with different encoding via discovery and configuration."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Code for handling MQTT discovery updates for platforms without entities was specialized for `notify`. `tag` and `device_automation`. This PR moves the discovery logic and device updates to a centralized place.

For `notify` the discovery topic is now reset when the device is removed to avoid rediscovery after a restart.
This was already implemented for the `tag` platform.

DONE: `notfify` and `tag`
TODO: `device_automation`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
