### PR TITLE
Hide switch_as_x tracked entity

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -90,13 +90,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_id = async_add_to_device(hass, entry, entity_id)
 
-    # Hide the wrapped entry if registered
-    entity_entry = registry.async_get(entity_id)
-    if entity_entry is not None and not entity_entry.hidden:
-        registry.async_update_entity(
-            entity_id, hidden_by=er.RegistryEntryHider.INTEGRATION
-        )
-
     hass.config_entries.async_setup_platforms(
         entry, (entry.options[CONF_TARGET_DOMAIN],)
     )

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -7,7 +7,11 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.const import CONF_ENTITY_ID, Platform
-from homeassistant.helpers import helper_config_entry_flow, selector
+from homeassistant.helpers import (
+    entity_registry as er,
+    helper_config_entry_flow,
+    selector,
+)
 
 from .const import CONF_TARGET_DOMAIN, DOMAIN
 
@@ -42,7 +46,15 @@ class SwitchAsXConfigFlowHandler(
     config_flow = CONFIG_FLOW
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
-        """Return config entry title."""
+        """Return config entry title and hide the wrapped entity if registered."""
+        # Hide the wrapped entry if registered
+        registry = er.async_get(self.hass)
+        entity_entry = registry.async_get(options[CONF_ENTITY_ID])
+        if entity_entry is not None and not entity_entry.hidden:
+            registry.async_update_entity(
+                options[CONF_ENTITY_ID], hidden_by=er.RegistryEntryHider.INTEGRATION
+            )
+
         return helper_config_entry_flow.wrapped_entity_config_entry_title(
             self.hass, options[CONF_ENTITY_ID]
         )

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -89,6 +89,7 @@ class RegistryEntryHider(StrEnum):
     """What hid a registry entry."""
 
     INTEGRATION = "integration"
+    USER = "user"
 
 
 # DISABLED_* are deprecated, to be removed in 2022.3

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -59,7 +59,7 @@ SAVE_DELAY = 10
 _LOGGER = logging.getLogger(__name__)
 
 STORAGE_VERSION_MAJOR = 1
-STORAGE_VERSION_MINOR = 5
+STORAGE_VERSION_MINOR = 6
 STORAGE_KEY = "core.entity_registry"
 
 # Attributes relevant to describing entity
@@ -83,6 +83,12 @@ class RegistryEntryDisabler(StrEnum):
     HASS = "hass"
     INTEGRATION = "integration"
     USER = "user"
+
+
+class RegistryEntryHider(StrEnum):
+    """What hid a registry entry."""
+
+    INTEGRATION = "integration"
 
 
 # DISABLED_* are deprecated, to be removed in 2022.3
@@ -120,6 +126,7 @@ class RegistryEntry:
     entity_category: EntityCategory | None = attr.ib(
         default=None, converter=_convert_to_entity_category
     )
+    hidden_by: RegistryEntryHider | None = attr.ib(default=None)
     icon: str | None = attr.ib(default=None)
     id: str = attr.ib(factory=uuid_util.random_uuid_hex)
     name: str | None = attr.ib(default=None)
@@ -142,6 +149,11 @@ class RegistryEntry:
     def disabled(self) -> bool:
         """Return if entry is disabled."""
         return self.disabled_by is not None
+
+    @property
+    def hidden(self) -> bool:
+        """Return if entry is hidden."""
+        return self.hidden_by is not None
 
     @callback
     def write_unavailable_state(self, hass: HomeAssistant) -> None:
@@ -327,8 +339,9 @@ class EntityRegistry:
         # To influence entity ID generation
         known_object_ids: Iterable[str] | None = None,
         suggested_object_id: str | None = None,
-        # To disable an entity if it gets created
+        # To disable or hide an entity if it gets created
         disabled_by: RegistryEntryDisabler | None = None,
+        hidden_by: RegistryEntryHider | None = None,
         # Data that we want entry to have
         area_id: str | None = None,
         capabilities: Mapping[str, Any] | None = None,
@@ -400,6 +413,7 @@ class EntityRegistry:
             disabled_by=disabled_by,
             entity_category=_convert_to_entity_category(entity_category),
             entity_id=entity_id,
+            hidden_by=hidden_by,
             original_device_class=original_device_class,
             original_icon=original_icon,
             original_name=original_name,
@@ -505,6 +519,7 @@ class EntityRegistry:
         disabled_by: RegistryEntryDisabler | None | UndefinedType = UNDEFINED,
         # Type str (ENTITY_CATEG*) is deprecated as of 2021.12, use EntityCategory
         entity_category: EntityCategory | str | None | UndefinedType = UNDEFINED,
+        hidden_by: RegistryEntryHider | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         new_entity_id: str | UndefinedType = UNDEFINED,
@@ -540,6 +555,7 @@ class EntityRegistry:
             ("device_id", device_id),
             ("disabled_by", disabled_by),
             ("entity_category", entity_category),
+            ("hidden_by", hidden_by),
             ("icon", icon),
             ("name", name),
             ("original_device_class", original_device_class),
@@ -651,6 +667,7 @@ class EntityRegistry:
                         entity["entity_category"], raise_report=False
                     ),
                     entity_id=entity["entity_id"],
+                    hidden_by=entity["hidden_by"],
                     icon=entity["icon"],
                     id=entity["id"],
                     name=entity["name"],
@@ -686,6 +703,7 @@ class EntityRegistry:
                 "disabled_by": entry.disabled_by,
                 "entity_category": entry.entity_category,
                 "entity_id": entry.entity_id,
+                "hidden_by": entry.hidden_by,
                 "icon": entry.icon,
                 "id": entry.id,
                 "name": entry.name,
@@ -845,6 +863,11 @@ async def _async_migrate(
         # Version 1.5 adds entity options
         for entity in data["entities"]:
             entity["options"] = {}
+
+    if old_major_version == 1 and old_minor_version < 6:
+        # Version 1.6 adds hidden_by
+        for entity in data["entities"]:
+            entity["hidden_by"] = None
 
     if old_major_version > 1:
         raise NotImplementedError

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -4,7 +4,11 @@ import pytest
 from homeassistant.components.config import entity_registry
 from homeassistant.const import ATTR_ICON
 from homeassistant.helpers.device_registry import DeviceEntryDisabler
-from homeassistant.helpers.entity_registry import RegistryEntry, RegistryEntryDisabler
+from homeassistant.helpers.entity_registry import (
+    RegistryEntry,
+    RegistryEntryDisabler,
+    RegistryEntryHider,
+)
 
 from tests.common import (
     MockConfigEntry,
@@ -57,6 +61,7 @@ async def test_list_entities(hass, client):
             "area_id": None,
             "disabled_by": None,
             "entity_id": "test_domain.name",
+            "hidden_by": None,
             "name": "Hello World",
             "icon": None,
             "platform": "test_platform",
@@ -68,6 +73,7 @@ async def test_list_entities(hass, client):
             "area_id": None,
             "disabled_by": None,
             "entity_id": "test_domain.no_name",
+            "hidden_by": None,
             "name": None,
             "icon": None,
             "platform": "test_platform",
@@ -109,6 +115,7 @@ async def test_get_entity(hass, client):
         "disabled_by": None,
         "entity_category": None,
         "entity_id": "test_domain.name",
+        "hidden_by": None,
         "icon": None,
         "name": "Hello World",
         "original_device_class": None,
@@ -136,6 +143,7 @@ async def test_get_entity(hass, client):
         "disabled_by": None,
         "entity_category": None,
         "entity_id": "test_domain.no_name",
+        "hidden_by": None,
         "icon": None,
         "name": None,
         "original_device_class": None,
@@ -170,7 +178,7 @@ async def test_update_entity(hass, client):
     assert state.name == "before update"
     assert state.attributes[ATTR_ICON] == "icon:before update"
 
-    # UPDATE AREA, DEVICE_CLASS, ICON AND NAME
+    # UPDATE AREA, DEVICE_CLASS, HIDDEN_BY, ICON AND NAME
     await client.send_json(
         {
             "id": 6,
@@ -178,6 +186,7 @@ async def test_update_entity(hass, client):
             "entity_id": "test_domain.world",
             "area_id": "mock-area-id",
             "device_class": "custom_device_class",
+            "hidden_by": RegistryEntryHider.USER,
             "icon": "icon:after update",
             "name": "after update",
         }
@@ -195,6 +204,7 @@ async def test_update_entity(hass, client):
             "disabled_by": None,
             "entity_category": None,
             "entity_id": "test_domain.world",
+            "hidden_by": RegistryEntryHider.USER,
             "icon": "icon:after update",
             "name": "after update",
             "original_device_class": None,
@@ -248,6 +258,7 @@ async def test_update_entity(hass, client):
             "disabled_by": None,
             "entity_category": None,
             "entity_id": "test_domain.world",
+            "hidden_by": RegistryEntryHider.USER,
             "icon": "icon:after update",
             "name": "after update",
             "original_device_class": None,
@@ -306,6 +317,7 @@ async def test_update_entity_require_restart(hass, client):
             "entity_category": None,
             "entity_id": "test_domain.world",
             "icon": None,
+            "hidden_by": None,
             "name": None,
             "original_device_class": None,
             "original_icon": None,
@@ -409,6 +421,7 @@ async def test_update_entity_no_changes(hass, client):
             "disabled_by": None,
             "entity_category": None,
             "entity_id": "test_domain.world",
+            "hidden_by": None,
             "icon": None,
             "name": "name of entity",
             "original_device_class": None,
@@ -492,6 +505,7 @@ async def test_update_entity_id(hass, client):
             "disabled_by": None,
             "entity_category": None,
             "entity_id": "test_domain.planet",
+            "hidden_by": None,
             "icon": None,
             "name": None,
             "original_device_class": None,

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -1,4 +1,6 @@
 """Test the Switch as X config flow."""
+from __future__ import annotations
+
 from unittest.mock import AsyncMock
 
 import pytest
@@ -8,6 +10,7 @@ from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAI
 from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+from homeassistant.helpers import entity_registry as er
 
 
 @pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
@@ -47,6 +50,64 @@ async def test_config_flow(
         CONF_ENTITY_ID: "switch.ceiling",
         CONF_TARGET_DOMAIN: target_domain,
     }
+
+
+@pytest.mark.parametrize(
+    "hidden_by_before,hidden_by_after",
+    (
+        (er.RegistryEntryHider.USER.value, er.RegistryEntryHider.USER.value),
+        (None, er.RegistryEntryHider.INTEGRATION.value),
+    ),
+)
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_config_flow_registered_entity(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    mock_setup_entry: AsyncMock,
+    hidden_by_before: er.RegistryEntryHider | None,
+    hidden_by_after: er.RegistryEntryHider,
+) -> None:
+    """Test the config flow hides a registered entity."""
+    registry = er.async_get(hass)
+    switch_entity_entry = registry.async_get_or_create(
+        "switch", "test", "unique", suggested_object_id="ceiling"
+    )
+    assert switch_entity_entry.entity_id == "switch.ceiling"
+    registry.async_update_entity("switch.ceiling", hidden_by=hidden_by_before)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENTITY_ID: "switch.ceiling",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "ceiling"
+    assert result["data"] == {}
+    assert result["options"] == {
+        CONF_ENTITY_ID: "switch.ceiling",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "switch.ceiling",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+
+    switch_entity_entry = registry.async_get("switch.ceiling")
+    assert switch_entity_entry.hidden_by == hidden_by_after
 
 
 @pytest.mark.parametrize("target_domain", (Platform.LIGHT,))

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -1,4 +1,6 @@
 """Tests for the Switch as X."""
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest
@@ -295,3 +297,81 @@ async def test_device(hass: HomeAssistant, target_domain: Platform) -> None:
     entity_entry = entity_registry.async_get(f"{target_domain}.abc")
     assert entity_entry
     assert entity_entry.device_id == switch_entity_entry.device_id
+
+
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_setup_and_remove_config_entry(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test removing a config entry."""
+    registry = er.async_get(hass)
+
+    # Setup the config entry
+    switch_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.test",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+    )
+    switch_as_x_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are present
+    assert hass.states.get(f"{target_domain}.abc") is not None
+    assert registry.async_get(f"{target_domain}.abc") is not None
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(switch_as_x_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed
+    assert hass.states.get(f"{target_domain}.my_min_max") is None
+    assert registry.async_get(f"{target_domain}.my_min_max") is None
+
+
+@pytest.mark.parametrize(
+    "hidden_by_before,hidden_by_after",
+    (
+        (er.RegistryEntryHider.USER.value, er.RegistryEntryHider.USER.value),
+        (er.RegistryEntryHider.INTEGRATION.value, None),
+    ),
+)
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_reset_hidden_by(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    hidden_by_before: er.RegistryEntryHider | None,
+    hidden_by_after: er.RegistryEntryHider,
+) -> None:
+    """Test removing a config entry resets hidden by."""
+    registry = er.async_get(hass)
+
+    switch_entity_entry = registry.async_get_or_create("switch", "test", "unique")
+    registry.async_update_entity(
+        switch_entity_entry.entity_id, hidden_by=hidden_by_before
+    )
+
+    # Add the config entry
+    switch_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+    )
+    switch_as_x_config_entry.add_to_hass(hass)
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(switch_as_x_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check hidden by is reset
+    switch_entity_entry = registry.async_get(switch_entity_entry.entity_id)
+    assert switch_entity_entry.hidden_by == hidden_by_after


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hide `switch_as_x` tracked entity.
The tracked entity will be hidden when the config entry is setup, and unhidden when the config entry is removed.

This introduces a new flag `hidden_by` to entity registry entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
