### PR TITLE
Add remote platform to Kaleidescape integration

### DIFF
--- a/homeassistant/components/kaleidescape/__init__.py
+++ b/homeassistant/components/kaleidescape/__init__.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SENSOR]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/kaleidescape/remote.py
+++ b/homeassistant/components/kaleidescape/remote.py
@@ -1,0 +1,73 @@
+"""Kaleidescape remote."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from kaleidescape import const as kaleidescape_const
+
+from homeassistant.components.remote import RemoteEntity
+
+from .const import DOMAIN as KALEIDESCAPE_DOMAIN
+from .entity import KaleidescapeEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the platform from a config entry."""
+    entities = [KaleidescapeRemote(hass.data[KALEIDESCAPE_DOMAIN][entry.entry_id])]
+    async_add_entities(entities)
+
+
+class KaleidescapeRemote(KaleidescapeEntity, RemoteEntity):
+    """Representation of a Kaleidescape device."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return self._device.power.state == kaleidescape_const.DEVICE_POWER_STATE_ON
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        await self._device.leave_standby()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        await self._device.enter_standby()
+
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send a command to a device."""
+        for single_command in command:
+            if single_command == "select":
+                await self._device.select()
+            elif single_command == "up":
+                await self._device.up()
+            elif single_command == "down":
+                await self._device.down()
+            elif single_command == "left":
+                await self._device.left()
+            elif single_command == "right":
+                await self._device.right()
+            elif single_command == "cancel":
+                await self._device.cancel()
+            elif single_command == "replay":
+                await self._device.replay()
+            elif single_command == "scan_forward":
+                await self._device.scan_forward()
+            elif single_command == "scan_reverse":
+                await self._device.scan_reverse()
+            elif single_command == "go_movie_covers":
+                await self._device.go_movie_covers()
+            elif single_command == "menu_toggle":
+                await self._device.menu_toggle()

--- a/homeassistant/components/kaleidescape/remote.py
+++ b/homeassistant/components/kaleidescape/remote.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from kaleidescape import const as kaleidescape_const
@@ -21,8 +20,6 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -32,7 +29,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-VALID_COMMANDS = [
+VALID_COMMANDS = {
     "select",
     "up",
     "down",
@@ -44,7 +41,7 @@ VALID_COMMANDS = [
     "scan_reverse",
     "go_movie_covers",
     "menu_toggle",
-]
+}
 
 
 class KaleidescapeRemote(KaleidescapeEntity, RemoteEntity):
@@ -66,7 +63,6 @@ class KaleidescapeRemote(KaleidescapeEntity, RemoteEntity):
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to a device."""
         for cmd in command:
-            if cmd in VALID_COMMANDS:
-                await getattr(self._device, cmd)()
-            else:
+            if cmd not in VALID_COMMANDS:
                 raise HomeAssistantError(f"{cmd} is not a known command")
+            await getattr(self._device, cmd)()

--- a/homeassistant/components/kaleidescape/remote.py
+++ b/homeassistant/components/kaleidescape/remote.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from kaleidescape import const as kaleidescape_const
 
 from homeassistant.components.remote import RemoteEntity
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN as KALEIDESCAPE_DOMAIN
 from .entity import KaleidescapeEntity
@@ -31,6 +32,21 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+VALID_COMMANDS = [
+    "select",
+    "up",
+    "down",
+    "left",
+    "right",
+    "cancel",
+    "replay",
+    "scan_forward",
+    "scan_reverse",
+    "go_movie_covers",
+    "menu_toggle",
+]
+
+
 class KaleidescapeRemote(KaleidescapeEntity, RemoteEntity):
     """Representation of a Kaleidescape device."""
 
@@ -49,26 +65,8 @@ class KaleidescapeRemote(KaleidescapeEntity, RemoteEntity):
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to a device."""
-        for single_command in command:
-            if single_command == "select":
-                await self._device.select()
-            elif single_command == "up":
-                await self._device.up()
-            elif single_command == "down":
-                await self._device.down()
-            elif single_command == "left":
-                await self._device.left()
-            elif single_command == "right":
-                await self._device.right()
-            elif single_command == "cancel":
-                await self._device.cancel()
-            elif single_command == "replay":
-                await self._device.replay()
-            elif single_command == "scan_forward":
-                await self._device.scan_forward()
-            elif single_command == "scan_reverse":
-                await self._device.scan_reverse()
-            elif single_command == "go_movie_covers":
-                await self._device.go_movie_covers()
-            elif single_command == "menu_toggle":
-                await self._device.menu_toggle()
+        for cmd in command:
+            if cmd in VALID_COMMANDS:
+                await getattr(self._device, cmd)()
+            else:
+                raise HomeAssistantError(f"{cmd} is not a known command")

--- a/homeassistant/components/kaleidescape/remote.py
+++ b/homeassistant/components/kaleidescape/remote.py
@@ -1,4 +1,5 @@
-"""Kaleidescape remote."""
+"""Sensor platform for Kaleidescape integration."""
+
 from __future__ import annotations
 
 import logging

--- a/tests/components/kaleidescape/test_remote.py
+++ b/tests/components/kaleidescape/test_remote.py
@@ -1,4 +1,4 @@
-"""Tests for Kaleidescape media player platform."""
+"""Tests for Kaleidescape remote platform."""
 
 from unittest.mock import MagicMock
 

--- a/tests/components/kaleidescape/test_remote.py
+++ b/tests/components/kaleidescape/test_remote.py
@@ -1,0 +1,137 @@
+"""Tests for Kaleidescape media player platform."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_SERIAL
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = f"remote.kaleidescape_device_{MOCK_SERIAL}"
+
+
+async def test_entity(
+    hass: HomeAssistant,
+    mock_device: MagicMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test entity attributes."""
+    assert hass.states.get(ENTITY_ID)
+
+
+async def test_services(
+    hass: HomeAssistant,
+    mock_device: MagicMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test service calls."""
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    assert mock_device.leave_standby.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    assert mock_device.enter_standby.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["select"]},
+        blocking=True,
+    )
+    assert mock_device.select.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["up"]},
+        blocking=True,
+    )
+    assert mock_device.up.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["down"]},
+        blocking=True,
+    )
+    assert mock_device.down.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["left"]},
+        blocking=True,
+    )
+    assert mock_device.left.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["right"]},
+        blocking=True,
+    )
+    assert mock_device.right.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["cancel"]},
+        blocking=True,
+    )
+    assert mock_device.cancel.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["replay"]},
+        blocking=True,
+    )
+    assert mock_device.replay.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["scan_forward"]},
+        blocking=True,
+    )
+    assert mock_device.scan_forward.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["scan_reverse"]},
+        blocking=True,
+    )
+    assert mock_device.scan_reverse.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["go_movie_covers"]},
+        blocking=True,
+    )
+    assert mock_device.go_movie_covers.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["menu_toggle"]},
+        blocking=True,
+    )
+    assert mock_device.menu_toggle.call_count == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add remote platform to new Kaleidescape integration (https://github.com/home-assistant/core/pull/67711).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21995

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
