### PR TITLE
Add switch_as_x entity to wrapped switch's device

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENTITY_ID
-from homeassistant.core import Event, HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 
 from .light import LightSwitch
@@ -20,9 +20,67 @@ DOMAIN = "switch_as_x"
 _LOGGER = logging.getLogger(__name__)
 
 
+@callback
+def async_add_to_device(
+    hass: HomeAssistant, entry: ConfigEntry, entity_id: str
+) -> str | None:
+    """Add our config entry to the tracked entity's device."""
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    device_id = None
+
+    wrapped_switch = registry.async_get(entity_id)
+    if (
+        not (wrapped_switch := registry.async_get(entity_id))
+        or not (device_id := wrapped_switch.device_id)
+        or not (device_entry := device_registry.async_get(device_id))
+    ):
+        return device_id
+
+    device_registry.async_update_device(device_id, add_config_entry_id=entry.entry_id)
+
+    if (
+        not wrapped_switch.config_entry_id
+        or wrapped_switch.config_entry_id not in device_entry.config_entries
+    ):
+        return device_id
+
+    @callback
+    def async_device_updated(event):
+        """Handle the update of a device.
+
+        Will remove our config entry from the switch's device if the switch's config
+        entry is removed from it.
+        """
+        if (
+            event.data["device_id"] != device_id
+            or event.data["action"] != "update"
+            or "config_entries" not in event.data["changes"]
+        ):
+            return
+
+        if not (device_entry := device_registry.async_get(device_id)):
+            # The device is already removed, no need to do any cleanup
+            return False
+        if wrapped_switch.config_entry_id in device_entry.config_entries:
+            # Not removed from device
+            return False
+
+        device_registry.async_update_device(
+            device_id, remove_config_entry_id=entry.entry_id
+        )
+
+    entry.async_on_unload(
+        hass.bus.async_listen(dr.EVENT_DEVICE_REGISTRY_UPDATED, async_device_updated)
+    )
+
+    return device_id
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     try:
         entity_id = er.async_validate_entity_id(registry, entry.options[CONF_ENTITY_ID])
     except vol.Invalid:
@@ -39,17 +97,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if data["action"] == "remove":
             await hass.config_entries.async_remove(entry.entry_id)
 
-        if data["action"] != "update" or "entity_id" not in data["changes"]:
+        if data["action"] != "update":
             return
 
-        # Entity_id changed, reload the config entry
-        await hass.config_entries.async_reload(entry.entry_id)
+        if "entity_id" in data["changes"]:
+            # Entity_id changed, reload the config entry
+            await hass.config_entries.async_reload(entry.entry_id)
+
+        if device_id and "device_id" in data["changes"]:
+            # If the tracked switch is no longer in the device, remove our config entry
+            # from the device
+            if (
+                not (entity_entry := registry.async_get(data["entity_id"]))
+                or not device_registry.async_get(device_id)
+                or entity_entry.device_id == device_id
+            ):
+                # No need to do any cleanup
+                return
+
+            device_registry.async_update_device(
+                device_id, remove_config_entry_id=entry.entry_id
+            )
 
     entry.async_on_unload(
         async_track_entity_registry_updated_event(
             hass, entity_id, async_registry_updated
         )
     )
+
+    device_id = async_add_to_device(hass, entry, entity_id)
 
     hass.config_entries.async_setup_platforms(entry, (entry.options["target_domain"],))
     return True

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -90,17 +90,17 @@ async def test_device_registry_config_entry_1(hass: HomeAssistant, target_domain
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
-    test_config_entry = MockConfigEntry()
+    switch_config_entry = MockConfigEntry()
 
     device_entry = device_registry.async_get_or_create(
-        config_entry_id=test_config_entry.entry_id,
+        config_entry_id=switch_config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     switch_entity_entry = entity_registry.async_get_or_create(
         "switch",
         "test",
         "unique",
-        config_entry=test_config_entry,
+        config_entry=switch_config_entry,
         device_id=device_entry.id,
     )
     # Add another config entry to the same device
@@ -128,9 +128,11 @@ async def test_device_registry_config_entry_1(hass: HomeAssistant, target_domain
 
     # Remove the wrapped switch's config entry from the device
     device_registry.async_update_device(
-        device_entry.id, remove_config_entry_id=test_config_entry.entry_id
+        device_entry.id, remove_config_entry_id=switch_config_entry.entry_id
     )
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    # Check that the switch_as_x config entry is removed from the device
     device_entry = device_registry.async_get(device_entry.id)
     assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
 
@@ -141,17 +143,17 @@ async def test_device_registry_config_entry_2(hass: HomeAssistant, target_domain
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
-    test_config_entry = MockConfigEntry()
+    switch_config_entry = MockConfigEntry()
 
     device_entry = device_registry.async_get_or_create(
-        config_entry_id=test_config_entry.entry_id,
+        config_entry_id=switch_config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     switch_entity_entry = entity_registry.async_get_or_create(
         "switch",
         "test",
         "unique",
-        config_entry=test_config_entry,
+        config_entry=switch_config_entry,
         device_id=device_entry.id,
     )
 
@@ -176,5 +178,6 @@ async def test_device_registry_config_entry_2(hass: HomeAssistant, target_domain
     # Remove the wrapped switch from the device
     entity_registry.async_update_entity(switch_entity_entry.entity_id, device_id=None)
     await hass.async_block_till_done()
+    # Check that the switch_as_x config entry is removed from the device
     device_entry = device_registry.async_get(device_entry.id)
     assert switch_as_x_config_entry.entry_id not in device_entry.config_entries

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -5,7 +5,7 @@ import pytest
 
 from homeassistant.components.switch_as_x import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -82,3 +82,99 @@ async def test_entity_registry_events(hass: HomeAssistant, target_domain):
     assert hass.states.get(f"{target_domain}.abc") is None
     assert registry.async_get(f"{target_domain}.abc") is None
     assert len(hass.config_entries.async_entries("switch_as_x")) == 0
+
+
+@pytest.mark.parametrize("target_domain", ("light",))
+async def test_device_registry_config_entry_1(hass: HomeAssistant, target_domain):
+    """Test we add our config entry to the tracked switch's device."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    test_config_entry = MockConfigEntry()
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=test_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "unique",
+        config_entry=test_config_entry,
+        device_id=device_entry.id,
+    )
+    # Add another config entry to the same device
+    device_registry.async_update_device(
+        device_entry.id, add_config_entry_id=MockConfigEntry().entry_id
+    )
+
+    switch_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={"entity_id": switch_entity_entry.id, "target_domain": target_domain},
+        title="ABC",
+    )
+
+    switch_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    assert entity_entry.device_id == switch_entity_entry.device_id
+
+    device_entry = device_registry.async_get(device_entry.id)
+    assert switch_as_x_config_entry.entry_id in device_entry.config_entries
+
+    # Remove the wrapped switch's config entry from the device
+    device_registry.async_update_device(
+        device_entry.id, remove_config_entry_id=test_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+    device_entry = device_registry.async_get(device_entry.id)
+    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+
+
+@pytest.mark.parametrize("target_domain", ("light",))
+async def test_device_registry_config_entry_2(hass: HomeAssistant, target_domain):
+    """Test we add our config entry to the tracked switch's device."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    test_config_entry = MockConfigEntry()
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=test_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    switch_entity_entry = entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "unique",
+        config_entry=test_config_entry,
+        device_id=device_entry.id,
+    )
+
+    switch_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={"entity_id": switch_entity_entry.id, "target_domain": target_domain},
+        title="ABC",
+    )
+
+    switch_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    assert entity_entry.device_id == switch_entity_entry.device_id
+
+    device_entry = device_registry.async_get(device_entry.id)
+    assert switch_as_x_config_entry.entry_id in device_entry.config_entries
+
+    # Remove the wrapped switch from the device
+    entity_registry.async_update_entity(switch_entity_entry.entity_id, device_id=None)
+    await hass.async_block_till_done()
+    device_entry = device_registry.async_get(device_entry.id)
+    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `switch_as_x` entity to wrapped switch's device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
