### PR TITLE
Listen to entity registry events for wrapped switch in switch_as_x

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -7,8 +7,9 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_entity_registry_updated_event
 
 from .light import LightSwitch
 
@@ -23,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     registry = er.async_get(hass)
     try:
-        er.async_validate_entity_id(registry, entry.options[CONF_ENTITY_ID])
+        entity_id = er.async_validate_entity_id(registry, entry.options[CONF_ENTITY_ID])
     except vol.Invalid:
         # The entity is identified by an unknown entity registry ID
         _LOGGER.error(
@@ -31,6 +32,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.options[CONF_ENTITY_ID],
         )
         return False
+
+    async def async_registry_updated(event: Event) -> None:
+        """Handle entity registry update."""
+        data = event.data
+        if data["action"] == "remove":
+            await hass.config_entries.async_remove(entry.entry_id)
+
+        if data["action"] != "update" or "entity_id" not in data["changes"]:
+            return
+
+        # Entity_id changed, reload the config entry
+        await hass.config_entries.async_reload(entry.entry_id)
+
+    entry.async_on_unload(
+        async_track_entity_registry_updated_event(
+            hass, entity_id, async_registry_updated
+        )
+    )
 
     hass.config_entries.async_setup_platforms(entry, (entry.options["target_domain"],))
     return True

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -1,8 +1,11 @@
 """Tests for the Switch as X."""
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components.switch_as_x import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -25,3 +28,59 @@ async def test_config_entry_unregistered_uuid(hass: HomeAssistant, target_domain
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
+
+
+@pytest.mark.parametrize("target_domain", ("light",))
+async def test_entity_registry_events(hass: HomeAssistant, target_domain):
+    """Test entity registry events are tracked."""
+    registry = er.async_get(hass)
+    registry_entry = registry.async_get_or_create("switch", "test", "unique")
+    switch_entity_id = registry_entry.entity_id
+    hass.states.async_set(switch_entity_id, "on")
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={"entity_id": registry_entry.id, "target_domain": target_domain},
+        title="ABC",
+    )
+
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(f"{target_domain}.abc").state == "on"
+
+    # Change entity_id
+    new_switch_entity_id = f"{switch_entity_id}_new"
+    registry.async_update_entity(switch_entity_id, new_entity_id=new_switch_entity_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(f"{target_domain}.abc").state == "unavailable"
+
+    # The old entity_id should no longer be tracked
+    hass.states.async_set(switch_entity_id, "off")
+    await hass.async_block_till_done()
+    assert hass.states.get(f"{target_domain}.abc").state == "unavailable"
+
+    # Check tracking the new entity_id
+    hass.states.async_set(new_switch_entity_id, "off")
+    await hass.async_block_till_done()
+    assert hass.states.get(f"{target_domain}.abc").state == "off"
+
+    # Check changing name does not reload the config entry
+    with patch(
+        "homeassistant.components.switch_as_x.async_unload_entry",
+    ) as mock_setup_entry:
+        registry.async_update_entity(new_switch_entity_id, name="New name")
+        await hass.async_block_till_done()
+    mock_setup_entry.assert_not_called()
+
+    # Check removing the entity removes the config entry
+    registry.async_remove(new_switch_entity_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(f"{target_domain}.abc") is None
+    assert registry.async_get(f"{target_domain}.abc") is None
+    assert len(hass.config_entries.async_entries("switch_as_x")) == 0

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -55,17 +55,15 @@ async def test_entity_registry_events(hass: HomeAssistant, target_domain):
     # Change entity_id
     new_switch_entity_id = f"{switch_entity_id}_new"
     registry.async_update_entity(switch_entity_id, new_entity_id=new_switch_entity_id)
+    hass.states.async_set(new_switch_entity_id, "off")
     await hass.async_block_till_done()
-
-    assert hass.states.get(f"{target_domain}.abc").state == "unavailable"
-
-    # The old entity_id should no longer be tracked
-    hass.states.async_set(switch_entity_id, "off")
-    await hass.async_block_till_done()
-    assert hass.states.get(f"{target_domain}.abc").state == "unavailable"
 
     # Check tracking the new entity_id
-    hass.states.async_set(new_switch_entity_id, "off")
+    await hass.async_block_till_done()
+    assert hass.states.get(f"{target_domain}.abc").state == "off"
+
+    # The old entity_id should no longer be tracked
+    hass.states.async_set(switch_entity_id, "on")
     await hass.async_block_till_done()
     assert hass.states.get(f"{target_domain}.abc").state == "off"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Listen to entity registry events for wrapped switch in `switch_as_x`:
- If the wrapped entity's `entity_id` changes, reload the entry to start tracking the new `entity_id`
- If the wrapped entity is removed, removed the `switch_as_x` config entry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
