### PR TITLE
Add set filter

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1796,6 +1796,11 @@ def iif(
     return if_false
 
 
+def to_set(iterable: Iterable[Any]) -> set[Any]:
+    """Convert a list to a set."""
+    return set(iterable)
+
+
 @contextmanager
 def set_template(template_str: str, action: str) -> Generator:
     """Store template being parsed or rendered in a Contextvar to aid error handling."""
@@ -1909,6 +1914,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["relative_time"] = relative_time
         self.filters["slugify"] = slugify
         self.filters["iif"] = iif
+        self.filters["set"] = to_set
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -1939,6 +1945,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["unpack"] = struct_unpack
         self.globals["slugify"] = slugify
         self.globals["iif"] = iif
+        self.globals["set"] = to_set
         self.tests["is_number"] = is_number
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -977,6 +977,18 @@ def test_slugify(hass):
     )
 
 
+def test_set(hass):
+    """Test the set filter."""
+    assert template.Template("{{ set(['a', 'b', 'a']) }}", hass).async_render() == {
+        "a",
+        "b",
+    }
+    assert template.Template("{{ ['a', 'b', 'a'] | set }}", hass).async_render() == {
+        "a",
+        "b",
+    }
+
+
 def test_ordinal(hass):
     """Test the ordinal filter."""
     tests = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new filter `set` to templates. Essentially just converts what it is passed to a set.

The primary reason I think a user might care about this is when trying to write a template which filters a list of entities/devices to just the ones in a particular area. Currently the best way to do this task is something like this this:
```j2
{{ entities_list | select( 'in', ('Kitchen' | area_entities)) | list }}
```
The problem is I found this isn't particularly quick. As part of https://github.com/home-assistant/core/pull/67943 I tried to improve it by adding an `in_area` test but turned out that wasn't much better (as you can see from the perf comparisons in the comments).

But during that testing I realized `select` and `reject` accept a set and that did improve performance significantly (put my simple benchmark tests below). So adding this filter allows users to take advantage of that like this:
```j2
{{ entities_list | select('in', ('Kitchen' | area_entities | set)) | list
```
Or any other time they find themselves filtering one list by another long list.

Note that templates cannot currently output a set, it gets converted to a list:
![Screen Shot 2022-03-10 at 7 49 18 PM](https://user-images.githubusercontent.com/2037026/157781136-ab3af8a6-e6bf-4094-abed-cf1ca558ba91.png)

That might confuse some users if they try and stick the results of a template like that into a variable in a script or automation. I didn't think it was important enough to need fixing as part of this PR but can look into it if others disgree.

<details>
<summary>Benchmark tests</summary>

**List**
```py
@benchmark
async def select_in(hass):
    """Run 100 entity IDs into 500 in select(in) 1000 times."""
    variables = {
        "in_list": [f"sensor.number_{i+35}" for i in range(25)]
        + [f"sensor.fail_{i}" for i in range(75)],
        "test_list": [f"sensor.number_{i}" for i in range(500)],
    }
    template = template_helper.Template(
        "{{ in_list | select('in', test_list) | list }}", hass
    )

    start = timer()
    for _ in range(1000):
        template.async_render(variables=variables)
    return timer() - start
```
```
root ➜ hass --script benchmark select_in
Using event loop: _UnixSelectorEventLoop
Benchmark select_in done in 0.5612765420000017s
Benchmark select_in done in 0.5602246249999894s
Benchmark select_in done in 0.5421851250000032s
Benchmark select_in done in 0.474540042000001s
Benchmark select_in done in 0.4619620419999819s
```
**Set**
```py
@benchmark
async def select_in(hass):
    """Run 100 entity IDs into 500 in select(in) 1000 times."""
    variables = {
        "in_list": [f"sensor.number_{i+35}" for i in range(25)]
        + [f"sensor.fail_{i}" for i in range(75)],
        "test_list": [f"sensor.number_{i}" for i in range(500)],
    }
    template = template_helper.Template(
        "{{ in_list | select('in', test_list | set) | list }}", hass
    )

    start = timer()
    for _ in range(1000):
        template.async_render(variables=variables)
    return timer() - start
```
```
root ➜ hass --script benchmark select_in
Using event loop: _UnixSelectorEventLoop
Benchmark select_in done in 0.2625477090005006s
Benchmark select_in done in 0.25622829100029776s
Benchmark select_in done in 0.2574692500002129s
Benchmark select_in done in 0.25353670900040015s
Benchmark select_in done in 0.2535037919997194s
```

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
