### PR TITLE
Autoresume in-progress items from Plex media browser

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import wraps
 import json
 import logging
+from urllib.parse import parse_qs
 
 import plexapi.exceptions
 import requests.exceptions
@@ -490,6 +491,12 @@ class PlexMediaPlayer(MediaPlayerEntity):
         if media_id.startswith(PLEX_URI_SCHEME):
             media_id = media_id[len(PLEX_URI_SCHEME) :]
 
+        if "?" in media_id:
+            media_id, query_params = media_id.split("?")
+            extra_params = parse_qs(query_params)
+        else:
+            extra_params = {}
+
         if media_type == "station":
             playqueue = self.plex_server.create_station_playqueue(media_id)
             try:
@@ -503,6 +510,8 @@ class PlexMediaPlayer(MediaPlayerEntity):
         src = json.loads(media_id)
         if isinstance(src, int):
             src = {"plex_key": src}
+
+        src.update(extra_params)
 
         offset = 0
 

--- a/tests/components/plex/test_browse_media.py
+++ b/tests/components/plex/test_browse_media.py
@@ -1,6 +1,5 @@
 """Tests for Plex media browser."""
 from http import HTTPStatus
-import json
 from unittest.mock import patch
 
 from homeassistant.components.media_player.const import (
@@ -306,8 +305,7 @@ async def test_browse_media(
     assert msg["success"]
     result = msg["result"]
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "show"
-    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
-    result_id = int(json.loads(result_payload)["plex_key"])
+    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
     assert result["title"] == mock_plex_server.fetch_item(result_id).title
     assert result["children"][0]["title"] == f"{mock_season.title} ({mock_season.year})"
 
@@ -337,8 +335,7 @@ async def test_browse_media(
     assert msg["success"]
     result = msg["result"]
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "season"
-    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
-    result_id = int(json.loads(result_payload)["plex_key"])
+    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
     assert (
         result["title"]
         == f"{mock_season.parentTitle} - {mock_season.title} ({mock_season.year})"
@@ -393,8 +390,7 @@ async def test_browse_media(
     assert mock_fetch.called
     assert msg["success"]
     result = msg["result"]
-    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
-    result_id = int(json.loads(result_payload)["plex_key"])
+    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "artist"
     assert result["title"] == mock_artist.title
     assert result["children"][0]["title"] == "Radio Station"
@@ -415,8 +411,7 @@ async def test_browse_media(
 
     assert msg["success"]
     result = msg["result"]
-    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
-    result_id = int(json.loads(result_payload)["plex_key"])
+    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "album"
     assert (
         result["title"]

--- a/tests/components/plex/test_browse_media.py
+++ b/tests/components/plex/test_browse_media.py
@@ -1,5 +1,6 @@
 """Tests for Plex media browser."""
 from http import HTTPStatus
+import json
 from unittest.mock import patch
 
 from homeassistant.components.media_player.const import (
@@ -305,7 +306,8 @@ async def test_browse_media(
     assert msg["success"]
     result = msg["result"]
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "show"
-    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
+    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
+    result_id = int(json.loads(result_payload)["plex_key"])
     assert result["title"] == mock_plex_server.fetch_item(result_id).title
     assert result["children"][0]["title"] == f"{mock_season.title} ({mock_season.year})"
 
@@ -335,7 +337,8 @@ async def test_browse_media(
     assert msg["success"]
     result = msg["result"]
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "season"
-    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
+    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
+    result_id = int(json.loads(result_payload)["plex_key"])
     assert (
         result["title"]
         == f"{mock_season.parentTitle} - {mock_season.title} ({mock_season.year})"
@@ -390,7 +393,8 @@ async def test_browse_media(
     assert mock_fetch.called
     assert msg["success"]
     result = msg["result"]
-    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
+    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
+    result_id = int(json.loads(result_payload)["plex_key"])
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "artist"
     assert result["title"] == mock_artist.title
     assert result["children"][0]["title"] == "Radio Station"
@@ -411,7 +415,8 @@ async def test_browse_media(
 
     assert msg["success"]
     result = msg["result"]
-    result_id = int(result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :])
+    result_payload = result[ATTR_MEDIA_CONTENT_ID][len(PLEX_URI_SCHEME) :]
+    result_id = int(json.loads(result_payload)["plex_key"])
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "album"
     assert (
         result["title"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will autoresume items from the last partially watched position when played from the special "Continue Watching" or "On Deck" folders in the Plex media browser.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.


The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
