### PR TITLE
Bump mypy to 0.940

### DIFF
--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -98,7 +98,7 @@ class CO2Sensor(update_coordinator.CoordinatorEntity[CO2SignalResponse], SensorE
     @property
     def native_value(self) -> StateType:
         """Return sensor state."""
-        if (value := self.coordinator.data["data"][self._description.key]) is None:  # type: ignore[misc]
+        if (value := self.coordinator.data["data"][self._description.key]) is None:  # type: ignore[literal-required]
             return None
         return round(value, 2)
 

--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -291,7 +291,7 @@ class EnergyManager:
             "device_consumption",
         ):
             if key in update:
-                data[key] = update[key]  # type: ignore[misc]
+                data[key] = update[key]  # type: ignore[literal-required]
 
         self.data = data
         self._store.async_delay_save(lambda: cast(dict, self.data), 60)

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -102,9 +102,9 @@ def async_populate_data_from_discovery(
             device.get(discovery_key) is not None
             and conf_key
             not in data_updates  # Prefer the model num from TCP instead of UDP
-            and current_data.get(conf_key) != device[discovery_key]  # type: ignore[misc]
+            and current_data.get(conf_key) != device[discovery_key]  # type: ignore[literal-required]
         ):
-            data_updates[conf_key] = device[discovery_key]  # type: ignore[misc]
+            data_updates[conf_key] = device[discovery_key]  # type: ignore[literal-required]
 
 
 @callback

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -44,7 +44,6 @@ def _async_device_entities(
     for device in data.get_by_types({model_type}):
         assert isinstance(device, (Camera, Light, Sensor, Viewer, Doorlock))
         for description in descs:
-            assert isinstance(description, EntityDescription)
             if description.ufp_required_field:
                 required_field = get_nested_attr(device, description.ufp_required_field)
                 if not required_field:

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -18,7 +18,7 @@ T = TypeVar("T", bound=ProtectDeviceModel)
 
 
 @dataclass
-class ProtectRequiredKeysMixin(Generic[T]):
+class ProtectRequiredKeysMixin(EntityDescription, Generic[T]):
     """Mixin for required keys."""
 
     ufp_required_field: str | None = None
@@ -54,7 +54,6 @@ class ProtectSetableKeysMixin(ProtectRequiredKeysMixin, Generic[T]):
 
     async def ufp_set(self, obj: T, value: Any) -> None:
         """Set value for UniFi Protect device."""
-        assert isinstance(self, EntityDescription)
         _LOGGER.debug("Setting %s to %s for %s", self.name, value, obj.name)
         if self.ufp_set_method is not None:
             await getattr(obj, self.ufp_set_method)(value)

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -478,7 +478,7 @@ class EntityPlatform:
                     "via_device",
                 ):
                     if key in device_info:
-                        processed_dev_info[key] = device_info[key]  # type: ignore[misc]
+                        processed_dev_info[key] = device_info[key]  # type: ignore[literal-required]
 
                 if "configuration_url" in device_info:
                     if device_info["configuration_url"] is None:

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,7 @@ warn_incomplete_stub = true
 warn_redundant_casts = true
 warn_unused_configs = true
 warn_unused_ignores = true
+enable_error_code = ignore-without-code
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_subclassing_any = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ codecov==2.1.12
 coverage==6.3.2
 freezegun==1.1.0
 mock-open==1.4.0
-mypy==0.931
+mypy==0.940
 pre-commit==2.17.0
 pylint==2.12.2
 pipdeptree==2.2.1

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -247,6 +247,7 @@ GENERAL_SETTINGS: Final[dict[str, str]] = {
     "warn_redundant_casts": "true",
     "warn_unused_configs": "true",
     "warn_unused_ignores": "true",
+    "enable_error_code": "ignore-without-code",
 }
 
 # This is basically the list of checks which is enabled for "strict=true".


### PR DESCRIPTION
## Proposed change
Bump mypy to 0.940.
Blog post: http://mypy-lang.blogspot.com/2022/03/mypy-0940-released.html

Most relevant change(s):
* New `ignore-without-code` option. Used to require an error code with `type: ignore`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
