### PR TITLE
Add diagnostics to stream's Stream objects

### DIFF
--- a/homeassistant/components/stream/diagnostics.py
+++ b/homeassistant/components/stream/diagnostics.py
@@ -1,0 +1,33 @@
+"""Diagnostics for debugging.
+
+The stream component does not have config entries itself, and all diagnostics
+information is managed by dependent components (e.g. camera)
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+
+class Diagnostics:
+    """Holds diagnostics counters and key/values."""
+
+    def __init__(self) -> None:
+        """Initialize Diagnostics."""
+        self._counter: Counter = Counter()
+        self._values: dict[str, Any] = {}
+
+    def increment(self, key: str) -> None:
+        """Increment a counter for the spcified key/event."""
+        self._counter.update(Counter({key: 1}))
+
+    def set_value(self, key: str, value: Any) -> None:
+        """Update a key/value pair."""
+        self._values[key] = value
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return diagnostics as a debug dictionary."""
+        result = {k: self._counter[k] for k in self._counter}
+        result.update(self._values)
+        return result

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -477,9 +477,9 @@ def stream_worker(
     if audio_stream and audio_stream.profile is None:
         audio_stream = None
     stream_state.diagnostics.set_value("container_format", container.format.name)
-    stream_state.diagnostics.set_value("video_stream", video_stream.name)
+    stream_state.diagnostics.set_value("video_codec", video_stream.name)
     if audio_stream:
-        stream_state.diagnostics.set_value("audio_stream", audio_stream.name)
+        stream_state.diagnostics.set_value("audio_codec", audio_stream.name)
 
     dts_validator = TimestampValidator()
     container_packets = PeekIterator(

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -177,6 +177,14 @@ async def test_hls_stream(
     fail_response = await hls_client.get()
     assert fail_response.status == HTTPStatus.NOT_FOUND
 
+    assert stream.get_diagnostics() == {
+        "container_format": "mov,mp4,m4a,3gp,3g2,mj2",
+        "keepalive": False,
+        "start_worker": 1,
+        "video_stream": "h264",
+        "worker_error": 1,
+    }
+
 
 async def test_stream_timeout(
     hass, hass_client, setup_component, stream_worker_sync, h264_video

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -181,7 +181,7 @@ async def test_hls_stream(
         "container_format": "mov,mp4,m4a,3gp,3g2,mj2",
         "keepalive": False,
         "start_worker": 1,
-        "video_stream": "h264",
+        "video_codec": "h264",
         "worker_error": 1,
     }
 

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -270,7 +270,7 @@ class MockPyAv:
 
 def run_worker(hass, stream, stream_source):
     """Run the stream worker under test."""
-    stream_state = StreamState(hass, stream.outputs)
+    stream_state = StreamState(hass, stream.outputs, stream._diagnostics)
     stream_worker(
         stream_source, {}, stream_state, KeyFrameConverter(hass), threading.Event()
     )
@@ -872,6 +872,14 @@ async def test_h265_video_is_hvc1(hass, record_worker_sync):
     await record_worker_sync.join()
 
     stream.stop()
+
+    assert stream.get_diagnostics() == {
+        "container_format": "mov,mp4,m4a,3gp,3g2,mj2",
+        "keepalive": False,
+        "start_worker": 1,
+        "video_stream": "hevc",
+        "worker_error": 1,
+    }
 
 
 async def test_get_image(hass, record_worker_sync):

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -877,7 +877,7 @@ async def test_h265_video_is_hvc1(hass, record_worker_sync):
         "container_format": "mov,mp4,m4a,3gp,3g2,mj2",
         "keepalive": False,
         "start_worker": 1,
-        "video_stream": "hevc",
+        "video_codec": "hevc",
         "worker_error": 1,
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics key/value pair to the Stream object. Diagnostics support
in camera integration will be added in a follow up and will access the
diagnostics on the Stream object, similar to the examples in the unit
test.

This does not do anything on its own until camera calls it, but pulled out into a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
