### PR TITLE
Add switch platform to the Mazda integration

### DIFF
--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -43,6 +43,7 @@ PLATFORMS = [
     Platform.DEVICE_TRACKER,
     Platform.LOCK,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 
@@ -52,7 +53,9 @@ async def with_timeout(task, timeout_seconds=10):
         return await task
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(  # noqa: C901
+    hass: HomeAssistant, entry: ConfigEntry
+) -> bool:
     """Set up Mazda Connected Services from a config entry."""
     email = entry.data[CONF_EMAIL]
     password = entry.data[CONF_PASSWORD]
@@ -117,6 +120,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning(
                 "The mazda.%s service is deprecated and has been replaced by a button entity; "
                 "Please use the button entity instead",
+                service_call.service,
+            )
+
+        if service_call.service in ("start_charging", "stop_charging"):
+            _LOGGER.warning(
+                "The mazda.%s service is deprecated and has been replaced by a switch entity; "
+                "Please use the charging switch entity instead",
                 service_call.service,
             )
 

--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -53,9 +53,7 @@ async def with_timeout(task, timeout_seconds=10):
         return await task
 
 
-async def async_setup_entry(  # noqa: C901
-    hass: HomeAssistant, entry: ConfigEntry
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Mazda Connected Services from a config entry."""
     email = entry.data[CONF_EMAIL]
     password = entry.data[CONF_PASSWORD]
@@ -223,17 +221,12 @@ async def async_setup_entry(  # noqa: C901
 
     # Register services
     for service in SERVICES:
-        if service == "send_poi":
-            hass.services.async_register(
-                DOMAIN,
-                service,
-                async_handle_service_call,
-                schema=service_schema_send_poi,
-            )
-        else:
-            hass.services.async_register(
-                DOMAIN, service, async_handle_service_call, schema=service_schema
-            )
+        hass.services.async_register(
+            DOMAIN,
+            service,
+            async_handle_service_call,
+            schema=service_schema_send_poi if service == "send_poi" else service_schema,
+        )
 
     return True
 

--- a/homeassistant/components/mazda/switch.py
+++ b/homeassistant/components/mazda/switch.py
@@ -1,0 +1,73 @@
+"""Platform for Mazda switch integration."""
+from pymazda import Client as MazdaAPIClient
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import MazdaEntity
+from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the switch platform."""
+    client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+
+    async_add_entities(
+        MazdaChargingSwitch(client, coordinator, index)
+        for index, data in enumerate(coordinator.data)
+        if data["isElectric"]
+    )
+
+
+class MazdaChargingSwitch(MazdaEntity, SwitchEntity):
+    """Class for the charging switch."""
+
+    def __init__(
+        self,
+        client: MazdaAPIClient,
+        coordinator: DataUpdateCoordinator,
+        index: int,
+    ) -> None:
+        """Initialize Mazda charging switch."""
+        super().__init__(client, coordinator, index)
+
+        self._attr_name = f"{self.vehicle_name} Charging"
+        self._attr_unique_id = self.vin
+        self._attr_icon = "mdi:ev-station"
+
+    @property
+    def is_on(self):
+        """Return true if the vehicle is charging."""
+        return self.data["evStatus"]["chargeInfo"]["charging"]
+
+    async def async_turn_on(self, **kwargs):
+        """Start charging the vehicle."""
+        await self.client.start_charging(self.vehicle_id)
+
+        # Request that the vehicle provide a status update
+        await self.client.refresh_vehicle_status(self.vehicle_id)
+
+        # Retrieve the latest status update
+        await self.coordinator.async_request_refresh()
+
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Stop charging the vehicle."""
+        await self.client.stop_charging(self.vehicle_id)
+
+        # Request that the vehicle provide a status update
+        await self.client.refresh_vehicle_status(self.vehicle_id)
+
+        # Retrieve the latest status update
+        await self.coordinator.async_request_refresh()
+
+        self.async_write_ha_state()

--- a/tests/components/mazda/test_switch.py
+++ b/tests/components/mazda/test_switch.py
@@ -1,0 +1,68 @@
+"""The switch tests for the Mazda Connected Services integration."""
+
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+
+async def test_switch_setup(hass):
+    """Test setup of the switch entity."""
+    await init_integration(hass, electric_vehicle=True)
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("switch.my_mazda3_charging")
+    assert entry
+    assert entry.unique_id == "JM000000000000000"
+
+    state = hass.states.get("switch.my_mazda3_charging")
+    assert state
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Charging"
+
+    assert state.state == STATE_ON
+
+
+async def test_start_charging(hass):
+    """Test turning on the charging switch."""
+    client_mock = await init_integration(hass, electric_vehicle=True)
+
+    client_mock.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.my_mazda3_charging"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    client_mock.start_charging.assert_called_once()
+    client_mock.refresh_vehicle_status.assert_called_once()
+    client_mock.get_vehicle_status.assert_called_once()
+    client_mock.get_ev_vehicle_status.assert_called_once()
+
+
+async def test_stop_charging(hass):
+    """Test turning off the charging switch."""
+    client_mock = await init_integration(hass, electric_vehicle=True)
+
+    client_mock.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.my_mazda3_charging"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    client_mock.stop_charging.assert_called_once()
+    client_mock.refresh_vehicle_status.assert_called_once()
+    client_mock.get_vehicle_status.assert_called_once()
+    client_mock.get_ev_vehicle_status.assert_called_once()

--- a/tests/components/mazda/test_switch.py
+++ b/tests/components/mazda/test_switch.py
@@ -6,7 +6,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
     STATE_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_ICON
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
@@ -24,6 +24,7 @@ async def test_switch_setup(hass):
     state = hass.states.get("switch.my_mazda3_charging")
     assert state
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Charging"
+    assert state.attributes.get(ATTR_ICON) == "mdi:ev-station"
 
     assert state.state == STATE_ON
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Mazda services `start_charging` and `stop_charging` are deprecated and replaced by a charging switch entity. Please use the switch entity instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a switch entity to view and control the charging state of the vehicle. The entity will only be created if the vehicle is electric.

If possible, it would be great if this could be included in 2022.4, so that the breaking changes can occur in the same release as those from https://github.com/home-assistant/core/pull/67597, instead of having breaking changes in two separate releases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21984

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
