### PR TITLE
Add fan support for decora_wifi component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -195,7 +195,7 @@ omit =
     homeassistant/components/darksky/weather.py
     homeassistant/components/ddwrt/device_tracker.py
     homeassistant/components/decora/light.py
-    homeassistant/components/decora_wifi/light.py
+    homeassistant/components/decora_wifi/*
     homeassistant/components/delijn/*
     homeassistant/components/deluge/sensor.py
     homeassistant/components/deluge/switch.py

--- a/.strict-typing
+++ b/.strict-typing
@@ -66,6 +66,7 @@ homeassistant.components.deconz.config_flow
 homeassistant.components.deconz.diagnostics
 homeassistant.components.deconz.gateway
 homeassistant.components.deconz.services
+homeassistant.components.decora_wifi.*
 homeassistant.components.device_automation.*
 homeassistant.components.device_tracker.*
 homeassistant.components.devolo_home_control.*

--- a/homeassistant/components/decora_wifi/common.py
+++ b/homeassistant/components/decora_wifi/common.py
@@ -1,0 +1,141 @@
+"""Shared utilities for the decora_wifi platform."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+import logging
+from typing import Any
+
+# pylint: disable=import-error
+from decora_wifi import DecoraWiFiSession
+from decora_wifi.models.iot_switch import IotSwitch
+from decora_wifi.models.person import Person
+from decora_wifi.models.residence import Residence
+from decora_wifi.models.residential_account import ResidentialAccount
+
+from homeassistant.components import persistent_notification
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+_LOGGER = logging.getLogger(__name__)
+
+NOTIFICATION_ID = "leviton_notification"
+NOTIFICATION_TITLE = "myLeviton Decora Setup"
+
+
+class BaseDecoraWifiEntity(Entity):
+    """Encapsulates common functionality for all Decora Wifi switches."""
+
+    def __init__(self, switch: IotSwitch) -> None:
+        """Initialize BaseDecoraWifiEntity."""
+        self._switch = switch
+        self._attr_unique_id = str(switch.id)
+
+    @property
+    def name(self) -> str:
+        """Get the switch's name."""
+
+        return str(self._switch.name)
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the switch is on."""
+
+        return str(self._switch.power) == "ON"
+
+    def turn_off(self, **kwargs: dict[str, Any]) -> None:
+        """Turn the switch off."""
+
+        attribs = {"power": "OFF"}
+        try:
+            self._switch.update_attributes(attribs)
+        except ValueError:
+            _LOGGER.error("Failed to turn off myLeviton switch")
+
+    def update(self) -> None:
+        """Fetch the switch's current state."""
+
+        try:
+            self._switch.refresh()
+        except ValueError:
+            _LOGGER.error("Failed to update myLeviton switch data")
+
+
+class EntityTypes(Enum):
+    """Supported Decora WiFi entity types."""
+
+    LIGHT = auto()
+    FAN = auto()
+
+
+def _setup_platform(
+    entity_type: EntityTypes,
+    model: type[BaseDecoraWifiEntity],
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    email = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    session = DecoraWiFiSession()
+
+    try:
+        success = session.login(email, password)
+
+        # If login failed, notify user.
+        if success is None:
+            msg = "Failed to log into myLeviton Services. Check credentials."
+            _LOGGER.error(msg)
+            persistent_notification.create(
+                hass, msg, title=NOTIFICATION_TITLE, notification_id=NOTIFICATION_ID
+            )
+            return
+
+        # Gather all the available devices...
+        perms = session.user.get_residential_permissions()
+        all_switches = []
+        for permission in perms:
+            if permission.residentialAccountId is not None:
+                acct = ResidentialAccount(session, permission.residentialAccountId)
+                for residence in acct.get_residences():
+                    for switch in residence.get_iot_switches():
+                        all_switches.append(switch)
+            elif permission.residenceId is not None:
+                residence = Residence(session, permission.residenceId)
+                for switch in residence.get_iot_switches():
+                    all_switches.append(switch)
+
+        switches = filter(
+            None,
+            [map_switch_type(entity_type, model, sw) for sw in all_switches],
+        )
+        add_entities(switches)
+    except ValueError:
+        _LOGGER.error("Failed to communicate with myLeviton Service")
+
+    # Listen for the stop event and log out.
+    def logout(event: Event) -> None:
+        try:
+            if session is not None:
+                Person.logout(session)
+        except ValueError:
+            _LOGGER.error("Failed to log out of myLeviton Service")
+
+    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
+
+
+def map_switch_type(
+    entity_type: EntityTypes, model: type[BaseDecoraWifiEntity], switch: IotSwitch
+) -> BaseDecoraWifiEntity | None:
+    """Map decora_wifi's IotSwitch type to custom types as appropriate."""
+
+    fan_models = ["DW4SF"]
+    if entity_type == EntityTypes.FAN and switch.model in fan_models:
+        return model(switch)
+    if entity_type == EntityTypes.LIGHT and switch.model not in fan_models:
+        return model(switch)
+    return None

--- a/homeassistant/components/decora_wifi/fan.py
+++ b/homeassistant/components/decora_wifi/fan.py
@@ -1,0 +1,138 @@
+"""Interfaces with the myLeviton API for Decora Smart WiFi products."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.fan import (
+    PLATFORM_SCHEMA,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_SET_SPEED,
+    FanEntity,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .common import BaseDecoraWifiEntity, EntityTypes, _setup_platform
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up Decora fan controllers."""
+
+    _setup_platform(
+        EntityTypes.FAN,
+        DecoraWifiFanController,
+        hass,
+        config,
+        add_entities,
+        discovery_info,
+    )
+
+
+class DecoraWifiFanController(BaseDecoraWifiEntity, FanEntity):
+    """Encapsulates functionality specific to Decora WiFi fan controllers."""
+
+    PERCENTAGE_ATTRIB_KEY = "brightness"
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of supported non-zero speeds."""
+
+        return len(self.preset_modes) - 1
+
+    @property
+    def supported_features(self) -> int:
+        """Return supported features."""
+
+        if self._switch.canSetLevel:
+            return SUPPORT_SET_SPEED | SUPPORT_PRESET_MODE
+        return 0
+
+    @property
+    def preset_modes(self) -> list[str]:
+        """Return the supported preset modes."""
+
+        return ["Off", "Low", "Medium", "High", "Max"]
+
+    @property
+    def preset_mode(self) -> str:
+        """Return the current preset name."""
+
+        percentage = self._switch.brightness
+        idx = int(percentage / self.percentage_step)
+        return self.preset_modes[idx]
+
+    @property
+    def percentage(self) -> int:
+        """Return the current percentage."""
+
+        return int(self._switch.brightness)
+
+    def turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> None:
+        """Turn the fan on."""
+
+        attribs: dict[str, Any] = {"power": "ON"}
+
+        if percentage is not None:
+            attribs[self.PERCENTAGE_ATTRIB_KEY] = self._get_valid_percentage(percentage)
+        elif preset_mode is not None:
+            attribs[self.PERCENTAGE_ATTRIB_KEY] = self._preset_mode_to_percentage(
+                preset_mode
+            )
+
+        try:
+            self._switch.update_attributes(attribs)
+        except ValueError:
+            _LOGGER.error("Failed to turn on myLeviton switch")
+
+    def set_percentage(self, percentage: int) -> None:
+        """Update the fan's speed."""
+
+        percentage = self._get_valid_percentage(percentage)
+        if percentage == 0:
+            self.turn_off()
+        else:
+            self.turn_on(percentage=percentage)
+
+    def _get_valid_percentage(self, percentage: int) -> int:
+        """Get the nearest valid fan speed."""
+
+        return percentage * round(percentage / self.percentage_step)
+
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Update the fan's speed based on a preset."""
+
+        if preset_mode == self.preset_modes[0]:
+            self.turn_off()
+        else:
+            self.turn_on(preset_mode=preset_mode)
+
+    def _preset_mode_to_percentage(self, preset_mode: str) -> int:
+        """Convert a preset mode to a percentage."""
+
+        if preset_mode not in self.preset_modes:
+            return 0
+
+        return int(self.preset_modes.index(preset_mode) * self.percentage_step)

--- a/homeassistant/components/decora_wifi/light.py
+++ b/homeassistant/components/decora_wifi/light.py
@@ -2,15 +2,10 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
-# pylint: disable=import-error
-from decora_wifi import DecoraWiFiSession
-from decora_wifi.models.person import Person
-from decora_wifi.models.residence import Residence
-from decora_wifi.models.residential_account import ResidentialAccount
 import voluptuous as vol
 
-from homeassistant.components import persistent_notification
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_TRANSITION,
@@ -19,21 +14,20 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     LightEntity,
 )
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger(__name__)
+from .common import BaseDecoraWifiEntity, EntityTypes, _setup_platform
 
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
 )
 
-NOTIFICATION_ID = "leviton_notification"
-NOTIFICATION_TITLE = "myLeviton Decora Setup"
+_LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(
@@ -42,87 +36,34 @@ def setup_platform(
     add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Decora WiFi platform."""
+    """Set up Decora lights."""
 
-    email = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
-    session = DecoraWiFiSession()
-
-    try:
-        success = session.login(email, password)
-
-        # If login failed, notify user.
-        if success is None:
-            msg = "Failed to log into myLeviton Services. Check credentials."
-            _LOGGER.error(msg)
-            persistent_notification.create(
-                hass, msg, title=NOTIFICATION_TITLE, notification_id=NOTIFICATION_ID
-            )
-            return
-
-        # Gather all the available devices...
-        perms = session.user.get_residential_permissions()
-        all_switches = []
-        for permission in perms:
-            if permission.residentialAccountId is not None:
-                acct = ResidentialAccount(session, permission.residentialAccountId)
-                for residence in acct.get_residences():
-                    for switch in residence.get_iot_switches():
-                        all_switches.append(switch)
-            elif permission.residenceId is not None:
-                residence = Residence(session, permission.residenceId)
-                for switch in residence.get_iot_switches():
-                    all_switches.append(switch)
-
-        add_entities(DecoraWifiLight(sw) for sw in all_switches)
-    except ValueError:
-        _LOGGER.error("Failed to communicate with myLeviton Service")
-
-    # Listen for the stop event and log out.
-    def logout(event):
-        """Log out..."""
-        try:
-            if session is not None:
-                Person.logout(session)
-        except ValueError:
-            _LOGGER.error("Failed to log out of myLeviton Service")
-
-    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
+    _setup_platform(
+        EntityTypes.LIGHT, DecoraWifiLight, hass, config, add_entities, discovery_info
+    )
 
 
-class DecoraWifiLight(LightEntity):
-    """Representation of a Decora WiFi switch."""
-
-    def __init__(self, switch):
-        """Initialize the switch."""
-        self._switch = switch
-        self._attr_unique_id = switch.serial
+class DecoraWifiLight(BaseDecoraWifiEntity, LightEntity):
+    """Encapsulates functionality specific to Decora WiFi fan controllers."""
 
     @property
-    def supported_features(self):
-        """Return supported features."""
+    def supported_features(self) -> int:
+        """Return the switch's supported features."""
+
         if self._switch.canSetLevel:
             return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
         return 0
 
     @property
-    def name(self):
-        """Return the display name of this switch."""
-        return self._switch.name
+    def brightness(self) -> int:
+        """Return the switch's current brightness."""
 
-    @property
-    def brightness(self):
-        """Return the brightness of the dimmer switch."""
         return int(self._switch.brightness * 255 / 100)
 
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self._switch.power == "ON"
+    def turn_on(self, **kwargs: dict[str, Any]) -> None:
+        """Turn the light on and adjust brightness."""
 
-    def turn_on(self, **kwargs):
-        """Instruct the switch to turn on & adjust brightness."""
-        attribs = {"power": "ON"}
+        attribs: dict[str, Any] = {"power": "ON"}
 
         if ATTR_BRIGHTNESS in kwargs:
             min_level = self._switch.data.get("minLevel", 0)
@@ -132,25 +73,10 @@ class DecoraWifiLight(LightEntity):
             attribs["brightness"] = brightness
 
         if ATTR_TRANSITION in kwargs:
-            transition = int(kwargs[ATTR_TRANSITION])
+            transition = kwargs[ATTR_TRANSITION]
             attribs["fadeOnTime"] = attribs["fadeOffTime"] = transition
 
         try:
             self._switch.update_attributes(attribs)
         except ValueError:
             _LOGGER.error("Failed to turn on myLeviton switch")
-
-    def turn_off(self, **kwargs):
-        """Instruct the switch to turn off."""
-        attribs = {"power": "OFF"}
-        try:
-            self._switch.update_attributes(attribs)
-        except ValueError:
-            _LOGGER.error("Failed to turn off myLeviton switch")
-
-    def update(self):
-        """Fetch new state data for this switch."""
-        try:
-            self._switch.refresh()
-        except ValueError:
-            _LOGGER.error("Failed to update myLeviton switch data")

--- a/mypy.ini
+++ b/mypy.ini
@@ -528,6 +528,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.decora_wifi.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.device_automation.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds explicit support for Leviton Decora fan controllers. Leviton fan
controllers only support increments of 25% power, so it can be frustrating to
try to get a light entity to land precisely on an increment of 25% for a fan
controller.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21996

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] ~New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
