### PR TITLE
Bump amcrest version to 1.9.7

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -52,6 +52,7 @@ from .const import (
     DATA_AMCREST,
     DEVICES,
     DOMAIN,
+    RESOLUTION_LIST,
     SERVICE_EVENT,
     SERVICE_UPDATE,
 )
@@ -75,8 +76,6 @@ RECHECK_INTERVAL = timedelta(minutes=1)
 
 NOTIFICATION_ID = "amcrest_notification"
 NOTIFICATION_TITLE = "Amcrest Camera Setup"
-
-RESOLUTION_LIST = {"high": 0, "low": 1}
 
 SCAN_INTERVAL = timedelta(seconds=10)
 

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -35,6 +35,7 @@ from .const import (
     DATA_AMCREST,
     DEVICES,
     DOMAIN,
+    RESOLUTION_TO_STREAM,
     SERVICE_UPDATE,
     SNAPSHOT_TIMEOUT,
 )
@@ -533,13 +534,14 @@ class AmcrestCam(Camera):
                 return
 
     async def _async_get_video(self) -> bool:
-        stream = {0: "Main", 1: "Extra"}
         return await self._api.async_is_video_enabled(
-            channel=0, stream=stream[self._resolution]
+            channel=0, stream=RESOLUTION_TO_STREAM[self._resolution]
         )
 
     async def _async_set_video(self, enable: bool) -> None:
-        await self._api.async_set_video_enabled(enable, channel=0)
+        await self._api.async_set_video_enabled(
+            enable, channel=0, stream=RESOLUTION_TO_STREAM[self._resolution]
+        )
 
     async def _async_enable_video(self, enable: bool) -> None:
         """Enable or disable camera video stream."""
@@ -585,10 +587,14 @@ class AmcrestCam(Camera):
         )
 
     async def _async_get_audio(self) -> bool:
-        return await self._api.async_audio_enabled
+        return await self._api.async_is_audio_enabled(
+            channel=0, stream=RESOLUTION_TO_STREAM[self._resolution]
+        )
 
     async def _async_set_audio(self, enable: bool) -> None:
-        await self._api.async_set_audio_enabled(enable)
+        await self._api.async_set_audio_enabled(
+            enable, channel=0, stream=RESOLUTION_TO_STREAM[self._resolution]
+        )
 
     async def _async_enable_audio(self, enable: bool) -> None:
         """Enable or disable audio stream."""

--- a/homeassistant/components/amcrest/const.py
+++ b/homeassistant/components/amcrest/const.py
@@ -13,3 +13,6 @@ SNAPSHOT_TIMEOUT = 20
 
 SERVICE_EVENT = "event"
 SERVICE_UPDATE = "update"
+
+RESOLUTION_LIST = {"high": 0, "low": 1}
+RESOLUTION_TO_STREAM = {0: "Main", 1: "Extra"}

--- a/homeassistant/components/amcrest/manifest.json
+++ b/homeassistant/components/amcrest/manifest.json
@@ -2,7 +2,7 @@
   "domain": "amcrest",
   "name": "Amcrest",
   "documentation": "https://www.home-assistant.io/integrations/amcrest",
-  "requirements": ["amcrest==1.9.5"],
+  "requirements": ["amcrest==1.9.7"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@flacjacket"],
   "iot_class": "local_polling",

--- a/homeassistant/components/amcrest/manifest.json
+++ b/homeassistant/components/amcrest/manifest.json
@@ -2,7 +2,7 @@
   "domain": "amcrest",
   "name": "Amcrest",
   "documentation": "https://www.home-assistant.io/integrations/amcrest",
-  "requirements": ["amcrest==1.9.4"],
+  "requirements": ["amcrest==1.9.5"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@flacjacket"],
   "iot_class": "local_polling",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -286,7 +286,7 @@ amberelectric==1.0.3
 ambiclimate==0.2.1
 
 # homeassistant.components.amcrest
-amcrest==1.9.4
+amcrest==1.9.5
 
 # homeassistant.components.androidtv
 androidtv[async]==0.0.63

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -286,7 +286,7 @@ amberelectric==1.0.3
 ambiclimate==0.2.1
 
 # homeassistant.components.amcrest
-amcrest==1.9.5
+amcrest==1.9.7
 
 # homeassistant.components.androidtv
 androidtv[async]==0.0.63


### PR DESCRIPTION
## Type of change

Bump the `amcrest` python dependency to the latest version. Of note here:
- This release adds additional handling of httpx exceptions which should alleviate some of the spurious 500 errors that would leak through.
- There are API changes that allow the video and audio to be enabled and disabled on the particular stream, which is applied in this update.
- New error handling and retry logic should allow the event stream to error out and retry when the camera is disconnected rather than continuing to read when it should have timed out.

Changelogs [1.9.5](https://github.com/tchellomello/python-amcrest/releases/tag/1.9.5) [1.9.6](https://github.com/tchellomello/python-amcrest/releases/tag/1.9.6) [1.9.7](https://github.com/tchellomello/python-amcrest/releases/tag/1.9.7) [full changes](https://github.com/tchellomello/python-amcrest/compare/1.9.4...1.9.7)

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - Fixes #66601
  - Fixes #66633
  - Fixes #66661
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
