### PR TITLE
Add base entity to Switch as X

### DIFF
--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -1,0 +1,86 @@
+"""Base entity for the Switch as X integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import Event, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.event import async_track_state_change_event
+
+
+class BaseEntity(ToggleEntity):
+    """Represents a Switch as a X."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        name: str,
+        switch_entity_id: str,
+        unique_id: str | None,
+        device_id: str | None = None,
+    ) -> None:
+        """Initialize Light Switch."""
+        self._device_id = device_id
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        self._switch_entity_id = switch_entity_id
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Forward the turn_on command to the switch in this light switch."""
+        await self.hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._switch_entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Forward the turn_off command to the switch in this light switch."""
+        await self.hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._switch_entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+
+        @callback
+        def async_state_changed_listener(event: Event | None = None) -> None:
+            """Handle child updates."""
+            if (
+                state := self.hass.states.get(self._switch_entity_id)
+            ) is None or state.state == STATE_UNAVAILABLE:
+                self._attr_available = False
+                return
+
+            self._attr_available = True
+            self._attr_is_on = state.state == STATE_ON
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._switch_entity_id], async_state_changed_listener
+            )
+        )
+
+        # Call once on adding
+        async_state_changed_listener()
+
+        # Add this entity to the wrapped switch's device
+        registry = er.async_get(self.hass)
+        if registry.async_get(self.entity_id) is not None:
+            registry.async_update_entity(self.entity_id, device_id=self._device_id)

--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -13,11 +13,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.entity import Entity, ToggleEntity
 from homeassistant.helpers.event import async_track_state_change_event
 
 
-class BaseEntity(ToggleEntity):
+class BaseEntity(Entity):
     """Represents a Switch as a X."""
 
     _attr_should_poll = False
@@ -34,6 +34,44 @@ class BaseEntity(ToggleEntity):
         self._attr_name = name
         self._attr_unique_id = unique_id
         self._switch_entity_id = switch_entity_id
+
+    @callback
+    def async_state_changed_listener(self, event: Event | None = None) -> None:
+        """Handle child updates."""
+        if (
+            state := self.hass.states.get(self._switch_entity_id)
+        ) is None or state.state == STATE_UNAVAILABLE:
+            self._attr_available = False
+            return
+
+        self._attr_available = True
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+
+        @callback
+        def _async_state_changed_listener(event: Event | None = None) -> None:
+            """Handle child updates."""
+            self.async_state_changed_listener(event)
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._switch_entity_id], _async_state_changed_listener
+            )
+        )
+
+        # Call once on adding
+        _async_state_changed_listener()
+
+        # Add this entity to the wrapped switch's device
+        registry = er.async_get(self.hass)
+        if registry.async_get(self.entity_id) is not None:
+            registry.async_update_entity(self.entity_id, device_id=self._device_id)
+
+
+class BaseToggleEntity(BaseEntity, ToggleEntity):
+    """Represents a Switch as a ToggleEntity."""
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to the switch in this light switch."""
@@ -55,32 +93,14 @@ class BaseEntity(ToggleEntity):
             context=self._context,
         )
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
+    @callback
+    def async_state_changed_listener(self, event: Event | None = None) -> None:
+        """Handle child updates."""
+        super().async_state_changed_listener(event)
+        if (
+            not self.available
+            or (state := self.hass.states.get(self._switch_entity_id)) is None
+        ):
+            return
 
-        @callback
-        def async_state_changed_listener(event: Event | None = None) -> None:
-            """Handle child updates."""
-            if (
-                state := self.hass.states.get(self._switch_entity_id)
-            ) is None or state.state == STATE_UNAVAILABLE:
-                self._attr_available = False
-                return
-
-            self._attr_available = True
-            self._attr_is_on = state.state == STATE_ON
-            self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self._switch_entity_id], async_state_changed_listener
-            )
-        )
-
-        # Call once on adding
-        async_state_changed_listener()
-
-        # Add this entity to the wrapped switch's device
-        registry = er.async_get(self.hass)
-        if registry.async_get(self.entity_id) is not None:
-            registry.async_update_entity(self.entity_id, device_id=self._device_id)
+        self._attr_is_on = state.state == STATE_ON

--- a/homeassistant/components/switch_as_x/light.py
+++ b/homeassistant/components/switch_as_x/light.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import BaseEntity
+from .entity import BaseToggleEntity
 
 
 async def async_setup_entry(
@@ -36,7 +36,7 @@ async def async_setup_entry(
     )
 
 
-class LightSwitch(BaseEntity, LightEntity):
+class LightSwitch(BaseToggleEntity, LightEntity):
     """Represents a Switch as a Light."""
 
     _attr_color_mode = COLOR_MODE_ONOFF

--- a/homeassistant/components/switch_as_x/light.py
+++ b/homeassistant/components/switch_as_x/light.py
@@ -1,23 +1,14 @@
 """Light support for switch entities."""
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.light import COLOR_MODE_ONOFF, LightEntity
-from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    CONF_ENTITY_ID,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-)
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change_event
+
+from .entity import BaseEntity
 
 
 async def async_setup_entry(
@@ -26,7 +17,6 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Initialize Light Switch config entry."""
-
     registry = er.async_get(hass)
     entity_id = er.async_validate_entity_id(
         registry, config_entry.options[CONF_ENTITY_ID]
@@ -46,72 +36,8 @@ async def async_setup_entry(
     )
 
 
-class LightSwitch(LightEntity):
+class LightSwitch(BaseEntity, LightEntity):
     """Represents a Switch as a Light."""
 
     _attr_color_mode = COLOR_MODE_ONOFF
-    _attr_should_poll = False
     _attr_supported_color_modes = {COLOR_MODE_ONOFF}
-
-    def __init__(
-        self,
-        name: str,
-        switch_entity_id: str,
-        unique_id: str | None,
-        device_id: str | None = None,
-    ) -> None:
-        """Initialize Light Switch."""
-        self._device_id = device_id
-        self._attr_name = name
-        self._attr_unique_id = unique_id
-        self._switch_entity_id = switch_entity_id
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Forward the turn_on command to the switch in this light switch."""
-        await self.hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: self._switch_entity_id},
-            blocking=True,
-            context=self._context,
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Forward the turn_off command to the switch in this light switch."""
-        await self.hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: self._switch_entity_id},
-            blocking=True,
-            context=self._context,
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def async_state_changed_listener(event: Event | None = None) -> None:
-            """Handle child updates."""
-            if (
-                state := self.hass.states.get(self._switch_entity_id)
-            ) is None or state.state == STATE_UNAVAILABLE:
-                self._attr_available = False
-                return
-
-            self._attr_available = True
-            self._attr_is_on = state.state == STATE_ON
-            self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, [self._switch_entity_id], async_state_changed_listener
-            )
-        )
-
-        # Call once on adding
-        async_state_changed_listener()
-
-        # Add this entity to the wrapped switch's device
-        registry = er.async_get(self.hass)
-        if registry.async_get(self.entity_id) is not None:
-            registry.async_update_entity(self.entity_id, device_id=self._device_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extracts a base entity out of the LightSwitch entity. A bare entity, and one that handles toggle-based entities.

This is an intermediate step that allows for adding support for other entity platforms more easily in follow-up PRs (e.g., Fan, Cover, Humidifier, Siren, Lock, etc).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
