### PR TITLE
Migrate SleepIQ unique IDs that are using sleeper name instead of sleeper ID

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -144,7 +144,7 @@ async def _async_migrate_unique_ids(
         if parts[0] not in bed_ids or not old_unique_id.endswith(tuple(sensor_types)):
             return None
 
-        sensor_type = filter(old_unique_id.endswith, sensor_types).__next__()
+        sensor_type = next(filter(old_unique_id.endswith, sensor_types), None)
         sleeper_name = "_".join(parts[1:]).removesuffix(f"_{sensor_type}")
         sleeper_id = names_to_ids.get(sleeper_name)
 

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -128,7 +128,7 @@ async def _async_migrate_unique_ids(
         for sleeper in bed.sleepers
     }
 
-    bed_ids = [bed.id for bed in gateway.beds.values()]
+    bed_ids = {bed.id for bed in gateway.beds.values()}
 
     @callback
     def _async_migrator(entity_entry: er.RegistryEntry) -> dict[str, Any] | None:

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -1,5 +1,8 @@
 """Support for SleepIQ from SleepNumber."""
+from __future__ import annotations
+
 import logging
+from typing import Any
 
 from asyncsleepiq import (
     AsyncSleepIQ,
@@ -10,14 +13,15 @@ from asyncsleepiq import (
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, PRESSURE, Platform
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import DOMAIN, IS_IN_BED, SLEEP_NUMBER
 from .coordinator import (
     SleepIQData,
     SleepIQDataUpdateCoordinator,
@@ -87,6 +91,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except SleepIQAPIException as err:
         raise ConfigEntryNotReady(str(err) or "Error reading from SleepIQ API") from err
 
+    await _async_migrate_unique_ids(hass, entry, gateway)
+
     coordinator = SleepIQDataUpdateCoordinator(hass, gateway, email)
     pause_coordinator = SleepIQPauseUpdateCoordinator(hass, gateway, email)
 
@@ -110,3 +116,48 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, gateway: AsyncSleepIQ
+) -> None:
+    """Migrate old unique ids."""
+    names_to_ids = {
+        sleeper.name: sleeper.sleeper_id
+        for bed in gateway.beds.values()
+        for sleeper in bed.sleepers
+    }
+
+    bed_ids = [bed.id for bed in gateway.beds.values()]
+
+    @callback
+    def _async_migrator(entity_entry: er.RegistryEntry) -> dict[str, Any] | None:
+        # Old format for sleeper entities was {bed_id}_{sleeper.name}_{sensor_type}.....
+        # New format is {sleeper.sleeper_id}_{sensor_type}....
+        sensor_types = [IS_IN_BED, PRESSURE, SLEEP_NUMBER]
+
+        old_unique_id = entity_entry.unique_id
+        parts = old_unique_id.split("_")
+
+        # If it doesn't begin with a bed id or end with one of the sensor types,
+        # it doesn't need to be migrated
+        if parts[0] not in bed_ids or not old_unique_id.endswith(tuple(sensor_types)):
+            return None
+
+        sensor_type = filter(old_unique_id.endswith, sensor_types).__next__()
+        sleeper_name = "_".join(parts[1:]).removesuffix(f"_{sensor_type}")
+        sleeper_id = names_to_ids.get(sleeper_name)
+
+        if not sleeper_id:
+            return None
+
+        new_unique_id = f"{sleeper_id}_{sensor_type}"
+
+        _LOGGER.info(
+            "Migrating unique_id from [%s] to [%s]",
+            old_unique_id,
+            new_unique_id,
+        )
+        return {"new_unique_id": new_unique_id}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _async_migrator)

--- a/homeassistant/components/sleepiq/entity.py
+++ b/homeassistant/components/sleepiq/entity.py
@@ -78,4 +78,4 @@ class SleepIQSleeperEntity(SleepIQBedEntity):
         super().__init__(coordinator, bed)
 
         self._attr_name = f"SleepNumber {bed.name} {sleeper.name} {ENTITY_TYPES[name]}"
-        self._attr_unique_id = f"{bed.id}_{sleeper.name}_{name}"
+        self._attr_unique_id = f"{sleeper.sleeper_id}_{name}"

--- a/tests/components/sleepiq/test_binary_sensor.py
+++ b/tests/components/sleepiq/test_binary_sensor.py
@@ -10,11 +10,12 @@ from homeassistant.const import (
 from homeassistant.helpers import entity_registry as er
 
 from tests.components.sleepiq.conftest import (
-    BED_ID,
     BED_NAME,
     BED_NAME_LOWER,
+    SLEEPER_L_ID,
     SLEEPER_L_NAME,
     SLEEPER_L_NAME_LOWER,
+    SLEEPER_R_ID,
     SLEEPER_R_NAME,
     SLEEPER_R_NAME_LOWER,
     setup_platform,
@@ -41,7 +42,7 @@ async def test_binary_sensors(hass, mock_asyncsleepiq):
         f"binary_sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_is_in_bed"
     )
     assert entity
-    assert entity.unique_id == f"{BED_ID}_{SLEEPER_L_NAME}_is_in_bed"
+    assert entity.unique_id == f"{SLEEPER_L_ID}_is_in_bed"
 
     state = hass.states.get(
         f"binary_sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_is_in_bed"
@@ -58,4 +59,4 @@ async def test_binary_sensors(hass, mock_asyncsleepiq):
         f"binary_sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_is_in_bed"
     )
     assert entity
-    assert entity.unique_id == f"{BED_ID}_{SLEEPER_R_NAME}_is_in_bed"
+    assert entity.unique_id == f"{SLEEPER_R_ID}_is_in_bed"

--- a/tests/components/sleepiq/test_sensor.py
+++ b/tests/components/sleepiq/test_sensor.py
@@ -4,11 +4,12 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON
 from homeassistant.helpers import entity_registry as er
 
 from tests.components.sleepiq.conftest import (
-    BED_ID,
     BED_NAME,
     BED_NAME_LOWER,
+    SLEEPER_L_ID,
     SLEEPER_L_NAME,
     SLEEPER_L_NAME_LOWER,
+    SLEEPER_R_ID,
     SLEEPER_R_NAME,
     SLEEPER_R_NAME_LOWER,
     setup_platform,
@@ -34,7 +35,7 @@ async def test_sleepnumber_sensors(hass, mock_asyncsleepiq):
         f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_sleepnumber"
     )
     assert entry
-    assert entry.unique_id == f"{BED_ID}_{SLEEPER_L_NAME}_sleep_number"
+    assert entry.unique_id == f"{SLEEPER_L_ID}_sleep_number"
 
     state = hass.states.get(
         f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_sleepnumber"
@@ -50,7 +51,7 @@ async def test_sleepnumber_sensors(hass, mock_asyncsleepiq):
         f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_sleepnumber"
     )
     assert entry
-    assert entry.unique_id == f"{BED_ID}_{SLEEPER_R_NAME}_sleep_number"
+    assert entry.unique_id == f"{SLEEPER_R_ID}_sleep_number"
 
 
 async def test_pressure_sensors(hass, mock_asyncsleepiq):
@@ -72,7 +73,7 @@ async def test_pressure_sensors(hass, mock_asyncsleepiq):
         f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_pressure"
     )
     assert entry
-    assert entry.unique_id == f"{BED_ID}_{SLEEPER_L_NAME}_pressure"
+    assert entry.unique_id == f"{SLEEPER_L_ID}_pressure"
 
     state = hass.states.get(
         f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_pressure"
@@ -88,4 +89,4 @@ async def test_pressure_sensors(hass, mock_asyncsleepiq):
         f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_pressure"
     )
     assert entry
-    assert entry.unique_id == f"{BED_ID}_{SLEEPER_R_NAME}_pressure"
+    assert entry.unique_id == f"{SLEEPER_R_ID}_pressure"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a migration to the SleepIQ integration to migrate all the sensors and binary sensors that currently use the sleeper name in the unique ID. The migrated unique IDs use the sleeper ID instead of the name.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
