### PR TITLE
Small improvements for Switch as X

### DIFF
--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -11,11 +11,10 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 
+from .const import CONF_TARGET_DOMAIN
 from .light import LightSwitch
 
 __all__ = ["LightSwitch"]
-
-DOMAIN = "switch_as_x"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # If the tracked switch is no longer in the device, remove our config entry
             # from the device
             if (
-                not (entity_entry := registry.async_get(data["entity_id"]))
+                not (entity_entry := registry.async_get(data[CONF_ENTITY_ID]))
                 or not device_registry.async_get(device_id)
                 or entity_entry.device_id == device_id
             ):
@@ -91,12 +90,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_id = async_add_to_device(hass, entry, entity_id)
 
-    hass.config_entries.async_setup_platforms(entry, (entry.options["target_domain"],))
+    hass.config_entries.async_setup_platforms(
+        entry, (entry.options[CONF_TARGET_DOMAIN],)
+    )
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(
-        entry, (entry.options["target_domain"],)
+        entry, (entry.options[CONF_TARGET_DOMAIN],)
     )

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -6,19 +6,26 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.helpers import helper_config_entry_flow, selector
 
-from . import DOMAIN
+from .const import CONF_TARGET_DOMAIN, DOMAIN
 
 CONFIG_FLOW = {
     "user": helper_config_entry_flow.HelperFlowStep(
         vol.Schema(
             {
-                vol.Required("entity_id"): selector.selector(
-                    {"entity": {"domain": "switch"}}
+                vol.Required(CONF_ENTITY_ID): selector.selector(
+                    {"entity": {"domain": Platform.SWITCH}}
                 ),
-                vol.Required("target_domain"): selector.selector(
-                    {"select": {"options": ["light"]}}
+                vol.Required(CONF_TARGET_DOMAIN): selector.selector(
+                    {
+                        "select": {
+                            "options": [
+                                {"value": Platform.LIGHT, "label": "Light"},
+                            ]
+                        }
+                    }
                 ),
             }
         )
@@ -36,5 +43,5 @@ class SwitchAsXConfigFlowHandler(
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return helper_config_entry_flow.wrapped_entity_config_entry_title(
-            self.hass, options["entity_id"]
+            self.hass, options[CONF_ENTITY_ID]
         )

--- a/homeassistant/components/switch_as_x/const.py
+++ b/homeassistant/components/switch_as_x/const.py
@@ -1,0 +1,7 @@
+"""Constants for the Switch as X integration."""
+
+from typing import Final
+
+DOMAIN: Final = "switch_as_x"
+
+CONF_TARGET_DOMAIN: Final = "target_domain"

--- a/tests/components/switch_as_x/conftest.py
+++ b/tests/components/switch_as_x/conftest.py
@@ -1,0 +1,16 @@
+"""Fixtures for the Switch as X integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.switch_as_x.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -8,7 +8,6 @@ from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAI
 from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
-from homeassistant.helpers import entity_registry as er
 
 
 @pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
@@ -48,20 +47,6 @@ async def test_config_flow(
         CONF_ENTITY_ID: "switch.ceiling",
         CONF_TARGET_DOMAIN: target_domain,
     }
-
-    # Check the wrapped switch has a state and is added to the registry
-    state = hass.states.get(f"{target_domain}.ceiling")
-    assert state
-    assert state.state == "unavailable"
-
-    # Name copied from config entry title
-    assert state.name == "ceiling"
-
-    # Check the light is added to the entity registry
-    registry = er.async_get(hass)
-    entity_entry = registry.async_get(f"{target_domain}.ceiling")
-    assert entity_entry
-    assert entity_entry.unique_id == config_entry.entry_id
 
 
 @pytest.mark.parametrize("target_domain", (Platform.LIGHT,))

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -1,17 +1,22 @@
 """Test the Switch as X config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.switch_as_x import DOMAIN, async_setup_entry
+from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
 from homeassistant.helpers import entity_registry as er
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_config_flow(hass: HomeAssistant, target_domain) -> None:
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_config_flow(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    mock_setup_entry: AsyncMock,
+) -> None:
     """Test the config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -19,37 +24,34 @@ async def test_config_flow(hass: HomeAssistant, target_domain) -> None:
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    with patch(
-        "homeassistant.components.switch_as_x.async_setup_entry",
-        wraps=async_setup_entry,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "entity_id": "switch.ceiling",
-                "target_domain": target_domain,
-            },
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENTITY_ID: "switch.ceiling",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "ceiling"
     assert result["data"] == {}
     assert result["options"] == {
-        "entity_id": "switch.ceiling",
-        "target_domain": target_domain,
+        CONF_ENTITY_ID: "switch.ceiling",
+        CONF_TARGET_DOMAIN: target_domain,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert config_entry.data == {}
     assert config_entry.options == {
-        "entity_id": "switch.ceiling",
-        "target_domain": target_domain,
+        CONF_ENTITY_ID: "switch.ceiling",
+        CONF_TARGET_DOMAIN: target_domain,
     }
 
     # Check the wrapped switch has a state and is added to the registry
     state = hass.states.get(f"{target_domain}.ceiling")
+    assert state
     assert state.state == "unavailable"
 
     # Name copied from config entry title
@@ -58,11 +60,16 @@ async def test_config_flow(hass: HomeAssistant, target_domain) -> None:
     # Check the light is added to the entity registry
     registry = er.async_get(hass)
     entity_entry = registry.async_get(f"{target_domain}.ceiling")
+    assert entity_entry
     assert entity_entry.unique_id == config_entry.entry_id
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_options(hass: HomeAssistant, target_domain) -> None:
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_options(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    mock_setup_entry: AsyncMock,
+) -> None:
     """Test reconfiguring."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -70,15 +77,14 @@ async def test_options(hass: HomeAssistant, target_domain) -> None:
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    with patch(
-        "homeassistant.components.switch_as_x.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"entity_id": "switch.ceiling", "target_domain": target_domain},
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENTITY_ID: "switch.ceiling",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
 

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -3,22 +3,28 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.switch_as_x import DOMAIN
+from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import CONF_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_config_entry_unregistered_uuid(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_config_entry_unregistered_uuid(
+    hass: HomeAssistant, target_domain: str
+) -> None:
     """Test light switch setup from config entry with unknown entity registry id."""
     fake_uuid = "a266a680b608c32770e6c45bfe6b8411"
 
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": fake_uuid, "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: fake_uuid,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 
@@ -30,8 +36,8 @@ async def test_config_entry_unregistered_uuid(hass: HomeAssistant, target_domain
     assert len(hass.states.async_all()) == 0
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_entity_registry_events(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_entity_registry_events(hass: HomeAssistant, target_domain: str) -> None:
     """Test entity registry events are tracked."""
     registry = er.async_get(hass)
     registry_entry = registry.async_get_or_create("switch", "test", "unique")
@@ -41,7 +47,10 @@ async def test_entity_registry_events(hass: HomeAssistant, target_domain):
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": registry_entry.id, "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: registry_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 
@@ -50,22 +59,22 @@ async def test_entity_registry_events(hass: HomeAssistant, target_domain):
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{target_domain}.abc").state == "on"
+    assert hass.states.get(f"{target_domain}.abc").state == STATE_ON
 
     # Change entity_id
     new_switch_entity_id = f"{switch_entity_id}_new"
     registry.async_update_entity(switch_entity_id, new_entity_id=new_switch_entity_id)
-    hass.states.async_set(new_switch_entity_id, "off")
+    hass.states.async_set(new_switch_entity_id, STATE_OFF)
     await hass.async_block_till_done()
 
     # Check tracking the new entity_id
     await hass.async_block_till_done()
-    assert hass.states.get(f"{target_domain}.abc").state == "off"
+    assert hass.states.get(f"{target_domain}.abc").state == STATE_OFF
 
     # The old entity_id should no longer be tracked
-    hass.states.async_set(switch_entity_id, "on")
+    hass.states.async_set(switch_entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert hass.states.get(f"{target_domain}.abc").state == "off"
+    assert hass.states.get(f"{target_domain}.abc").state == STATE_OFF
 
     # Check changing name does not reload the config entry
     with patch(
@@ -84,8 +93,10 @@ async def test_entity_registry_events(hass: HomeAssistant, target_domain):
     assert len(hass.config_entries.async_entries("switch_as_x")) == 0
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_device_registry_config_entry_1(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_device_registry_config_entry_1(
+    hass: HomeAssistant, target_domain: str
+) -> None:
     """Test we add our config entry to the tracked switch's device."""
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
@@ -111,7 +122,10 @@ async def test_device_registry_config_entry_1(hass: HomeAssistant, target_domain
     switch_as_x_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": switch_entity_entry.id, "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 
@@ -137,8 +151,10 @@ async def test_device_registry_config_entry_1(hass: HomeAssistant, target_domain
     assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_device_registry_config_entry_2(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_device_registry_config_entry_2(
+    hass: HomeAssistant, target_domain: str
+) -> None:
     """Test we add our config entry to the tracked switch's device."""
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
@@ -160,7 +176,10 @@ async def test_device_registry_config_entry_2(hass: HomeAssistant, target_domain
     switch_as_x_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": switch_entity_entry.id, "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 

--- a/tests/components/switch_as_x/test_light.py
+++ b/tests/components/switch_as_x/test_light.py
@@ -2,26 +2,44 @@
 import pytest
 
 from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
+    ATTR_COLOR_TEMP,
+    ATTR_EFFECT,
+    ATTR_EFFECT_LIST,
+    ATTR_HS_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
+    ATTR_WHITE_VALUE,
     COLOR_MODE_ONOFF,
+    DOMAIN as LIGHT_DOMAIN,
 )
-from homeassistant.components.switch_as_x import DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
-from tests.components.light import common
-from tests.components.switch import common as switch_common
 
 
-async def test_default_state(hass):
+async def test_default_state(hass: HomeAssistant) -> None:
     """Test light switch default state."""
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": "switch.test", "target_domain": "light"},
+        options={
+            CONF_ENTITY_ID: "switch.test",
+            CONF_TARGET_DOMAIN: Platform.LIGHT,
+        },
         title="Christmas Tree Lights",
     )
     config_entry.add_to_hass(hass)
@@ -32,87 +50,120 @@ async def test_default_state(hass):
     assert state is not None
     assert state.state == "unavailable"
     assert state.attributes["supported_features"] == 0
-    assert state.attributes.get("brightness") is None
-    assert state.attributes.get("hs_color") is None
-    assert state.attributes.get("color_temp") is None
-    assert state.attributes.get("white_value") is None
-    assert state.attributes.get("effect_list") is None
-    assert state.attributes.get("effect") is None
+    assert state.attributes.get(ATTR_BRIGHTNESS) is None
+    assert state.attributes.get(ATTR_HS_COLOR) is None
+    assert state.attributes.get(ATTR_COLOR_TEMP) is None
+    assert state.attributes.get(ATTR_WHITE_VALUE) is None
+    assert state.attributes.get(ATTR_EFFECT_LIST) is None
+    assert state.attributes.get(ATTR_EFFECT) is None
     assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [COLOR_MODE_ONOFF]
     assert state.attributes.get(ATTR_COLOR_MODE) is None
 
 
-async def test_light_service_calls(hass):
+async def test_light_service_calls(hass: HomeAssistant) -> None:
     """Test service calls to light."""
     await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": "switch.decorative_lights", "target_domain": "light"},
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_TARGET_DOMAIN: Platform.LIGHT,
+        },
         title="decorative_lights",
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.decorative_lights").state == "on"
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
 
-    await common.async_toggle(hass, "light.decorative_lights")
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "light.decorative_lights"},
+        blocking=True,
+    )
 
-    assert hass.states.get("switch.decorative_lights").state == "off"
-    assert hass.states.get("light.decorative_lights").state == "off"
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("light.decorative_lights").state == STATE_OFF
 
-    await common.async_turn_on(hass, "light.decorative_lights")
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "light.decorative_lights"},
+        blocking=True,
+    )
 
-    assert hass.states.get("switch.decorative_lights").state == "on"
-    assert hass.states.get("light.decorative_lights").state == "on"
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
     assert (
         hass.states.get("light.decorative_lights").attributes.get(ATTR_COLOR_MODE)
         == COLOR_MODE_ONOFF
     )
 
-    await common.async_turn_off(hass, "light.decorative_lights")
-    await hass.async_block_till_done()
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "light.decorative_lights"},
+        blocking=True,
+    )
 
-    assert hass.states.get("switch.decorative_lights").state == "off"
-    assert hass.states.get("light.decorative_lights").state == "off"
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("light.decorative_lights").state == STATE_OFF
 
 
-async def test_switch_service_calls(hass):
+async def test_switch_service_calls(hass: HomeAssistant) -> None:
     """Test service calls to switch."""
     await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": "switch.decorative_lights", "target_domain": "light"},
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_TARGET_DOMAIN: Platform.LIGHT,
+        },
         title="decorative_lights",
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.decorative_lights").state == "on"
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
 
-    await switch_common.async_turn_off(hass, "switch.decorative_lights")
-    await hass.async_block_till_done()
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
 
-    assert hass.states.get("switch.decorative_lights").state == "off"
-    assert hass.states.get("light.decorative_lights").state == "off"
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("light.decorative_lights").state == STATE_OFF
 
-    await switch_common.async_turn_on(hass, "switch.decorative_lights")
-    await hass.async_block_till_done()
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
 
-    assert hass.states.get("switch.decorative_lights").state == "on"
-    assert hass.states.get("light.decorative_lights").state == "on"
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("light.decorative_lights").state == STATE_ON
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_config_entry_entity_id(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_config_entry_entity_id(
+    hass: HomeAssistant, target_domain: Platform
+) -> None:
     """Test light switch setup from config entry with entity id."""
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": "switch.abc", "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: "switch.abc",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 
@@ -124,6 +175,7 @@ async def test_config_entry_entity_id(hass: HomeAssistant, target_domain):
     assert DOMAIN in hass.config.components
 
     state = hass.states.get(f"{target_domain}.abc")
+    assert state
     assert state.state == "unavailable"
     # Name copied from config entry title
     assert state.name == "ABC"
@@ -131,11 +183,12 @@ async def test_config_entry_entity_id(hass: HomeAssistant, target_domain):
     # Check the light is added to the entity registry
     registry = er.async_get(hass)
     entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
     assert entity_entry.unique_id == config_entry.entry_id
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_config_entry_uuid(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_config_entry_uuid(hass: HomeAssistant, target_domain: Platform) -> None:
     """Test light switch setup from config entry with entity registry id."""
     registry = er.async_get(hass)
     registry_entry = registry.async_get_or_create("switch", "test", "unique")
@@ -143,7 +196,10 @@ async def test_config_entry_uuid(hass: HomeAssistant, target_domain):
     config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": registry_entry.id, "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: registry_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 
@@ -155,8 +211,8 @@ async def test_config_entry_uuid(hass: HomeAssistant, target_domain):
     assert hass.states.get(f"{target_domain}.abc")
 
 
-@pytest.mark.parametrize("target_domain", ("light",))
-async def test_device(hass: HomeAssistant, target_domain):
+@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
+async def test_device(hass: HomeAssistant, target_domain: Platform) -> None:
     """Test the entity is added to the wrapped entity's device."""
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
@@ -174,7 +230,10 @@ async def test_device(hass: HomeAssistant, target_domain):
     switch_as_x_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={"entity_id": switch_entity_entry.id, "target_domain": target_domain},
+        options={
+            CONF_ENTITY_ID: switch_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
         title="ABC",
     )
 
@@ -184,4 +243,5 @@ async def test_device(hass: HomeAssistant, target_domain):
     await hass.async_block_till_done()
 
     entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
     assert entity_entry.device_id == switch_entity_entry.device_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Couple of small improvements for Switch as X.

- Introduces a constants file
- Make use of more available constants throughout the integration (including tests)
- Adjust the config flow to use key/values for the options selector. This prevents we show domain keys in the "as X" part of the config flow to the user.
- Fixed/completed some half typed method signatures in tests.
- Remove the use of common helpers in tests and use service calls directly instead.
- Removes testing integration results from config flow tests (mixed responsibilities)
- Other small stuff

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
