### PR TITLE
Add fixture for enabling disabled entities in WLED tests

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for component testing."""
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -22,3 +23,13 @@ def prevent_io():
         return_value=[],
     ):
         yield
+
+
+@pytest.fixture
+def entity_registry_enabled_by_default() -> Generator[AsyncMock, None, None]:
+    """Test fixture that ensures all entities are enabled in the registry."""
+    with patch(
+        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
+        return_value=True,
+    ) as mock_entity_registry_enabled_by_default:
+        yield mock_entity_registry_enabled_by_default

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for WLED integration tests."""
 from collections.abc import Generator
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from wled import Device as WLEDDevice
@@ -73,13 +73,3 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
-
-
-@pytest.fixture
-def enable_all_entities() -> Generator[AsyncMock, None, None]:
-    """Test fixture that ensures all entities are enabled in the registry."""
-    with patch(
-        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-        return_value=True,
-    ) as mock_entity_registry_enabled_by_default:
-        yield mock_entity_registry_enabled_by_default

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for WLED integration tests."""
 from collections.abc import Generator
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from wled import Device as WLEDDevice
@@ -73,3 +73,13 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+@pytest.fixture
+def enable_all_entities() -> Generator[AsyncMock, None, None]:
+    """Test fixture that ensures all entities are enabled in the registry."""
+    with patch(
+        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
+        return_value=True,
+    ) as mock_entity_registry_enabled_by_default:
+        yield mock_entity_registry_enabled_by_default

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the WLED sensor platform."""
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,61 +28,12 @@ async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_wled: MagicMock,
+    enable_all_entities: AsyncMock,
 ) -> None:
     """Test the creation and values of the WLED sensors."""
     registry = er.async_get(hass)
-
-    # Pre-create registry entries for disabled by default sensors
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "aabbccddeeff_uptime",
-        suggested_object_id="wled_rgb_light_uptime",
-        disabled_by=None,
-    )
-
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "aabbccddeeff_free_heap",
-        suggested_object_id="wled_rgb_light_free_memory",
-        disabled_by=None,
-    )
-
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "aabbccddeeff_wifi_signal",
-        suggested_object_id="wled_rgb_light_wifi_signal",
-        disabled_by=None,
-    )
-
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "aabbccddeeff_wifi_rssi",
-        suggested_object_id="wled_rgb_light_wifi_rssi",
-        disabled_by=None,
-    )
-
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "aabbccddeeff_wifi_channel",
-        suggested_object_id="wled_rgb_light_wifi_channel",
-        disabled_by=None,
-    )
-
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        "aabbccddeeff_wifi_bssid",
-        suggested_object_id="wled_rgb_light_wifi_bssid",
-        disabled_by=None,
-    )
-
-    # Setup
     mock_config_entry.add_to_hass(hass)
+
     test_time = datetime(2019, 11, 11, 9, 10, 32, tzinfo=dt_util.UTC)
     with patch("homeassistant.components.wled.sensor.utcnow", return_value=test_time):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -124,19 +75,19 @@ async def test_sensors(
     assert entry.unique_id == "aabbccddeeff_free_heap"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wifi_signal")
+    state = hass.states.get("sensor.wled_rgb_light_wi_fi_signal")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "76"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    entry = registry.async_get("sensor.wled_rgb_light_wifi_signal")
+    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_signal")
     assert entry
     assert entry.unique_id == "aabbccddeeff_wifi_signal"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wifi_rssi")
+    state = hass.states.get("sensor.wled_rgb_light_wi_fi_rssi")
     assert state
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.SIGNAL_STRENGTH
     assert (
@@ -145,29 +96,29 @@ async def test_sensors(
     )
     assert state.state == "-62"
 
-    entry = registry.async_get("sensor.wled_rgb_light_wifi_rssi")
+    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_rssi")
     assert entry
     assert entry.unique_id == "aabbccddeeff_wifi_rssi"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wifi_channel")
+    state = hass.states.get("sensor.wled_rgb_light_wi_fi_channel")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.state == "11"
 
-    entry = registry.async_get("sensor.wled_rgb_light_wifi_channel")
+    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_channel")
     assert entry
     assert entry.unique_id == "aabbccddeeff_wifi_channel"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
 
-    state = hass.states.get("sensor.wled_rgb_light_wifi_bssid")
+    state = hass.states.get("sensor.wled_rgb_light_wi_fi_bssid")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:wifi"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.state == "AA:AA:AA:AA:AA:BB"
 
-    entry = registry.async_get("sensor.wled_rgb_light_wifi_bssid")
+    entry = registry.async_get("sensor.wled_rgb_light_wi_fi_bssid")
     assert entry
     assert entry.unique_id == "aabbccddeeff_wifi_bssid"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -28,7 +28,7 @@ async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_wled: MagicMock,
-    enable_all_entities: AsyncMock,
+    entity_registry_enabled_by_default: AsyncMock,
 ) -> None:
     """Test the creation and values of the WLED sensors."""
     registry = er.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a fixture to the WLED tests to allow for removing a bunch of test code (and also makes an upcoming PR easier to test).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
