### PR TITLE
Prevent adding plugwise products used as secondary controllers

### DIFF
--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from plugwise.exceptions import InvalidAuthentication, PlugwiseException
+from plugwise.exceptions import (
+    InvalidAuthentication,
+    InvalidSetupError,
+    PlugwiseException,
+)
 from plugwise.smile import Smile
 import voluptuous as vol
 
@@ -124,6 +128,8 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 api = await validate_gw_input(self.hass, user_input)
+            except InvalidSetupError:
+                errors[CONF_BASE] = "invalid_setup"
             except InvalidAuthentication:
                 errors[CONF_BASE] = "invalid_auth"
             except PlugwiseException:

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -32,7 +32,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_setup": "Add your Adam instead of your Anna, see the documentation",
+      "invalid_setup": "Add your Adam instead of your Anna, see the Home Assistant Plugwise integration documentation for more information",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -32,6 +32,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_setup": "Add your Adam instead of your Anna, see the documentation",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from plugwise.exceptions import (
     ConnectionFailedError,
     InvalidAuthentication,
+    InvalidSetupError,
     PlugwiseException,
 )
 import pytest
@@ -223,6 +224,7 @@ async def test_zercoconf_discovery_update_configuration(hass: HomeAssistant) -> 
     "side_effect,reason",
     [
         (InvalidAuthentication, "invalid_auth"),
+        (InvalidSetupError, "invalid_setup"),
         (ConnectionFailedError, "cannot_connect"),
         (PlugwiseException, "cannot_connect"),
         (RuntimeError, "unknown"),


### PR DESCRIPTION
## Proposed change
Module update (via) #68082: [0.16.8](https://github.com/plugwise/python-plugwise/releases/tag/v0.16.8) also includes detection on Adam presence when an Anna is added, this PR will prohibit installing an Anna that is part of an Adam installation. 
This PR should resemble the first half of the overall prevention, the second (to be PR) being the cancellation of the discovery of the Anna. This PR just prevents users from both adding manually and from discovery.

Background information for reviewers: the Anna is a standalone climate control device, but it can also be used as 'just a thermostat' in the Adam setup. As the Adam is in control in such a setup a user should only add the Adam. There is already a warning in the integration documentation but not in (the) HA (frontend) itself.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
