### PR TITLE
Use a dedicated executor pool for database operations

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -14,7 +14,11 @@ import voluptuous as vol
 
 from homeassistant.components import frontend, websocket_api
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.recorder import history, models as history_models
+from homeassistant.components.recorder import (
+    get_instance,
+    history,
+    models as history_models,
+)
 from homeassistant.components.recorder.statistics import (
     list_statistic_ids,
     statistics_during_period,
@@ -142,7 +146,7 @@ async def ws_get_statistics_during_period(
     else:
         end_time = None
 
-    statistics = await hass.async_add_executor_job(
+    statistics = await get_instance(hass).async_add_executor_job(
         statistics_during_period,
         hass,
         start_time,
@@ -164,7 +168,7 @@ async def ws_get_list_statistic_ids(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
 ) -> None:
     """Fetch a list of available statistic_id."""
-    statistic_ids = await hass.async_add_executor_job(
+    statistic_ids = await get_instance(hass).async_add_executor_job(
         list_statistic_ids,
         hass,
         msg.get("statistic_type"),
@@ -232,7 +236,7 @@ class HistoryPeriodView(HomeAssistantView):
 
         return cast(
             web.Response,
-            await hass.async_add_executor_job(
+            await get_instance(hass).async_add_executor_job(
                 self._sorted_significant_states_json,
                 hass,
                 start_time,

--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -7,7 +7,7 @@ import math
 
 import voluptuous as vol
 
-from homeassistant.components.recorder import history
+from homeassistant.components.recorder import get_instance, history
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import (
     CONF_ENTITY_ID,
@@ -225,7 +225,7 @@ class HistoryStatsSensor(SensorEntity):
             # Don't compute anything as the value cannot have changed
             return
 
-        await self.hass.async_add_executor_job(
+        await get_instance(self.hass).async_add_executor_job(
             self._update, start, end, now_timestamp, start_timestamp, end_timestamp
         )
 

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.components import frontend
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.history import sqlalchemy_filter_from_include_exclude_conf
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import (
     Events,
     States,
@@ -254,7 +255,7 @@ class LogbookView(HomeAssistantView):
                 )
             )
 
-        return await hass.async_add_executor_job(json_events)
+        return await get_instance(hass).async_add_executor_job(json_events)
 
 
 def humanify(hass, events, entity_attr_cache, context_lookup):

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -6,6 +6,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import States
 from homeassistant.components.recorder.util import execute, session_scope
 from homeassistant.const import (
@@ -283,7 +284,9 @@ class Plant(Entity):
         """After being added to hass, load from history."""
         if ENABLE_LOAD_HISTORY and "recorder" in self.hass.config.components:
             # only use the database if it's configured
-            await self.hass.async_add_executor_job(self._load_history_from_db)
+            await get_instance(self.hass).async_add_executor_job(
+                self._load_history_from_db
+            )
             self.async_write_ha_state()
 
         async_track_state_change_event(

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -191,7 +191,6 @@ CONFIG_SCHEMA = vol.Schema(
 MAX_DB_EXECUTOR_WORKERS = POOL_SIZE - 1
 
 
-@bind_hass
 def get_instance(hass: HomeAssistant) -> Recorder:
     """Get the recorder instance."""
     return hass.data[DATA_INSTANCE]

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -12,9 +12,10 @@ import queue
 import sqlite3
 import threading
 import time
-from typing import Any
+from typing import Any, TypeVar
 
 from sqlalchemy import create_engine, event as sqlalchemy_event, exc, func, select
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session
@@ -61,6 +62,7 @@ from .const import (
     MAX_QUEUE_BACKLOG,
     SQLITE_URL_PREFIX,
 )
+from .executor import DBInterruptibleThreadPoolExecutor
 from .models import (
     Base,
     Events,
@@ -69,7 +71,7 @@ from .models import (
     StatisticsRuns,
     process_timestamp,
 )
-from .pool import RecorderPool
+from .pool import POOL_SIZE, RecorderPool
 from .util import (
     dburl_to_path,
     end_incomplete_runs,
@@ -82,6 +84,9 @@ from .util import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
 
 SERVICE_PURGE = "purge"
 SERVICE_PURGE_ENTITIES = "purge_entities"
@@ -180,6 +185,16 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+# Subtrace one for the recorder thread
+MAX_DB_EXECUTOR_WORKERS = POOL_SIZE - 1
+
+
+@bind_hass
+def get_instance(hass: HomeAssistant) -> Recorder:
+    """Get the recorder instance."""
+    return hass.data[DATA_INSTANCE]
 
 
 @bind_hass
@@ -510,7 +525,7 @@ class Recorder(threading.Thread):
         self.async_db_ready: asyncio.Future = asyncio.Future()
         self.async_recorder_ready = asyncio.Event()
         self._queue_watch = threading.Event()
-        self.engine: Any = None
+        self.engine: Engine | None = None
         self.run_info: Any = None
 
         self.entity_filter = entity_filter
@@ -530,12 +545,31 @@ class Recorder(threading.Thread):
         self._queue_watcher = None
         self._db_supports_row_number = True
         self._database_lock_task: DatabaseLockTask | None = None
+        self._db_executor: DBInterruptibleThreadPoolExecutor | None = None
 
         self.enabled = True
 
     def set_enable(self, enable):
         """Enable or disable recording events and states."""
         self.enabled = enable
+
+    @callback
+    def async_start_executor(self):
+        """Start the executor."""
+        if self._db_executor:
+            self._stop_executor()
+        self._db_executor = DBInterruptibleThreadPoolExecutor(
+            thread_name_prefix="DbWorker",
+            max_workers=MAX_DB_EXECUTOR_WORKERS,
+            shutdown_hook=self._shutdown_pool,
+        )
+
+    def _shutdown_pool(self):
+        """Close the dbpool connections in the current thread."""
+        assert self.engine is not None
+        pool = self.engine.pool
+        if hasattr(pool, "shutdown"):
+            pool.shutdown()
 
     @callback
     def async_initialize(self):
@@ -546,6 +580,19 @@ class Recorder(threading.Thread):
         self._queue_watcher = async_track_time_interval(
             self.hass, self._async_check_queue, timedelta(minutes=10)
         )
+
+    @callback
+    def async_add_executor_job(
+        self, target: Callable[..., T], *args: Any
+    ) -> asyncio.Future[T]:
+        """Add an executor job from within the event loop."""
+        return self.hass.loop.run_in_executor(self._db_executor, target, *args)
+
+    def _stop_executor(self) -> None:
+        """Stop the executor."""
+        assert self._db_executor is not None
+        self._db_executor.shutdown()
+        self._db_executor = None
 
     @callback
     def _async_check_queue(self, *_):
@@ -673,6 +720,7 @@ class Recorder(threading.Thread):
     def async_connection_success(self):
         """Connect success tasks."""
         self.async_db_ready.set_result(True)
+        self.async_start_executor()
 
     @callback
     def _async_recorder_ready(self):
@@ -1200,6 +1248,7 @@ class Recorder(threading.Thread):
     def _shutdown(self):
         """Save end time for current run."""
         self.hass.add_job(self._async_stop_queue_watcher_and_event_listener)
+        self._stop_executor()
         self._end_session()
         self._close_connection()
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -186,7 +186,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-# Subtrace one for the recorder thread
+# Pool size must accommodate Recorder thread + All db executors
 MAX_DB_EXECUTOR_WORKERS = POOL_SIZE - 1
 
 
@@ -565,10 +565,8 @@ class Recorder(threading.Thread):
 
     def _shutdown_pool(self):
         """Close the dbpool connections in the current thread."""
-        assert self.engine is not None
-        pool = self.engine.pool
-        if hasattr(pool, "shutdown"):
-            pool.shutdown()
+        if hasattr(self.engine.pool, "shutdown"):
+            self.engine.pool.shutdown()
 
     @callback
     def async_initialize(self):

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -57,6 +57,7 @@ from . import history, migration, purge, statistics, websocket_api
 from .const import (
     CONF_DB_INTEGRITY_CHECK,
     DATA_INSTANCE,
+    DB_WORKER_PREFIX,
     DOMAIN,
     MAX_QUEUE_BACKLOG,
     SQLITE_URL_PREFIX,
@@ -558,7 +559,7 @@ class Recorder(threading.Thread):
         if self._db_executor:
             self._stop_executor()
         self._db_executor = DBInterruptibleThreadPoolExecutor(
-            thread_name_prefix="DbWorker",
+            thread_name_prefix=DB_WORKER_PREFIX,
             max_workers=MAX_DB_EXECUTOR_WORKERS,
             shutdown_hook=self._shutdown_pool,
         )

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -556,8 +556,6 @@ class Recorder(threading.Thread):
     @callback
     def async_start_executor(self):
         """Start the executor."""
-        if self._db_executor:
-            self._stop_executor()
         self._db_executor = DBInterruptibleThreadPoolExecutor(
             thread_name_prefix=DB_WORKER_PREFIX,
             max_workers=MAX_DB_EXECUTOR_WORKERS,

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -15,7 +15,6 @@ import time
 from typing import Any, TypeVar
 
 from sqlalchemy import create_engine, event as sqlalchemy_event, exc, func, select
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session
@@ -525,7 +524,7 @@ class Recorder(threading.Thread):
         self.async_db_ready: asyncio.Future = asyncio.Future()
         self.async_recorder_ready = asyncio.Event()
         self._queue_watch = threading.Event()
-        self.engine: Engine | None = None
+        self.engine: Any = None
         self.run_info: Any = None
 
         self.entity_filter = entity_filter

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -15,3 +15,5 @@ MAX_QUEUE_BACKLOG = 30000
 # We can increase this back to 1000 once most
 # have upgraded their sqlite version
 MAX_ROWS_TO_PURGE = 998
+
+DB_WORKER_PREFIX = "DbWorker"

--- a/homeassistant/components/recorder/executor.py
+++ b/homeassistant/components/recorder/executor.py
@@ -1,0 +1,55 @@
+"""Database executor helpers."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures.thread import _threads_queues, _worker
+import threading
+from typing import Any
+import weakref
+
+from homeassistant.util.executor import InterruptibleThreadPoolExecutor
+
+
+def _worker_with_shutdown_hook(shutdown_hook, *args, **kwargs):
+    """Create a worker that calls a function after its finished."""
+    _worker(*args, **kwargs)
+    shutdown_hook()
+
+
+class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
+    """A database instance that will not deadlock on shutdown."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Init the executor."""
+        self._shutdown_hook: Callable[[], None] = kwargs.pop("shutdown_hook")
+        super().__init__(*args, **kwargs)
+
+    def _adjust_thread_count(self) -> None:
+        # if idle threads are available, don't spin new threads
+        if self._idle_semaphore.acquire(  # pylint: disable=consider-using-with
+            timeout=0
+        ):
+            return
+
+        # When the executor gets lost, the weakref callback will wake up
+        # the worker threads.
+        def weakref_cb(_, q=self._work_queue):  # pylint: disable=invalid-name
+            q.put(None)
+
+        num_threads = len(self._threads)
+        if num_threads < self._max_workers:
+            thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+            executor_thread = threading.Thread(
+                name=thread_name,
+                target=_worker_with_shutdown_hook,
+                args=(
+                    self._shutdown_hook,
+                    weakref.ref(self, weakref_cb),
+                    self._work_queue,
+                    self._initializer,
+                    self._initargs,
+                ),
+            )
+            executor_thread.start()
+            self._threads.add(executor_thread)  # type: ignore[attr-defined]
+            _threads_queues[executor_thread] = self._work_queue  # type: ignore[index]

--- a/homeassistant/components/recorder/executor.py
+++ b/homeassistant/components/recorder/executor.py
@@ -20,11 +20,12 @@ class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
     """A database instance that will not deadlock on shutdown."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Init the executor."""
+        """Init the executor with a shutdown hook support."""
         self._shutdown_hook: Callable[[], None] = kwargs.pop("shutdown_hook")
         super().__init__(*args, **kwargs)
 
     def _adjust_thread_count(self) -> None:
+        """Port from cpython 3.10 since the default does not support a shutdown hook."""
         # if idle threads are available, don't spin new threads
         if self._idle_semaphore.acquire(  # pylint: disable=consider-using-with
             timeout=0

--- a/homeassistant/components/recorder/executor.py
+++ b/homeassistant/components/recorder/executor.py
@@ -25,7 +25,10 @@ class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
         super().__init__(*args, **kwargs)
 
     def _adjust_thread_count(self) -> None:
-        """Port from cpython 3.10 since the default does not support a shutdown hook."""
+        """Overridden to add support for shutdown hook.
+        
+        Based on the CPython 3.10 implementation.
+        """
         # if idle threads are available, don't spin new threads
         if self._idle_semaphore.acquire(  # pylint: disable=consider-using-with
             timeout=0

--- a/homeassistant/components/recorder/executor.py
+++ b/homeassistant/components/recorder/executor.py
@@ -26,7 +26,7 @@ class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
 
     def _adjust_thread_count(self) -> None:
         """Overridden to add support for shutdown hook.
-        
+
         Based on the CPython 3.10 implementation.
         """
         # if idle threads are available, don't spin new threads

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -4,6 +4,8 @@ import threading
 
 from sqlalchemy.pool import NullPool, SingletonThreadPool
 
+from .const import DB_WORKER_PREFIX
+
 POOL_SIZE = 5
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +26,9 @@ class RecorderPool(SingletonThreadPool, NullPool):
     def recorder_or_dbworker(self) -> bool:
         """Check if the thread is a recorder or dbworker thread."""
         thread_name = threading.current_thread().name
-        return bool(thread_name == "Recorder" or thread_name.startswith("DbWorker"))
+        return bool(
+            thread_name == "Recorder" or thread_name.startswith(DB_WORKER_PREFIX)
+        )
 
     def _do_return_conn(self, conn):
         if self.recorder_or_dbworker:

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -1,34 +1,54 @@
 """A pool for sqlite connections."""
+import logging
 import threading
 
-from sqlalchemy.pool import NullPool, StaticPool
+from sqlalchemy.pool import NullPool, SingletonThreadPool
+
+POOL_SIZE = 5
+_LOGGER = logging.getLogger(__name__)
 
 
-class RecorderPool(StaticPool, NullPool):
-    """A hybrid of NullPool and StaticPool.
+class RecorderPool(SingletonThreadPool, NullPool):
+    """A hybrid of NullPool and SingletonThreadPool.
 
-    When called from the creating thread acts like StaticPool
+    When called from the creating thread or db executor acts like SingletonThreadPool
     When called from any other thread, acts like NullPool
     """
 
     def __init__(self, *args, **kw):  # pylint: disable=super-init-not-called
         """Create the pool."""
-        self._tid = threading.current_thread().ident
-        StaticPool.__init__(self, *args, **kw)
+        kw["pool_size"] = POOL_SIZE
+        SingletonThreadPool.__init__(self, *args, **kw)
+
+    @property
+    def recorder_or_dbworker(self) -> bool:
+        """Check if the thread is a recorder or dbworker thread."""
+        thread_name = threading.current_thread().name
+        return bool(thread_name == "Recorder" or thread_name.startswith("DbWorker"))
 
     def _do_return_conn(self, conn):
-        if threading.current_thread().ident == self._tid:
+        if self.recorder_or_dbworker:
             return super()._do_return_conn(conn)
         conn.close()
 
+    def shutdown(self):
+        """Close the connection."""
+        if self.recorder_or_dbworker and (conn := self._conn.current()):
+            conn.close()
+
     def dispose(self):
         """Dispose of the connection."""
-        if threading.current_thread().ident == self._tid:
+        if self.recorder_or_dbworker:
             return super().dispose()
 
     def _do_get(self):
-        if threading.current_thread().ident == self._tid:
+        if self.recorder_or_dbworker:
             return super()._do_get()
+        _LOGGER.warning(
+            "Database access is slower in the default executor, "
+            "use homeassistant.components.recorder.get_instance(hass).async_add_executor_job() "
+            "for database operations"
+        )
         return super(  # pylint: disable=bad-super-call
             NullPool, self
         )._create_connection()

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -49,9 +49,9 @@ class RecorderPool(SingletonThreadPool, NullPool):
         if self.recorder_or_dbworker:
             return super()._do_get()
         report(
-            "Database access is slower in the default executor, "
-            "use homeassistant.components.recorder.get_instance(hass).async_add_executor_job() "
-            "for database operations",
+            "accesses the database without the database executor; "
+            "Use homeassistant.components.recorder.get_instance(hass).async_add_executor_job() "
+            "for faster database operations",
             exclude_integrations={"recorder"},
             error_if_core=False,
         )

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -1,13 +1,13 @@
 """A pool for sqlite connections."""
-import logging
 import threading
 
 from sqlalchemy.pool import NullPool, SingletonThreadPool
 
+from homeassistant.helpers.frame import report
+
 from .const import DB_WORKER_PREFIX
 
 POOL_SIZE = 5
-_LOGGER = logging.getLogger(__name__)
 
 
 class RecorderPool(SingletonThreadPool, NullPool):
@@ -48,10 +48,12 @@ class RecorderPool(SingletonThreadPool, NullPool):
     def _do_get(self):
         if self.recorder_or_dbworker:
             return super()._do_get()
-        _LOGGER.warning(
+        report(
             "Database access is slower in the default executor, "
             "use homeassistant.components.recorder.get_instance(hass).async_add_executor_job() "
-            "for database operations"
+            "for database operations",
+            exclude_integrations={"recorder"},
+            error_if_core=False,
         )
         return super(  # pylint: disable=bad-super-call
             NullPool, self

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -40,7 +40,8 @@ async def ws_validate_statistics(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
 ) -> None:
     """Fetch a list of available statistic_id."""
-    statistic_ids = await hass.async_add_executor_job(
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    statistic_ids = await instance.async_add_executor_job(
         validate_statistics,
         hass,
     )

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -49,3 +49,5 @@ def test_recorder_pool(caplog):
     new_thread.join()
     assert "Database access is slower in the default executor" not in caplog.text
     assert connections[6] == connections[7]
+
+    engine.pool.shutdown()

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -4,10 +4,11 @@ import threading
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from homeassistant.components.recorder.const import DB_WORKER_PREFIX
 from homeassistant.components.recorder.pool import RecorderPool
 
 
-def test_recorder_pool():
+def test_recorder_pool(caplog):
     """Test RecorderPool gives the same connection in the creating thread."""
 
     engine = create_engine("sqlite://", poolclass=RecorderPool)
@@ -25,10 +26,26 @@ def test_recorder_pool():
         session.close()
 
     _get_connection_twice()
-    assert connections[0] == connections[1]
+    assert "Database access is slower in the default executor" in caplog.text
+    assert connections[0] != connections[1]
 
+    caplog.clear()
     new_thread = threading.Thread(target=_get_connection_twice)
     new_thread.start()
     new_thread.join()
-
+    assert "Database access is slower in the default executor" in caplog.text
     assert connections[2] != connections[3]
+
+    caplog.clear()
+    new_thread = threading.Thread(target=_get_connection_twice, name=DB_WORKER_PREFIX)
+    new_thread.start()
+    new_thread.join()
+    assert "Database access is slower in the default executor" not in caplog.text
+    assert connections[4] == connections[5]
+
+    caplog.clear()
+    new_thread = threading.Thread(target=_get_connection_twice, name="Recorder")
+    new_thread.start()
+    new_thread.join()
+    assert "Database access is slower in the default executor" not in caplog.text
+    assert connections[6] == connections[7]

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -29,28 +29,28 @@ def test_recorder_pool(caplog):
         session.close()
 
     _get_connection_twice()
-    assert "Database access is slower in the default executor" in caplog.text
+    assert "accesses the database without the database executor" in caplog.text
     assert connections[0] != connections[1]
 
     caplog.clear()
     new_thread = threading.Thread(target=_get_connection_twice)
     new_thread.start()
     new_thread.join()
-    assert "Database access is slower in the default executor" in caplog.text
+    assert "accesses the database without the database executor" in caplog.text
     assert connections[2] != connections[3]
 
     caplog.clear()
     new_thread = threading.Thread(target=_get_connection_twice, name=DB_WORKER_PREFIX)
     new_thread.start()
     new_thread.join()
-    assert "Database access is slower in the default executor" not in caplog.text
+    assert "accesses the database without the database executor" not in caplog.text
     assert connections[4] == connections[5]
 
     caplog.clear()
     new_thread = threading.Thread(target=_get_connection_twice, name="Recorder")
     new_thread.start()
     new_thread.join()
-    assert "Database access is slower in the default executor" not in caplog.text
+    assert "accesses the database without the database executor" not in caplog.text
     assert connections[6] == connections[7]
 
     shutdown = True
@@ -58,5 +58,5 @@ def test_recorder_pool(caplog):
     new_thread = threading.Thread(target=_get_connection_twice, name=DB_WORKER_PREFIX)
     new_thread.start()
     new_thread.join()
-    assert "Database access is slower in the default executor" not in caplog.text
+    assert "accesses the database without the database executor" not in caplog.text
     assert connections[8] != connections[9]

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -570,8 +570,17 @@ async def test_write_lock_db(hass, tmp_path):
 
     instance = hass.data[DATA_INSTANCE]
 
+    def _drop_table():
+        with instance.engine.connect() as connection:
+            connection.execute(text("DROP TABLE events;"))
+
     with util.write_lock_db_sqlite(instance):
         # Database should be locked now, try writing SQL command
-        with instance.engine.connect() as connection:
-            with pytest.raises(OperationalError):
-                connection.execute(text("DROP TABLE events;"))
+        with pytest.raises(OperationalError):
+            # This needs to be called in another thread since
+            # the lock method is BEGIN IMMEDIATE and since we have
+            # a connection per thread with sqlite now, we cannot do it
+            # in the same thread as the one holding the lock since it
+            # would be allowed to proceed as the goal is to prevent
+            # all the other threads from accessing the database
+            await hass.async_add_executor_job(_drop_table)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


- Reduces the risk that database queries time out if the executor
  is tied up and vise-versa (failure mode due to database being broken)
  Before this change, loading a page with a lot of history graphs
  (or mini ones) can tie up all the executor threads and causes sync integrations
  to fall a bit behind updating.  This change avoids the problem.

- Switch sqlite to use `SingletonThreadPool`: 
  We have not been able to use `SingletonThreadPool` because when
  Home Assistant shuts down, the engine would get disposed of
  with the sqlite connections opened in other threads which
  cannot be [done](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/pool/impl.py#L367).
  To solve this issue, we do all the database work in a dedicated
  executor thread pool which has a shutdown hook to close out
  the connection at the end. 

  By using `SingletonThreadPool` instead of `NullPool` each database operation
  no longer closes and opens the sqlite database which is not only
  cpu intensive, it also not nice to SD cards (and why I finally got around to doing this). 
  The net result is sqlite connection checkout is less latent and now similar (or better) 
  when compared other db engines (everything else uses a shared pool which is
  the sqlalchemy default)

  Previously we were only able to keep open the db connection on the Recorder thread
  since we could ensure that the database connection was always closed in the thread
  it was opened.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
