### PR TITLE
Add cover platform to Switch as X

### DIFF
--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -22,6 +22,7 @@ CONFIG_FLOW = {
                     {
                         "select": {
                             "options": [
+                                {"value": Platform.COVER, "label": "Cover"},
                                 {"value": Platform.LIGHT, "label": "Light"},
                             ]
                         }

--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -1,0 +1,83 @@
+"""Cover support for switch entities."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.cover import SUPPORT_CLOSE, SUPPORT_OPEN, CoverEntity
+from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import BaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Cover Switch config entry."""
+    registry = er.async_get(hass)
+    entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_ENTITY_ID]
+    )
+    wrapped_switch = registry.async_get(entity_id)
+    device_id = wrapped_switch.device_id if wrapped_switch else None
+
+    async_add_entities(
+        [
+            CoverSwitch(
+                config_entry.title,
+                entity_id,
+                config_entry.entry_id,
+                device_id,
+            )
+        ]
+    )
+
+
+class CoverSwitch(BaseEntity, CoverEntity):
+    """Represents a Switch as a Cover."""
+
+    _attr_supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        await self.hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self._switch_entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close cover."""
+        await self.hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self._switch_entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    @callback
+    def async_state_changed_listener(self, event: Event | None = None) -> None:
+        """Handle child updates."""
+        super().async_state_changed_listener(event)
+        if (
+            not self.available
+            or (state := self.hass.states.get(self._switch_entity_id)) is None
+        ):
+            return
+
+        self._attr_is_closed = state.state != STATE_ON

--- a/tests/components/switch_as_x/test_cover.py
+++ b/tests/components/switch_as_x/test_cover.py
@@ -1,0 +1,121 @@
+"""Tests for the Switch as X Cover platform."""
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_CLOSED,
+    STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_default_state(hass: HomeAssistant) -> None:
+    """Test cover switch default state."""
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.test",
+            CONF_TARGET_DOMAIN: Platform.COVER,
+        },
+        title="Garage Door",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.garage_door")
+    assert state is not None
+    assert state.state == "unavailable"
+    assert state.attributes["supported_features"] == 3
+
+
+async def test_service_calls(hass: HomeAssistant) -> None:
+    """Test service calls to cover."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_TARGET_DOMAIN: Platform.COVER,
+        },
+        title="garage_door",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("cover.garage_door").state == STATE_OPEN
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "cover.garage_door"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("cover.garage_door").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {CONF_ENTITY_ID: "cover.garage_door"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("cover.garage_door").state == STATE_OPEN
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {CONF_ENTITY_ID: "cover.garage_door"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("cover.garage_door").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("cover.garage_door").state == STATE_OPEN
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("cover.garage_door").state == STATE_CLOSED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("cover.garage_door").state == STATE_OPEN

--- a/tests/components/switch_as_x/test_light.py
+++ b/tests/components/switch_as_x/test_light.py
@@ -1,6 +1,4 @@
 """Tests for the Switch as X Light platform."""
-import pytest
-
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
@@ -25,7 +23,6 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -150,98 +147,3 @@ async def test_switch_service_calls(hass: HomeAssistant) -> None:
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
     assert hass.states.get("light.decorative_lights").state == STATE_ON
-
-
-@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
-async def test_config_entry_entity_id(
-    hass: HomeAssistant, target_domain: Platform
-) -> None:
-    """Test light switch setup from config entry with entity id."""
-    config_entry = MockConfigEntry(
-        data={},
-        domain=DOMAIN,
-        options={
-            CONF_ENTITY_ID: "switch.abc",
-            CONF_TARGET_DOMAIN: target_domain,
-        },
-        title="ABC",
-    )
-
-    config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert DOMAIN in hass.config.components
-
-    state = hass.states.get(f"{target_domain}.abc")
-    assert state
-    assert state.state == "unavailable"
-    # Name copied from config entry title
-    assert state.name == "ABC"
-
-    # Check the light is added to the entity registry
-    registry = er.async_get(hass)
-    entity_entry = registry.async_get(f"{target_domain}.abc")
-    assert entity_entry
-    assert entity_entry.unique_id == config_entry.entry_id
-
-
-@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
-async def test_config_entry_uuid(hass: HomeAssistant, target_domain: Platform) -> None:
-    """Test light switch setup from config entry with entity registry id."""
-    registry = er.async_get(hass)
-    registry_entry = registry.async_get_or_create("switch", "test", "unique")
-
-    config_entry = MockConfigEntry(
-        data={},
-        domain=DOMAIN,
-        options={
-            CONF_ENTITY_ID: registry_entry.id,
-            CONF_TARGET_DOMAIN: target_domain,
-        },
-        title="ABC",
-    )
-
-    config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(f"{target_domain}.abc")
-
-
-@pytest.mark.parametrize("target_domain", (Platform.LIGHT,))
-async def test_device(hass: HomeAssistant, target_domain: Platform) -> None:
-    """Test the entity is added to the wrapped entity's device."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
-    test_config_entry = MockConfigEntry()
-
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=test_config_entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-    )
-    switch_entity_entry = entity_registry.async_get_or_create(
-        "switch", "test", "unique", device_id=device_entry.id
-    )
-
-    switch_as_x_config_entry = MockConfigEntry(
-        data={},
-        domain=DOMAIN,
-        options={
-            CONF_ENTITY_ID: switch_entity_entry.id,
-            CONF_TARGET_DOMAIN: target_domain,
-        },
-        title="ABC",
-    )
-
-    switch_as_x_config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(switch_as_x_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
-    assert entity_entry
-    assert entity_entry.device_id == switch_entity_entry.device_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for Covers to the Switch as X integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
