### PR TITLE
Clean up Whois tests use entity_registry_enabled_by_default fixture

### DIFF
--- a/tests/components/whois/conftest.py
+++ b/tests/components/whois/conftest.py
@@ -124,13 +124,3 @@ async def init_integration_missing_some_attrs(
     await hass.async_block_till_done()
 
     return mock_config_entry
-
-
-@pytest.fixture
-def enable_all_entities() -> Generator[AsyncMock, None, None]:
-    """Test fixture that ensures all entities are enabled in the registry."""
-    with patch(
-        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-        return_value=True,
-    ) as mock_entity_registry_enabled_by_default:
-        yield mock_entity_registry_enabled_by_default

--- a/tests/components/whois/test_sensor.py
+++ b/tests/components/whois/test_sensor.py
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 @pytest.mark.freeze_time("2022-01-01 12:00:00", tz_offset=0)
 async def test_whois_sensors(
     hass: HomeAssistant,
-    enable_all_entities: AsyncMock,
+    entity_registry_enabled_by_default: AsyncMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the Whois sensors."""
@@ -146,7 +146,7 @@ async def test_whois_sensors(
 @pytest.mark.freeze_time("2022-01-01 12:00:00", tz_offset=0)
 async def test_whois_sensors_missing_some_attrs(
     hass: HomeAssistant,
-    enable_all_entities: AsyncMock,
+    entity_registry_enabled_by_default: AsyncMock,
     init_integration_missing_some_attrs: MockConfigEntry,
 ) -> None:
     """Test the Whois sensors with owner and reseller missing."""
@@ -213,7 +213,7 @@ async def test_disabled_by_default_sensors(
 async def test_no_data(
     hass: HomeAssistant,
     mock_whois: MagicMock,
-    enable_all_entities: AsyncMock,
+    entity_registry_enabled_by_default: AsyncMock,
     init_integration: MockConfigEntry,
     entity_id: str,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now we have a generic fixture in place, we don't need the custom one anymore in these tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
