### PR TITLE
Fix Spotify podcasts & Plex `allow_multiple` on Sonos

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "requirements": ["soco==0.27.0"],
+  "requirements": ["soco==0.27.1"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["plex", "spotify", "zeroconf", "media_source"],
   "zeroconf": ["_sonos._tcp.local."],

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "requirements": ["soco==0.26.4"],
+  "requirements": ["soco==0.27.0"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["plex", "spotify", "zeroconf", "media_source"],
   "zeroconf": ["_sonos._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2160,7 +2160,7 @@ smhi-pkg==1.0.15
 snapcast==2.1.3
 
 # homeassistant.components.sonos
-soco==0.27.0
+soco==0.27.1
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2160,7 +2160,7 @@ smhi-pkg==1.0.15
 snapcast==2.1.3
 
 # homeassistant.components.sonos
-soco==0.26.4
+soco==0.27.0
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1373,7 +1373,7 @@ smarthab==0.21
 smhi-pkg==1.0.15
 
 # homeassistant.components.sonos
-soco==0.27.0
+soco==0.27.1
 
 # homeassistant.components.solaredge
 solaredge==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1373,7 +1373,7 @@ smarthab==0.21
 smhi-pkg==1.0.15
 
 # homeassistant.components.sonos
-soco==0.26.4
+soco==0.27.0
 
 # homeassistant.components.solaredge
 solaredge==0.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/SoCo/SoCo/releases/tag/v0.27.0
https://github.com/SoCo/SoCo/compare/v0.26.4...v0.27.0

and

https://github.com/SoCo/SoCo/releases/tag/v0.27.1
https://github.com/SoCo/SoCo/compare/v0.27.0...v0.27.1

Provides new functionality for future PRs, but also immediately fixes:
* Playing Spotify podcasts (https://github.com/SoCo/SoCo/pull/902)
  * Allows:
  ```
  service: media_player.play_media
  data:
    entity_id: media_player.kitchen_sonos
    media_content_type: music
    media_content_id: https://open.spotify.com/episode/3K72efeqTcmHiUYGfafARv
  ```
* Playing Plex `allow_multiple` queries (https://github.com/SoCo/SoCo/pull/907)
  * Allows:
  ```
  service: media_player.play_media
  data:
    entity_id: media_player.kitchen_sonos
    media_content_type: music
    media_content_id: >
        plex://{"library_name": "Music", "libtype": "album", "sort": "random", "allow_multiple": "true", "maxresults": 3}
  ```

PR title has been named as such to ensure user-facing fixes do not go unnoticed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #65004
- This PR is related to issue: #66962
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
