### PR TITLE
Normalize enqueuing Plex media on Sonos

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -574,11 +574,14 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             else:
                 shuffle = False
             media = lookup_plex_media(self.hass, media_type, json.dumps(payload))
-            if not kwargs.get(ATTR_MEDIA_ENQUEUE):
-                soco.clear_queue()
             if shuffle:
                 self.set_shuffle(True)
-            plex_plugin.play_now(media)
+            if kwargs.get(ATTR_MEDIA_ENQUEUE):
+                plex_plugin.add_to_queue(media)
+            else:
+                soco.clear_queue()
+                plex_plugin.add_to_queue(media)
+                soco.play_from_queue(0)
             return
 
         share_link = self.coordinator.share_link

--- a/tests/components/sonos/test_plex_playback.py
+++ b/tests/components/sonos/test_plex_playback.py
@@ -25,8 +25,8 @@ async def test_plex_play_media(hass, async_autosetup_sonos):
     with patch(
         "homeassistant.components.sonos.media_player.lookup_plex_media"
     ) as mock_lookup, patch(
-        "soco.plugins.plex.PlexPlugin.play_now"
-    ) as mock_play_now, patch(
+        "soco.plugins.plex.PlexPlugin.add_to_queue"
+    ) as mock_add_to_queue, patch(
         "homeassistant.components.sonos.media_player.SonosMediaPlayerEntity.set_shuffle"
     ) as mock_shuffle:
         # Test successful Plex service call
@@ -42,14 +42,14 @@ async def test_plex_play_media(hass, async_autosetup_sonos):
         )
 
         assert len(mock_lookup.mock_calls) == 1
-        assert len(mock_play_now.mock_calls) == 1
+        assert len(mock_add_to_queue.mock_calls) == 1
         assert not mock_shuffle.called
         assert mock_lookup.mock_calls[0][1][1] == MEDIA_TYPE_MUSIC
         assert mock_lookup.mock_calls[0][1][2] == media_content_id
 
         # Test handling shuffle in payload
         mock_lookup.reset_mock()
-        mock_play_now.reset_mock()
+        mock_add_to_queue.reset_mock()
         shuffle_media_content_id = '{"library_name": "Music", "artist_name": "Artist", "album_name": "Album", "shuffle": 1}'
 
         assert await hass.services.async_call(
@@ -65,14 +65,14 @@ async def test_plex_play_media(hass, async_autosetup_sonos):
 
         assert mock_shuffle.called
         assert len(mock_lookup.mock_calls) == 1
-        assert len(mock_play_now.mock_calls) == 1
+        assert len(mock_add_to_queue.mock_calls) == 1
         assert mock_lookup.mock_calls[0][1][1] == MEDIA_TYPE_MUSIC
         assert mock_lookup.mock_calls[0][1][2] == media_content_id
 
         # Test failed Plex service call
         mock_lookup.reset_mock()
         mock_lookup.side_effect = HomeAssistantError
-        mock_play_now.reset_mock()
+        mock_add_to_queue.reset_mock()
 
         with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
@@ -86,4 +86,4 @@ async def test_plex_play_media(hass, async_autosetup_sonos):
                 blocking=True,
             )
         assert mock_lookup.called
-        assert not mock_play_now.called
+        assert not mock_add_to_queue.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Depends on #68131.

To fit the behavior of playing other media types, this change will:
* Only enqueue media at the end of the queue (and do not begin playback or change the currently playing track) with the optional `enqueue` service parameter.
* Replace the current playqueue on the device if `enqueue` is **not** set.

This will fix behavior to match the current documentation: https://www.home-assistant.io/integrations/sonos/#playing-media.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
