### PR TITLE
Ensure that YAML import updates the config entry in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from functools import partial
-import socket
 from typing import Any
 from urllib.parse import urlparse
 
@@ -87,12 +86,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return True
 
     for entry_config in config[DOMAIN]:
-        ip_address = await hass.async_add_executor_job(
-            socket.gethostbyname, entry_config[CONF_HOST]
-        )
-        hass.data[DOMAIN][ip_address] = {
-            CONF_ON_ACTION: entry_config.get(CONF_ON_ACTION)
-        }
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -235,9 +235,6 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # We need to import even if we cannot validate
         # since the TV may be off at startup
         await self._async_set_name_host_from_input(user_input)
-        self._async_abort_entries_match(
-            {CONF_HOST: self._host},
-        )
         entry, _ = self._async_get_existing_matching_entry()
         if entry:
             if self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -235,13 +235,15 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # We need to import even if we cannot validate
         # since the TV may be off at startup
         await self._async_set_name_host_from_input(user_input)
+        self._async_abort_entries_match(
+            {CONF_HOST: self._host},
+        )
         entry, _ = self._async_get_existing_matching_entry()
         if entry:
-            if not all(entry.data.get(k) == v for k, v in user_input.items()):
-                LOGGER.debug("Updating config entry from YAML: %s", user_input)
-                self.hass.config_entries.async_update_entry(
-                    entry, data={**entry.data, **user_input}
-                )
+            if self.hass.config_entries.async_update_entry(
+                entry, data={**entry.data, **user_input}
+            ):
+                LOGGER.debug("Updated config entry from YAML: %s", user_input)
             raise data_entry_flow.AbortFlow("already_configured")
 
         port = user_input.get(CONF_PORT)

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -234,6 +234,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle configuration by yaml file."""
         # We need to import even if we cannot validate
         # since the TV may be off at startup
+        LOGGER.debug("Importing config entry from YAML: %s", user_input)
         await self._async_set_name_host_from_input(user_input)
         entry, _ = self._async_get_existing_matching_entry()
         if entry:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -100,10 +100,8 @@ async def async_setup_entry(
     """Set up the Samsung TV from a config entry."""
     bridge = hass.data[DOMAIN][entry.entry_id]
 
-    host = entry.data[CONF_HOST]
     on_script = None
-    data = hass.data[DOMAIN]
-    if turn_on_action := data.get(host, {}).get(CONF_ON_ACTION):
+    if turn_on_action := entry.data.get(CONF_ON_ACTION):
         on_script = Script(
             hass, turn_on_action, entry.data.get(CONF_NAME, DEFAULT_NAME), DOMAIN
         )

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -946,7 +946,7 @@ async def test_import_legacy(
         CONF_PORT: 55000,
         CONF_ON_ACTION: [{"delay": "00:00:01"}],
     }
-    assert "Updating config entry from YAML:" in caplog.text
+    assert "Updated config entry from YAML:" in caplog.text
 
     # Import identical updated data
     caplog.clear()
@@ -958,7 +958,7 @@ async def test_import_legacy(
     await hass.async_block_till_done()
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
-    assert "Updating config entry from YAML:" not in caplog.text
+    assert "Updated config entry from YAML:" not in caplog.text
 
 
 @pytest.mark.usefixtures("remote", "remotews", "rest_api_failing")

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -899,8 +899,11 @@ async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remote")
-async def test_import_legacy(hass: HomeAssistant) -> None:
+async def test_import_legacy(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test importing from yaml with hostname."""
+    # Import basic data
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
@@ -916,37 +919,16 @@ async def test_import_legacy(hass: HomeAssistant) -> None:
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].data[CONF_METHOD] == METHOD_LEGACY
-    assert entries[0].data[CONF_PORT] == LEGACY_PORT
-
-
-@pytest.mark.usefixtures("remote")
-async def test_import_legacy_update(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """
-    Test importing from yaml with hostname.
-
-    CONF_ON_ACTION should be updated.
-    """
-    # Import basic data (same as above)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: "fake_host",
-            CONF_MANUFACTURER: "Samsung",
-            CONF_METHOD: "legacy",
-            CONF_NAME: "fake",
-            CONF_PORT: 55000,
-        },
-    )
-    entry.add_to_hass(hass)
-
-    entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(entries) == 1
-    assert CONF_ON_ACTION not in entries[0].data
+    assert entries[0].data == {
+        CONF_HOST: "fake_host",
+        CONF_MANUFACTURER: "Samsung",
+        CONF_METHOD: "legacy",
+        CONF_NAME: "fake",
+        CONF_PORT: 55000,
+    }
 
     # Import updated data
+    assert CONF_ON_ACTION not in entries[0].data
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure that if the YAML configuration is updated, the corresponding config entry is also updated.

In particular, I have discovered that changing the `turn_on_action` in YAML does not currently update the config entry, even though it is imported initially.

This removes the need to store extra information in `hass.data`, and should make deprecating YAML in the future easier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
