### PR TITLE
Update aioairzone to v0.1.0

### DIFF
--- a/homeassistant/components/airzone/__init__.py
+++ b/homeassistant/components/airzone/__init__.py
@@ -1,6 +1,8 @@
 """The Airzone integration."""
 from __future__ import annotations
 
+from typing import Any
+
 from aioairzone.common import ConnectionOptions
 from aioairzone.const import AZD_ID, AZD_NAME, AZD_SYSTEM, AZD_ZONES
 from aioairzone.localapi_device import AirzoneLocalApi
@@ -26,7 +28,7 @@ class AirzoneEntity(CoordinatorEntity):
         coordinator: AirzoneUpdateCoordinator,
         entry: ConfigEntry,
         system_zone_id: str,
-        zone_data: dict,
+        zone_data: dict[str, Any],
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -36,7 +38,6 @@ class AirzoneEntity(CoordinatorEntity):
             "manufacturer": MANUFACTURER,
             "name": f"Airzone [{system_zone_id}] {zone_data[AZD_NAME]}",
         }
-        self.airzone: AirzoneLocalApi = coordinator.airzone
         self.system_id = zone_data[AZD_SYSTEM]
         self.system_zone_id = system_zone_id
         self.zone_id = zone_data[AZD_ID]

--- a/homeassistant/components/airzone/__init__.py
+++ b/homeassistant/components/airzone/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from aioairzone.common import ConnectionOptions
-from aioairzone.const import AZD_ZONES
+from aioairzone.const import AZD_ID, AZD_NAME, AZD_SYSTEM, AZD_ZONES
 from aioairzone.localapi_device import AirzoneLocalApi
 
 from homeassistant.config_entries import ConfigEntry
@@ -26,7 +26,7 @@ class AirzoneEntity(CoordinatorEntity):
         coordinator: AirzoneUpdateCoordinator,
         entry: ConfigEntry,
         system_zone_id: str,
-        zone_name: str,
+        zone_data: dict,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -34,9 +34,12 @@ class AirzoneEntity(CoordinatorEntity):
         self._attr_device_info: DeviceInfo = {
             "identifiers": {(DOMAIN, f"{entry.entry_id}_{system_zone_id}")},
             "manufacturer": MANUFACTURER,
-            "name": f"Airzone [{system_zone_id}] {zone_name}",
+            "name": f"Airzone [{system_zone_id}] {zone_data[AZD_NAME]}",
         }
+        self.airzone: AirzoneLocalApi = coordinator.airzone
+        self.system_id = zone_data[AZD_SYSTEM]
         self.system_zone_id = system_zone_id
+        self.zone_id = zone_data[AZD_ID]
 
     def get_zone_value(self, key):
         """Return zone value by key."""

--- a/homeassistant/components/airzone/coordinator.py
+++ b/homeassistant/components/airzone/coordinator.py
@@ -23,7 +23,7 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(self, hass: HomeAssistant, airzone: AirzoneLocalApi) -> None:
         """Initialize."""
-        self.airzone: AirzoneLocalApi = airzone
+        self.airzone = airzone
 
         super().__init__(
             hass,

--- a/homeassistant/components/airzone/coordinator.py
+++ b/homeassistant/components/airzone/coordinator.py
@@ -23,7 +23,7 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(self, hass: HomeAssistant, airzone: AirzoneLocalApi) -> None:
         """Initialize."""
-        self.airzone = airzone
+        self.airzone: AirzoneLocalApi = airzone
 
         super().__init__(
             hass,

--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -3,7 +3,7 @@
   "name": "Airzone",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airzone",
-  "requirements": ["aioairzone==0.0.2"],
+  "requirements": ["aioairzone==0.1.0"],
   "codeowners": ["@Noltari"],
   "iot_class": "local_polling",
   "loggers": ["aioairzone"]

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -1,7 +1,7 @@
 """Support for the Airzone sensors."""
 from __future__ import annotations
 
-from typing import Final
+from typing import Any, Final
 
 from aioairzone.const import AZD_HUMIDITY, AZD_NAME, AZD_TEMP, AZD_TEMP_UNIT, AZD_ZONES
 
@@ -74,7 +74,7 @@ class AirzoneSensor(AirzoneEntity, SensorEntity):
         description: SensorEntityDescription,
         entry: ConfigEntry,
         system_zone_id: str,
-        zone_data: dict,
+        zone_data: dict[str, Any],
     ) -> None:
         """Initialize."""
         super().__init__(coordinator, entry, system_zone_id, zone_data)

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -50,8 +50,6 @@ async def async_setup_entry(
 
     sensors = []
     for system_zone_id, zone_data in coordinator.data[AZD_ZONES].items():
-        zone_name = zone_data[AZD_NAME]
-
         for description in SENSOR_TYPES:
             if description.key in zone_data:
                 sensors.append(
@@ -60,7 +58,7 @@ async def async_setup_entry(
                         description,
                         entry,
                         system_zone_id,
-                        zone_name,
+                        zone_data,
                     )
                 )
 
@@ -76,11 +74,11 @@ class AirzoneSensor(AirzoneEntity, SensorEntity):
         description: SensorEntityDescription,
         entry: ConfigEntry,
         system_zone_id: str,
-        zone_name: str,
+        zone_data: dict,
     ) -> None:
         """Initialize."""
-        super().__init__(coordinator, entry, system_zone_id, zone_name)
-        self._attr_name = f"{zone_name} {description.name}"
+        super().__init__(coordinator, entry, system_zone_id, zone_data)
+        self._attr_name = f"{zone_data[AZD_NAME]} {description.name}"
         self._attr_unique_id = f"{entry.entry_id}_{system_zone_id}_{description.key}"
         self.entity_description = description
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,7 +107,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.5
 
 # homeassistant.components.airzone
-aioairzone==0.0.2
+aioairzone==0.1.0
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -88,7 +88,7 @@ aio_geojson_nsw_rfs_incidents==0.4
 aio_georss_gdacs==0.5
 
 # homeassistant.components.airzone
-aioairzone==0.0.2
+aioairzone==0.1.0
 
 # homeassistant.components.ambient_station
 aioambient==2021.11.0


### PR DESCRIPTION
## Proposed change
Update aioairzone to v0.1.0 and add code improvements needed for https://github.com/home-assistant/core/pull/67924 and https://github.com/home-assistant/core/pull/68140.

Release notes:
- https://github.com/Noltari/aioairzone/releases/tag/0.0.3
- https://github.com/Noltari/aioairzone/releases/tag/0.0.4
- https://github.com/Noltari/aioairzone/releases/tag/0.1.0

Git compare: https://github.com/Noltari/aioairzone/compare/0.0.2...0.1.0

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. https://github.com/Noltari/aioairzone/compare/0.0.2...0.1.0
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
