### PR TITLE
Add support for menu step

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -523,7 +523,7 @@ class FlowHandler:
         self,
         *,
         step_id: str,
-        options: list[str] | dict[str, str],
+        menu_options: list[str] | dict[str, str],
         description_placeholders: dict | None = None,
     ) -> FlowResult:
         """Show a navigation menu to the user.
@@ -535,8 +535,8 @@ class FlowHandler:
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": step_id,
-            "data_schema": vol.Schema({"next_step_id": vol.In(options)}),
-            "menu_options": options,
+            "data_schema": vol.Schema({"next_step_id": vol.In(menu_options)}),
+            "menu_options": menu_options,
             "description_placeholders": description_placeholders,
         }
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -82,6 +82,7 @@ class FlowResult(TypedDict, total=False):
     context: dict[str, Any]
     result: Any
     last_step: bool | None
+    options: Mapping[str, Any]
     menu_options: list[str] | Mapping[str, Any]
 
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -21,6 +21,7 @@ RESULT_TYPE_EXTERNAL_STEP = "external"
 RESULT_TYPE_EXTERNAL_STEP_DONE = "external_done"
 RESULT_TYPE_SHOW_PROGRESS = "progress"
 RESULT_TYPE_SHOW_PROGRESS_DONE = "progress_done"
+RESULT_TYPE_MENU = "menu"
 
 # Event that is fired when a flow is progressed via external or progress source.
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
@@ -81,7 +82,7 @@ class FlowResult(TypedDict, total=False):
     context: dict[str, Any]
     result: Any
     last_step: bool | None
-    options: Mapping[str, Any]
+    menu_options: list[str] | Mapping[str, Any]
 
 
 @callback
@@ -249,7 +250,15 @@ class FlowManager(abc.ABC):
         if cur_step.get("data_schema") is not None and user_input is not None:
             user_input = cur_step["data_schema"](user_input)
 
-        result = await self._async_handle_step(flow, cur_step["step_id"], user_input)
+        # Handle a menu navigation choice
+        if cur_step["type"] == RESULT_TYPE_MENU and user_input:
+            result = await self._async_handle_step(
+                flow, user_input["next_step_id"], None
+            )
+        else:
+            result = await self._async_handle_step(
+                flow, cur_step["step_id"], user_input
+            )
 
         if cur_step["type"] in (RESULT_TYPE_EXTERNAL_STEP, RESULT_TYPE_SHOW_PROGRESS):
             if cur_step["type"] == RESULT_TYPE_EXTERNAL_STEP and result["type"] not in (
@@ -343,6 +352,7 @@ class FlowManager(abc.ABC):
             RESULT_TYPE_EXTERNAL_STEP_DONE,
             RESULT_TYPE_SHOW_PROGRESS,
             RESULT_TYPE_SHOW_PROGRESS_DONE,
+            RESULT_TYPE_MENU,
         ):
             raise ValueError(f"Handler returned incorrect type: {result['type']}")
 
@@ -352,6 +362,7 @@ class FlowManager(abc.ABC):
             RESULT_TYPE_EXTERNAL_STEP_DONE,
             RESULT_TYPE_SHOW_PROGRESS,
             RESULT_TYPE_SHOW_PROGRESS_DONE,
+            RESULT_TYPE_MENU,
         ):
             flow.cur_step = result
             return result
@@ -505,6 +516,28 @@ class FlowHandler:
             "flow_id": self.flow_id,
             "handler": self.handler,
             "step_id": next_step_id,
+        }
+
+    @callback
+    def async_show_menu(
+        self,
+        *,
+        step_id: str,
+        options: list[str] | dict[str, str],
+        description_placeholders: dict | None = None,
+    ) -> FlowResult:
+        """Show a navigation menu to the user.
+
+        Options dict maps step_id => i18n label
+        """
+        return {
+            "type": RESULT_TYPE_MENU,
+            "flow_id": self.flow_id,
+            "handler": self.handler,
+            "step_id": step_id,
+            "data_schema": vol.Schema({"next_step_id": vol.In(options)}),
+            "menu_options": options,
+            "description_placeholders": description_placeholders,
         }
 
 

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from aiohttp import web
 import voluptuous as vol
+import voluptuous_serialize
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.http import HomeAssistantView
@@ -32,10 +33,8 @@ class _BaseFlowManagerView(HomeAssistantView):
             data.pop("data")
             return data
 
-        if result["type"] != data_entry_flow.RESULT_TYPE_FORM:
+        if "data_schema" not in result:
             return result
-
-        import voluptuous_serialize  # pylint: disable=import-outside-toplevel
 
         data = result.copy()
 

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -110,6 +110,7 @@ def gen_data_entry_schema(
                 step_title_class("title"): cv.string_with_no_html,
                 vol.Optional("description"): cv.string_with_no_html,
                 vol.Optional("data"): {str: cv.string_with_no_html},
+                vol.Optional("menu_options"): {str: cv.string_with_no_html},
             }
         },
         vol.Optional("error"): {str: cv.string_with_no_html},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for a menu step in a data entry flow to help the user navigating to different options.

When menu_options is a:

- list of step IDs: labels are translated via `strings.json` and supports placeholders
- dictionary: step_id => label


https://user-images.githubusercontent.com/1444314/158463111-1b67e495-1d50-4c7d-8483-ebe5f8403848.mp4

Frontend PR: https://github.com/home-assistant/frontend/pull/12055


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
