### PR TITLE
Make TypeVars private (1)

### DIFF
--- a/homeassistant/components/diagnostics/util.py
+++ b/homeassistant/components/diagnostics/util.py
@@ -8,7 +8,7 @@ from homeassistant.core import callback
 
 from .const import REDACTED
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 @overload
@@ -17,18 +17,18 @@ def async_redact_data(data: Mapping, to_redact: Iterable[Any]) -> dict:  # type:
 
 
 @overload
-def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
+def async_redact_data(data: _T, to_redact: Iterable[Any]) -> _T:
     ...
 
 
 @callback
-def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
+def async_redact_data(data: _T, to_redact: Iterable[Any]) -> _T:
     """Redact sensitive data in a dict."""
     if not isinstance(data, (Mapping, list)):
         return data
 
     if isinstance(data, list):
-        return cast(T, [async_redact_data(val, to_redact) for val in data])
+        return cast(_T, [async_redact_data(val, to_redact) for val in data])
 
     redacted = {**data}
 
@@ -40,4 +40,4 @@ def async_redact_data(data: T, to_redact: Iterable[Any]) -> T:
         elif isinstance(value, list):
             redacted[key] = [async_redact_data(item, to_redact) for item in value]
 
-    return cast(T, redacted)
+    return cast(_T, redacted)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -99,15 +99,13 @@ STAGE_3_SHUTDOWN_TIMEOUT = 30
 
 block_async_io.enable()
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 _R = TypeVar("_R")
 _R_co = TypeVar("_R_co", covariant=True)  # pylint: disable=invalid-name
 # Internal; not helpers.typing.UNDEFINED due to circular dependency
 _UNDEF: dict[Any, Any] = {}
-# pylint: disable=invalid-name
-CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable[..., Any])
-CALLBACK_TYPE = Callable[[], None]
-# pylint: enable=invalid-name
+_CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+CALLBACK_TYPE = Callable[[], None]  # pylint: disable=invalid-name
 
 CORE_STORAGE_KEY = "core.config"
 CORE_STORAGE_VERSION = 1
@@ -165,7 +163,7 @@ def valid_state(state: str) -> bool:
     return len(state) <= MAX_LENGTH_STATE_STATE
 
 
-def callback(func: CALLABLE_T) -> CALLABLE_T:
+def callback(func: _CallableT) -> _CallableT:
     """Annotation to mark method as safe to call from within the event loop."""
     setattr(func, "_hass_callback", True)
     return func
@@ -480,8 +478,8 @@ class HomeAssistant:
 
     @callback
     def async_add_executor_job(
-        self, target: Callable[..., T], *args: Any
-    ) -> asyncio.Future[T]:
+        self, target: Callable[..., _T], *args: Any
+    ) -> asyncio.Future[_T]:
         """Add an executor job from within the event loop."""
         task = self.loop.run_in_executor(None, target, *args)
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -35,9 +35,7 @@ from .util.async_ import gather_with_concurrency
 if TYPE_CHECKING:
     from .core import HomeAssistant
 
-CALLABLE_T = TypeVar(  # pylint: disable=invalid-name
-    "CALLABLE_T", bound=Callable[..., Any]
-)
+_CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -805,7 +803,7 @@ class Helpers:
         return wrapped
 
 
-def bind_hass(func: CALLABLE_T) -> CALLABLE_T:
+def bind_hass(func: _CallableT) -> _CallableT:
     """Decorate function to indicate that first argument is hass."""
     setattr(func, "__bind_hass", True)
     return func

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.util import dt as dt_util
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 # mypy: no-warn-return-any
 
-CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # pylint: disable=invalid-name
+_CallableT = TypeVar("_CallableT", bound=Callable)
 
 BENCHMARKS: dict[str, Callable] = {}
 
@@ -54,7 +54,7 @@ async def run_benchmark(bench):
     await hass.async_stop()
 
 
-def benchmark(func: CALLABLE_T) -> CALLABLE_T:
+def benchmark(func: _CallableT) -> _CallableT:
     """Decorate to mark a benchmark."""
     BENCHMARKS[func.__name__] = func
     return func

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -15,8 +15,8 @@ import slugify as unicode_slug
 
 from .dt import as_local, utcnow
 
-T = TypeVar("T")
-U = TypeVar("U")  # pylint: disable=invalid-name
+_T = TypeVar("_T")
+_U = TypeVar("_U")
 
 RE_SANITIZE_FILENAME = re.compile(r"(~|\.\.|/|\\)")
 RE_SANITIZE_PATH = re.compile(r"(~|\.(\.)+)")
@@ -63,8 +63,8 @@ def repr_helper(inp: Any) -> str:
 
 
 def convert(
-    value: T | None, to_type: Callable[[T], U], default: U | None = None
-) -> U | None:
+    value: _T | None, to_type: Callable[[_T], _U], default: _U | None = None
+) -> _U | None:
     """Convert value to to_type, returns default if fails."""
     try:
         return default if value is None else to_type(value)

--- a/homeassistant/util/percentage.py
+++ b/homeassistant/util/percentage.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from typing import TypeVar
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
-def ordered_list_item_to_percentage(ordered_list: list[T], item: T) -> int:
+def ordered_list_item_to_percentage(ordered_list: list[_T], item: _T) -> int:
     """Determine the percentage of an item in an ordered list.
 
     When using this utility for fan speeds, do not include "off"
@@ -29,7 +29,7 @@ def ordered_list_item_to_percentage(ordered_list: list[T], item: T) -> int:
     return (list_position * 100) // list_len
 
 
-def percentage_to_ordered_list_item(ordered_list: list[T], percentage: int) -> T:
+def percentage_to_ordered_list_item(ordered_list: list[_T], percentage: int) -> _T:
     """Find the item that most closely matches the percentage in an ordered list.
 
     When using this utility for fan speeds, do not include "off"

--- a/homeassistant/util/read_only_dict.py
+++ b/homeassistant/util/read_only_dict.py
@@ -7,11 +7,11 @@ def _readonly(*args: Any, **kwargs: Any) -> Any:
     raise RuntimeError("Cannot modify ReadOnlyDict")
 
 
-Key = TypeVar("Key")
-Value = TypeVar("Value")
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 
-class ReadOnlyDict(dict[Key, Value]):
+class ReadOnlyDict(dict[_KT, _VT]):
     """Read only version of dict that is compatible with dict types."""
 
     __setitem__ = _readonly

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -19,7 +19,7 @@ from .objects import Input, NodeListClass, NodeStrClass
 # mypy: allow-untyped-calls, no-warn-return-any
 
 JSON_TYPE = Union[list, dict, str]  # pylint: disable=invalid-name
-DICT_T = TypeVar("DICT_T", bound=dict)  # pylint: disable=invalid-name
+_DictT = TypeVar("_DictT", bound=dict)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,8 +144,8 @@ def _add_reference(
 
 @overload
 def _add_reference(
-    obj: DICT_T, loader: SafeLineLoader, node: yaml.nodes.Node
-) -> DICT_T:
+    obj: _DictT, loader: SafeLineLoader, node: yaml.nodes.Node
+) -> _DictT:
     ...
 
 


### PR DESCRIPTION
## Proposed change
As suggested in #68154, this PR changes the first batch of TypeVars to private.
The main advantage is that they don't accidentally get imported and used somewhere else. It's recommended to create new TypeVars for each Module if necessary.

I've also adjusted the naming scheme while I'm at it. [PEP8](https://peps.python.org/pep-0008/#type-variable-names) recommends to use `CapWords` with an optional `co` / `contra` suffix. Additionally, from looking at typeshed, some other rules make also sense.
* `_T`, `_R`, `_U`, `_KT`, `_VT` are usually good names.
* A `T` suffix can be used: `_CallableT`.
* The name should **not** end with `Type` as this suffix usually indicates type aliases.

The next pylint version will support name checks of TypeVars which should help enforce these rules.
_The ones mentioned will be the default. We are free to adjust the regex for Home Assistant though._

A few more good examples
https://github.com/home-assistant/core/blob/65c670c2c7c468fb8d32c9a391a62104648d1017/homeassistant/components/esphome/__init__.py#L535-L537


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
