### PR TITLE
Validate TTS base url

### DIFF
--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from unittest.mock import PropertyMock, patch
 
 import pytest
+import voluptuous as vol
 import yarl
 
 from homeassistant.components import tts
@@ -16,6 +17,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.setup import async_setup_component
+from homeassistant.util.network import normalize_url
 
 from tests.common import assert_setup_component, async_mock_service
 
@@ -689,3 +691,40 @@ async def test_tags_with_wave(hass, demo_provider):
     )
 
     assert tagged_data != demo_data
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "http://example.local:8123",
+        "http://example.local",
+        "http://example.local:80",
+        "https://example.com",
+        "https://example.com:443",
+        "https://example.com:8123",
+    ),
+)
+def test_valid_base_url(value):
+    """Test we validate base urls."""
+    assert tts.valid_base_url(value) == normalize_url(value)
+    # Test we strip trailing `/`
+    assert tts.valid_base_url(value + "/") == normalize_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "http://example.local:8123/sub-path",
+        "http://example.local/sub-path",
+        "https://example.com/sub-path",
+        "https://example.com:8123/sub-path",
+        "mailto:some@email",
+        "http:example.com",
+        "http:/example.com",
+        "http//example.com",
+    ),
+)
+def test_invalid_base_url(value):
+    """Test we catch bad base urls."""
+    with pytest.raises(vol.Invalid):
+        tts.valid_base_url(value)

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -722,6 +722,7 @@ def test_valid_base_url(value):
         "http:example.com",
         "http:/example.com",
         "http//example.com",
+        "example.com",
     ),
 )
 def test_invalid_base_url(value):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If you have an invalid base URL set for a TTS platform, the TTS say service wont' work. This is very hard to debug as the URLs are send to other devices which might not report bad URLs.

The base URL was previously validated as just a string and now it's actually verified it's set to a host. 

Will probably catch what is causing #67606

Note, ideally users do not use this `tts.base_url` but just rely on the internal URL.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
