### PR TITLE
Bump PyNaCl to 1.5.0

### DIFF
--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mobile App",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
-  "requirements": ["PyNaCl==1.4.0"],
+  "requirements": ["PyNaCl==1.5.0"],
   "dependencies": ["http", "webhook", "person", "tag", "websocket_api"],
   "after_dependencies": ["cloud", "camera", "notify"],
   "codeowners": ["@home-assistant/core"],

--- a/homeassistant/components/owntracks/helper.py
+++ b/homeassistant/components/owntracks/helper.py
@@ -2,7 +2,7 @@
 try:
     import nacl
 except ImportError:
-    nacl = None
+    nacl = None  # type: ignore[assignment]
 
 
 def supports_encryption() -> bool:

--- a/homeassistant/components/owntracks/manifest.json
+++ b/homeassistant/components/owntracks/manifest.json
@@ -3,7 +3,7 @@
   "name": "OwnTracks",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/owntracks",
-  "requirements": ["PyNaCl==1.4.0"],
+  "requirements": ["PyNaCl==1.5.0"],
   "dependencies": ["webhook"],
   "after_dependencies": ["mqtt", "cloud"],
   "codeowners": [],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,5 +1,5 @@
 PyJWT==2.1.0
-PyNaCl==1.4.0
+PyNaCl==1.5.0
 aiodiscover==1.4.8
 aiohttp==3.8.1
 aiohttp_cors==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -21,7 +21,7 @@ PyMVGLive==1.1.4
 
 # homeassistant.components.mobile_app
 # homeassistant.components.owntracks
-PyNaCl==1.4.0
+PyNaCl==1.5.0
 
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.homekit

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -17,7 +17,7 @@ PyFlick==0.0.2
 
 # homeassistant.components.mobile_app
 # homeassistant.components.owntracks
-PyNaCl==1.4.0
+PyNaCl==1.5.0
 
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.homekit


### PR DESCRIPTION
## Proposed change
The current version of PyNaCl (1.4.0) can't be installed on amd64 Macs. While this shouldn't affect production users, this issue pollutes the logs when using an M1 Mac as a dev machine. Updating to 1.5.0 adds wheels for M1 Macs and appears to be fully compatibile with 1.4.0 code.

Changelog: https://github.com/pyca/pynacl/blob/main/CHANGELOG.rst#150-2022-01-07


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
