### PR TITLE
Add backup platform to recorder

### DIFF
--- a/homeassistant/components/recorder/backup.py
+++ b/homeassistant/components/recorder/backup.py
@@ -2,6 +2,7 @@
 from logging import getLogger
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from . import Recorder
 from .const import DATA_INSTANCE
@@ -20,4 +21,5 @@ async def async_post_backup(hass: HomeAssistant) -> None:
     """Perform operations after a backup finishes."""
     instance: Recorder = hass.data[DATA_INSTANCE]
     _LOGGER.info("Backup end notification, releasing write lock")
-    instance.unlock_database()
+    if not instance.unlock_database():
+        raise HomeAssistantError("Could not release database write lock")

--- a/homeassistant/components/recorder/backup.py
+++ b/homeassistant/components/recorder/backup.py
@@ -6,6 +6,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import Recorder
 from .const import DATA_INSTANCE
+from .util import async_migration_in_progress
 
 _LOGGER = getLogger(__name__)
 
@@ -14,6 +15,8 @@ async def async_pre_backup(hass: HomeAssistant) -> None:
     """Perform operations before a backup starts."""
     _LOGGER.info("Backup start notification, locking database for writes")
     instance: Recorder = hass.data[DATA_INSTANCE]
+    if async_migration_in_progress(hass):
+        raise HomeAssistantError("Database migration in progress")
     await instance.lock_database()
 
 

--- a/homeassistant/components/recorder/backup.py
+++ b/homeassistant/components/recorder/backup.py
@@ -1,0 +1,23 @@
+"""Backup platform for the Recorder integration."""
+from logging import getLogger
+
+from homeassistant.core import HomeAssistant
+
+from . import Recorder
+from .const import DATA_INSTANCE
+
+_LOGGER = getLogger(__name__)
+
+
+async def async_pre_backup(hass: HomeAssistant) -> None:
+    """Perform operations before a backup starts."""
+    _LOGGER.info("Backup start notification, locking database for writes")
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    await instance.lock_database()
+
+
+async def async_post_backup(hass: HomeAssistant) -> None:
+    """Perform operations after a backup finishes."""
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    _LOGGER.info("Backup end notification, releasing write lock")
+    instance.unlock_database()

--- a/tests/components/recorder/test_backup.py
+++ b/tests/components/recorder/test_backup.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.recorder.backup import async_post_backup, async_pre_backup
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import async_init_recorder_component
 
@@ -41,5 +42,17 @@ async def test_async_post_backup(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.recorder.backup.Recorder.unlock_database"
     ) as unlock_mock:
+        await async_post_backup(hass)
+        assert unlock_mock.called
+
+
+async def test_async_post_backup_failure(hass: HomeAssistant) -> None:
+    """Test post backup failure."""
+    await async_init_recorder_component(hass)
+
+    with patch(
+        "homeassistant.components.recorder.backup.Recorder.unlock_database",
+        return_value=False,
+    ) as unlock_mock, pytest.raises(HomeAssistantError):
         await async_post_backup(hass)
         assert unlock_mock.called

--- a/tests/components/recorder/test_backup.py
+++ b/tests/components/recorder/test_backup.py
@@ -35,6 +35,17 @@ async def test_async_pre_backup_with_timeout(hass: HomeAssistant) -> None:
         assert lock_mock.called
 
 
+async def test_async_pre_backup_with_migration(hass: HomeAssistant) -> None:
+    """Test pre backup with migration."""
+    await async_init_recorder_component(hass)
+
+    with patch(
+        "homeassistant.components.recorder.backup.async_migration_in_progress",
+        return_value=True,
+    ), pytest.raises(HomeAssistantError):
+        await async_pre_backup(hass)
+
+
 async def test_async_post_backup(hass: HomeAssistant) -> None:
     """Test post backup."""
     await async_init_recorder_component(hass)

--- a/tests/components/recorder/test_backup.py
+++ b/tests/components/recorder/test_backup.py
@@ -1,0 +1,45 @@
+"""Test backup platform for the Recorder integration."""
+
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.recorder.backup import async_post_backup, async_pre_backup
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_init_recorder_component
+
+
+async def test_async_pre_backup(hass: HomeAssistant) -> None:
+    """Test pre backup."""
+    await async_init_recorder_component(hass)
+
+    with patch(
+        "homeassistant.components.recorder.backup.Recorder.lock_database"
+    ) as lock_mock:
+        await async_pre_backup(hass)
+        assert lock_mock.called
+
+
+async def test_async_pre_backup_with_timeout(hass: HomeAssistant) -> None:
+    """Test pre backup with timeout."""
+    await async_init_recorder_component(hass)
+
+    with patch(
+        "homeassistant.components.recorder.backup.Recorder.lock_database",
+        side_effect=TimeoutError(),
+    ) as lock_mock, pytest.raises(TimeoutError):
+        await async_pre_backup(hass)
+        assert lock_mock.called
+
+
+async def test_async_post_backup(hass: HomeAssistant) -> None:
+    """Test post backup."""
+    await async_init_recorder_component(hass)
+
+    with patch(
+        "homeassistant.components.recorder.backup.Recorder.unlock_database"
+    ) as unlock_mock:
+        await async_post_backup(hass)
+        assert unlock_mock.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds backup platform to the recorder to lock/unlock during backup.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
