### PR TITLE
Add Cover to Z-Wave.Me integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1470,6 +1470,7 @@ omit =
     homeassistant/components/zwave_me/__init__.py
     homeassistant/components/zwave_me/binary_sensor.py
     homeassistant/components/zwave_me/button.py
+    homeassistant/components/zwave_me/cover.py
     homeassistant/components/zwave_me/climate.py
     homeassistant/components/zwave_me/helpers.py
     homeassistant/components/zwave_me/light.py

--- a/homeassistant/components/zwave_me/const.py
+++ b/homeassistant/components/zwave_me/const.py
@@ -12,6 +12,7 @@ class ZWaveMePlatform(StrEnum):
     BINARY_SENSOR = "sensorBinary"
     BUTTON = "toggleButton"
     CLIMATE = "thermostat"
+    COVER = "motor"
     LOCK = "doorlock"
     NUMBER = "switchMultilevel"
     SWITCH = "switchBinary"
@@ -25,6 +26,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CLIMATE,
+    Platform.COVER,
     Platform.LIGHT,
     Platform.LOCK,
     Platform.NUMBER,

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -46,7 +46,7 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
         """Open cover."""
         self.controller.zwave_api.send_command(self.device.id, "exact?level=99")
 
-    def set_cover_position(self, value: float) -> None:
+    def set_cover_position(self, **kwargs: Any) -> None:
         """Update the current value."""
         self.controller.zwave_api.send_command(
             self.device.id, f"exact?level={str(round(value))}"

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -2,6 +2,7 @@
 from typing import Any
 
 from homeassistant.components.cover import (
+    ATTR_POSITION,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
@@ -51,7 +52,7 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
     def set_cover_position(self, **kwargs: Any) -> None:
         """Update the current value."""
         self.controller.zwave_api.send_command(
-            self.device.id, f"exact?level={str(round(value))}"
+            self.device.id, f"exact?level={str(round(kwargs[ATTR_POSITION]))}"
         )
 
     @property

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -55,7 +55,7 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
         """Update the current value."""
         value = kwargs[ATTR_POSITION]
         self.controller.zwave_api.send_command(
-            self.device.id, f"exact?level={str(value) if value < 100 else '99'}"
+            self.device.id, f"exact?level={str(min(value, 99))}"
         )
 
     @property

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -53,8 +53,9 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
 
     def set_cover_position(self, **kwargs: Any) -> None:
         """Update the current value."""
+        value = kwargs[ATTR_POSITION]
         self.controller.zwave_api.send_command(
-            self.device.id, f"exact?level={str(kwargs[ATTR_POSITION])}"
+            self.device.id, f"exact?level={str(value) if value < 100 else '99'}"
         )
 
     @property

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -1,4 +1,6 @@
 """Representation of a cover."""
+from __future__ import annotations
+
 from typing import Any
 
 from homeassistant.components.cover import (
@@ -52,7 +54,7 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
     def set_cover_position(self, **kwargs: Any) -> None:
         """Update the current value."""
         self.controller.zwave_api.send_command(
-            self.device.id, f"exact?level={str(round(kwargs[ATTR_POSITION]))}"
+            self.device.id, f"exact?level={str(kwargs[ATTR_POSITION])}"
         )
 
     @property

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -1,9 +1,9 @@
 """Representation of a cover."""
 from homeassistant.components.cover import (
-    CoverEntity,
+    SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
-    SUPPORT_CLOSE,
+    CoverEntity,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -1,4 +1,6 @@
 """Representation of a cover."""
+from typing import Any
+
 from homeassistant.components.cover import (
     SUPPORT_CLOSE,
     SUPPORT_OPEN,

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -1,0 +1,66 @@
+"""Representation of a cover."""
+from homeassistant.components.cover import (
+    CoverEntity,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    SUPPORT_CLOSE,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import ZWaveMeEntity
+from .const import DOMAIN, ZWaveMePlatform
+
+DEVICE_NAME = ZWaveMePlatform.COVER
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the cover platform."""
+
+    @callback
+    def add_new_device(new_device):
+        controller = hass.data[DOMAIN][config_entry.entry_id]
+        cover = ZWaveMeCover(controller, new_device)
+
+        async_add_entities(
+            [
+                cover,
+            ]
+        )
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, f"ZWAVE_ME_NEW_{DEVICE_NAME.upper()}", add_new_device
+        )
+    )
+
+
+class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
+    """Representation of a ZWaveMe Multilevel Cover."""
+
+    def close_cover(self, **kwargs):
+        """Close cover."""
+        self.controller.zwave_api.send_command(self.device.id, "exact?level=0")
+
+    def open_cover(self, **kwargs):
+        """Open cover."""
+        self.controller.zwave_api.send_command(self.device.id, "exact?level=99")
+
+    def set_cover_position(self, value: float) -> None:
+        """Update the current value."""
+        self.controller.zwave_api.send_command(
+            self.device.id, f"exact?level={str(round(value))}"
+        )
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return current position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return self.device.level
+
+    @property
+    def supported_features(self) -> int:
+        """Return the supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION

--- a/homeassistant/components/zwave_me/manifest.json
+++ b/homeassistant/components/zwave_me/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/integrations/zwave_me",
   "iot_class": "local_push",
   "requirements": [
-    "zwave_me_ws==0.2.2",
+    "zwave_me_ws==0.2.3",
     "url-normalize==1.4.1"
   ],
   "after_dependencies": ["zeroconf"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2494,4 +2494,4 @@ zm-py==0.5.2
 zwave-js-server-python==0.35.2
 
 # homeassistant.components.zwave_me
-zwave_me_ws==0.2.2
+zwave_me_ws==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1596,4 +1596,4 @@ zigpy==0.43.0
 zwave-js-server-python==0.35.2
 
 # homeassistant.components.zwave_me
-zwave_me_ws==0.2.2
+zwave_me_ws==0.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade: https://github.com/Z-Wave-Me/zwave-me-ws/releases/tag/v0.2.3
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22032

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
