### PR TITLE
Fix TypeError in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -321,6 +321,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
         if self._app_list is None and (remote := self._get_remote()):
             with contextlib.suppress(TypeError, WebSocketTimeoutException):
                 raw_app_list: list[dict[str, str]] = remote.app_list()
+                LOGGER.debug("Received app list: %s", raw_app_list)
                 self._app_list = {
                     app["name"]: app["appId"]
                     for app in sorted(raw_app_list, key=lambda app: app["name"])

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -319,7 +319,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
     def _get_app_list(self) -> dict[str, str] | None:
         """Get installed app list."""
         if self._app_list is None and (remote := self._get_remote()):
-            with contextlib.suppress(WebSocketTimeoutException):
+            with contextlib.suppress(TypeError, WebSocketTimeoutException):
                 raw_app_list: list[dict[str, str]] = remote.app_list()
                 self._app_list = {
                     app["name"]: app["appId"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix TypeError in SamsungTV.
It seems that some TVs reply to the app_list command with invalid information.
I'm pretty sure that's due to the old version of the upstream library not handling message order correctly and sending back invalid information.

⚠️ This is targetted against rc branch because samsungtv has been fully refactored to async for 2022.4.

Original error
```console
Update for media_player.samsung_q60_series_50 fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 535, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 744, in async_device_update
    raise exc
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/media_player.py", line 169, in async_update
    await self._async_update_app_list()
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/media_player.py", line 172, in _async_update_app_list
    self._app_list = await self._bridge.async_get_app_list()
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/bridge.py", line 317, in async_get_app_list
    return await self.hass.async_add_executor_job(self._get_app_list)
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/bridge.py", line 326, in _get_app_list
    for app in sorted(raw_app_list, key=lambda app: app["name"])
  File "/usr/src/homeassistant/homeassistant/components/samsungtv/bridge.py", line 326, in <lambda>
    for app in sorted(raw_app_list, key=lambda app: app["name"])
TypeError: string indices must be integers
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68217
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
