### PR TITLE
Add inverter size to Forecast.Solar

### DIFF
--- a/homeassistant/components/forecast_solar/__init__.py
+++ b/homeassistant/components/forecast_solar/__init__.py
@@ -30,7 +30,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # this if statement is here to catch that.
     api_key = entry.options.get(CONF_API_KEY) or None
 
-    if (inverter_size := entry.options.get(CONF_INVERTER_SIZE)) not in (None, 0):
+    if (
+        inverter_size := entry.options.get(CONF_INVERTER_SIZE)
+    ) is not None and inverter_size > 0:
         inverter_size = inverter_size / 1000
 
     session = async_get_clientsession(hass)

--- a/homeassistant/components/forecast_solar/__init__.py
+++ b/homeassistant/components/forecast_solar/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_AZIMUTH,
     CONF_DAMPING,
     CONF_DECLINATION,
+    CONF_INVERTER_SIZE,
     CONF_MODULES_POWER,
     DOMAIN,
 )
@@ -29,6 +30,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # this if statement is here to catch that.
     api_key = entry.options.get(CONF_API_KEY) or None
 
+    if (inverter_size := entry.options.get(CONF_INVERTER_SIZE)) not in (None, 0):
+        inverter_size = inverter_size / 1000
+
     session = async_get_clientsession(hass)
     forecast = ForecastSolar(
         api_key=api_key,
@@ -39,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         azimuth=(entry.options[CONF_AZIMUTH] - 180),
         kwp=(entry.options[CONF_MODULES_POWER] / 1000),
         damping=entry.options.get(CONF_DAMPING, 0),
+        inverter=inverter_size,
     )
 
     # Free account have a resolution of 1 hour, using that as the default

--- a/homeassistant/components/forecast_solar/config_flow.py
+++ b/homeassistant/components/forecast_solar/config_flow.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_AZIMUTH,
     CONF_DAMPING,
     CONF_DECLINATION,
+    CONF_INVERTER_SIZE,
     CONF_MODULES_POWER,
     DOMAIN,
 )
@@ -118,6 +119,14 @@ class ForecastSolarOptionFlowHandler(OptionsFlow):
                         CONF_DAMPING,
                         default=self.config_entry.options.get(CONF_DAMPING, 0.0),
                     ): vol.Coerce(float),
+                    vol.Optional(
+                        CONF_INVERTER_SIZE,
+                        description={
+                            "suggested_value": self.config_entry.options.get(
+                                CONF_INVERTER_SIZE
+                            )
+                        },
+                    ): vol.Coerce(int),
                 }
             ),
         )

--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -14,6 +14,7 @@ CONF_DECLINATION = "declination"
 CONF_AZIMUTH = "azimuth"
 CONF_MODULES_POWER = "modules power"
 CONF_DAMPING = "damping"
+CONF_INVERTER_SIZE = "inverter size"
 
 SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
     ForecastSolarSensorEntityDescription(

--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -14,7 +14,7 @@ CONF_DECLINATION = "declination"
 CONF_AZIMUTH = "azimuth"
 CONF_MODULES_POWER = "modules power"
 CONF_DAMPING = "damping"
-CONF_INVERTER_SIZE = "inverter size"
+CONF_INVERTER_SIZE = "inverter_size"
 
 SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
     ForecastSolarSensorEntityDescription(

--- a/homeassistant/components/forecast_solar/manifest.json
+++ b/homeassistant/components/forecast_solar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Forecast.Solar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/forecast_solar",
-  "requirements": ["forecast_solar==2.1.0"],
+  "requirements": ["forecast_solar==2.2.0"],
   "codeowners": ["@klaasnicolaas", "@frenck"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/homeassistant/components/forecast_solar/strings.json
+++ b/homeassistant/components/forecast_solar/strings.json
@@ -22,6 +22,7 @@
           "api_key": "Forecast.Solar API Key (optional)",
           "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
           "damping": "Damping factor: adjusts the results in the morning and evening",
+          "inverter size": "Inverter size (Watt)",
           "declination": "Declination (0 = Horizontal, 90 = Vertical)",
           "modules power": "Total Watt peak power of your solar modules"
         }

--- a/homeassistant/components/forecast_solar/strings.json
+++ b/homeassistant/components/forecast_solar/strings.json
@@ -22,7 +22,7 @@
           "api_key": "Forecast.Solar API Key (optional)",
           "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
           "damping": "Damping factor: adjusts the results in the morning and evening",
-          "inverter size": "Inverter size (Watt)",
+          "inverter_size": "Inverter size (Watt)",
           "declination": "Declination (0 = Horizontal, 90 = Vertical)",
           "modules power": "Total Watt peak power of your solar modules"
         }

--- a/homeassistant/components/forecast_solar/translations/en.json
+++ b/homeassistant/components/forecast_solar/translations/en.json
@@ -21,6 +21,7 @@
                     "api_key": "Forecast.Solar API Key (optional)",
                     "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
                     "damping": "Damping factor: adjusts the results in the morning and evening",
+                    "inverter size": "Inverter size (Watt)",
                     "declination": "Declination (0 = Horizontal, 90 = Vertical)",
                     "modules power": "Total Watt peak power of your solar modules"
                 },

--- a/homeassistant/components/forecast_solar/translations/en.json
+++ b/homeassistant/components/forecast_solar/translations/en.json
@@ -21,7 +21,7 @@
                     "api_key": "Forecast.Solar API Key (optional)",
                     "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
                     "damping": "Damping factor: adjusts the results in the morning and evening",
-                    "inverter size": "Inverter size (Watt)",
+                    "inverter_size": "Inverter size (Watt)",
                     "declination": "Declination (0 = Horizontal, 90 = Vertical)",
                     "modules power": "Total Watt peak power of your solar modules"
                 },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -654,7 +654,7 @@ fnvhash==0.1.0
 foobot_async==1.0.0
 
 # homeassistant.components.forecast_solar
-forecast_solar==2.1.0
+forecast_solar==2.2.0
 
 # homeassistant.components.fortios
 fortiosapi==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -446,7 +446,7 @@ fnvhash==0.1.0
 foobot_async==1.0.0
 
 # homeassistant.components.forecast_solar
-forecast_solar==2.1.0
+forecast_solar==2.2.0
 
 # homeassistant.components.freebox
 freebox-api==0.0.10

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -11,6 +11,7 @@ from homeassistant.components.forecast_solar.const import (
     CONF_AZIMUTH,
     CONF_DAMPING,
     CONF_DECLINATION,
+    CONF_INVERTER_SIZE,
     CONF_MODULES_POWER,
     DOMAIN,
 )
@@ -38,6 +39,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_AZIMUTH: 190,
             CONF_MODULES_POWER: 5100,
             CONF_DAMPING: 0.5,
+            CONF_INVERTER_SIZE: 2000,
         },
     )
 

--- a/tests/components/forecast_solar/test_config_flow.py
+++ b/tests/components/forecast_solar/test_config_flow.py
@@ -5,6 +5,7 @@ from homeassistant.components.forecast_solar.const import (
     CONF_AZIMUTH,
     CONF_DAMPING,
     CONF_DECLINATION,
+    CONF_INVERTER_SIZE,
     CONF_MODULES_POWER,
     DOMAIN,
 )
@@ -81,6 +82,7 @@ async def test_options_flow(
             CONF_AZIMUTH: 22,
             CONF_MODULES_POWER: 2122,
             CONF_DAMPING: 0.25,
+            CONF_INVERTER_SIZE: 2000,
         },
     )
 
@@ -91,4 +93,5 @@ async def test_options_flow(
         CONF_AZIMUTH: 22,
         CONF_MODULES_POWER: 2122,
         CONF_DAMPING: 0.25,
+        CONF_INVERTER_SIZE: 2000,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the ability to Forecast.Solar to specify an inverter size in watts.
This required updating the python package to: 2.2.0

https://github.com/home-assistant-libs/forecast_solar/releases/tag/2.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22051

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
