### PR TITLE
Update pyaussiebb to 0.0.14

### DIFF
--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -6,6 +6,7 @@ import logging
 
 from aiohttp import ClientError
 from aussiebb.asyncio import AussieBB
+from aussiebb.const import FETCH_TYPES
 from aussiebb.exceptions import AuthenticationException, UnrecognisedServiceType
 
 from homeassistant.config_entries import ConfigEntry
@@ -31,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     try:
         await client.login()
-        services = await client.get_services()
+        services = await client.get_services(drop_types=FETCH_TYPES)
     except AuthenticationException as exc:
         raise ConfigEntryAuthFailed() from exc
     except ClientError as exc:

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from aiohttp import ClientError
 from aussiebb.asyncio import AussieBB, AuthenticationException
+from aussiebb.const import FETCH_TYPES
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -54,7 +55,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 self.data = user_input
-                self.services = await self.client.get_services()  # type: ignore[union-attr]
+                self.services = await self.client.get_services(drop_types=FETCH_TYPES)  # type: ignore[union-attr]
 
                 if not self.services:
                     return self.async_abort(reason="no_services_found")

--- a/homeassistant/components/aussie_broadband/manifest.json
+++ b/homeassistant/components/aussie_broadband/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aussie_broadband",
   "requirements": [
-    "pyaussiebb==0.0.11"
+    "pyaussiebb==0.0.13"
   ],
   "codeowners": [
     "@nickw444",

--- a/homeassistant/components/aussie_broadband/manifest.json
+++ b/homeassistant/components/aussie_broadband/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aussie_broadband",
   "requirements": [
-    "pyaussiebb==0.0.13"
+    "pyaussiebb==0.0.14"
   ],
   "codeowners": [
     "@nickw444",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1350,7 +1350,7 @@ pyatome==0.1.1
 pyatv==0.10.0
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.11
+pyaussiebb==0.0.14
 
 # homeassistant.components.balboa
 pybalboa==0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -890,7 +890,7 @@ pyatmo==6.2.4
 pyatv==0.10.0
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.11
+pyaussiebb==0.0.14
 
 # homeassistant.components.balboa
 pybalboa==0.13


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Updating `pyaussiebb` package.

- Better support for VOIP services.
- Ignore non-supported services.

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Fixes #65760 by adding support for pagination
- Fixes #68101 by adding service type
- Fixes yaleman/pyaussiebb#22 by adding Opticomm services
- Fixes yaleman/pyaussiebb#27 by filtering FetchTV services


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

n/a

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. - https://github.com/yaleman/pyaussiebb/blob/main/CHANGELOG.md 
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
