### PR TITLE
Add config flow for sun

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_ELEVATION,
     EVENT_CORE_CONFIG_UPDATE,
@@ -18,11 +19,11 @@ from homeassistant.helpers.sun import (
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
+from .const import DOMAIN
+
 # mypy: allow-untyped-calls, allow-untyped-defs, no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "sun"
 
 ENTITY_ID = "sun.sun"
 
@@ -80,7 +81,27 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             "Elevation is now configured in Home Assistant core. "
             "See https://www.home-assistant.io/docs/configuration/basic/"
         )
-    Sun(hass)
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=config,
+        )
+    )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up from a config entry."""
+    hass.data[DOMAIN] = Sun(hass)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    sun = hass.data.pop(DOMAIN)
+    sun.remove_listeners()
+    hass.states.async_remove(sun.entity_id)
     return True
 
 
@@ -100,6 +121,9 @@ class Sun(Entity):
         self.solar_elevation = self.solar_azimuth = None
         self.rising = self.phase = None
         self._next_change = None
+        self._config_listener = None
+        self._update_events_listener = None
+        self._update_sun_position_listener = None
 
         @callback
         def update_location(_event):
@@ -108,10 +132,24 @@ class Sun(Entity):
                 return
             self.location = location
             self.elevation = elevation
+            if self._update_events_listener:
+                self._update_events_listener()
             self.update_events()
 
         update_location(None)
-        self.hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, update_location)
+        self._config_listener = self.hass.bus.async_listen(
+            EVENT_CORE_CONFIG_UPDATE, update_location
+        )
+
+    @callback
+    def remove_listeners(self):
+        """Remove listeners."""
+        if self._config_listener:
+            self._config_listener()
+        if self._update_events_listener:
+            self._update_events_listener()
+        if self._update_sun_position_listener:
+            self._update_sun_position_listener()
 
     @property
     def name(self):
@@ -211,10 +249,12 @@ class Sun(Entity):
         _LOGGER.debug(
             "sun phase_update@%s: phase=%s", utc_point_in_time.isoformat(), self.phase
         )
+        if self._update_sun_position_listener:
+            self._update_sun_position_listener()
         self.update_sun_position()
 
         # Set timer for the next solar event
-        event.async_track_point_in_utc_time(
+        self._update_events_listener = event.async_track_point_in_utc_time(
             self.hass, self.update_events, self._next_change
         )
         _LOGGER.debug("next time: %s", self._next_change.isoformat())
@@ -245,6 +285,6 @@ class Sun(Entity):
         # position update just drop it
         if utc_point_in_time + delta * 1.25 > self._next_change:
             return
-        event.async_track_point_in_utc_time(
+        self._update_sun_position_listener = event.async_track_point_in_utc_time(
             self.hass, self.update_sun_position, utc_point_in_time + delta
         )

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -284,6 +284,7 @@ class Sun(Entity):
         # if the next update is within 1.25 of the next
         # position update just drop it
         if utc_point_in_time + delta * 1.25 > self._next_change:
+            self._update_sun_position_listener = None
             return
         self._update_sun_position_listener = event.async_track_point_in_utc_time(
             self.hass, self.update_sun_position, utc_point_in_time + delta

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -1,0 +1,33 @@
+"""Config flow to configure the Sun integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DEFAULT_NAME, DOMAIN
+
+
+class SunConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow for Sun."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(title=DEFAULT_NAME, data={})
+
+        return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle import from configuration.yaml."""
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -26,7 +26,7 @@ class SunConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(title=DEFAULT_NAME, data={})
 
-        return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+        return self.async_show_form(step_id="user")
 
     async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
         """Handle import from configuration.yaml."""

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.data_entry_flow import FlowResult
 

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Sun integration."""
+from typing import Final
+
+DOMAIN: Final = "sun"
+
+DEFAULT_NAME: Final = "Sun"

--- a/homeassistant/components/sun/manifest.json
+++ b/homeassistant/components/sun/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/sun",
   "codeowners": ["@Swamp-Ig"],
   "quality_scale": "internal",
-  "iot_class": "calculated"
+  "iot_class": "calculated",
+  "config_flow": true
 }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -1,5 +1,15 @@
 {
   "title": "Sun",
+  "config": {
+    "step": {
+      "user": {
+        "description": "[%key:common::config_flow::description::confirm_setup%]"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    }
+  },
   "state": {
     "_": {
       "above_horizon": "Above horizon",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -322,6 +322,7 @@ FLOWS = [
     "steamist",
     "stookalert",
     "subaru",
+    "sun",
     "surepetcare",
     "switch_as_x",
     "switchbot",

--- a/tests/components/sun/test_config_flow.py
+++ b/tests/components/sun/test_config_flow.py
@@ -1,0 +1,75 @@
+"""Tests for the Sun config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.sun.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_user_flow(hass: HomeAssistant) -> None:
+    """Test the full user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    with patch(
+        "homeassistant.components.sun.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result.get("title") == "Sun"
+    assert result.get("data") == {}
+    assert result.get("options") == {}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("source", [SOURCE_USER, SOURCE_IMPORT])
+async def test_single_instance_allowed(
+    hass: HomeAssistant,
+    source: str,
+) -> None:
+    """Test we abort if already setup."""
+    mock_config_entry = MockConfigEntry(domain=DOMAIN)
+
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": source}
+    )
+
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "single_instance_allowed"
+
+
+async def test_import_flow(
+    hass: HomeAssistant,
+) -> None:
+    """Test the import configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={},
+    )
+
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result.get("title") == "Sun"
+    assert result.get("data") == {}
+    assert result.get("options") == {}

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -10,6 +10,8 @@ import homeassistant.core as ha
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from tests.common import MockConfigEntry
+
 
 async def test_setting_rising(hass, legacy_patchable_time):
     """Test retrieving sun setting and rising."""
@@ -194,3 +196,22 @@ async def test_state_change_count(hass):
         await hass.async_block_till_done()
 
     assert len(events) < 721
+
+
+async def test_setup_and_remove_config_entry(hass: ha.HomeAssistant) -> None:
+    """Test setting up and removing a config entry."""
+    # Setup the config entry
+    config_entry = MockConfigEntry(domain=sun.DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the platform is setup correctly
+    assert hass.states.get("sun.sun") is not None
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed
+    assert hass.states.get("sun.sun") is None

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -107,7 +107,7 @@ async def test_setting_rising(hass, legacy_patchable_time):
     )
 
 
-async def test_state_change(hass, legacy_patchable_time):
+async def test_state_change(hass, legacy_patchable_time, caplog):
     """Test if the state changes at next setting/rising."""
     now = datetime(2016, 6, 1, 8, 0, 0, tzinfo=dt_util.UTC)
     with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=now):
@@ -133,11 +133,33 @@ async def test_state_change(hass, legacy_patchable_time):
 
     assert sun.STATE_ABOVE_HORIZON == hass.states.get(sun.ENTITY_ID).state
 
+    # Update core configuration
     with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=now):
         await hass.config.async_update(longitude=hass.config.longitude + 90)
         await hass.async_block_till_done()
 
     assert sun.STATE_ABOVE_HORIZON == hass.states.get(sun.ENTITY_ID).state
+
+    # Test listeners are not duplicated after a core configuration change
+    test_time = dt_util.parse_datetime(
+        hass.states.get(sun.ENTITY_ID).attributes[sun.STATE_ATTR_NEXT_DUSK]
+    )
+    assert test_time is not None
+
+    patched_time = test_time + timedelta(seconds=5)
+    caplog.clear()
+    with patch(
+        "homeassistant.helpers.condition.dt_util.utcnow", return_value=patched_time
+    ):
+        hass.bus.async_fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: patched_time})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    assert caplog.text.count("sun phase_update") == 1
+    # Called once by time listener, once from Sun.update_events
+    assert caplog.text.count("sun position_update") == 2
+
+    assert sun.STATE_BELOW_HORIZON == hass.states.get(sun.ENTITY_ID).state
 
 
 async def test_norway_in_june(hass):
@@ -198,20 +220,40 @@ async def test_state_change_count(hass):
     assert len(events) < 721
 
 
-async def test_setup_and_remove_config_entry(hass: ha.HomeAssistant) -> None:
+async def test_setup_and_remove_config_entry(
+    hass: ha.HomeAssistant, legacy_patchable_time
+) -> None:
     """Test setting up and removing a config entry."""
     # Setup the config entry
     config_entry = MockConfigEntry(domain=sun.DOMAIN)
     config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    now = datetime(2016, 6, 1, 8, 0, 0, tzinfo=dt_util.UTC)
+    with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=now):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     # Check the platform is setup correctly
-    assert hass.states.get("sun.sun") is not None
+    state = hass.states.get("sun.sun")
+    assert state is not None
+
+    test_time = dt_util.parse_datetime(
+        hass.states.get(sun.ENTITY_ID).attributes[sun.STATE_ATTR_NEXT_RISING]
+    )
+    assert test_time is not None
+    assert sun.STATE_BELOW_HORIZON == hass.states.get(sun.ENTITY_ID).state
 
     # Remove the config entry
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Check the state and entity registry entry are removed
+    # Check the state is removed, and does not reappear
+    assert hass.states.get("sun.sun") is None
+
+    patched_time = test_time + timedelta(seconds=5)
+    with patch(
+        "homeassistant.helpers.condition.dt_util.utcnow", return_value=patched_time
+    ):
+        hass.bus.async_fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: patched_time})
+        await hass.async_block_till_done()
+
     assert hass.states.get("sun.sun") is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow for sun

This also fixes bugs related to cancelling time listeners:
- Duplicated listeners were setup each time `EVENT_CORE_CONFIG_UPDATE` was handled
- `Sun.update_sun_position` is called from `Sun.update_events` but also sets up its own loop of time listeners


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22061

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
