### PR TITLE
Add select platform to Plugwise

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -898,6 +898,7 @@ omit =
     homeassistant/components/plaato/sensor.py
     homeassistant/components/plex/media_player.py
     homeassistant/components/plex/view.py
+    homeassistant/components/plugwise/select.py
     homeassistant/components/plum_lightpad/light.py
     homeassistant/components/pocketcasts/sensor.py
     homeassistant/components/point/__init__.py

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -122,8 +122,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes."""
         return {
-            "available_schedules": self.device.get("available_schedules"),
-            "selected_schedule": self.device.get("selected_schedule"),
+            "available_schemas": self.device.get("available_schedules"),
+            "selected_schema": self.device.get("selected_schedule"),
         }
 
     @plugwise_command

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -21,17 +21,10 @@ from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP, DOMAIN
+from .const import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP, DOMAIN, THERMOSTAT_CLASSES
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command
-
-THERMOSTAT_CLASSES = [
-    "thermostat",
-    "thermostatic_radiator_valve",
-    "zone_thermometer",
-    "zone_thermostat",
-]
 
 
 async def async_setup_entry(
@@ -129,8 +122,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes."""
         return {
-            "available_schemas": self.device.get("available_schedules"),
-            "selected_schema": self.device.get("selected_schedule"),
+            "available_schedules": self.device.get("available_schedules"),
+            "selected_schedule": self.device.get("selected_schedule"),
         }
 
     @plugwise_command

--- a/homeassistant/components/plugwise/const.py
+++ b/homeassistant/components/plugwise/const.py
@@ -24,6 +24,7 @@ PLATFORMS_GATEWAY = [
     Platform.CLIMATE,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.SELECT,
 ]
 ZEROCONF_MAP = {
     "smile": "P1",
@@ -43,3 +44,10 @@ DEFAULT_SCAN_INTERVAL = {
     "thermostat": timedelta(seconds=60),
 }
 DEFAULT_USERNAME = "smile"
+
+THERMOSTAT_CLASSES = [
+    "thermostat",
+    "thermostatic_radiator_valve",
+    "zone_thermometer",
+    "zone_thermostat",
+]

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, LOGGER, THERMOSTAT_CLASSES
+from .const import DOMAIN, THERMOSTAT_CLASSES
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -42,6 +42,11 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
         self._attr_current_option = self.device.get("selected_schedule")
         self._attr_options = self.device.get("available_schedules", [])
 
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return self.device.get("selected_schedule")
+
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.coordinator.api.set_schedule_state(
@@ -49,3 +54,4 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
             option,
             STATE_ON,
         )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -5,6 +5,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER, THERMOSTAT_CLASSES
@@ -52,13 +53,13 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        result = await self.coordinator.api.set_schedule_state(
-            self.device.get("location"),
-            option,
-            STATE_ON,
-        )
-        if result:
-            LOGGER.debug("Change schedule to %s was successful", option)
-            await self.coordinator.async_request_refresh()
-        else:
-            LOGGER.error("Failed changing schedule")
+        if not (
+            await self.coordinator.api.set_schedule_state(
+                self.device.get("location"),
+                option,
+                STATE_ON,
+            )
+        ):
+            raise HomeAssistantError(f"Failed to change to schedule {option}")
+        LOGGER.debug("Change schedule to %s was successful", option)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -39,13 +39,16 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
         super().__init__(coordinator, device_id)
         self._attr_unique_id = f"{device_id}-select_schedule"
         self._attr_name = (f"{self.device.get('name', '')} Select Schedule").lstrip()
-        self._attr_current_option = self.device.get("selected_schedule")
-        self._attr_options = self.device.get("available_schedules", [])
 
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self.device.get("selected_schedule")
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return self.device.get("available_schedules", [])
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -23,7 +23,7 @@ async def async_setup_entry(
         PlugwiseSelectEntity(coordinator, device_id)
         for device_id, device in coordinator.data.devices.items()
         if device["class"] in THERMOSTAT_CLASSES
-        and device.get("available_schedules") != ["None"]
+        and len(device.get("available_schedules")) > 1
     )
 
 
@@ -40,7 +40,7 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
         self._attr_unique_id = f"{device_id}-select_schedule"
         self._attr_name = (f"{self.device.get('name', '')} Select Schedule").lstrip()
         self._attr_current_option = self.device.get("selected_schedule")
-        self._attr_options = self.device.get("available_schedules", list[str])
+        self._attr_options = self.device.get("available_schedules", [])
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -22,7 +22,8 @@ async def async_setup_entry(
     async_add_entities(
         PlugwiseSelectEntity(coordinator, device_id)
         for device_id, device in coordinator.data.devices.items()
-        if device["class"] in THERMOSTAT_CLASSES and device["available_schedules"]
+        if device["class"] in THERMOSTAT_CLASSES
+        and device.get("available_schedules") != ["None"]
     )
 
 

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -1,0 +1,50 @@
+"""Plugwise Select component for Home Assistant."""
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, THERMOSTAT_CLASSES
+from .coordinator import PlugwiseDataUpdateCoordinator
+from .entity import PlugwiseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Smile selector from a config entry."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        PlugwiseSelectEntity(coordinator, device_id)
+        for device_id, device in coordinator.data.devices.items()
+        if device["class"] in THERMOSTAT_CLASSES and device["available_schedules"]
+    )
+
+
+class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
+    """Represent Smile selector."""
+
+    def __init__(
+        self,
+        coordinator: PlugwiseDataUpdateCoordinator,
+        device_id: str,
+    ) -> None:
+        """Initialise the selector."""
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"{device_id}-select_schedule"
+        self._attr_name = (f"{self.device.get('name', '')} Select Schedule").lstrip()
+        self._attr_current_option = self.device.get("selected_schedule")
+        self._attr_options = self.device.get("available_schedules", list[str])
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.coordinator.api.set_schedule_state(
+            self.device.get("location"),
+            option,
+            STATE_ON,
+        )

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -7,7 +7,7 @@ from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, THERMOSTAT_CLASSES
+from .const import DOMAIN, LOGGER, THERMOSTAT_CLASSES
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 
@@ -52,9 +52,13 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self.coordinator.api.set_schedule_state(
+        result = await self.coordinator.api.set_schedule_state(
             self.device.get("location"),
             option,
             STATE_ON,
         )
-        await self.coordinator.async_request_refresh()
+        if result:
+            LOGGER.debug("Change schedule to %s was successful", option)
+            await self.coordinator.async_request_refresh()
+        else:
+            LOGGER.error("Failed changing schedule")

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -61,5 +61,4 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
             )
         ):
             raise HomeAssistantError(f"Failed to change to schedule {option}")
-        LOGGER.debug("Change schedule to %s was successful", option)
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Breaking Change
Depreciation notice: the climate entity attributes `selected_schema` and `available_schemas` will be removed in a future release. This release introduces the `select` platform featuring these as well as the ability to switch a schedule.

## Proposed change
Introduce the `select` Platform to enable users to change the active climate schedule if the climate thermostat supports schedules.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.