### PR TITLE
Improve error handling process_play_media_url

### DIFF
--- a/homeassistant/components/media_player/browse_media.py
+++ b/homeassistant/components/media_player/browse_media.py
@@ -10,7 +10,9 @@ import yarl
 
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.network import (
+    NoURLAvailableError,
     get_supervisor_network_url,
     get_url,
     is_hass_url,
@@ -52,7 +54,12 @@ def async_process_play_media_url(
             base_url = get_supervisor_network_url(hass)
 
         if not base_url:
-            base_url = get_url(hass)
+            try:
+                base_url = get_url(hass)
+            except NoURLAvailableError as err:
+                raise HomeAssistantError(
+                    "Unable to determine Home Assistant URL to send to device"
+                ) from err
 
         media_content_id = f"{base_url}{media_content_id}"
 

--- a/homeassistant/components/media_player/browse_media.py
+++ b/homeassistant/components/media_player/browse_media.py
@@ -30,10 +30,10 @@ def async_process_play_media_url(
     for_supervisor_network: bool = False,
 ) -> str:
     """Update a media URL with authentication if it points at Home Assistant."""
-    if media_content_id[0] != "/" and not is_hass_url(hass, media_content_id):
-        return media_content_id
-
     parsed = yarl.URL(media_content_id)
+
+    if parsed.is_absolute() and not is_hass_url(hass, media_content_id):
+        return media_content_id
 
     if parsed.query:
         logging.getLogger(__name__).debug(

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -402,9 +402,6 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             stream_name = original_media_id
             stream_format = guess_stream_format(media_id, mime_type)
 
-        # If media ID is a relative URL, we serve it from HA.
-        media_id = async_process_play_media_url(self.hass, media_id)
-
         if media_type == FORMAT_CONTENT_TYPE[HLS_PROVIDER]:
             media_type = MEDIA_TYPE_VIDEO
             mime_type = FORMAT_CONTENT_TYPE[HLS_PROVIDER]
@@ -412,6 +409,9 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             stream_format = "hls"
 
         if media_type in (MEDIA_TYPE_MUSIC, MEDIA_TYPE_URL, MEDIA_TYPE_VIDEO):
+            # If media ID is a relative URL, we serve it from HA.
+            media_id = async_process_play_media_url(self.hass, media_id)
+
             parsed = yarl.URL(media_id)
 
             if mime_type is None:

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -62,7 +62,13 @@ def get_supervisor_network_url(
 
 def is_hass_url(hass: HomeAssistant, url: str) -> bool:
     """Return if the URL points at this Home Assistant instance."""
-    parsed = yarl.URL(normalize_url(url))
+    parsed = yarl.URL(url)
+
+    if not parsed.is_absolute():
+        return False
+
+    if parsed.is_default_port():
+        parsed = parsed.with_port(None)
 
     def host_ip() -> str | None:
         if hass.config.api is None or is_loopback(ip_address(hass.config.api.local_ip)):

--- a/homeassistant/util/network.py
+++ b/homeassistant/util/network.py
@@ -82,6 +82,6 @@ def is_ipv6_address(address: str) -> bool:
 def normalize_url(address: str) -> str:
     """Normalize a given URL."""
     url = yarl.URL(address.rstrip("/"))
-    if url.is_default_port():
+    if url.is_absolute() and url.is_default_port():
         return str(url.with_port(None))
     return str(url)

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -973,7 +973,7 @@ async def test_entity_play_media(hass: HomeAssistant, quick_play_mock):
         {
             ATTR_ENTITY_ID: entity_id,
             media_player.ATTR_MEDIA_CONTENT_TYPE: "audio",
-            media_player.ATTR_MEDIA_CONTENT_ID: "best.mp3",
+            media_player.ATTR_MEDIA_CONTENT_ID: "http://example.com/best.mp3",
             media_player.ATTR_MEDIA_EXTRA: {"metadata": {"metadatatype": 3}},
         },
         blocking=True,
@@ -984,7 +984,7 @@ async def test_entity_play_media(hass: HomeAssistant, quick_play_mock):
         chromecast,
         "default_media_receiver",
         {
-            "media_id": "best.mp3",
+            "media_id": "http://example.com/best.mp3",
             "media_type": "audio",
             "metadata": {"metadatatype": 3},
         },
@@ -1519,13 +1519,15 @@ async def test_group_media_control(hass, mz_mock, quick_play_mock):
     assert not chromecast.media_controller.stop.called
 
     # Verify play_media is not forwarded
-    await common.async_play_media(hass, "music", "best.mp3", entity_id)
+    await common.async_play_media(
+        hass, "music", "http://example.com/best.mp3", entity_id
+    )
     assert not grp_media.play_media.called
     assert not chromecast.media_controller.play_media.called
     quick_play_mock.assert_called_once_with(
         chromecast,
         "default_media_receiver",
-        {"media_id": "best.mp3", "media_type": "music"},
+        {"media_id": "http://example.com/best.mp3", "media_type": "music"},
     )
 
 
@@ -1799,7 +1801,7 @@ async def test_cast_platform_play_media(hass: HomeAssistant, quick_play_mock, ca
         {
             ATTR_ENTITY_ID: entity_id,
             media_player.ATTR_MEDIA_CONTENT_TYPE: "audio",
-            media_player.ATTR_MEDIA_CONTENT_ID: "best.mp3",
+            media_player.ATTR_MEDIA_CONTENT_ID: "http://example.com/best.mp3",
             media_player.ATTR_MEDIA_EXTRA: {"metadata": {"metadatatype": 3}},
         },
         blocking=True,
@@ -1807,7 +1809,7 @@ async def test_cast_platform_play_media(hass: HomeAssistant, quick_play_mock, ca
 
     # Assert the media player attempt to play media through the cast platform
     cast_platform_mock.async_play_media.assert_called_once_with(
-        hass, entity_id, chromecast, "audio", "best.mp3"
+        hass, entity_id, chromecast, "audio", "http://example.com/best.mp3"
     )
 
     # Assert pychromecast is used to play media

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -557,7 +557,7 @@ async def test_async_play_media_from_paused(hass, mock_api_object):
         SERVICE_PLAY_MEDIA,
         {
             ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
-            ATTR_MEDIA_CONTENT_ID: "somefile.mp3",
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
         },
     )
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -581,7 +581,7 @@ async def test_async_play_media_from_stopped(
         SERVICE_PLAY_MEDIA,
         {
             ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
-            ATTR_MEDIA_CONTENT_ID: "somefile.mp3",
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
         },
     )
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -616,7 +616,7 @@ async def test_async_play_media_tts_timeout(hass, mock_api_object):
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
-                ATTR_MEDIA_CONTENT_ID: "somefile.mp3",
+                ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
             },
         )
         state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -725,7 +725,7 @@ async def test_librespot_java_play_media(hass, pipe_control_api_object):
         SERVICE_PLAY_MEDIA,
         {
             ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
-            ATTR_MEDIA_CONTENT_ID: "somefile.mp3",
+            ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
         },
     )
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -747,7 +747,7 @@ async def test_librespot_java_play_media_pause_timeout(hass, pipe_control_api_ob
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
-                ATTR_MEDIA_CONTENT_ID: "somefile.mp3",
+                ATTR_MEDIA_CONTENT_ID: "http://example.com/somefile.mp3",
             },
         )
         state = hass.states.get(TEST_MASTER_ENTITY_NAME)

--- a/tests/components/media_player/test_browse_media.py
+++ b/tests/components/media_player/test_browse_media.py
@@ -7,6 +7,8 @@ from homeassistant.components.media_player.browse_media import (
     async_process_play_media_url,
 )
 from homeassistant.config import async_process_ha_core_config
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.network import NoURLAvailableError
 
 from tests.common import mock_component
 
@@ -48,6 +50,11 @@ async def test_process_play_media_url(hass, mock_sign_path):
         async_process_play_media_url(hass, "http://192.168.123.123:8123/path")
         == "http://192.168.123.123:8123/path?authSig=bla"
     )
+    with pytest.raises(HomeAssistantError), patch(
+        "homeassistant.components.media_player.browse_media.get_url",
+        side_effect=NoURLAvailableError,
+    ):
+        async_process_play_media_url(hass, "/path")
 
     # Test skip signing URLs that have a query param
     assert (

--- a/tests/components/media_player/test_browse_media.py
+++ b/tests/components/media_player/test_browse_media.py
@@ -68,6 +68,9 @@ async def test_process_play_media_url(hass, mock_sign_path):
         == "http://192.168.123.123:8123/path?hello=world"
     )
 
+    with pytest.raises(ValueError):
+        async_process_play_media_url(hass, "hello")
+
 
 async def test_process_play_media_url_for_addon(hass, mock_sign_path):
     """Test it uses the hostname for an addon if available."""

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -681,6 +681,9 @@ async def test_is_hass_url(hass):
     assert hass.config.external_url is None
 
     assert is_hass_url(hass, "http://example.com") is False
+    assert is_hass_url(hass, "bad_url") is False
+    assert is_hass_url(hass, "bad_url.com") is False
+    assert is_hass_url(hass, "http:/bad_url.com") is False
 
     hass.config.api = Mock(use_ssl=False, port=8123, local_ip="192.168.123.123")
     assert is_hass_url(hass, "http://192.168.123.123:8123") is True

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -91,3 +91,4 @@ def test_normalize_url():
         network_util.normalize_url("https://example.com:443/test/")
         == "https://example.com/test"
     )
+    assert network_util.normalize_url("/test/") == "/test"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #68021

And in #67606 I realized that passing a non-URL to `is_hass_url` could cause `normalize_url` to raise `ValueError`. This fixes both.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
