### PR TITLE
Add support for Sonos subwoofer gain controls

### DIFF
--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -19,6 +19,7 @@ LEVEL_TYPES = {
     "audio_delay": (0, 5),
     "bass": (-10, 10),
     "treble": (-10, 10),
+    "sub_gain": (-15, 15),
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -150,6 +150,7 @@ class SonosSpeaker:
         self.dialog_level: bool | None = None
         self.night_mode: bool | None = None
         self.sub_enabled: bool | None = None
+        self.sub_gain: int | None = None
         self.surround_enabled: bool | None = None
 
         # Misc features
@@ -490,7 +491,7 @@ class SonosSpeaker:
             if bool_var in variables:
                 setattr(self, bool_var, variables[bool_var] == "1")
 
-        for int_var in ("audio_delay", "bass", "treble"):
+        for int_var in ("audio_delay", "bass", "treble", "sub_gain"):
             if int_var in variables:
                 setattr(self, int_var, variables[int_var])
 

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -114,6 +114,7 @@ def soco_fixture(
         mock_soco.treble = -1
         mock_soco.mic_enabled = False
         mock_soco.sub_enabled = False
+        mock_soco.sub_gain = 5
         mock_soco.surround_enabled = True
         mock_soco.soundbar_audio_input_format = "Dolby 5.1"
         mock_soco.get_battery_info.return_value = battery_info

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -6,8 +6,8 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers import entity_registry as ent_reg
 
 
-async def test_audio_input_sensor(hass, async_autosetup_sonos, soco):
-    """Test audio input sensor."""
+async def test_number_entities(hass, async_autosetup_sonos, soco):
+    """Test number entities."""
     entity_registry = ent_reg.async_get(hass)
 
     bass_number = entity_registry.entities["number.zone_a_bass"]
@@ -30,3 +30,16 @@ async def test_audio_input_sensor(hass, async_autosetup_sonos, soco):
             blocking=True,
         )
         assert mock_audio_delay.called_with(3)
+
+    sub_gain_number = entity_registry.entities["number.zone_a_sub_gain"]
+    sub_gain_state = hass.states.get(sub_gain_number.entity_id)
+    assert sub_gain_state.state == "5"
+
+    with patch("soco.SoCo.sub_gain") as mock_sub_gain:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: sub_gain_number.entity_id, "value": -8},
+            blocking=True,
+        )
+        assert mock_sub_gain.called_with(-8)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposes the Sonos subwoofer gain controls (when a subwoofer exists) as a `number` entity.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22068

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
