### PR TITLE
Hue integration: update errors that should be supressed

### DIFF
--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -44,8 +44,12 @@ ALLOWED_ERRORS = [
     'device (light) is "soft off", command (on) may not have effect',
     "device (grouped_light) has communication issues, command (.on) may not have effect",
     'device (grouped_light) is "soft off", command (.on) may not have effect'
+    "device (grouped_light) has communication issues, command (.on.on) may not have effect",
+    'device (grouped_light) is "soft off", command (.on.on) may not have effect'
     "device (light) has communication issues, command (.on) may not have effect",
     'device (light) is "soft off", command (.on) may not have effect',
+    "device (light) has communication issues, command (.on.on) may not have effect",
+    'device (light) is "soft off", command (.on.on) may not have effect',
 ]
 
 

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -42,6 +42,10 @@ ALLOWED_ERRORS = [
     'device (groupedLight) is "soft off", command (on) may not have effect',
     "device (light) has communication issues, command (on) may not have effect",
     'device (light) is "soft off", command (on) may not have effect',
+    "device (grouped_light) has communication issues, command (.on) may not have effect",
+    'device (grouped_light) is "soft off", command (.on) may not have effect'
+    "device (light) has communication issues, command (.on) may not have effect",
+    'device (light) is "soft off", command (.on) may not have effect',
 ]
 
 

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -39,6 +39,8 @@ from .helpers import (
 ALLOWED_ERRORS = [
     "device (light) has communication issues, command (on) may not have effect",
     'device (light) is "soft off", command (on) may not have effect',
+    "device (light) has communication issues, command (.on) may not have effect",
+    'device (light) is "soft off", command (.on) may not have effect',
 ]
 
 

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -41,6 +41,8 @@ ALLOWED_ERRORS = [
     'device (light) is "soft off", command (on) may not have effect',
     "device (light) has communication issues, command (.on) may not have effect",
     'device (light) is "soft off", command (.on) may not have effect',
+    "device (light) has communication issues, command (.on.on) may not have effect",
+    'device (light) is "soft off", command (.on.on) may not have effect',
 ]
 
 


### PR DESCRIPTION
## Proposed change

The error messages have changed a small bit in a recent bridge/api update.
Adds the new format to the list of errors that may be ignored.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #68231
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
