### PR TITLE
Make powerwall attribute sensors their own sensors

### DIFF
--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -121,12 +121,13 @@ async def async_setup_entry(
     ]
 
     for meter in data.meters.meters:
+        if not data.meters.get_meter(meter).is_active():
+            continue
         entities.append(PowerWallExportSensor(powerwall_data, meter))
         entities.append(PowerWallImportSensor(powerwall_data, meter))
         entities.extend(
             PowerWallEnergySensor(powerwall_data, meter, description)
             for description in POWERWALL_INSTANT_SENSORS
-            if data.meters.get_meter(meter).is_active()
         )
 
     async_add_entities(entities)

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -52,7 +52,7 @@ def _get_meter_power(meter: Meter) -> float:
 
 
 def _get_meter_frequency(meter: Meter) -> float:
-    """Get the current value in hZ."""
+    """Get the current value in Hz."""
     return round(meter.frequency, 1)
 
 

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -121,8 +121,6 @@ async def async_setup_entry(
     ]
 
     for meter in data.meters.meters:
-        if not data.meters.get_meter(meter).is_active():
-            continue
         entities.append(PowerWallExportSensor(powerwall_data, meter))
         entities.append(PowerWallImportSensor(powerwall_data, meter))
         entities.extend(

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -2,7 +2,14 @@
 from unittest.mock import patch
 
 from homeassistant.components.powerwall.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS, PERCENTAGE
+from homeassistant.components.sensor import ATTR_STATE_CLASS
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_IP_ADDRESS,
+    PERCENTAGE,
+)
 from homeassistant.helpers import device_registry as dr
 
 from .mocks import _mock_powerwall_with_fixtures
@@ -10,7 +17,7 @@ from .mocks import _mock_powerwall_with_fixtures
 from tests.common import MockConfigEntry
 
 
-async def test_sensors(hass):
+async def test_sensors(hass, entity_registry_enabled_by_default):
     """Test creation of the sensors."""
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)
@@ -35,77 +42,49 @@ async def test_sensors(hass):
     assert reg_device.manufacturer == "Tesla"
     assert reg_device.name == "MySite"
 
-    state = hass.states.get("sensor.powerwall_site_now")
-    assert state.state == "0.032"
-    expected_attributes = {
-        "frequency": 60,
-        "instant_average_voltage": 120.7,
-        "unit_of_measurement": "kW",
-        "friendly_name": "Powerwall Site Now",
-        "device_class": "power",
-        "is_active": False,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    for key, value in expected_attributes.items():
-        assert state.attributes[key] == value
-
-    assert float(hass.states.get("sensor.powerwall_site_export").state) == 10429.5
-    assert float(hass.states.get("sensor.powerwall_site_import").state) == 4824.2
-
-    export_attributes = hass.states.get("sensor.powerwall_site_export").attributes
-    assert export_attributes["unit_of_measurement"] == "kWh"
-
     state = hass.states.get("sensor.powerwall_load_now")
     assert state.state == "1.971"
-    expected_attributes = {
-        "frequency": 60,
-        "instant_average_voltage": 120.7,
-        "unit_of_measurement": "kW",
-        "friendly_name": "Powerwall Load Now",
-        "device_class": "power",
-        "is_active": True,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    for key, value in expected_attributes.items():
-        assert state.attributes[key] == value
+    attributes = state.attributes
+    assert attributes[ATTR_DEVICE_CLASS] == "power"
+    assert attributes[ATTR_UNIT_OF_MEASUREMENT] == "kW"
+    assert attributes[ATTR_STATE_CLASS] == "measurement"
+    assert attributes[ATTR_FRIENDLY_NAME] == "Powerwall Load Now"
+
+    state = hass.states.get("sensor.powerwall_load_frequency_now")
+    assert state.state == "60"
+    attributes = state.attributes
+    assert attributes[ATTR_DEVICE_CLASS] == "frequency"
+    assert attributes[ATTR_UNIT_OF_MEASUREMENT] == "Hz"
+    assert attributes[ATTR_STATE_CLASS] == "measurement"
+    assert attributes[ATTR_FRIENDLY_NAME] == "Powerwall Load Frequency Now"
+
+    state = hass.states.get("sensor.powerwall_load_average_voltage_now")
+    assert state.state == "120.7"
+    attributes = state.attributes
+    assert attributes[ATTR_DEVICE_CLASS] == "voltage"
+    assert attributes[ATTR_UNIT_OF_MEASUREMENT] == "V"
+    assert attributes[ATTR_STATE_CLASS] == "measurement"
+    assert attributes[ATTR_FRIENDLY_NAME] == "Powerwall Load Average Voltage Now"
+
+    state = hass.states.get("sensor.powerwall_load_average_current_now")
+    assert state.state == "0"
+    attributes = state.attributes
+    assert attributes[ATTR_DEVICE_CLASS] == "current"
+    assert attributes[ATTR_UNIT_OF_MEASUREMENT] == "A"
+    assert attributes[ATTR_STATE_CLASS] == "measurement"
+    assert attributes[ATTR_FRIENDLY_NAME] == "Powerwall Load Average Current Now"
 
     assert float(hass.states.get("sensor.powerwall_load_export").state) == 1056.8
     assert float(hass.states.get("sensor.powerwall_load_import").state) == 4693.0
 
     state = hass.states.get("sensor.powerwall_battery_now")
     assert state.state == "-8.55"
-    expected_attributes = {
-        "frequency": 60.0,
-        "instant_average_voltage": 240.6,
-        "unit_of_measurement": "kW",
-        "friendly_name": "Powerwall Battery Now",
-        "device_class": "power",
-        "is_active": True,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    for key, value in expected_attributes.items():
-        assert state.attributes[key] == value
 
     assert float(hass.states.get("sensor.powerwall_battery_export").state) == 3620.0
     assert float(hass.states.get("sensor.powerwall_battery_import").state) == 4216.2
 
     state = hass.states.get("sensor.powerwall_solar_now")
     assert state.state == "10.49"
-    expected_attributes = {
-        "frequency": 60,
-        "instant_average_voltage": 120.7,
-        "unit_of_measurement": "kW",
-        "friendly_name": "Powerwall Solar Now",
-        "device_class": "power",
-        "is_active": True,
-    }
-    # Only test for a subset of attributes in case
-    # HA changes the implementation and a new one appears
-    for key, value in expected_attributes.items():
-        assert state.attributes[key] == value
 
     assert float(hass.states.get("sensor.powerwall_solar_export").state) == 9864.2
     assert float(hass.states.get("sensor.powerwall_solar_import").state) == 28.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `frequency`, `current`, and `voltage` attributes on `powerwall` instant meter sensors are now their own entities. The `is_active` attribute has been removed as it can already be derived from the reading. As these sensors generated significant amount of state changes, the new sensors are not enabled by default. They can be enabled in the UI.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
