### PR TITLE
Avoid selecting attributes in the history api when `no_attributes` is passed

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -224,6 +224,7 @@ class HistoryPeriodView(HomeAssistantView):
         )
 
         minimal_response = "minimal_response" in request.query
+        no_attributes = "no_attributes" in request.query
 
         hass = request.app["hass"]
 
@@ -245,6 +246,7 @@ class HistoryPeriodView(HomeAssistantView):
                 include_start_time_state,
                 significant_changes_only,
                 minimal_response,
+                no_attributes,
             ),
         )
 
@@ -257,6 +259,7 @@ class HistoryPeriodView(HomeAssistantView):
         include_start_time_state,
         significant_changes_only,
         minimal_response,
+        no_attributes,
     ):
         """Fetch significant stats from the database as json."""
         timer_start = time.perf_counter()
@@ -272,6 +275,7 @@ class HistoryPeriodView(HomeAssistantView):
                 include_start_time_state,
                 significant_changes_only,
                 minimal_response,
+                no_attributes,
             )
 
         result = list(result.values())

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -164,7 +164,7 @@ def state_changes_during_period(
     end_time: datetime | None = None,
     entity_id: str | None = None,
     no_attributes: bool = False,
-    descending: bool = True,
+    descending: bool = False,
     limit: int | None = None,
     include_start_time_state: bool = True,
 ) -> dict[str, list[State]]:

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -480,7 +480,7 @@ def _sorted_states_to_dict(
     return {key: val for key, val in result.items() if val}
 
 
-def get_state(hass, utc_point_in_time, entity_id, run=None):
+def get_state(hass, utc_point_in_time, entity_id, run=None, no_attributes=False):
     """Return a state at a specific point in time."""
-    states = get_states(hass, utc_point_in_time, (entity_id,), run)
+    states = get_states(hass, utc_point_in_time, (entity_id,), run, None, no_attributes)
     return states[0] if states else None

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -6,8 +6,9 @@ from itertools import groupby
 import logging
 import time
 
-from sqlalchemy import and_, bindparam, func
+from sqlalchemy import Text, and_, bindparam, func
 from sqlalchemy.ext import baked
+from sqlalchemy.sql.expression import literal
 
 from homeassistant.components import recorder
 from homeassistant.core import split_entity_id
@@ -44,13 +45,20 @@ NEED_ATTRIBUTE_DOMAINS = {
     "water_heater",
 }
 
-QUERY_STATES = [
+BASE_STATES = [
     States.domain,
     States.entity_id,
     States.state,
     States.attributes,
     States.last_changed,
     States.last_updated,
+]
+QUERY_STATE_NO_ATTR = [
+    *BASE_STATES,
+    literal(value=None, type_=Text).label("shared_attrs"),
+]
+QUERY_STATES = [
+    *BASE_STATES,
     StateAttributes.shared_attrs,
 ]
 
@@ -92,10 +100,16 @@ def get_significant_states_with_session(
     thermostat so that we get current temperature in our graphs).
     """
     timer_start = time.perf_counter()
-
-    baked_query = hass.data[HISTORY_BAKERY](
-        lambda session: session.query(*QUERY_STATES)
+    need_attributes = (
+        entity_ids is None
+        or not minimal_response
+        or any(
+            split_entity_id(ent_id)[0] in NEED_ATTRIBUTE_DOMAINS
+            for ent_id in entity_ids
+        )
     )
+    query_keys = QUERY_STATES if need_attributes else QUERY_STATE_NO_ATTR
+    baked_query = hass.data[HISTORY_BAKERY](lambda session: session.query(*query_keys))
 
     if significant_changes_only:
         baked_query += lambda q: q.filter(
@@ -120,9 +134,10 @@ def get_significant_states_with_session(
     if end_time is not None:
         baked_query += lambda q: q.filter(States.last_updated < bindparam("end_time"))
 
-    baked_query += lambda q: q.outerjoin(
-        StateAttributes, States.attributes_id == StateAttributes.attributes_id
-    )
+    if need_attributes:
+        baked_query += lambda q: q.outerjoin(
+            StateAttributes, States.attributes_id == StateAttributes.attributes_id
+        )
     baked_query += lambda q: q.order_by(States.entity_id, States.last_updated)
 
     states = execute(
@@ -144,6 +159,7 @@ def get_significant_states_with_session(
         filters,
         include_start_time_state,
         minimal_response,
+        need_attributes,
     )
 
 
@@ -241,7 +257,13 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
 
 
 def _get_states_with_session(
-    hass, session, utc_point_in_time, entity_ids=None, run=None, filters=None
+    hass,
+    session,
+    utc_point_in_time,
+    entity_ids=None,
+    run=None,
+    filters=None,
+    need_attributes=True,
 ):
     """Return the states at a specific point in time."""
     if entity_ids and len(entity_ids) == 1:
@@ -258,7 +280,8 @@ def _get_states_with_session(
 
     # We have more than one entity to look at so we need to do a query on states
     # since the last recorder run started.
-    query = session.query(*QUERY_STATES)
+    query_keys = QUERY_STATES if need_attributes else QUERY_STATE_NO_ATTR
+    query = session.query(*query_keys)
 
     if entity_ids:
         # We got an include-list of entities, accelerate the query by filtering already
@@ -278,9 +301,11 @@ def _get_states_with_session(
         query = query.join(
             most_recent_state_ids,
             States.state_id == most_recent_state_ids.c.max_state_id,
-        ).outerjoin(
-            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
         )
+        if need_attributes:
+            query = query.outerjoin(
+                StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
+            )
     else:
         # We did not get an include-list of entities, query all states in the inner
         # query, then filter out unwanted domains as well as applying the custom filter.
@@ -318,9 +343,10 @@ def _get_states_with_session(
         query = query.filter(~States.domain.in_(IGNORE_DOMAINS))
         if filters:
             query = filters.apply(query)
-        query = query.outerjoin(
-            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
-        )
+        if need_attributes:
+            query = query.outerjoin(
+                StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
+            )
 
     attr_cache = {}
     return [LazyState(row, attr_cache) for row in execute(query)]
@@ -358,6 +384,7 @@ def _sorted_states_to_dict(
     filters=None,
     include_start_time_state=True,
     minimal_response=False,
+    need_attributes=True,
 ):
     """Convert SQL results into JSON friendly data structure.
 
@@ -381,7 +408,13 @@ def _sorted_states_to_dict(
     if include_start_time_state:
         run = recorder.run_information_from_instance(hass, start_time)
         for state in _get_states_with_session(
-            hass, session, start_time, entity_ids, run=run, filters=filters
+            hass,
+            session,
+            start_time,
+            entity_ids,
+            run=run,
+            filters=filters,
+            need_attributes=need_attributes,
         ):
             state.last_changed = start_time
             state.last_updated = start_time

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -17,8 +17,12 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 
-from tests.common import init_recorder_component
-from tests.components.recorder.common import trigger_db_commit, wait_recording_done
+from tests.common import async_init_recorder_component, init_recorder_component
+from tests.components.recorder.common import (
+    async_wait_recording_done_without_instance,
+    trigger_db_commit,
+    wait_recording_done,
+)
 
 
 @pytest.mark.usefixtures("hass_history")
@@ -604,14 +608,36 @@ async def test_fetch_period_api_with_use_include_order(hass, hass_client):
 
 async def test_fetch_period_api_with_minimal_response(hass, hass_client):
     """Test the fetch period view for history with minimal_response."""
-    await hass.async_add_executor_job(init_recorder_component, hass)
+    await async_init_recorder_component(hass)
+    now = dt_util.utcnow()
     await async_setup_component(hass, "history", {})
-    await hass.async_add_executor_job(hass.data[recorder.DATA_INSTANCE].block_till_done)
+
+    hass.states.async_set("sensor.power", 0, {"attr": "any"})
+    await async_wait_recording_done_without_instance(hass)
+    hass.states.async_set("sensor.power", 50, {"attr": "any"})
+    await async_wait_recording_done_without_instance(hass)
+    hass.states.async_set("sensor.power", 23, {"attr": "any"})
+    await async_wait_recording_done_without_instance(hass)
     client = await hass_client()
     response = await client.get(
-        f"/api/history/period/{dt_util.utcnow().isoformat()}?minimal_response"
+        f"/api/history/period/{now.isoformat()}?filter_entity_id=sensor.power&minimal_response"
     )
     assert response.status == HTTPStatus.OK
+    response_json = await response.json()
+    assert len(response_json[0]) == 3
+    state_list = response_json[0]
+
+    assert state_list[0]["entity_id"] == "sensor.power"
+    assert state_list[0]["attributes"] == {}
+    assert state_list[0]["state"] == "0"
+
+    assert "attributes" not in state_list[1]
+    assert "entity_id" not in state_list[1]
+    assert state_list[1]["state"] == "50"
+
+    assert state_list[2]["entity_id"] == "sensor.power"
+    assert state_list[2]["attributes"] == {}
+    assert state_list[2]["state"] == "23"
 
 
 async def test_fetch_period_api_with_no_timestamp(hass, hass_client):

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -620,7 +620,7 @@ async def test_fetch_period_api_with_minimal_response(hass, hass_client):
     await async_wait_recording_done_without_instance(hass)
     client = await hass_client()
     response = await client.get(
-        f"/api/history/period/{now.isoformat()}?filter_entity_id=sensor.power&minimal_response"
+        f"/api/history/period/{now.isoformat()}?filter_entity_id=sensor.power&minimal_response&no_attributes"
     )
     assert response.status == HTTPStatus.OK
     response_json = await response.json()

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -125,13 +125,15 @@ def test_get_states_no_attributes(hass_recorder):
 
 
 @pytest.mark.parametrize(
-    "attributes, no_attributes",
+    "attributes, no_attributes, limit",
     [
-        ({"attr": True}, False),
-        ({}, True),
+        ({"attr": True}, False, 5000),
+        ({}, True, 5000),
+        ({"attr": True}, False, 3),
+        ({}, True, 3),
     ],
 )
-def test_state_changes_during_period(hass_recorder, attributes, no_attributes):
+def test_state_changes_during_period(hass_recorder, attributes, no_attributes, limit):
     """Test state change during period."""
     hass = hass_recorder()
     entity_id = "media_player.test"
@@ -163,10 +165,10 @@ def test_state_changes_during_period(hass_recorder, attributes, no_attributes):
         set_state("Plex")
 
     hist = history.state_changes_during_period(
-        hass, start, end, entity_id, no_attributes
+        hass, start, end, entity_id, no_attributes, limit=limit
     )
 
-    assert states == hist[entity_id]
+    assert states[:limit] == hist[entity_id]
 
 
 def test_get_last_state_changes(hass_recorder):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We want to get rid of direct database access in integrations, but there currently
  is no way to avoid selecting attributes.

- Additionally, attribute selection in history database queries make up most of the payload size.
  With `minimal_responses` we throw away 85%+ of the payload because most history api 
  requests do not need attributes and throw them away except for the unit of measurement

- We can avoid selecting them in the first place for domains that
  do not need them and already have the unit of measurement in memory via
  the state machine

- Now that attributes are stored in another table we can avoid traversing and 
  fetching the data from the database when they aren't needed

- A new flag `no_attributes` is added to the history api which can be applied
  when calls already have the attributes needed (currently unit of measurement)
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1242

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
