### PR TITLE
Add zha typing [core.discovery] (1)

### DIFF
--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -33,10 +33,11 @@ from .. import (  # noqa: F401 pylint: disable=unused-import,
     siren,
     switch,
 )
-from .channels import ChannelPool, base
+from .channels import base
 
 if TYPE_CHECKING:
     from ..entity import ZhaEntity
+    from .channels import ChannelPool
     from .device import ZHADevice
     from .gateway import ZHAGateway
     from .group import ZHAGroup

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Callable
 import logging
+from typing import TYPE_CHECKING
 
 from homeassistant import const as ha_const
 from homeassistant.core import HomeAssistant, callback
@@ -11,9 +12,11 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import async_entries_for_device
+from homeassistant.helpers.typing import ConfigType
 
-from . import const as zha_const, registries as zha_regs, typing as zha_typing
+from . import const as zha_const, registries as zha_regs
 from .. import (  # noqa: F401 pylint: disable=unused-import,
     alarm_control_panel,
     binary_sensor,
@@ -30,18 +33,24 @@ from .. import (  # noqa: F401 pylint: disable=unused-import,
     siren,
     switch,
 )
-from .channels import base
+from .channels import ChannelPool, base
+
+if TYPE_CHECKING:
+    from ..entity import ZhaEntity
+    from .device import ZHADevice
+    from .gateway import ZHAGateway
+    from .group import ZHAGroup
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @callback
 async def async_add_entities(
-    _async_add_entities: Callable,
+    _async_add_entities: AddEntitiesCallback,
     entities: list[
         tuple[
-            zha_typing.ZhaEntityType,
-            tuple[str, zha_typing.ZhaDeviceType, list[zha_typing.ChannelType]],
+            type[ZhaEntity],
+            tuple[str, ZHADevice, list[base.ZigbeeChannel]],
         ]
     ],
     update_before_add: bool = True,
@@ -50,20 +59,20 @@ async def async_add_entities(
     if not entities:
         return
     to_add = [ent_cls.create_entity(*args) for ent_cls, args in entities]
-    to_add = [entity for entity in to_add if entity is not None]
-    _async_add_entities(to_add, update_before_add=update_before_add)
+    entities_to_add = [entity for entity in to_add if entity is not None]
+    _async_add_entities(entities_to_add, update_before_add=update_before_add)
     entities.clear()
 
 
 class ProbeEndpoint:
     """All discovered channels and entities of an endpoint."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize instance."""
-        self._device_configs = {}
+        self._device_configs: ConfigType = {}
 
     @callback
-    def discover_entities(self, channel_pool: zha_typing.ChannelPoolType) -> None:
+    def discover_entities(self, channel_pool: ChannelPool) -> None:
         """Process an endpoint on a zigpy device."""
         self.discover_by_device_type(channel_pool)
         self.discover_multi_entities(channel_pool)
@@ -71,12 +80,14 @@ class ProbeEndpoint:
         zha_regs.ZHA_ENTITIES.clean_up()
 
     @callback
-    def discover_by_device_type(self, channel_pool: zha_typing.ChannelPoolType) -> None:
+    def discover_by_device_type(self, channel_pool: ChannelPool) -> None:
         """Process an endpoint on a zigpy device."""
 
         unique_id = channel_pool.unique_id
 
-        component = self._device_configs.get(unique_id, {}).get(ha_const.CONF_TYPE)
+        component: str | None = self._device_configs.get(unique_id, {}).get(
+            ha_const.CONF_TYPE
+        )
         if component is None:
             ep_profile_id = channel_pool.endpoint.profile_id
             ep_device_type = channel_pool.endpoint.device_type
@@ -93,7 +104,7 @@ class ProbeEndpoint:
             channel_pool.async_new_entity(component, entity_class, unique_id, claimed)
 
     @callback
-    def discover_by_cluster_id(self, channel_pool: zha_typing.ChannelPoolType) -> None:
+    def discover_by_cluster_id(self, channel_pool: ChannelPool) -> None:
         """Process an endpoint on a zigpy device."""
 
         items = zha_regs.SINGLE_INPUT_CLUSTER_DEVICE_CLASS.items()
@@ -125,8 +136,8 @@ class ProbeEndpoint:
     @staticmethod
     def probe_single_cluster(
         component: str,
-        channel: zha_typing.ChannelType,
-        ep_channels: zha_typing.ChannelPoolType,
+        channel: base.ZigbeeChannel,
+        ep_channels: ChannelPool,
     ) -> None:
         """Probe specified cluster for specific component."""
         if component is None or component not in zha_const.PLATFORMS:
@@ -142,9 +153,7 @@ class ProbeEndpoint:
         ep_channels.claim_channels(claimed)
         ep_channels.async_new_entity(component, entity_class, unique_id, claimed)
 
-    def handle_on_off_output_cluster_exception(
-        self, ep_channels: zha_typing.ChannelPoolType
-    ) -> None:
+    def handle_on_off_output_cluster_exception(self, ep_channels: ChannelPool) -> None:
         """Process output clusters of the endpoint."""
 
         profile_id = ep_channels.endpoint.profile_id
@@ -167,7 +176,7 @@ class ProbeEndpoint:
 
     @staticmethod
     @callback
-    def discover_multi_entities(channel_pool: zha_typing.ChannelPoolType) -> None:
+    def discover_multi_entities(channel_pool: ChannelPool) -> None:
         """Process an endpoint on and discover multiple entities."""
 
         ep_profile_id = channel_pool.endpoint.profile_id
@@ -209,7 +218,9 @@ class ProbeEndpoint:
 
     def initialize(self, hass: HomeAssistant) -> None:
         """Update device overrides config."""
-        zha_config = hass.data[zha_const.DATA_ZHA].get(zha_const.DATA_ZHA_CONFIG, {})
+        zha_config: ConfigType = hass.data[zha_const.DATA_ZHA].get(
+            zha_const.DATA_ZHA_CONFIG, {}
+        )
         if overrides := zha_config.get(zha_const.CONF_DEVICE_CONFIG):
             self._device_configs.update(overrides)
 
@@ -217,10 +228,11 @@ class ProbeEndpoint:
 class GroupProbe:
     """Determine the appropriate component for a group."""
 
-    def __init__(self):
+    _hass: HomeAssistant
+
+    def __init__(self) -> None:
         """Initialize instance."""
-        self._hass = None
-        self._unsubs = []
+        self._unsubs: list[Callable[[], None]] = []
 
     def initialize(self, hass: HomeAssistant) -> None:
         """Initialize the group probe."""
@@ -231,7 +243,7 @@ class GroupProbe:
             )
         )
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Clean up on when zha shuts down."""
         for unsub in self._unsubs[:]:
             unsub()
@@ -240,13 +252,15 @@ class GroupProbe:
     @callback
     def _reprobe_group(self, group_id: int) -> None:
         """Reprobe a group for entities after its members change."""
-        zha_gateway = self._hass.data[zha_const.DATA_ZHA][zha_const.DATA_ZHA_GATEWAY]
+        zha_gateway: ZHAGateway = self._hass.data[zha_const.DATA_ZHA][
+            zha_const.DATA_ZHA_GATEWAY
+        ]
         if (zha_group := zha_gateway.groups.get(group_id)) is None:
             return
         self.discover_group_entities(zha_group)
 
     @callback
-    def discover_group_entities(self, group: zha_typing.ZhaGroupType) -> None:
+    def discover_group_entities(self, group: ZHAGroup) -> None:
         """Process a group and create any entities that are needed."""
         # only create a group entity if there are 2 or more members in a group
         if len(group.members) < 2:
@@ -262,7 +276,9 @@ class GroupProbe:
         if not entity_domains:
             return
 
-        zha_gateway = self._hass.data[zha_const.DATA_ZHA][zha_const.DATA_ZHA_GATEWAY]
+        zha_gateway: ZHAGateway = self._hass.data[zha_const.DATA_ZHA][
+            zha_const.DATA_ZHA_GATEWAY
+        ]
         for domain in entity_domains:
             entity_class = zha_regs.ZHA_ENTITIES.get_group_entity(domain)
             if entity_class is None:
@@ -281,12 +297,12 @@ class GroupProbe:
         async_dispatcher_send(self._hass, zha_const.SIGNAL_ADD_ENTITIES)
 
     @staticmethod
-    def determine_entity_domains(
-        hass: HomeAssistant, group: zha_typing.ZhaGroupType
-    ) -> list[str]:
+    def determine_entity_domains(hass: HomeAssistant, group: ZHAGroup) -> list[str]:
         """Determine the entity domains for this group."""
         entity_domains: list[str] = []
-        zha_gateway = hass.data[zha_const.DATA_ZHA][zha_const.DATA_ZHA_GATEWAY]
+        zha_gateway: ZHAGateway = hass.data[zha_const.DATA_ZHA][
+            zha_const.DATA_ZHA_GATEWAY
+        ]
         all_domain_occurrences = []
         for member in group.members:
             if member.device.is_coordinator:


### PR DESCRIPTION
## Proposed change
* Replace imports from [zha/core/typing.py](https://github.com/home-assistant/core/blob/2022.3.5/homeassistant/components/zha/core/typing.py)
  * `ZhaEntityType` -> `ZhaEntity`
  * `ZhaDeviceType` -> `ZHADevice`
  * `ChannelType` -> `base.ZigbeeChannel`
  * `ChannelPoolType` -> `ChannelPool`
  * `ZhaGroupType` -> `ZHAGroup`
* Fix `async_add_entities` typing. The `entities` parameter need to accept a class type, not an instance.
-> `type[ZhaEntity]`
* `GroupProbe._hass`: Don't initialize it with `None` as this complicates typing. Before `GroupProbe` is used, `initialize` is called anyway which sets `_hass`.
https://github.com/home-assistant/core/blob/e0b577f8bd6def01d91227b4960b051636f465d9/homeassistant/components/zha/core/gateway.py#L128-L131
https://github.com/home-assistant/core/blob/e0b577f8bd6def01d91227b4960b051636f465d9/homeassistant/components/zha/__init__.py#L101-L102


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
