### PR TITLE
Migrate usgs_earthquakes_feed to async library

### DIFF
--- a/homeassistant/components/usgs_earthquakes_feed/manifest.json
+++ b/homeassistant/components/usgs_earthquakes_feed/manifest.json
@@ -2,7 +2,7 @@
   "domain": "usgs_earthquakes_feed",
   "name": "U.S. Geological Survey Earthquake Hazards (USGS)",
   "documentation": "https://www.home-assistant.io/integrations/usgs_earthquakes_feed",
-  "requirements": ["geojson_client==0.6"],
+  "requirements": ["aio_geojson_usgs_earthquakes==0.1"],
   "codeowners": ["@exxamalte"],
   "iot_class": "cloud_polling",
   "loggers": ["geojson_client"]

--- a/homeassistant/components/usgs_earthquakes_feed/manifest.json
+++ b/homeassistant/components/usgs_earthquakes_feed/manifest.json
@@ -5,5 +5,5 @@
   "requirements": ["aio_geojson_usgs_earthquakes==0.1"],
   "codeowners": ["@exxamalte"],
   "iot_class": "cloud_polling",
-  "loggers": ["geojson_client"]
+  "loggers": ["aio_geojson_usgs_earthquakes"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -103,6 +103,9 @@ aio_geojson_geonetnz_volcano==0.6
 # homeassistant.components.nsw_rural_fire_service_feed
 aio_geojson_nsw_rfs_incidents==0.4
 
+# homeassistant.components.usgs_earthquakes_feed
+aio_geojson_usgs_earthquakes==0.1
+
 # homeassistant.components.gdacs
 aio_georss_gdacs==0.7
 
@@ -693,9 +696,6 @@ geniushub-client==0.6.30
 
 # homeassistant.components.geocaching
 geocachingapi==0.2.1
-
-# homeassistant.components.usgs_earthquakes_feed
-geojson_client==0.6
 
 # homeassistant.components.aprs
 geopy==2.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -90,6 +90,9 @@ aio_geojson_geonetnz_volcano==0.6
 # homeassistant.components.nsw_rural_fire_service_feed
 aio_geojson_nsw_rfs_incidents==0.4
 
+# homeassistant.components.usgs_earthquakes_feed
+aio_geojson_usgs_earthquakes==0.1
+
 # homeassistant.components.gdacs
 aio_georss_gdacs==0.7
 
@@ -493,9 +496,6 @@ gcal-sync==0.7.1
 
 # homeassistant.components.geocaching
 geocachingapi==0.2.1
-
-# homeassistant.components.usgs_earthquakes_feed
-geojson_client==0.6
 
 # homeassistant.components.aprs
 geopy==2.1.0

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -3,6 +3,7 @@ import datetime
 from unittest.mock import ANY, MagicMock, call, patch
 
 from aio_geojson_usgs_earthquakes import UsgsEarthquakeHazardsProgramFeed
+from freezegun import freeze_time
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -113,7 +114,7 @@ async def test_setup(hass):
 
     # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
+    with freeze_time(utcnow), patch(
         "aio_geojson_client.feed.GeoJsonFeed.update"
     ) as mock_feed_update:
         mock_feed_update.return_value = (

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -90,7 +90,7 @@ def _generate_mock_feed_entry(
     return feed_entry
 
 
-async def test_setup(hass, legacy_patchable_time):
+async def test_setup(hass):
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -90,7 +90,7 @@ def _generate_mock_feed_entry(
     return feed_entry
 
 
-async def test_setup(hass):
+async def test_setup(hass, legacy_patchable_time):
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
     mock_entry_1 = _generate_mock_feed_entry(
@@ -185,7 +185,7 @@ async def test_setup(hass):
             }
             assert round(abs(float(state.state) - 25.5), 7) == 0
 
-            # Simulate an update - one existing, one new entry,
+            # Simulate an update - two existing, one new entry,
             # one outdated entry
             mock_feed_update.return_value = (
                 "OK",

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -1,6 +1,8 @@
 """The tests for the USGS Earthquake Hazards Program Feed platform."""
 import datetime
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
+
+from aio_geojson_usgs_earthquakes import UsgsEarthquakeHazardsProgramFeed
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -112,10 +114,9 @@ async def test_setup(hass):
     # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
     with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
-        "geojson_client.usgs_earthquake_hazards_program_feed."
-        "UsgsEarthquakeHazardsProgramFeed"
-    ) as mock_feed:
-        mock_feed.return_value.update.return_value = (
+        "aio_geojson_client.feed.GeoJsonFeed.update"
+    ) as mock_feed_update:
+        mock_feed_update.return_value = (
             "OK",
             [mock_entry_1, mock_entry_2, mock_entry_3],
         )
@@ -186,7 +187,7 @@ async def test_setup(hass):
 
             # Simulate an update - one existing, one new entry,
             # one outdated entry
-            mock_feed.return_value.update.return_value = (
+            mock_feed_update.return_value = (
                 "OK",
                 [mock_entry_1, mock_entry_4, mock_entry_3],
             )
@@ -198,7 +199,7 @@ async def test_setup(hass):
 
             # Simulate an update - empty data, but successful update,
             # so no changes to entities.
-            mock_feed.return_value.update.return_value = "OK_NO_DATA", None
+            mock_feed_update.return_value = "OK_NO_DATA", None
             async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -206,7 +207,7 @@ async def test_setup(hass):
             assert len(all_states) == 3
 
             # Simulate an update - empty data, removes all entities
-            mock_feed.return_value.update.return_value = "ERROR", None
+            mock_feed_update.return_value = "ERROR", None
             async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -220,10 +221,12 @@ async def test_setup_with_custom_location(hass):
     mock_entry_1 = _generate_mock_feed_entry("1234", "Title 1", 20.5, (-31.1, 150.1))
 
     with patch(
-        "geojson_client.usgs_earthquake_hazards_program_feed."
-        "UsgsEarthquakeHazardsProgramFeed"
-    ) as mock_feed:
-        mock_feed.return_value.update.return_value = "OK", [mock_entry_1]
+        "aio_geojson_usgs_earthquakes.feed_manager.UsgsEarthquakeHazardsProgramFeed",
+        wraps=UsgsEarthquakeHazardsProgramFeed,
+    ) as mock_feed, patch(
+        "aio_geojson_client.feed.GeoJsonFeed.update"
+    ) as mock_feed_update:
+        mock_feed_update.return_value = "OK", [mock_entry_1]
 
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(
@@ -240,6 +243,7 @@ async def test_setup_with_custom_location(hass):
             assert len(all_states) == 1
 
             assert mock_feed.call_args == call(
+                ANY,
                 (15.1, 25.2),
                 "past_hour_m25_earthquakes",
                 filter_minimum_magnitude=0.0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change migrates the `usgs_earthquakes_feed` integration to a new async library. The functionality of the integration itself is not changing.
Changelog of the new library: https://github.com/exxamalte/python-aio-geojson-usgs-earthquakes/blob/main/CHANGELOG.md

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
