### PR TITLE
Add config flow to Tankerkoenig

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1195,7 +1195,9 @@ omit =
     homeassistant/components/tado/sensor.py
     homeassistant/components/tado/water_heater.py
     homeassistant/components/tank_utility/sensor.py
-    homeassistant/components/tankerkoenig/*
+    homeassistant/components/tankerkoenig/__init__.py
+    homeassistant/components/tankerkoenig/const.py
+    homeassistant/components/tankerkoenig/sensor.py
     homeassistant/components/tapsaff/binary_sensor.py
     homeassistant/components/tautulli/const.py
     homeassistant/components/tautulli/coordinator.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1009,8 +1009,8 @@ build.json @home-assistant/supervisor
 /tests/components/tag/ @balloob @dmulcahey
 /homeassistant/components/tailscale/ @frenck
 /tests/components/tailscale/ @frenck
-/homeassistant/components/tankerkoenig/* @guillempages @mib1185
-/tests/components/tankerkoenig/* @guillempages @mib1185
+/homeassistant/components/tankerkoenig/ @guillempages @mib1185
+/tests/components/tankerkoenig/ @guillempages @mib1185
 /homeassistant/components/tapsaff/ @bazwilliams
 /homeassistant/components/tasmota/ @emontnemery
 /tests/components/tasmota/ @emontnemery

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1009,7 +1009,8 @@ build.json @home-assistant/supervisor
 /tests/components/tag/ @balloob @dmulcahey
 /homeassistant/components/tailscale/ @frenck
 /tests/components/tailscale/ @frenck
-/homeassistant/components/tankerkoenig/ @guillempages
+/homeassistant/components/tankerkoenig/* @guillempages @mib1185
+/tests/components/tankerkoenig/* @guillempages @mib1185
 /homeassistant/components/tapsaff/ @bazwilliams
 /homeassistant/components/tasmota/ @emontnemery
 /tests/components/tasmota/ @emontnemery

--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_SHOW_ON_MAP,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -126,9 +126,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry, [Platform.SENSOR]
     )
     if unload_ok:
-        entry_data: TankerkoenigData = hass.data[DOMAIN][entry.unique_id]
-        assert entry_data.undo_update_listener is not None
-        entry_data.undo_update_listener()
         hass.data[DOMAIN].pop(entry.unique_id)
 
     return unload_ok
@@ -147,7 +144,6 @@ class TankerkoenigData:
         self._api_key = entry.data[CONF_API_KEY]
         self._selected_stations = entry.data[CONF_STATIONS]
         self._hass = hass
-        self.undo_update_listener: CALLBACK_TYPE | None = None
         self.stations: dict[str, dict] = {}
         self.fuel_types = entry.data[CONF_FUEL_TYPES]
         self.show_on_map = entry.options[CONF_SHOW_ON_MAP]

--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -93,7 +93,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 },
                 CONF_RADIUS: conf[CONF_RADIUS],
                 CONF_STATIONS: conf[CONF_STATIONS],
-                CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
                 CONF_SHOW_ON_MAP: conf[CONF_SHOW_ON_MAP],
             },
         )
@@ -153,7 +152,6 @@ class TankerkoenigData:
         self.undo_update_listener: CALLBACK_TYPE | None = None
         self.stations: dict[str, dict] = {}
         self.fuel_types = entry.data[CONF_FUEL_TYPES]
-        self.update_interval = entry.options[CONF_SCAN_INTERVAL]
         self.show_on_map = entry.options[CONF_SHOW_ON_MAP]
 
     def setup(self):

--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -155,10 +155,7 @@ class TankerkoenigData:
         self.show_on_map = entry.options[CONF_SHOW_ON_MAP]
 
     def setup(self):
-        """Set up the tankerkoenig API.
-
-        Read the initial data from the server, to initialize the list of fuel stations to monitor.
-        """
+        """Set up the tankerkoenig API."""
         for station_id in self._selected_stations:
             try:
                 additional_station_data = pytankerkoenig.getStationData(

--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -110,9 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Could not setup integration")
         return False
 
-    tankerkoenig.undo_update_listener = entry.add_update_listener(
-        _async_update_listener
-    )
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = tankerkoenig

--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     setup_ok = await hass.async_add_executor_job(tankerkoenig.setup)
     if not setup_ok:
         _LOGGER.error("Could not setup integration")
-        return False
+        raise ConfigEntryNotReady
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 

--- a/homeassistant/components/tankerkoenig/config_flow.py
+++ b/homeassistant/components/tankerkoenig/config_flow.py
@@ -1,0 +1,260 @@
+"""Config flow for Tankerkoenig."""
+from __future__ import annotations
+
+from typing import Any
+
+from pytankerkoenig import customException, getNearbyStations
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LOCATION,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    CONF_RADIUS,
+    CONF_SCAN_INTERVAL,
+    CONF_SHOW_ON_MAP,
+    CONF_UNIT_OF_MEASUREMENT,
+    LENGTH_KILOMETERS,
+    TIME_MINUTES,
+)
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import selector
+
+from .const import (
+    CONF_FUEL_TYPES,
+    CONF_STATIONS,
+    DEFAULT_RADIUS,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    FUEL_TYPES,
+)
+
+SCHEMA_OPTIONS = vol.Schema(
+    {
+        vol.Required(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            vol.Coerce(int), vol.Clamp(min=5, max=60)
+        ),
+        vol.Required(CONF_SHOW_ON_MAP, default=True): bool,
+    }
+)
+
+
+class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Init the FlowHandler."""
+        super().__init__()
+        self._data: dict[str, Any] = {}
+        self._stations: dict[str, str] = {}
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> OptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+        """Import YAML configuration."""
+        await self.async_set_unique_id(
+            f"{DOMAIN}_{config[CONF_LOCATION][CONF_LATITUDE]}_{config[CONF_LOCATION][CONF_LONGITUDE]}"
+        )
+        self._abort_if_unique_id_configured()
+
+        selected_station_ids: list[str] = []
+        # add all nearby stations
+        nearby_stations = await self._get_nearby_stations(config)
+        for station in nearby_stations.get("stations", []):
+            selected_station_ids.append(station["id"])
+
+        # add all manual added stations
+        for station_id in config[CONF_STATIONS]:
+            selected_station_ids.append(station_id)
+
+        return self._create_entry(
+            data={
+                CONF_NAME: "Home",
+                CONF_API_KEY: config[CONF_API_KEY],
+                CONF_FUEL_TYPES: config[CONF_FUEL_TYPES],
+                CONF_LOCATION: config[CONF_LOCATION],
+                CONF_RADIUS: config[CONF_RADIUS],
+                CONF_STATIONS: selected_station_ids,
+            },
+            options={
+                CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+                CONF_SHOW_ON_MAP: config[CONF_SHOW_ON_MAP],
+            },
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if not user_input:
+            return self._show_form_user()
+
+        await self.async_set_unique_id(
+            f"{DOMAIN}_{user_input[CONF_LOCATION][CONF_LATITUDE]}_{user_input[CONF_LOCATION][CONF_LONGITUDE]}"
+        )
+        self._abort_if_unique_id_configured()
+
+        data = await self._get_nearby_stations(user_input)
+        if not data.get("ok"):
+            return self._show_form_user(
+                user_input, errors={CONF_API_KEY: "invalid_auth"}
+            )
+        if stations := data.get("stations"):
+            for station in stations:
+                self._stations[
+                    station["id"]
+                ] = f"{station['place']} {station['street']} {station['houseNumber']} - {station['brand']} ({station['dist']}km)"
+
+        else:
+            return self._show_form_user(user_input, errors={CONF_RADIUS: "no_stations"})
+
+        self._data = user_input
+
+        return await self.async_step_select_station()
+
+    async def async_step_select_station(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the step select_station of a flow initialized by the user."""
+        if not user_input:
+            return self.async_show_form(
+                step_id="select_station",
+                description_placeholders={
+                    "stations_count": len(list(self._stations.keys()))
+                },
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_STATIONS): cv.multi_select(self._stations)}
+                ),
+            )
+
+        return self._create_entry(
+            data={**self._data, **user_input},
+            options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL, CONF_SHOW_ON_MAP: True},
+        )
+
+    def _show_form_user(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        if user_input is None:
+            user_input = {}
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_NAME, default=user_input.get(CONF_NAME, "")
+                    ): cv.string,
+                    vol.Required(
+                        CONF_API_KEY, default=user_input.get(CONF_API_KEY, "")
+                    ): cv.string,
+                    vol.Required(
+                        CONF_FUEL_TYPES,
+                        default=user_input.get(
+                            CONF_FUEL_TYPES, list(FUEL_TYPES.keys())
+                        ),
+                    ): cv.multi_select(FUEL_TYPES),
+                    vol.Required(
+                        CONF_LOCATION,
+                        default=user_input.get(
+                            CONF_LOCATION,
+                            {
+                                "latitude": self.hass.config.latitude,
+                                "longitude": self.hass.config.longitude,
+                            },
+                        ),
+                    ): selector({"location": {}}),
+                    vol.Required(
+                        CONF_RADIUS, default=user_input.get(CONF_RADIUS, DEFAULT_RADIUS)
+                    ): selector(
+                        {
+                            "number": {
+                                "min": 0.1,
+                                "max": 25,
+                                "step": 0.1,
+                                CONF_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
+                            }
+                        }
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    def _create_entry(
+        self, data: dict[str, Any], options: dict[str, Any]
+    ) -> FlowResult:
+        return self.async_create_entry(
+            title=data[CONF_NAME],
+            data=data,
+            options=options,
+        )
+
+    async def _get_nearby_stations(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Fetch nearby stations."""
+        try:
+            return await self.hass.async_add_executor_job(
+                getNearbyStations,
+                data[CONF_API_KEY],
+                data[CONF_LOCATION][CONF_LATITUDE],
+                data[CONF_LOCATION][CONF_LONGITUDE],
+                data[CONF_RADIUS],
+                "all",
+                "dist",
+            )
+        except customException as err:
+            return {"ok": False, "message": err, "exception": True}
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle an options flow."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options[CONF_SCAN_INTERVAL],
+                    ): selector(
+                        {
+                            "number": {
+                                "min": 5,
+                                "max": 240,
+                                "step": 1,
+                                CONF_UNIT_OF_MEASUREMENT: TIME_MINUTES,
+                            }
+                        }
+                    ),
+                    vol.Required(
+                        CONF_SHOW_ON_MAP,
+                        default=self.config_entry.options[CONF_SHOW_ON_MAP],
+                    ): bool,
+                }
+            ),
+        )

--- a/homeassistant/components/tankerkoenig/config_flow.py
+++ b/homeassistant/components/tankerkoenig/config_flow.py
@@ -48,7 +48,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
         """Import YAML configuration."""
         await self.async_set_unique_id(
-            f"{DOMAIN}_{config[CONF_LOCATION][CONF_LATITUDE]}_{config[CONF_LOCATION][CONF_LONGITUDE]}"
+            f"{config[CONF_LOCATION][CONF_LATITUDE]}_{config[CONF_LOCATION][CONF_LONGITUDE]}"
         )
         self._abort_if_unique_id_configured()
 
@@ -84,7 +84,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self._show_form_user()
 
         await self.async_set_unique_id(
-            f"{DOMAIN}_{user_input[CONF_LOCATION][CONF_LATITUDE]}_{user_input[CONF_LOCATION][CONF_LONGITUDE]}"
+            f"{user_input[CONF_LOCATION][CONF_LATITUDE]}_{user_input[CONF_LOCATION][CONF_LONGITUDE]}"
         )
         self._abort_if_unique_id_configured()
 
@@ -113,9 +113,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             return self.async_show_form(
                 step_id="select_station",
-                description_placeholders={
-                    "stations_count": len(list(self._stations.keys()))
-                },
+                description_placeholders={"stations_count": len(self._stations)},
                 data_schema=vol.Schema(
                     {vol.Required(CONF_STATIONS): cv.multi_select(self._stations)}
                 ),
@@ -145,9 +143,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ): cv.string,
                     vol.Required(
                         CONF_FUEL_TYPES,
-                        default=user_input.get(
-                            CONF_FUEL_TYPES, list(FUEL_TYPES.keys())
-                        ),
+                        default=user_input.get(CONF_FUEL_TYPES, list(FUEL_TYPES)),
                     ): cv.multi_select(FUEL_TYPES),
                     vol.Required(
                         CONF_LOCATION,

--- a/homeassistant/components/tankerkoenig/config_flow.py
+++ b/homeassistant/components/tankerkoenig/config_flow.py
@@ -97,7 +97,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             for station in stations:
                 self._stations[
                     station["id"]
-                ] = f"{station['place']} {station['street']} {station['houseNumber']} - {station['brand']} ({station['dist']}km)"
+                ] = f"{station['brand']} {station['street']} {station['houseNumber']} - ({station['dist']}km)"
 
         else:
             return self._show_form_user(user_input, errors={CONF_RADIUS: "no_stations"})

--- a/homeassistant/components/tankerkoenig/config_flow.py
+++ b/homeassistant/components/tankerkoenig/config_flow.py
@@ -14,34 +14,16 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_NAME,
     CONF_RADIUS,
-    CONF_SCAN_INTERVAL,
     CONF_SHOW_ON_MAP,
     CONF_UNIT_OF_MEASUREMENT,
     LENGTH_KILOMETERS,
-    TIME_MINUTES,
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import selector
 
-from .const import (
-    CONF_FUEL_TYPES,
-    CONF_STATIONS,
-    DEFAULT_RADIUS,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-    FUEL_TYPES,
-)
-
-SCHEMA_OPTIONS = vol.Schema(
-    {
-        vol.Required(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
-            vol.Coerce(int), vol.Clamp(min=5, max=60)
-        ),
-        vol.Required(CONF_SHOW_ON_MAP, default=True): bool,
-    }
-)
+from .const import CONF_FUEL_TYPES, CONF_STATIONS, DEFAULT_RADIUS, DOMAIN, FUEL_TYPES
 
 
 class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -90,7 +72,6 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_STATIONS: selected_station_ids,
             },
             options={
-                CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
                 CONF_SHOW_ON_MAP: config[CONF_SHOW_ON_MAP],
             },
         )
@@ -142,7 +123,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self._create_entry(
             data={**self._data, **user_input},
-            options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL, CONF_SHOW_ON_MAP: True},
+            options={CONF_SHOW_ON_MAP: True},
         )
 
     def _show_form_user(
@@ -238,19 +219,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_SCAN_INTERVAL,
-                        default=self.config_entry.options[CONF_SCAN_INTERVAL],
-                    ): selector(
-                        {
-                            "number": {
-                                "min": 5,
-                                "max": 240,
-                                "step": 1,
-                                CONF_UNIT_OF_MEASUREMENT: TIME_MINUTES,
-                            }
-                        }
-                    ),
                     vol.Required(
                         CONF_SHOW_ON_MAP,
                         default=self.config_entry.options[CONF_SHOW_ON_MAP],

--- a/homeassistant/components/tankerkoenig/const.py
+++ b/homeassistant/components/tankerkoenig/const.py
@@ -6,4 +6,7 @@ NAME = "tankerkoenig"
 CONF_FUEL_TYPES = "fuel_types"
 CONF_STATIONS = "stations"
 
-FUEL_TYPES = ["e5", "e10", "diesel"]
+DEFAULT_RADIUS = 2
+DEFAULT_SCAN_INTERVAL = 30
+
+FUEL_TYPES = {"e5": "Super", "e10": "Super E10", "diesel": "Diesel"}

--- a/homeassistant/components/tankerkoenig/manifest.json
+++ b/homeassistant/components/tankerkoenig/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tankerkoenig",
   "requirements": ["pytankerkoenig==0.0.6"],
-  "codeowners": ["@guillempages"],
+  "codeowners": ["@guillempages", "@mib1185"],
   "iot_class": "cloud_polling",
   "loggers": ["pytankerkoenig"]
 }

--- a/homeassistant/components/tankerkoenig/manifest.json
+++ b/homeassistant/components/tankerkoenig/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "tankerkoenig",
   "name": "Tankerkoenig",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tankerkoenig",
   "requirements": ["pytankerkoenig==0.0.6"],
   "codeowners": ["@guillempages"],

--- a/homeassistant/components/tankerkoenig/sensor.py
+++ b/homeassistant/components/tankerkoenig/sensor.py
@@ -137,7 +137,7 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo | None:
         """Return device info."""
         return DeviceInfo(
-            connections={(ATTR_ID, self._station_id)},
+            identifiers={(ATTR_ID, self._station_id)},
             name=f"{self._city} {self._street} {self._house_number} {self._brand}",
             model=self._brand,
             configuration_url="https://www.tankerkoenig.de",

--- a/homeassistant/components/tankerkoenig/sensor.py
+++ b/homeassistant/components/tankerkoenig/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from . import TankerkoenigData
-from .const import DOMAIN, NAME
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ async def async_setup_entry(
         _LOGGER,
         name=NAME,
         update_method=async_update_data,
-        update_interval=timedelta(minutes=tankerkoenig.update_interval),
+        update_interval=timedelta(minutes=DEFAULT_SCAN_INTERVAL),
     )
 
     # Fetch initial data so we have data when entities subscribe

--- a/homeassistant/components/tankerkoenig/sensor.py
+++ b/homeassistant/components/tankerkoenig/sensor.py
@@ -110,7 +110,7 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{self._city} {self._street} {self._house_number} {self._brand} {FUEL_TYPES[self._fuel_type]}"
+        return f"{self._brand} {self._street} {self._house_number} {FUEL_TYPES[self._fuel_type]}"
 
     @property
     def icon(self):
@@ -138,7 +138,7 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
         """Return device info."""
         return DeviceInfo(
             identifiers={(ATTR_ID, self._station_id)},
-            name=f"{self._city} {self._street} {self._house_number} {self._brand}",
+            name=f"{self._brand} {self._street} {self._house_number}",
             model=self._brand,
             configuration_url="https://www.tankerkoenig.de",
         )

--- a/homeassistant/components/tankerkoenig/sensor.py
+++ b/homeassistant/components/tankerkoenig/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from . import TankerkoenigData
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, NAME
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, FUEL_TYPES, NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,7 +78,6 @@ async def async_setup_entry(
                 fuel,
                 station,
                 coordinator,
-                f"{NAME}_{station['name']}_{fuel}",
                 tankerkoenig.show_on_map,
             )
             entities.append(sensor)
@@ -92,13 +91,12 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
 
     _attr_state_class = STATE_CLASS_MEASUREMENT
 
-    def __init__(self, fuel_type, station, coordinator, name, show_on_map):
+    def __init__(self, fuel_type, station, coordinator, show_on_map):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._station = station
         self._station_id = station["id"]
         self._fuel_type = fuel_type
-        self._name = name
         self._latitude = station["lat"]
         self._longitude = station["lng"]
         self._city = station["place"]
@@ -112,7 +110,7 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name
+        return f"{self._city} {self._street} {self._house_number} {self._brand} {FUEL_TYPES[self._fuel_type]}"
 
     @property
     def icon(self):
@@ -141,7 +139,7 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
         return DeviceInfo(
             connections={(ATTR_ID, self._station_id)},
             name=f"{self._city} {self._street} {self._house_number} {self._brand}",
-            manufacturer=self._brand,
+            model=self._brand,
             configuration_url="https://www.tankerkoenig.de",
         )
 

--- a/homeassistant/components/tankerkoenig/strings.json
+++ b/homeassistant/components/tankerkoenig/strings.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Tankerkoenig",
+        "data": {
+          "name": "Region name",
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "fuel_types": "Fuel types",
+          "latitude": "[%key:common::config_flow::data::latitude%]",
+          "longitude": "[%key:common::config_flow::data::longitude%]",
+          "stations": "Additional fuel stations",
+          "radius": "Search radius"
+        }
+      },
+      "select_station":{
+        "title": "Select stations to add",
+        "description": "found {stations_count} stations in radius",
+        "data": {
+          "stations": "Stations"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_location%]"
+    },
+    "error": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "no_stations": "Could not find any station in range."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Tankerkoenig options",
+        "data": {
+          "scan_interval": "Update Interval",
+          "show_on_map": "Show stations on map"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/tankerkoenig/strings.json
+++ b/homeassistant/components/tankerkoenig/strings.json
@@ -7,8 +7,7 @@
           "name": "Region name",
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "fuel_types": "Fuel types",
-          "latitude": "[%key:common::config_flow::data::latitude%]",
-          "longitude": "[%key:common::config_flow::data::longitude%]",
+          "location": "[%key:common::config_flow::data::location%]",
           "stations": "Additional fuel stations",
           "radius": "Search radius"
         }

--- a/homeassistant/components/tankerkoenig/strings.json
+++ b/homeassistant/components/tankerkoenig/strings.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "title": "Tankerkoenig",
         "data": {
           "name": "Region name",
           "api_key": "[%key:common::config_flow::data::api_key%]",

--- a/homeassistant/components/tankerkoenig/translations/en.json
+++ b/homeassistant/components/tankerkoenig/translations/en.json
@@ -23,8 +23,7 @@
                     "name": "Region name",
                     "radius": "Search radius",
                     "stations": "Additional fuel stations"
-                },
-                "title": "Tankerkoenig"
+                }
             }
         }
     },

--- a/homeassistant/components/tankerkoenig/translations/en.json
+++ b/homeassistant/components/tankerkoenig/translations/en.json
@@ -1,0 +1,43 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Location is already configured"
+        },
+        "error": {
+            "invalid_auth": "Invalid authentication",
+            "no_stations": "Could not find any station in range."
+        },
+        "step": {
+            "select_station": {
+                "data": {
+                    "stations": "Stations"
+                },
+                "description": "found {stations_count} stations in radius",
+                "title": "Select stations to add"
+            },
+            "user": {
+                "data": {
+                    "api_key": "API Key",
+                    "fuel_types": "Fuel types",
+                    "latitude": "Latitude",
+                    "longitude": "Longitude",
+                    "name": "Region name",
+                    "radius": "Search radius",
+                    "stations": "Additional fuel stations"
+                },
+                "title": "Tankerkoenig"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Update Interval",
+                    "show_on_map": "Show stations on map"
+                },
+                "title": "Tankerkoenig options"
+            }
+        }
+    }
+}

--- a/homeassistant/components/tankerkoenig/translations/en.json
+++ b/homeassistant/components/tankerkoenig/translations/en.json
@@ -19,8 +19,7 @@
                 "data": {
                     "api_key": "API Key",
                     "fuel_types": "Fuel types",
-                    "latitude": "Latitude",
-                    "longitude": "Longitude",
+                    "location": "Location",
                     "name": "Region name",
                     "radius": "Search radius",
                     "stations": "Additional fuel stations"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -335,6 +335,7 @@ FLOWS = {
         "system_bridge",
         "tado",
         "tailscale",
+        "tankerkoenig",
         "tasmota",
         "tellduslive",
         "tesla_wall_connector",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1216,6 +1216,9 @@ pysqueezebox==0.5.5
 # homeassistant.components.syncthru
 pysyncthru==0.7.10
 
+# homeassistant.components.tankerkoenig
+pytankerkoenig==0.0.6
+
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.14
 

--- a/tests/components/tankerkoenig/__init__.py
+++ b/tests/components/tankerkoenig/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Tankerkoenig component."""

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -6,7 +6,6 @@ from pytankerkoenig import customException
 from homeassistant.components.tankerkoenig.const import (
     CONF_FUEL_TYPES,
     CONF_STATIONS,
-    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
@@ -17,7 +16,6 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_NAME,
     CONF_RADIUS,
-    CONF_SCAN_INTERVAL,
     CONF_SHOW_ON_MAP,
 )
 from homeassistant.core import HomeAssistant
@@ -112,7 +110,6 @@ async def test_user(hass: HomeAssistant):
             "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
             "36b4b812-xxxx-xxxx-xxxx-c51735325858",
         ]
-        assert result["options"][CONF_SCAN_INTERVAL] == 30
         assert result["options"][CONF_SHOW_ON_MAP]
 
         await hass.async_block_till_done()
@@ -208,7 +205,6 @@ async def test_import(hass: HomeAssistant):
             "3bcd61da-yyyy-yyyy-yyyy-19d5523a7ae8",
             "36b4b812-yyyy-yyyy-yyyy-c51735325858",
         ]
-        assert result["options"][CONF_SCAN_INTERVAL] == 30
         assert result["options"][CONF_SHOW_ON_MAP]
 
         await hass.async_block_till_done()
@@ -222,7 +218,7 @@ async def test_options_flow(hass: HomeAssistant):
     mock_config = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_USER_DATA,
-        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL, CONF_SHOW_ON_MAP: True},
+        options={CONF_SHOW_ON_MAP: True},
         unique_id=f"{DOMAIN}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
     )
     mock_config.add_to_hass(hass)
@@ -239,8 +235,7 @@ async def test_options_flow(hass: HomeAssistant):
     assert result["step_id"] == "init"
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_SCAN_INTERVAL: 37, CONF_SHOW_ON_MAP: False},
+        user_input={CONF_SHOW_ON_MAP: False},
     )
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert mock_config.options[CONF_SCAN_INTERVAL] == 37
     assert not mock_config.options[CONF_SHOW_ON_MAP]

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -123,7 +123,7 @@ async def test_user_already_configured(hass: HomeAssistant):
     mock_config = MockConfigEntry(
         domain=DOMAIN,
         data={**MOCK_USER_DATA, **MOCK_STATIONS_DATA},
-        unique_id=f"{DOMAIN}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
+        unique_id=f"{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
     )
     mock_config.add_to_hass(hass)
 

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -227,6 +227,13 @@ async def test_options_flow(hass: HomeAssistant):
     )
     mock_config.add_to_hass(hass)
 
+    with patch(
+        "homeassistant.components.tankerkoenig.async_setup_entry"
+    ) as mock_setup_entry:
+        await mock_config.async_setup(hass)
+        await hass.async_block_till_done()
+        assert mock_setup_entry.called
+
     result = await hass.config_entries.options.async_init(mock_config.entry_id)
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "init"

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -1,0 +1,239 @@
+"""Tests for Tankerkoenig config flow."""
+from unittest.mock import patch
+
+from pytankerkoenig import customException
+
+from homeassistant.components.tankerkoenig.const import (
+    CONF_FUEL_TYPES,
+    CONF_STATIONS,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LOCATION,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    CONF_RADIUS,
+    CONF_SCAN_INTERVAL,
+    CONF_SHOW_ON_MAP,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+MOCK_USER_DATA = {
+    CONF_NAME: "Home",
+    CONF_API_KEY: "269534f6-xxxx-xxxx-xxxx-yyyyzzzzxxxx",
+    CONF_FUEL_TYPES: ["e5"],
+    CONF_LOCATION: {CONF_LATITUDE: 51.0, CONF_LONGITUDE: 13.0},
+    CONF_RADIUS: 2.0,
+}
+
+MOCK_STATIONS_DATA = {
+    CONF_STATIONS: [
+        "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+        "36b4b812-xxxx-xxxx-xxxx-c51735325858",
+    ],
+}
+
+MOCK_IMPORT_DATA = {
+    CONF_API_KEY: "269534f6-xxxx-xxxx-xxxx-yyyyzzzzxxxx",
+    CONF_FUEL_TYPES: ["e5"],
+    CONF_LOCATION: {CONF_LATITUDE: 51.0, CONF_LONGITUDE: 13.0},
+    CONF_RADIUS: 2.0,
+    CONF_STATIONS: [
+        "3bcd61da-yyyy-yyyy-yyyy-19d5523a7ae8",
+        "36b4b812-yyyy-yyyy-yyyy-c51735325858",
+    ],
+    CONF_SHOW_ON_MAP: True,
+}
+
+MOCK_NEARVY_STATIONS_OK = {
+    "ok": True,
+    "stations": [
+        {
+            "id": "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+            "brand": "BrandA",
+            "place": "CityA",
+            "street": "Main",
+            "houseNumber": "1",
+            "dist": 1,
+        },
+        {
+            "id": "36b4b812-xxxx-xxxx-xxxx-c51735325858",
+            "brand": "BrandB",
+            "place": "CityB",
+            "street": "School",
+            "houseNumber": "2",
+            "dist": 2,
+        },
+    ],
+}
+
+
+async def test_user(hass: HomeAssistant):
+    """Test starting a flow by user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.async_setup_entry"
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.tankerkoenig.config_flow.getNearbyStations",
+        return_value=MOCK_NEARVY_STATIONS_OK,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["step_id"] == "select_station"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_STATIONS_DATA
+        )
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["data"][CONF_NAME] == "Home"
+        assert result["data"][CONF_API_KEY] == "269534f6-xxxx-xxxx-xxxx-yyyyzzzzxxxx"
+        assert result["data"][CONF_FUEL_TYPES] == ["e5"]
+        assert result["data"][CONF_LOCATION] == {"latitude": 51.0, "longitude": 13.0}
+        assert result["data"][CONF_RADIUS] == 2.0
+        assert result["data"][CONF_STATIONS] == [
+            "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+            "36b4b812-xxxx-xxxx-xxxx-c51735325858",
+        ]
+        assert result["options"][CONF_SCAN_INTERVAL] == 30
+        assert result["options"][CONF_SHOW_ON_MAP]
+
+        await hass.async_block_till_done()
+
+    assert mock_setup_entry.called
+
+
+async def test_user_already_configured(hass: HomeAssistant):
+    """Test starting a flow by user with an already configured region."""
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_USER_DATA, **MOCK_STATIONS_DATA},
+        unique_id=f"{DOMAIN}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
+    )
+    mock_config.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_USER_DATA
+    )
+
+    assert result["type"] == RESULT_TYPE_ABORT
+
+
+async def test_exception_security(hass: HomeAssistant):
+    """Test starting a flow by user with invalid api key."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.getNearbyStations",
+        side_effect=customException,
+    ):
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["step_id"] == "user"
+        assert result["errors"][CONF_API_KEY] == "invalid_auth"
+
+
+async def test_user_no_stations(hass: HomeAssistant):
+    """Test starting a flow by user which does not find any station."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.getNearbyStations",
+        return_value={"ok": True, "stations": []},
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["step_id"] == "user"
+        assert result["errors"][CONF_RADIUS] == "no_stations"
+
+
+async def test_import(hass: HomeAssistant):
+    """Test starting a flow by import."""
+    with patch(
+        "homeassistant.components.tankerkoenig.async_setup_entry"
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.tankerkoenig.config_flow.getNearbyStations",
+        return_value=MOCK_NEARVY_STATIONS_OK,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_IMPORT_DATA
+        )
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["data"][CONF_NAME] == "Home"
+        assert result["data"][CONF_API_KEY] == "269534f6-xxxx-xxxx-xxxx-yyyyzzzzxxxx"
+        assert result["data"][CONF_FUEL_TYPES] == ["e5"]
+        assert result["data"][CONF_LOCATION] == {"latitude": 51.0, "longitude": 13.0}
+        assert result["data"][CONF_RADIUS] == 2.0
+        assert result["data"][CONF_STATIONS] == [
+            "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+            "36b4b812-xxxx-xxxx-xxxx-c51735325858",
+            "3bcd61da-yyyy-yyyy-yyyy-19d5523a7ae8",
+            "36b4b812-yyyy-yyyy-yyyy-c51735325858",
+        ]
+        assert result["options"][CONF_SCAN_INTERVAL] == 30
+        assert result["options"][CONF_SHOW_ON_MAP]
+
+        await hass.async_block_till_done()
+
+    assert mock_setup_entry.called
+
+
+async def test_options_flow(hass: HomeAssistant):
+    """Test options flow."""
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_USER_DATA,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL, CONF_SHOW_ON_MAP: True},
+        unique_id=f"{DOMAIN}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
+    )
+    mock_config.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(mock_config.entry_id)
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 37, CONF_SHOW_ON_MAP: False},
+    )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert mock_config.options[CONF_SCAN_INTERVAL] == 37
+    assert not mock_config.options[CONF_SHOW_ON_MAP]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Tankerkoenig integration migrated to configuration via the UI. Configuring Tankerkoenig via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.
Further the update interval will be set to 30 minutes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a two step configuration flow and further an options flow.
It use the `location`and the `number` selector for some inputs.
For each station an own device is registered in HA.

config flow - step 1 - basis config
![image](https://user-images.githubusercontent.com/35783820/159133092-563b86dc-698e-4863-abce-4c62df27e9ac.png)

config flow - step 2 - select stations you want to add entities for
![image](https://user-images.githubusercontent.com/35783820/159133127-1b7ad1a1-d4f8-4fbe-b9bc-94d2a4689599.png)

options flow
![image](https://user-images.githubusercontent.com/35783820/159133305-936339ff-f160-453c-b7cb-cfeca14bf763.png)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/22074

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
