### PR TITLE
Raise if referenced entity does not support service

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -220,7 +220,7 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
             )
         await super().async_added_to_hass()
 
-    async def _async_alarm_arm(self, state, script=None, code=None):
+    async def _async_alarm_arm(self, state, script, code):
         """Arm the panel to specified state with supplied script."""
         optimistic_set = False
 
@@ -228,10 +228,7 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
             self._state = state
             optimistic_set = True
 
-        if script is not None:
-            await script.async_run({ATTR_CODE: code}, context=self._context)
-        else:
-            _LOGGER.error("No script action defined for %s", state)
+        await script.async_run({ATTR_CODE: code}, context=self._context)
 
         if optimistic_set:
             self.async_write_ha_state()

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -527,7 +527,7 @@ def async_set_service_schema(
 
 
 @bind_hass
-async def entity_service_call(
+async def entity_service_call(  # noqa: C901
     hass: HomeAssistant,
     platforms: Iterable[EntityPlatform],
     func: str | Callable[..., Any],
@@ -646,6 +646,12 @@ async def entity_service_call(
                 for feature_set in required_features
             )
         ):
+            # If entity explicitly referenced, raise an error
+            if referenced is not None and entity.entity_id in referenced.referenced:
+                raise HomeAssistantError(
+                    f"Entity {entity.entity_id} does not support this service."
+                )
+
             continue
 
         entities.append(entity)

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er, network
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
@@ -1225,15 +1226,18 @@ async def test_entity_control(hass: HomeAssistant):
     chromecast.media_controller.pause.assert_called_once_with()
 
     # Media previous
-    await common.async_media_previous_track(hass, entity_id)
+    with pytest.raises(HomeAssistantError):
+        await common.async_media_previous_track(hass, entity_id)
     chromecast.media_controller.queue_prev.assert_not_called()
 
     # Media next
-    await common.async_media_next_track(hass, entity_id)
+    with pytest.raises(HomeAssistantError):
+        await common.async_media_next_track(hass, entity_id)
     chromecast.media_controller.queue_next.assert_not_called()
 
     # Media seek
-    await common.async_media_seek(hass, 123, entity_id)
+    with pytest.raises(HomeAssistantError):
+        await common.async_media_seek(hass, 123, entity_id)
     chromecast.media_controller.seek.assert_not_called()
 
     # Enable support for queue and seek

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -3,6 +3,7 @@ from dynalite_devices_lib.cover import DynaliteTimeCoverWithTiltDevice
 import pytest
 
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
+from homeassistant.exceptions import HomeAssistantError
 
 from .common import (
     ATTR_ARGS,
@@ -65,9 +66,10 @@ async def test_cover_without_tilt(hass, mock_device):
     """Test a cover with no tilt."""
     mock_device.has_tilt = False
     await create_entity_from_device(hass, mock_device)
-    await hass.services.async_call(
-        "cover", "open_cover_tilt", {"entity_id": "cover.name"}, blocking=True
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "cover", "open_cover_tilt", {"entity_id": "cover.name"}, blocking=True
+        )
     await hass.async_block_till_done()
     mock_device.async_open_cover_tilt.assert_not_called()
 

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import State
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry, mock_restore_cache
 from tests.components.rfxtrx.conftest import create_rfx_test_cfg
@@ -181,19 +182,21 @@ async def test_rfy_cover(hass, rfxtrx):
         blocking=True,
     )
 
-    await hass.services.async_call(
-        "cover",
-        "open_cover_tilt",
-        {"entity_id": "cover.rfy_010203_1"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "cover",
+            "open_cover_tilt",
+            {"entity_id": "cover.rfy_010203_1"},
+            blocking=True,
+        )
 
-    await hass.services.async_call(
-        "cover",
-        "close_cover_tilt",
-        {"entity_id": "cover.rfy_010203_1"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "cover",
+            "close_cover_tilt",
+            {"entity_id": "cover.rfy_010203_1"},
+            blocking=True,
+        )
 
     assert rfxtrx.transport.send.mock_calls == [
         call(bytearray(b"\x08\x1a\x00\x00\x01\x02\x03\x01\x00")),

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -234,19 +234,11 @@ async def _test_service_call(
 
 
 async def _test_no_service_call(
-    hass, service, method, entity_id, partition_id, expect_ha_error=False, **kwargs
+    hass, service, method, entity_id, partition_id, **kwargs
 ):
-    try:
-        with patch(f"homeassistant.components.risco.RiscoAPI.{method}") as set_mock:
-            await _call_alarm_service(hass, service, entity_id, **kwargs)
-            set_mock.assert_not_awaited()
-    except HomeAssistantError:
-        if expect_ha_error:
-            return
-        else:
-            raise
-
-    assert not expect_ha_error, "Expected Home Assistant error"
+    with patch(f"homeassistant.components.risco.RiscoAPI.{method}") as set_mock:
+        await _call_alarm_service(hass, service, entity_id, **kwargs)
+        set_mock.assert_not_awaited()
 
 
 async def _call_alarm_service(hass, service, entity_id, **kwargs):
@@ -346,24 +338,24 @@ async def test_sets_with_correct_code(hass, two_part_alarm):
     await _test_service_call(
         hass, SERVICE_ALARM_ARM_NIGHT, "group_arm", SECOND_ENTITY_ID, 1, "C", **code
     )
-    await _test_no_service_call(
-        hass,
-        SERVICE_ALARM_ARM_CUSTOM_BYPASS,
-        "partial_arm",
-        FIRST_ENTITY_ID,
-        0,
-        expect_ha_error=True,
-        **code,
-    )
-    await _test_no_service_call(
-        hass,
-        SERVICE_ALARM_ARM_CUSTOM_BYPASS,
-        "partial_arm",
-        SECOND_ENTITY_ID,
-        1,
-        expect_ha_error=True,
-        **code,
-    )
+    with pytest.raises(HomeAssistantError):
+        await _test_no_service_call(
+            hass,
+            SERVICE_ALARM_ARM_CUSTOM_BYPASS,
+            "partial_arm",
+            FIRST_ENTITY_ID,
+            0,
+            **code,
+        )
+    with pytest.raises(HomeAssistantError):
+        await _test_no_service_call(
+            hass,
+            SERVICE_ALARM_ARM_CUSTOM_BYPASS,
+            "partial_arm",
+            SECOND_ENTITY_ID,
+            1,
+            **code,
+        )
 
 
 async def test_sets_with_incorrect_code(hass, two_part_alarm):
@@ -395,21 +387,21 @@ async def test_sets_with_incorrect_code(hass, two_part_alarm):
     await _test_no_service_call(
         hass, SERVICE_ALARM_ARM_NIGHT, "group_arm", SECOND_ENTITY_ID, 1, **code
     )
-    await _test_no_service_call(
-        hass,
-        SERVICE_ALARM_ARM_CUSTOM_BYPASS,
-        "partial_arm",
-        FIRST_ENTITY_ID,
-        0,
-        expect_ha_error=True,
-        **code,
-    )
-    await _test_no_service_call(
-        hass,
-        SERVICE_ALARM_ARM_CUSTOM_BYPASS,
-        "partial_arm",
-        SECOND_ENTITY_ID,
-        1,
-        expect_ha_error=True,
-        **code,
-    )
+    with pytest.raises(HomeAssistantError):
+        await _test_no_service_call(
+            hass,
+            SERVICE_ALARM_ARM_CUSTOM_BYPASS,
+            "partial_arm",
+            FIRST_ENTITY_ID,
+            0,
+            **code,
+        )
+    with pytest.raises(HomeAssistantError):
+        await _test_no_service_call(
+            hass,
+            SERVICE_ALARM_ARM_CUSTOM_BYPASS,
+            "partial_arm",
+            SECOND_ENTITY_ID,
+            1,
+            **code,
+        )

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -60,6 +60,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -896,9 +897,10 @@ async def test_turn_on_wol(hass: HomeAssistant) -> None:
 async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Mock) -> None:
     """Test turn on."""
     await setup_samsungtv(hass, MOCK_CONFIG_NOTURNON)
-    assert await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID_NOTURNON}, True
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID_NOTURNON}, True
+        )
     # nothing called as not supported feature
     assert remote.control.call_count == 0
 

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -129,38 +129,6 @@ async def test_optimistic_states(hass, start_ha):
         assert hass.states.get(TEMPLATE_NAME).state == set_state
 
 
-@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
-@pytest.mark.parametrize(
-    "config",
-    [
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "value_template": "{{ states('alarm_control_panel.test') }}",
-                    }
-                },
-            }
-        },
-    ],
-)
-async def test_no_action_scripts(hass, start_ha):
-    """Test no action scripts per state."""
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_ARMED_AWAY)
-    await hass.async_block_till_done()
-
-    for func, set_state in [
-        (common.async_alarm_arm_away, STATE_ALARM_ARMED_AWAY),
-        (common.async_alarm_arm_home, STATE_ALARM_ARMED_AWAY),
-        (common.async_alarm_arm_night, STATE_ALARM_ARMED_AWAY),
-        (common.async_alarm_disarm, STATE_ALARM_ARMED_AWAY),
-    ]:
-        await func(hass, entity_id=TEMPLATE_NAME)
-        await hass.async_block_till_done()
-        assert hass.states.get(TEMPLATE_NAME).state == set_state
-
-
 @pytest.mark.parametrize("count,domain", [(0, "alarm_control_panel")])
 @pytest.mark.parametrize(
     "config,msg",

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -1,9 +1,12 @@
 """The tests for WebOS TV automation triggers."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components import automation
 from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
 
@@ -57,17 +60,18 @@ async def test_webostv_turn_on_trigger_device_id(hass, calls, client):
     with patch("homeassistant.config.load_yaml", return_value={}):
         await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
 
-    await hass.services.async_call(
-        "media_player",
-        "turn_on",
-        {"entity_id": ENTITY_ID},
-        blocking=True,
-    )
+    calls.clear()
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "media_player",
+            "turn_on",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+        )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == device.id
-    assert calls[0].data["id"] == 0
+    assert len(calls) == 0
 
 
 async def test_webostv_turn_on_trigger_entity_id(hass, calls, client):

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -552,6 +552,20 @@ async def test_call_with_required_features(hass, mock_entities):
     actual = [call[0][0] for call in test_service_mock.call_args_list]
     assert all(entity in actual for entity in expected)
 
+    # Test we raise if we target entity ID that does not support the service
+    test_service_mock.reset_mock()
+    with pytest.raises(exceptions.HomeAssistantError):
+        await service.entity_service_call(
+            hass,
+            [Mock(entities=mock_entities)],
+            test_service_mock,
+            ha.ServiceCall(
+                "test_domain", "test_service", {"entity_id": "light.living_room"}
+            ),
+            required_features=[SUPPORT_A],
+        )
+    assert test_service_mock.call_count == 0
+
 
 async def test_call_with_both_required_features(hass, mock_entities):
     """Test service calls invoked only if entity has both features."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If an entity is explicitly referenced as a target for a service that the entity doesn't support, we now raise an error instead of silently ignoring it.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If an entity is explicitly referenced for a service but the entity does not contain the supported_feature, raise an error instead of silently ignoring it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
