### PR TITLE
Avoid hashing attributes when they are already in the cache

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -985,7 +985,7 @@ class Recorder(threading.Thread):
         if event.event_type == EVENT_STATE_CHANGED:
             try:
                 dbstate = States.from_event(event)
-                dbstate_attributes = StateAttributes.from_event(event)
+                shared_attrs = StateAttributes.shared_attrs_from_event(event)
             except (TypeError, ValueError) as ex:
                 _LOGGER.warning(
                     "State is not JSON serializable: %s: %s",
@@ -995,27 +995,33 @@ class Recorder(threading.Thread):
                 return
 
             dbstate.attributes = None
-            shared_attrs = dbstate_attributes.shared_attrs
             # Matching attributes found in the pending commit
             if pending_attributes := self._pending_state_attributes.get(shared_attrs):
                 dbstate.state_attributes = pending_attributes
             # Matching attributes id found in the cache
             elif attributes_id := self._state_attributes_ids.get(shared_attrs):
                 dbstate.attributes_id = attributes_id
-            # Matching attributes found in the database
-            elif (
-                attributes := self.event_session.query(StateAttributes.attributes_id)
-                .filter(StateAttributes.hash == dbstate_attributes.hash)
-                .filter(StateAttributes.shared_attrs == shared_attrs)
-                .first()
-            ):
-                dbstate.attributes_id = attributes[0]
-                self._state_attributes_ids[shared_attrs] = attributes[0]
-            # No matching attributes found, save them in the DB
             else:
-                dbstate.state_attributes = dbstate_attributes
-                self._pending_state_attributes[shared_attrs] = dbstate_attributes
-                self.event_session.add(dbstate_attributes)
+                attr_hash = StateAttributes.hash_shared_attrs(shared_attrs)
+                # Matching attributes found in the database
+                if (
+                    attributes := self.event_session.query(
+                        StateAttributes.attributes_id
+                    )
+                    .filter(StateAttributes.hash == attr_hash)
+                    .filter(StateAttributes.shared_attrs == shared_attrs)
+                    .first()
+                ):
+                    dbstate.attributes_id = attributes[0]
+                    self._state_attributes_ids[shared_attrs] = attributes[0]
+                # No matching attributes found, save them in the DB
+                else:
+                    dbstate_attributes = StateAttributes(
+                        shared_attrs=shared_attrs, hash=attr_hash
+                    )
+                    dbstate.state_attributes = dbstate_attributes
+                    self._pending_state_attributes[shared_attrs] = dbstate_attributes
+                    self.event_session.add(dbstate_attributes)
 
             if old_state := self._old_states.pop(dbstate.entity_id, None):
                 if old_state.state_id:

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -1,5 +1,11 @@
 """Recorder constants."""
 
+from functools import partial
+import json
+from typing import Final
+
+from homeassistant.helpers.json import JSONEncoder
+
 DATA_INSTANCE = "recorder_instance"
 SQLITE_URL_PREFIX = "sqlite://"
 DOMAIN = "recorder"
@@ -17,3 +23,5 @@ MAX_QUEUE_BACKLOG = 30000
 MAX_ROWS_TO_PURGE = 998
 
 DB_WORKER_PREFIX = "DbWorker"
+
+JSON_DUMP: Final = partial(json.dumps, cls=JSONEncoder, separators=(",", ":"))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 import json
 import logging
-from typing import TypedDict, overload
+from typing import Any, TypedDict, overload
 
 from fnvhash import fnv1a_32
 from sqlalchemy import (
@@ -35,8 +35,9 @@ from homeassistant.const import (
     MAX_LENGTH_STATE_STATE,
 )
 from homeassistant.core import Context, Event, EventOrigin, State, split_entity_id
-from homeassistant.helpers.json import JSONEncoder
 import homeassistant.util.dt as dt_util
+
+from .const import JSON_DUMP
 
 # SQLAlchemy Schema
 # pylint: disable=invalid-name
@@ -116,8 +117,7 @@ class Events(Base):  # type: ignore[misc,valid-type]
         """Create an event database object from a native event."""
         return Events(
             event_type=event.event_type,
-            event_data=event_data
-            or json.dumps(event.data, cls=JSONEncoder, separators=(",", ":")),
+            event_data=event_data or JSON_DUMP(event.data),
             origin=str(event.origin.value),
             time_fired=event.time_fired,
             context_id=event.context.id,
@@ -186,15 +186,13 @@ class States(Base):  # type: ignore[misc,valid-type]
         )
 
     @staticmethod
-    def from_event(event):
+    def from_event(event) -> States:
         """Create object from a state_changed event."""
         entity_id = event.data["entity_id"]
-        state = event.data.get("new_state")
+        state: State | None = event.data.get("new_state")
+        dbstate = States(entity_id=entity_id, attributes=None)
 
-        dbstate = States(entity_id=entity_id)
-        dbstate.attributes = None
-
-        # State got deleted
+        # None state means the state was removed from the state machine
         if state is None:
             dbstate.state = ""
             dbstate.domain = split_entity_id(entity_id)[0]
@@ -208,7 +206,7 @@ class States(Base):  # type: ignore[misc,valid-type]
 
         return dbstate
 
-    def to_native(self, validate_entity_id=True):
+    def to_native(self, validate_entity_id: bool = True) -> State | None:
         """Convert to an HA state object."""
         try:
             return State(
@@ -221,7 +219,7 @@ class States(Base):  # type: ignore[misc,valid-type]
                 process_timestamp(self.last_updated),
                 # Join the events table on event_id to get the context instead
                 # as it will always be there for state_changed events
-                context=Context(id=None),
+                context=Context(id=None),  # type: ignore[arg-type]
                 validate_entity_id=validate_entity_id,
             )
         except ValueError:
@@ -251,23 +249,29 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         )
 
     @staticmethod
-    def from_event(event):
+    def from_event(event: Event) -> StateAttributes:
         """Create object from a state_changed event."""
-        state = event.data.get("new_state")
-        dbstate = StateAttributes()
-        # State got deleted
-        if state is None:
-            dbstate.shared_attrs = "{}"
-        else:
-            dbstate.shared_attrs = json.dumps(
-                dict(state.attributes),
-                cls=JSONEncoder,
-                separators=(",", ":"),
-            )
-        dbstate.hash = fnv1a_32(dbstate.shared_attrs.encode("utf-8"))
+        state: State | None = event.data.get("new_state")
+        # None state means the state was removed from the state machine
+        dbstate = StateAttributes(
+            shared_attrs="{}" if state is None else JSON_DUMP(state.attributes)
+        )
+        dbstate.hash = StateAttributes.hash_shared_attrs(dbstate.shared_attrs)
         return dbstate
 
-    def to_native(self):
+    @staticmethod
+    def shared_attrs_from_event(event: Event) -> str:
+        """Create shared_attrs from a state_changed event."""
+        state: State | None = event.data.get("new_state")
+        # None state means the state was removed from the state machine
+        return "{}" if state is None else JSON_DUMP(state.attributes)
+
+    @staticmethod
+    def hash_shared_attrs(shared_attrs: str) -> int:
+        """Return the hash of json encoded shared attributes."""
+        return fnv1a_32(shared_attrs.encode("utf-8"))
+
+    def to_native(self) -> dict[str, Any]:
         """Convert to an HA state object."""
         try:
             return json.loads(self.shared_attrs)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid hashing attributes when they are already in the cache.  Inspired by https://github.com/home-assistant/core/pull/68224#discussion_r829758210

Since 80-90% of the attributes ids are already in memory we
can avoid calculating the hash most of the time.

The existing tests cover this change.

Tested with https://github.com/bdraco/scaletest and it and hashing was gone on the profile.  
 
![slam_state_machine2](https://user-images.githubusercontent.com/663432/159139071-2e199a49-d05c-448a-967e-8c29be833367.svg)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
