### PR TITLE
Fix pip_check script

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -128,6 +128,7 @@ other: &other
 requirements: &requirements
   - .github/workflows/**
   - homeassistant/package_constraints.txt
+  - script/pip_check
   - requirements*.txt
   - setup.cfg
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -686,7 +686,7 @@ jobs:
 
   pip-check:
     runs-on: ubuntu-latest
-    if: needs.changes.outputs.requirements == 'true'
+    if: needs.changes.outputs.requirements == 'true' || github.event.inputs.full == 'true'
     needs:
       - changes
       - prepare-tests

--- a/script/pip_check
+++ b/script/pip_check
@@ -3,7 +3,7 @@ PIP_CACHE=$1
 
 # Number of existing dependency conflicts
 # Update if a PR resolve one!
-DEPENDENCY_CONFLICTS=4
+DEPENDENCY_CONFLICTS=7
 
 PIP_CHECK=$(pip check --cache-dir=$PIP_CACHE)
 LINE_COUNT=$(echo "$PIP_CHECK" | wc -l)
@@ -14,6 +14,7 @@ then
     echo "------"
     echo "Requirements change added another dependency conflict."
     echo "Make sure to check the 'pip check' output above!"
+    echo "Expected $DEPENDENCY_CONFLICTS conflicts, got $LINE_COUNT."
     exit 1
 elif [[ $((LINE_COUNT)) -lt $DEPENDENCY_CONFLICTS ]]
 then


### PR DESCRIPTION
## Proposed change
`pytz 2022.1` was released today which added some new dependency conflicts.
According to the [announcement](https://launchpad.net/pytz/+announcement/30598), the version is fully backwards compatible.

The new error messages
```
simplisafe-python 2022.2.1 has requirement pytz<2022.0,>=2019.3, but you have pytz 2022.1.
meteofrance-api 1.0.2 has requirement pytz<2022.0,>=2020.4, but you have pytz 2022.1.
aioridwell 2021.12.2 has requirement pytz<2022.0,>=2021.3, but you have pytz 2022.1.
```
I've already opened issues in the corresponding repos to get these fixed (hopefully soon).
* https://github.com/bachya/aioridwell/issues/28
* https://github.com/bachya/simplisafe-python/issues/316
* https://github.com/hacf-fr/meteofrance-api/issues/358

For now, I chose to bump the number of dependency conflicts. It would also be possible to add a constraint, but I would rather not pin a version with an outdated timezone database. Especially since it's otherwise fully compatible.

/CC: @MartinHjelmare


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
