### PR TITLE
Fix notify discovery setup

### DIFF
--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -116,9 +116,6 @@ async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
         """Handle for discovered platform."""
         await async_setup_platform(platform, discovery_info=info)
 
-    if hass.data[NOTIFY_DISCOVERY_DISPATCHER] is not None:
-        return
-
     hass.data[NOTIFY_DISCOVERY_DISPATCHER] = discovery.async_listen_platform(
         hass, DOMAIN, async_platform_discovered
     )

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -116,6 +116,9 @@ async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
         """Handle for discovered platform."""
         await async_setup_platform(platform, discovery_info=info)
 
+    if hass.data[NOTIFY_DISCOVERY_DISPATCHER] is not None:
+        return
+
     hass.data[NOTIFY_DISCOVERY_DISPATCHER] = discovery.async_listen_platform(
         hass, DOMAIN, async_platform_discovered
     )

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -156,6 +156,7 @@ async def async_reset_platform(hass: HomeAssistant, integration_name: str) -> No
     """Unregister notify services for an integration."""
     if NOTIFY_DISCOVERY_DISPATCHER in hass.data:
         hass.data[NOTIFY_DISCOVERY_DISPATCHER]()
+        hass.data[NOTIFY_DISCOVERY_DISPATCHER] = None
     if not _async_integration_has_notify_services(hass, integration_name):
         return
 

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -151,7 +151,8 @@ async def async_reload(hass: HomeAssistant, integration_name: str) -> None:
 @bind_hass
 async def async_reset_platform(hass: HomeAssistant, integration_name: str) -> None:
     """Unregister notify services for an integration."""
-    hass.data[NOTIFY_DISCOVERY_DISPATCHER]()
+    if NOTIFY_DISCOVERY_DISPATCHER in hass.data:
+        hass.data[NOTIFY_DISCOVERY_DISPATCHER]()
     if not _async_integration_has_notify_services(hass, integration_name):
         return
 

--- a/homeassistant/components/notify/legacy.py
+++ b/homeassistant/components/notify/legacy.py
@@ -29,6 +29,7 @@ from .const import (
 
 CONF_FIELDS = "fields"
 NOTIFY_SERVICES = "notify_services"
+NOTIFY_DISCOVERY = "notify_discovery"
 
 
 async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
@@ -114,7 +115,10 @@ async def async_setup_legacy(hass: HomeAssistant, config: ConfigType) -> None:
         """Handle for discovered platform."""
         await async_setup_platform(platform, discovery_info=info)
 
-    discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
+    # Avoid setting up duplicate listeners after a reload
+    if not hass.data.setdefault(NOTIFY_DISCOVERY, False):
+        discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
+        hass.data[NOTIFY_DISCOVERY] = True
 
 
 @callback

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -95,7 +95,7 @@ def async_listen_platform(
     hass: core.HomeAssistant,
     component: str,
     callback: Callable[[str, dict[str, Any] | None], Any],
-) -> None:
+) -> Callable[[], None]:
     """Register a platform loader listener.
 
     This method must be run in the event loop.
@@ -112,7 +112,7 @@ def async_listen_platform(
         if task:
             await task
 
-    async_dispatcher_connect(
+    return async_dispatcher_connect(
         hass, SIGNAL_PLATFORM_DISCOVERED.format(service), discovery_platform_listener
     )
 

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -21,6 +21,8 @@ from .typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORM_RESET_LOCK = "lock_async_reset_platform_{}"
+
 
 async def async_reload_integration_platforms(
     hass: HomeAssistant, integration_name: str, integration_platforms: Iterable[str]
@@ -79,7 +81,9 @@ async def _resetup_platform(
     if hasattr(component, "async_reset_platform"):
         # If the integration has its own way to reset
         # use this method.
-        async with hass.data.setdefault("lock_async_reset_platform", asyncio.Lock()):
+        async with hass.data.setdefault(
+            PLATFORM_RESET_LOCK.format(integration_platform), asyncio.Lock()
+        ):
             await component.async_reset_platform(hass, integration_name)
             await component.async_setup(hass, root_config)
         return

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -79,8 +79,9 @@ async def _resetup_platform(
     if hasattr(component, "async_reset_platform"):
         # If the integration has its own way to reset
         # use this method.
-        await component.async_reset_platform(hass, integration_name)
-        await component.async_setup(hass, root_config)
+        async with hass.data.setdefault("lock_async_reset_platform", asyncio.Lock()):
+            await component.async_reset_platform(hass, integration_name)
+            await component.async_setup(hass, root_config)
         return
 
     # If it's an entity platform, we use the entity_platform

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -19,10 +19,13 @@ from tests.common import MockPlatform, mock_platform
 class MockNotifyPlatform(MockPlatform):
     """Help to set up test notify service."""
 
-    def __init__(self, async_get_service):
+    def __init__(self, async_get_service=None, get_service=None):
         """Return the notify service."""
         super().__init__()
-        self.async_get_service = async_get_service
+        if async_get_service:
+            self.async_get_service = async_get_service
+        if get_service:
+            self.get_service = get_service
 
 
 async def test_same_targets(hass: HomeAssistant):
@@ -136,7 +139,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist, "testnotify")
 
-    async def async_get_service2(hass, config, discovery_info=None):
+    def get_service2(hass, config, discovery_info=None):
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"c": 3, "d": 4}
@@ -154,7 +157,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
     integration.file_path = tmp_path
 
     # Initialize a second platform
-    loaded_platform2 = MockNotifyPlatform(async_get_service=async_get_service2)
+    loaded_platform2 = MockNotifyPlatform(get_service=get_service2)
     mock_platform(hass, "testnotify2.notify", loaded_platform2)
 
     # Setup the testnotify platform

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -33,13 +33,8 @@ def mock_notify_platform(
 ):
     """Specialize the mock platform for notify."""
     loaded_platform = MockNotifyPlatform(async_get_service, get_service)
-    services_yaml_file = tmp_path / "services.yaml"
-    services_config = yaml.dump({})
-    services_yaml_file.write_text(services_config)
-    if integration is not None:
-        mock_platform(hass, f"{integration}.notify", loaded_platform)
-        integration = hass.data[DATA_INTEGRATIONS][integration]
-        integration.file_path = tmp_path
+    mock_platform(hass, f"{integration}.notify", loaded_platform)
+    integration = hass.data[DATA_INTEGRATIONS][integration]
 
     return loaded_platform
 

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -181,7 +181,7 @@ async def test_invalid_service(hass, caplog, tmp_path):
         hass,
         "notify",
         "testnotify",
-        {"notify": [{"platform": "testnotify"}]},
+        {},
         hass_config={"notify": [{"platform": "testnotify"}]},
     )
     await hass.async_block_till_done()
@@ -214,7 +214,7 @@ async def test_platform_setup_with_error(hass, caplog, tmp_path):
         hass,
         "notify",
         "testnotify",
-        {"notify": [{"platform": "testnotify"}]},
+        {},
         hass_config={"notify": [{"platform": "testnotify"}]},
     )
     await hass.async_block_till_done()
@@ -295,7 +295,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
         hass,
         "notify",
         "testnotify2",
-        {"notify": {}},
+        {},
         hass_config={"notify": [{"platform": "testnotify"}]},
     )
     await hass.async_block_till_done()
@@ -304,7 +304,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
     assert hass.services.has_service(notify.DOMAIN, "testnotify2_d")
     assert get_service_called.call_count == 1
     assert get_service_called.call_args[0][0] == {}
-    assert get_service_called.call_args[0][1] == {"notify": {}}
+    assert get_service_called.call_args[0][1] == {}
     get_service_called.reset_mock()
 
     # Perform a reload

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -19,12 +19,13 @@ from tests.common import MockPlatform, mock_platform
 class MockNotifyPlatform(MockPlatform):
     """Help to set up test notify service."""
 
-    def __init__(self, async_get_service=None):
+    def __init__(self, async_get_service=None, get_service=None):
         """Return the notify service."""
         super().__init__()
-        if not async_get_service:
-            return
-        self.async_get_service = async_get_service
+        if get_service:
+            self.get_service = get_service
+        if async_get_service:
+            self.async_get_service = async_get_service
 
 
 async def test_same_targets(hass: HomeAssistant):
@@ -149,11 +150,11 @@ async def test_invalid_platform(hass, caplog, tmp_path):
 async def test_invalid_service(hass, caplog, tmp_path):
     """Test service setup with an invalid service object or platform."""
 
-    async def async_get_service(hass, config, discovery_info=None):
+    def get_service(hass, config, discovery_info=None):
         """Return None for an invalid notify service."""
         return None
 
-    loaded_platform = MockNotifyPlatform(async_get_service=async_get_service)
+    loaded_platform = MockNotifyPlatform(get_service=get_service)
     mock_platform(hass, "testnotify.notify", loaded_platform)
     integration = hass.data[DATA_INTEGRATIONS]["testnotify"]
     integration.file_path = tmp_path

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -1,7 +1,27 @@
 """The tests for notify services that change targets."""
+
+from unittest.mock import Mock, patch
+
+import yaml
+
+from homeassistant import config as hass_config
 from homeassistant.components import notify
+from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.loader import DATA_INTEGRATIONS
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockPlatform, mock_platform
+
+
+class MockNotifyPlatform(MockPlatform):
+    """Help to set up test notify service."""
+
+    def __init__(self, async_get_service):
+        """Return the notify service."""
+        super().__init__()
+        self.async_get_service = async_get_service
 
 
 async def test_same_targets(hass: HomeAssistant):
@@ -73,10 +93,16 @@ async def test_remove_targets(hass: HomeAssistant):
 class NotificationService(notify.BaseNotificationService):
     """A test class for notification services."""
 
-    def __init__(self, hass):
+    def __init__(self, hass, target_list={"a": 1, "b": 2}):
         """Initialize the service."""
+
+        async def _async_make_reloadable(hass):
+            """Initialize the reload service."""
+            await async_setup_reload_service(hass, "testnotify", [notify.DOMAIN])
+
         self.hass = hass
-        self.target_list = {"a": 1, "b": 2}
+        self.target_list = target_list
+        hass.async_create_task(_async_make_reloadable(hass))
 
     @property
     def targets(self):
@@ -97,3 +123,52 @@ async def test_warn_template(hass, caplog):
     # We should only log it once
     assert caplog.text.count("Passing templates to notify service is deprecated") == 1
     assert hass.states.get("persistent_notification.notification") is not None
+
+
+async def test_setup_platform_and_reload(hass, caplog, tmp_path):
+    """Test service setup and reload."""
+    get_service_called = Mock()
+
+    async def async_get_service(hass, config, discovery_info=None):
+        """Get notify service for mocked platform."""
+        get_service_called()
+        targetlist = {"a": 1, "b": 2}
+        return NotificationService(hass, targetlist)
+
+    # Mock notify services file
+    services_yaml_file = tmp_path / "services.yaml"
+    services_config = yaml.dump(
+        {"notify": [{"description": "My custom notify service", "fields": {}}]}
+    )
+    services_yaml_file.write_text(services_config)
+    loaded_platform = MockNotifyPlatform(async_get_service=async_get_service)
+    mock_platform(hass, "testnotify.notify", loaded_platform)
+    integration = hass.data[DATA_INTEGRATIONS]["testnotify"]
+    integration.file_path = tmp_path
+
+    # Setup the platform
+    await notify.async_setup(hass, {"notify": [{"platform": "testnotify"}]})
+    await hass.async_block_till_done()
+    assert hass.services.has_service("testnotify", SERVICE_RELOAD)
+    assert hass.services.has_service(notify.DOMAIN, "testnotify_a")
+    assert hass.services.has_service(notify.DOMAIN, "testnotify_b")
+    assert get_service_called.call_count == 1
+
+    # Perform a reload
+    new_yaml_config_file = tmp_path / "configuration.yaml"
+    new_yaml_config = yaml.dump({"notify": [{"platform": "testnotify"}]})
+    new_yaml_config_file.write_text(new_yaml_config)
+
+    with patch.object(hass_config, "YAML_CONFIG_FILE", new_yaml_config_file):
+        await hass.services.async_call(
+            "testnotify",
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    # Check if the notify services still exist
+    assert hass.services.has_service(notify.DOMAIN, "testnotify_a")
+    assert hass.services.has_service(notify.DOMAIN, "testnotify_b")
+    assert get_service_called.call_count == 2

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -135,6 +135,8 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist)
 
+    await async_setup_component(hass, "notify", {})
+    config = {"notify": [{"platform": "testnotify"}]}
     # Mock notify services file
     services_yaml_file = tmp_path / "services.yaml"
     services_config = yaml.dump(
@@ -147,7 +149,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
     integration.file_path = tmp_path
 
     # Setup the platform
-    await notify.async_setup(hass, {"notify": [{"platform": "testnotify"}]})
+    await notify.async_setup(hass, config)
     await hass.async_block_till_done()
     assert hass.services.has_service("testnotify", SERVICE_RELOAD)
     assert hass.services.has_service(notify.DOMAIN, "testnotify_a")

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -19,13 +19,12 @@ from tests.common import MockPlatform, mock_platform
 class MockNotifyPlatform(MockPlatform):
     """Help to set up test notify service."""
 
-    def __init__(self, async_get_service=None, get_service=None):
+    def __init__(self, async_get_service=None):
         """Return the notify service."""
         super().__init__()
-        if async_get_service:
-            self.async_get_service = async_get_service
-        if get_service:
-            self.get_service = get_service
+        if not async_get_service:
+            return
+        self.async_get_service = async_get_service
 
 
 async def test_same_targets(hass: HomeAssistant):
@@ -214,7 +213,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist, "testnotify")
 
-    def get_service2(hass, config, discovery_info=None):
+    async def async_get_service2(hass, config, discovery_info=None):
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"c": 3, "d": 4}
@@ -232,7 +231,7 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
     integration.file_path = tmp_path
 
     # Initialize a second platform
-    loaded_platform2 = MockNotifyPlatform(get_service=get_service2)
+    loaded_platform2 = MockNotifyPlatform(async_get_service=async_get_service2)
     mock_platform(hass, "testnotify2.notify", loaded_platform2)
 
     # Setup the testnotify platform

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -10,7 +10,6 @@ from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.reload import async_setup_reload_service
-from homeassistant.loader import DATA_INTEGRATIONS
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockPlatform, mock_platform

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -34,7 +34,6 @@ def mock_notify_platform(
     """Specialize the mock platform for notify."""
     loaded_platform = MockNotifyPlatform(async_get_service, get_service)
     mock_platform(hass, f"{integration}.notify", loaded_platform)
-    integration = hass.data[DATA_INTEGRATIONS][integration]
 
     return loaded_platform
 

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -161,7 +161,7 @@ async def test_invalid_platform(hass, caplog, tmp_path):
         hass,
         "notify",
         "testnotify2",
-        {"notify": {}},
+        {},
         hass_config={"notify": [{"platform": "testnotify2"}]},
     )
     await hass.async_block_till_done()

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -135,8 +135,6 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist)
 
-    await async_setup_component(hass, "notify", {})
-    config = {"notify": [{"platform": "testnotify"}]}
     # Mock notify services file
     services_yaml_file = tmp_path / "services.yaml"
     services_config = yaml.dump(
@@ -148,8 +146,10 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
     integration = hass.data[DATA_INTEGRATIONS]["testnotify"]
     integration.file_path = tmp_path
 
-    # Setup the platform
-    await notify.async_setup(hass, config)
+    # Setup the testnotify platform
+    await async_setup_component(
+        hass, "notify", {"notify": [{"platform": "testnotify"}]}
+    )
     await hass.async_block_till_done()
     assert hass.services.has_service("testnotify", SERVICE_RELOAD)
     assert hass.services.has_service(notify.DOMAIN, "testnotify_a")

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -33,6 +33,9 @@ def mock_notify_platform(
 ):
     """Specialize the mock platform for notify."""
     loaded_platform = MockNotifyPlatform(async_get_service, get_service)
+    services_yaml_file = tmp_path / "services.yaml"
+    services_config = yaml.dump({})
+    services_yaml_file.write_text(services_config)
     if integration is not None:
         mock_platform(hass, f"{integration}.notify", loaded_platform)
         integration = hass.data[DATA_INTEGRATIONS][integration]
@@ -264,16 +267,10 @@ async def test_setup_platform_and_reload(hass, caplog, tmp_path):
         targetlist = {"c": 3, "d": 4}
         return NotificationService(hass, targetlist, "testnotify2")
 
-    # Mock notify services file
-    services_yaml_file = tmp_path / "services.yaml"
-    services_config = yaml.dump(
-        {"notify": [{"description": "My custom notify service", "fields": {}}]}
+    # Mock first platform
+    mock_notify_platform(
+        hass, tmp_path, "testnotify", async_get_service=async_get_service
     )
-    services_yaml_file.write_text(services_config)
-    loaded_platform = MockNotifyPlatform(async_get_service=async_get_service)
-    mock_platform(hass, "testnotify.notify", loaded_platform)
-    integration = hass.data[DATA_INTEGRATIONS]["testnotify"]
-    integration.file_path = tmp_path
 
     # Initialize a second platform testnotify2
     mock_notify_platform(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct the (legacy) notify discovery setup when performing a reload.
The current behavior causes discovered notifiy services to processed twice after a reload and even more times when a reload is repeated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
