### PR TITLE
Track number of persons in a Zone

### DIFF
--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -1,6 +1,7 @@
 """Support for the definition of zones."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 from typing import Any, cast
 
@@ -9,6 +10,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (
     ATTR_EDITABLE,
+    ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     CONF_ICON,
@@ -27,6 +29,7 @@ from homeassistant.helpers import (
     config_validation as cv,
     entity,
     entity_component,
+    event,
     service,
     storage,
 )
@@ -284,7 +287,10 @@ class Zone(entity.Entity):
         """Initialize the zone."""
         self._config = config
         self.editable = True
+        self._attrs: dict | None = None
+        self._remove_listener: Callable[[], None] | None = None
         self._generate_attrs()
+        self._persons_in_zone: set[str] = set()
 
     @classmethod
     def from_yaml(cls, config: dict) -> Zone:
@@ -295,9 +301,9 @@ class Zone(entity.Entity):
         return zone
 
     @property
-    def state(self) -> str:
+    def state(self) -> int:
         """Return the state property really does nothing for a zone."""
-        return "zoning"
+        return len(self._persons_in_zone)
 
     @property
     def name(self) -> str:
@@ -315,6 +321,11 @@ class Zone(entity.Entity):
         return self._config.get(CONF_ICON)
 
     @property
+    def extra_state_attributes(self) -> dict | None:
+        """Return the state attributes of the zone."""
+        return self._attrs
+
+    @property
     def should_poll(self) -> bool:
         """Zone does not poll."""
         return False
@@ -328,9 +339,58 @@ class Zone(entity.Entity):
         self.async_write_ha_state()
 
     @callback
+    def _person_state_change_listener(self, evt: Event) -> None:
+        person_entity_id = evt.data["entity_id"]
+        cur_count = len(self._persons_in_zone)
+        if (
+            (state := evt.data["new_state"])
+            and (latitude := state.attributes.get(ATTR_LATITUDE)) is not None
+            and (longitude := state.attributes.get(ATTR_LONGITUDE)) is not None
+            and (accuracy := state.attributes.get(ATTR_GPS_ACCURACY)) is not None
+            and (
+                zone_state := async_active_zone(
+                    self.hass, latitude, longitude, accuracy
+                )
+            )
+            and zone_state.entity_id == self.entity_id
+        ):
+            self._persons_in_zone.add(person_entity_id)
+        elif person_entity_id in self._persons_in_zone:
+            self._persons_in_zone.remove(person_entity_id)
+
+        if len(self._persons_in_zone) != cur_count:
+            self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        person_domain = "person"  # avoid circular import
+        persons = self.hass.states.async_entity_ids(person_domain)
+        for person in persons:
+            state = self.hass.states.get(person)
+            if (
+                state is None
+                or (latitude := state.attributes.get(ATTR_LATITUDE)) is None
+                or (longitude := state.attributes.get(ATTR_LONGITUDE)) is None
+                or (accuracy := state.attributes.get(ATTR_GPS_ACCURACY)) is None
+            ):
+                continue
+            zone_state = async_active_zone(self.hass, latitude, longitude, accuracy)
+            if zone_state is not None and zone_state.entity_id == self.entity_id:
+                self._persons_in_zone.add(person)
+
+        self.async_on_remove(
+            event.async_track_state_change_filtered(
+                self.hass,
+                event.TrackStates(False, set(), {person_domain}),
+                self._person_state_change_listener,
+            ).async_remove
+        )
+
+    @callback
     def _generate_attrs(self) -> None:
         """Generate new attrs based on config."""
-        self._attr_extra_state_attributes = {
+        self._attrs = {
             ATTR_LATITUDE: self._config[CONF_LATITUDE],
             ATTR_LONGITUDE: self._config[CONF_LONGITUDE],
             ATTR_RADIUS: self._config[CONF_RADIUS],

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
 from homeassistant.helpers import (
@@ -323,11 +324,6 @@ class Zone(entity.Entity):
         return self._config.get(CONF_ICON)
 
     @property
-    def extra_state_attributes(self) -> dict | None:
-        """Return the state attributes of the zone."""
-        return self._attrs
-
-    @property
     def should_poll(self) -> bool:
         """Zone does not poll."""
         return False
@@ -344,14 +340,7 @@ class Zone(entity.Entity):
     def _person_state_change_listener(self, evt: Event) -> None:
         person_entity_id = evt.data[ATTR_ENTITY_ID]
         cur_count = len(self._persons_in_zone)
-        if (
-            (state := evt.data.get("new_state"))
-            and state.state != STATE_NOT_HOME
-            and (
-                state.state == self.name
-                or (state.state == STATE_HOME and self.entity_id == ENTITY_ID_HOME)
-            )
-        ):
+        if self._state_is_in_zone(evt.data.get("new_state")):
             self._persons_in_zone.add(person_entity_id)
         elif person_entity_id in self._persons_in_zone:
             self._persons_in_zone.remove(person_entity_id)
@@ -365,15 +354,7 @@ class Zone(entity.Entity):
         person_domain = "person"  # avoid circular import
         persons = self.hass.states.async_entity_ids(person_domain)
         for person in persons:
-            state = self.hass.states.get(person)
-            if (
-                state
-                and state.state != STATE_NOT_HOME
-                and (
-                    state.state == self.name
-                    or (state.state == STATE_HOME and self.entity_id == ENTITY_ID_HOME)
-                )
-            ):
+            if self._state_is_in_zone(self.hass.states.get(person)):
                 self._persons_in_zone.add(person)
 
         self.async_on_remove(
@@ -387,10 +368,27 @@ class Zone(entity.Entity):
     @callback
     def _generate_attrs(self) -> None:
         """Generate new attrs based on config."""
-        self._attrs = {
+        self._attr_extra_state_attributes = {
             ATTR_LATITUDE: self._config[CONF_LATITUDE],
             ATTR_LONGITUDE: self._config[CONF_LONGITUDE],
             ATTR_RADIUS: self._config[CONF_RADIUS],
             ATTR_PASSIVE: self._config[CONF_PASSIVE],
             ATTR_EDITABLE: self.editable,
         }
+
+    @callback
+    def _state_is_in_zone(self, state: State | None) -> bool:
+        """Return if given state is in zone."""
+        return (
+            state is not None
+            and state.state
+            not in (
+                STATE_NOT_HOME,
+                STATE_UNKNOWN,
+                STATE_UNAVAILABLE,
+            )
+            and (
+                state.state.casefold() == self.name.casefold()
+                or (state.state == STATE_HOME and self.entity_id == ENTITY_ID_HOME)
+            )
+        )

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -316,7 +316,7 @@ async def test_load_from_storage(hass, storage_setup):
     """Test set up from storage."""
     assert await storage_setup()
     state = hass.states.get(f"{DOMAIN}.from_storage")
-    assert state.state == "zoning"
+    assert state.state == "0"
     assert state.name == "from storage"
     assert state.attributes.get(ATTR_EDITABLE)
 
@@ -328,12 +328,12 @@ async def test_editable_state_attribute(hass, storage_setup):
     )
 
     state = hass.states.get(f"{DOMAIN}.from_storage")
-    assert state.state == "zoning"
+    assert state.state == "0"
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == "from storage"
     assert state.attributes.get(ATTR_EDITABLE)
 
     state = hass.states.get(f"{DOMAIN}.yaml_option")
-    assert state.state == "zoning"
+    assert state.state == "0"
     assert not state.attributes.get(ATTR_EDITABLE)
 
 
@@ -457,7 +457,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
     assert resp["success"]
 
     state = hass.states.get(input_entity_id)
-    assert state.state == "zoning"
+    assert state.state == "0"
     assert state.attributes["latitude"] == 3
     assert state.attributes["longitude"] == 4
     assert state.attributes["passive"] is True
@@ -503,3 +503,110 @@ async def test_unavailable_zone(hass):
     assert zone.async_active_zone(hass, 0.0, 0.01) is None
 
     assert zone.in_zone(hass.states.get("zone.bla"), 0, 0) is False
+
+
+async def test_state(hass):
+    """Test the state of a zone."""
+    info = {
+        "name": "Test Zone",
+        "latitude": 32.880837,
+        "longitude": -117.237561,
+        "radius": 250,
+        "passive": False,
+    }
+    assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
+
+    assert len(hass.states.async_entity_ids("zone")) == 2
+    state = hass.states.get("zone.test_zone")
+    assert state.state == "0"
+
+    # Person entity enters zone
+    hass.states.async_set(
+        "person.person1",
+        "Test Zone",
+        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "1"
+    assert hass.states.get("zone.home").state == "0"
+
+    # Person entity enters zone
+    hass.states.async_set(
+        "person.person2",
+        "Test Zone",
+        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "2"
+    assert hass.states.get("zone.home").state == "0"
+
+    # Person entity enters another zone
+    hass.states.async_set(
+        "person.person1",
+        "home",
+        {"latitude": 32.87336, "longitude": -117.22743, "gps_accuracy": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "1"
+    assert hass.states.get("zone.home").state == "1"
+
+    # Person entity removed
+    hass.states.async_remove("person.person2")
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "0"
+    assert hass.states.get("zone.home").state == "1"
+
+
+async def test_state_2(hass):
+    """Test the state of a zone."""
+    hass.states.async_set("person.person1", "unknown")
+    hass.states.async_set("person.person2", "unknown")
+
+    info = {
+        "name": "Test Zone",
+        "latitude": 32.880837,
+        "longitude": -117.237561,
+        "radius": 250,
+        "passive": False,
+    }
+    assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
+
+    assert len(hass.states.async_entity_ids("zone")) == 2
+    state = hass.states.get("zone.test_zone")
+    assert state.state == "0"
+
+    # Person entity enters zone
+    hass.states.async_set(
+        "person.person1",
+        "Test Zone",
+        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "1"
+    assert hass.states.get("zone.home").state == "0"
+
+    # Person entity enters zone
+    hass.states.async_set(
+        "person.person2",
+        "Test Zone",
+        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "2"
+    assert hass.states.get("zone.home").state == "0"
+
+    # Person entity enters another zone
+    hass.states.async_set(
+        "person.person1",
+        "home",
+        {"latitude": 32.87336, "longitude": -117.22743, "gps_accuracy": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "1"
+    assert hass.states.get("zone.home").state == "1"
+
+    # Person entity removed
+    hass.states.async_remove("person.person2")
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "0"
+    assert hass.states.get("zone.home").state == "1"

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -524,68 +524,12 @@ async def test_state(hass):
     hass.states.async_set(
         "person.person1",
         "Test Zone",
-        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
     )
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "1"
     assert hass.states.get("zone.home").state == "0"
 
     # Person entity enters zone
-    hass.states.async_set(
-        "person.person2",
-        "Test Zone",
-        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "2"
-    assert hass.states.get("zone.home").state == "0"
-
-    # Person entity enters another zone
-    hass.states.async_set(
-        "person.person1",
-        "home",
-        {"latitude": 32.87336, "longitude": -117.22743, "gps_accuracy": 0},
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "1"
-    assert hass.states.get("zone.home").state == "1"
-
-    # Person entity removed
-    hass.states.async_remove("person.person2")
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "0"
-    assert hass.states.get("zone.home").state == "1"
-
-
-async def test_state_2(hass):
-    """Test the state of a zone."""
-    hass.states.async_set("person.person1", "unknown")
-    hass.states.async_set("person.person2", "unknown")
-
-    info = {
-        "name": "Test Zone",
-        "latitude": 32.880837,
-        "longitude": -117.237561,
-        "radius": 250,
-        "passive": False,
-    }
-    assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": info})
-
-    assert len(hass.states.async_entity_ids("zone")) == 2
-    state = hass.states.get("zone.test_zone")
-    assert state.state == "0"
-
-    # Person entity enters zone
-    hass.states.async_set(
-        "person.person1",
-        "Test Zone",
-        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "1"
-    assert hass.states.get("zone.home").state == "0"
-
-    # Person entity enters zone, without coordinates
     hass.states.async_set(
         "person.person2",
         "Test Zone",
@@ -601,12 +545,6 @@ async def test_state_2(hass):
     )
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "1"
-    assert hass.states.get("zone.home").state == "1"
-
-    # Person entity removed
-    hass.states.async_remove("person.person2")
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "0"
     assert hass.states.get("zone.home").state == "1"
 
     # Person entity enters not_home
@@ -614,6 +552,12 @@ async def test_state_2(hass):
         "person.person1",
         "not_home",
     )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "1"
+    assert hass.states.get("zone.home").state == "0"
+
+    # Person entity removed
+    hass.states.async_remove("person.person2")
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "0"
     assert hass.states.get("zone.home").state == "0"

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -529,10 +529,10 @@ async def test_state(hass):
     assert hass.states.get("zone.test_zone").state == "1"
     assert hass.states.get("zone.home").state == "0"
 
-    # Person entity enters zone
+    # Person entity enters zone (case insensitive)
     hass.states.async_set(
         "person.person2",
-        "Test Zone",
+        "TEST zone",
     )
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "2"

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -617,21 +617,3 @@ async def test_state_2(hass):
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "0"
     assert hass.states.get("zone.home").state == "0"
-
-    # Person entity enters home without coordinates
-    hass.states.async_set(
-        "person.person1",
-        "home",
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "0"
-    assert hass.states.get("zone.home").state == "1"
-
-    # Person entity enters home without coordinates
-    hass.states.async_set(
-        "person.person1",
-        "home",
-    )
-    await hass.async_block_till_done()
-    assert hass.states.get("zone.test_zone").state == "0"
-    assert hass.states.get("zone.home").state == "1"

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -585,11 +585,10 @@ async def test_state_2(hass):
     assert hass.states.get("zone.test_zone").state == "1"
     assert hass.states.get("zone.home").state == "0"
 
-    # Person entity enters zone
+    # Person entity enters zone, without coordinates
     hass.states.async_set(
         "person.person2",
         "Test Zone",
-        {"latitude": 32.880837, "longitude": -117.237561, "gps_accuracy": 0},
     )
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "2"
@@ -599,7 +598,6 @@ async def test_state_2(hass):
     hass.states.async_set(
         "person.person1",
         "home",
-        {"latitude": 32.87336, "longitude": -117.22743, "gps_accuracy": 0},
     )
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "1"
@@ -607,6 +605,33 @@ async def test_state_2(hass):
 
     # Person entity removed
     hass.states.async_remove("person.person2")
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "0"
+    assert hass.states.get("zone.home").state == "1"
+
+    # Person entity enters not_home
+    hass.states.async_set(
+        "person.person1",
+        "not_home",
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "0"
+    assert hass.states.get("zone.home").state == "0"
+
+    # Person entity enters home without coordinates
+    hass.states.async_set(
+        "person.person1",
+        "home",
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("zone.test_zone").state == "0"
+    assert hass.states.get("zone.home").state == "1"
+
+    # Person entity enters home without coordinates
+    hass.states.async_set(
+        "person.person1",
+        "home",
+    )
     await hass.async_block_till_done()
     assert hass.states.get("zone.test_zone").state == "0"
     assert hass.states.get("zone.home").state == "1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This reverts the revert #65344

Implements state of a Zone, based on the state of persons. Instead of the previous approach (that used object IDs and coordinates), this approach only relies on the actual state of person (and thus the device tracker) entity.

- If the current zone object ID matches the home zone, we accept `home` for the zone. This makes device_trackers like ping work when tied to a person (without providing a coordinate)
- If the current state is `not_home`, we ignore the state of the person. We don't know where they are.
- If the name of a zone is found in a person's state, the person is in the zone.

⚠️ The triggers of zones are based on coordinates, this behavior has not been changed and is still working as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
