### PR TITLE
Seperate emonitor extra_state_attributes into their own sensors

### DIFF
--- a/homeassistant/components/emonitor/sensor.py
+++ b/homeassistant/components/emonitor/sensor.py
@@ -1,9 +1,12 @@
 """Support for a Emonitor channel sensor."""
-from aioemonitor.monitor import EmonitorChannel
+from __future__ import annotations
+
+from aioemonitor.monitor import EmonitorChannel, EmonitorStatus
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +24,12 @@ from homeassistant.helpers.update_coordinator import (
 from . import name_short_mac
 from .const import DOMAIN
 
+SENSORS = (
+    SensorEntityDescription(key="inst_power"),
+    SensorEntityDescription(key="avg_power", name="Average"),
+    SensorEntityDescription(key="max_power", name="Max"),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -30,7 +39,7 @@ async def async_setup_entry(
     """Set up entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     channels = coordinator.data.channels
-    entities = []
+    entities: list[EmonitorPowerSensor] = []
     seen_channels = set()
     for channel_number, channel in channels.items():
         seen_channels.add(channel_number)
@@ -39,7 +48,10 @@ async def async_setup_entry(
         if channel.paired_with_channel in seen_channels:
             continue
 
-        entities.append(EmonitorPowerSensor(coordinator, channel_number))
+        entities.extend(
+            EmonitorPowerSensor(coordinator, description, channel_number)
+            for description in SENSORS
+        )
 
     async_add_entities(entities)
 
@@ -51,59 +63,60 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
     _attr_native_unit_of_measurement = POWER_WATT
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, coordinator: DataUpdateCoordinator, channel_number: int) -> None:
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        description: SensorEntityDescription,
+        channel_number: int,
+    ) -> None:
         """Initialize the channel sensor."""
+        self.entity_description = description
         self.channel_number = channel_number
         super().__init__(coordinator)
-        self._attr_unique_id = f"{self.mac_address}_{channel_number}"
+        mac_address = self.emonitor_status.network.mac_address
+        if description.name:
+            self._attr_name = f"{self.channel_data.label} {description.name}"
+        else:
+            self._attr_name = self.channel_data.label
+        self._attr_unique_id = f"{mac_address}_{channel_number}"
+        self._attr_device_info = DeviceInfo(
+            connections={(dr.CONNECTION_NETWORK_MAC, mac_address)},
+            manufacturer="Powerhouse Dynamics, Inc.",
+            name=name_short_mac(mac_address[-6:]),
+            sw_version=self.emonitor_status.hardware.firmware_version,
+        )
+
+    @property
+    def channels(self) -> dict[int, EmonitorChannel]:
+        """Return the channels dict."""
+        channels: dict[int, EmonitorChannel] = self.emonitor_status.channels
+        return channels
 
     @property
     def channel_data(self) -> EmonitorChannel:
-        """Channel data."""
-        return self.coordinator.data.channels[self.channel_number]
+        """Return the channel data."""
+        return self.channels[self.channel_number]
 
     @property
-    def paired_channel_data(self) -> EmonitorChannel:
-        """Channel data."""
-        return self.coordinator.data.channels[self.channel_data.paired_with_channel]
-
-    @property
-    def name(self) -> str:
-        """Name of the sensor."""
-        return self.channel_data.label
+    def emonitor_status(self) -> EmonitorStatus:
+        """Return the EmonitorStatus."""
+        return self.coordinator.data
 
     def _paired_attr(self, attr_name: str) -> float:
         """Cumulative attributes for channel and paired channel."""
-        attr_val = getattr(self.channel_data, attr_name)
-        if self.channel_data.paired_with_channel:
-            attr_val += getattr(self.paired_channel_data, attr_name)
+        channel_data = self.channels[self.channel_number]
+        paired_channel_data = self.channels[channel_data.paired_with_channel]
+        attr_val = getattr(channel_data, attr_name)
+        if channel_data.paired_with_channel:
+            attr_val += getattr(paired_channel_data, attr_name)
         return attr_val
 
     @property
     def native_value(self) -> StateType:
         """State of the sensor."""
-        return self._paired_attr("inst_power")
+        return self._paired_attr(self.entity_description.key)
 
     @property
     def extra_state_attributes(self) -> dict:
         """Return the device specific state attributes."""
-        return {
-            "channel": self.channel_number,
-            "avg_power": self._paired_attr("avg_power"),
-            "max_power": self._paired_attr("max_power"),
-        }
-
-    @property
-    def mac_address(self) -> str:
-        """Return the mac address of the device."""
-        return self.coordinator.data.network.mac_address
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return info about the emonitor device."""
-        return DeviceInfo(
-            connections={(dr.CONNECTION_NETWORK_MAC, self.mac_address)},
-            manufacturer="Powerhouse Dynamics, Inc.",
-            name=name_short_mac(self.mac_address[-6:]),
-            sw_version=self.coordinator.data.hardware.firmware_version,
-        )
+        return {"channel": self.channel_number}

--- a/homeassistant/components/emonitor/sensor.py
+++ b/homeassistant/components/emonitor/sensor.py
@@ -76,9 +76,10 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
         mac_address = self.emonitor_status.network.mac_address
         if description.name:
             self._attr_name = f"{self.channel_data.label} {description.name}"
+            self._attr_unique_id = f"{mac_address}_{channel_number}_{description.key}"
         else:
             self._attr_name = self.channel_data.label
-        self._attr_unique_id = f"{mac_address}_{channel_number}"
+            self._attr_unique_id = f"{mac_address}_{channel_number}"
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, mac_address)},
             manufacturer="Powerhouse Dynamics, Inc.",

--- a/homeassistant/components/emonitor/sensor.py
+++ b/homeassistant/components/emonitor/sensor.py
@@ -105,10 +105,9 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
     def _paired_attr(self, attr_name: str) -> float:
         """Cumulative attributes for channel and paired channel."""
         channel_data = self.channels[self.channel_number]
-        paired_channel_data = self.channels[channel_data.paired_with_channel]
         attr_val = getattr(channel_data, attr_name)
-        if channel_data.paired_with_channel:
-            attr_val += getattr(paired_channel_data, attr_name)
+        if paired_channel := channel_data.paired_with_channel:
+            attr_val += getattr(self.channels[paired_channel], attr_name)
         return attr_val
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `avg_power` and `max_power` extra attributes for Emonitor was now their own sensors.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
