### PR TITLE
POC: Restore last_changed when adding entities with the same state during startup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -25,6 +25,7 @@ from .const import (
 from .exceptions import HomeAssistantError
 from .helpers import area_registry, device_registry, entity_registry
 from .helpers.dispatcher import async_dispatcher_send
+from .helpers.restore_state import RestoreStateData
 from .helpers.typing import ConfigType
 from .setup import (
     DATA_SETUP,
@@ -540,11 +541,17 @@ async def _async_set_up_integrations(
 
     stage_2_domains = domains_to_setup - logging_domains - debuggers - stage_1_domains
 
+    async def _async_set_restore_state() -> None:
+        hass.states.async_set_restore_state(
+            await RestoreStateData.async_get_instance(hass)
+        )
+
     # Load the registries
     await asyncio.gather(
         device_registry.async_load(hass),
         entity_registry.async_load(hass),
         area_registry.async_load(hass),
+        _async_set_restore_state(),
     )
 
     # Start setup

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1353,6 +1353,7 @@ class StateMachine:
             if (
                 not force_update
                 and self._restore_state
+                and self._restore_state.restore_last_changed
                 and (restored_state := self._restore_state.last_states.get(entity_id))
                 and restored_state.state.state == new_state
             ):

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -246,19 +246,32 @@ async def test_dump_data(hass):
     args = mock_write_data.mock_calls[0][1]
     written_states = args[0]
 
-    # b0 should not be written, since it didn't extend RestoreEntity
-    # b1 should be written, since it is present in the current run
-    # b2 should not be written, since it is not registered with the helper
-    # b3 should be written, since it is still not expired
-    # b4 should not be written, since it is now expired
-    # b5 should be written, since current state is restored by entity registry
-    assert len(written_states) == 3
-    assert written_states[0]["state"]["entity_id"] == "input_boolean.b1"
+    # b0 should be partially written, since it didn't extend RestoreEntity
+    # b1 should be fully written, since it is present in the current run
+    # b2 should be partially written, since it is not registered with the helper
+    # b3 should be fully written, since it is still not expired
+    # b4 should be not be written, since it is now expired
+    # b5 should be fully written, since current state is restored by entity registry
+    assert len(written_states) == 5
+    assert written_states[0]["state"]["entity_id"] == "input_boolean.b0"
     assert written_states[0]["state"]["state"] == "on"
-    assert written_states[1]["state"]["entity_id"] == "input_boolean.b3"
-    assert written_states[1]["state"]["state"] == "off"
-    assert written_states[2]["state"]["entity_id"] == "input_boolean.b5"
-    assert written_states[2]["state"]["state"] == "off"
+    assert "attributes" not in written_states[0]["state"]
+
+    assert written_states[1]["state"]["entity_id"] == "input_boolean.b1"
+    assert written_states[1]["state"]["state"] == "on"
+    assert "attributes" in written_states[1]["state"]
+
+    assert written_states[2]["state"]["entity_id"] == "input_boolean.b2"
+    assert written_states[2]["state"]["state"] == "on"
+    assert "attributes" not in written_states[2]["state"]
+
+    assert written_states[3]["state"]["entity_id"] == "input_boolean.b3"
+    assert written_states[3]["state"]["state"] == "off"
+    assert "attributes" in written_states[3]["state"]
+
+    assert written_states[4]["state"]["entity_id"] == "input_boolean.b5"
+    assert written_states[4]["state"]["state"] == "off"
+    assert "attributes" in written_states[4]["state"]
 
     # Test that removed entities are not persisted
     await entity.async_remove()
@@ -271,11 +284,26 @@ async def test_dump_data(hass):
     assert mock_write_data.called
     args = mock_write_data.mock_calls[0][1]
     written_states = args[0]
-    assert len(written_states) == 2
-    assert written_states[0]["state"]["entity_id"] == "input_boolean.b3"
-    assert written_states[0]["state"]["state"] == "off"
-    assert written_states[1]["state"]["entity_id"] == "input_boolean.b5"
-    assert written_states[1]["state"]["state"] == "off"
+    assert len(written_states) == 5
+    assert written_states[0]["state"]["entity_id"] == "input_boolean.b0"
+    assert written_states[0]["state"]["state"] == "on"
+    assert "attributes" not in written_states[0]["state"]
+
+    assert written_states[1]["state"]["entity_id"] == "input_boolean.b1"
+    assert written_states[1]["state"]["state"] == "on"
+    assert "attributes" not in written_states[1]["state"]
+
+    assert written_states[2]["state"]["entity_id"] == "input_boolean.b2"
+    assert written_states[2]["state"]["state"] == "on"
+    assert "attributes" not in written_states[2]["state"]
+
+    assert written_states[3]["state"]["entity_id"] == "input_boolean.b3"
+    assert written_states[3]["state"]["state"] == "off"
+    assert "attributes" in written_states[3]["state"]
+
+    assert written_states[4]["state"]["entity_id"] == "input_boolean.b5"
+    assert written_states[4]["state"]["state"] == "off"
+    assert "attributes" in written_states[4]["state"]
 
 
 async def test_dump_error(hass):


### PR DESCRIPTION
This is a proof of concept for feedback.  I'm not sure if its a good idea but I ran out of reasons for it being a bad idea so I gave it a shot.

Implements https://community.home-assistant.io/t/retain-last-state-change-data-of-a-sensor-after-reboot/125148 and by extension https://github.com/home-assistant/architecture/issues/230#issuecomment-491319065


## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `last_changed` time is now restored to the value that was saved at shutdown for entities that are added to the state machine before the start event as long as they have same state as they previously had.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
