### PR TITLE
2022.3.6

### DIFF
--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -149,9 +149,19 @@ def _async_register_mac(
             return
 
         # Make sure entity has a config entry and was disabled by the
-        # default disable logic in the integration.
+        # default disable logic in the integration and new entities
+        # are allowed to be added.
         if (
             entity_entry.config_entry_id is None
+            or (
+                (
+                    config_entry := hass.config_entries.async_get_entry(
+                        entity_entry.config_entry_id
+                    )
+                )
+                is not None
+                and config_entry.pref_disable_new_entities
+            )
             or entity_entry.disabled_by != er.RegistryEntryDisabler.INTEGRATION
         ):
             return

--- a/homeassistant/components/enphase_envoy/config_flow.py
+++ b/homeassistant/components/enphase_envoy/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.util.network import is_ipv4_address
 
 from .const import DOMAIN
 
@@ -86,6 +87,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle a flow initialized by zeroconf discovery."""
+        if not is_ipv4_address(discovery_info.host):
+            return self.async_abort(reason="not_ipv4_address")
         serial = discovery_info.properties["serialnum"]
         await self.async_set_unique_id(serial)
         self.ip_address = discovery_info.host

--- a/homeassistant/components/enphase_envoy/translations/en.json
+++ b/homeassistant/components/enphase_envoy/translations/en.json
@@ -2,7 +2,8 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful",
+            "not_ipv4_address": "Only IPv4 addresess are supported"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
+import aiohttp
 from aiohue import LinkButtonNotPressed, create_app_key
 from aiohue.discovery import DiscoveredHueBridge, discover_bridge, discover_nupnp
 from aiohue.util import normalize_bridge_id
@@ -70,9 +71,12 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, host: str, bridge_id: str | None = None
     ) -> DiscoveredHueBridge:
         """Return a DiscoveredHueBridge object."""
-        bridge = await discover_bridge(
-            host, websession=aiohttp_client.async_get_clientsession(self.hass)
-        )
+        try:
+            bridge = await discover_bridge(
+                host, websession=aiohttp_client.async_get_clientsession(self.hass)
+            )
+        except aiohttp.ClientError:
+            return None
         if bridge_id is not None:
             bridge_id = normalize_bridge_id(bridge_id)
             assert bridge_id == bridge.id

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -42,6 +42,14 @@ ALLOWED_ERRORS = [
     'device (groupedLight) is "soft off", command (on) may not have effect',
     "device (light) has communication issues, command (on) may not have effect",
     'device (light) is "soft off", command (on) may not have effect',
+    "device (grouped_light) has communication issues, command (.on) may not have effect",
+    'device (grouped_light) is "soft off", command (.on) may not have effect'
+    "device (grouped_light) has communication issues, command (.on.on) may not have effect",
+    'device (grouped_light) is "soft off", command (.on.on) may not have effect'
+    "device (light) has communication issues, command (.on) may not have effect",
+    'device (light) is "soft off", command (.on) may not have effect',
+    "device (light) has communication issues, command (.on.on) may not have effect",
+    'device (light) is "soft off", command (.on.on) may not have effect',
 ]
 
 

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -39,6 +39,10 @@ from .helpers import (
 ALLOWED_ERRORS = [
     "device (light) has communication issues, command (on) may not have effect",
     'device (light) is "soft off", command (on) may not have effect',
+    "device (light) has communication issues, command (.on) may not have effect",
+    'device (light) is "soft off", command (.on) may not have effect',
+    "device (light) has communication issues, command (.on.on) may not have effect",
+    'device (light) is "soft off", command (.on.on) may not have effect',
 ]
 
 

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -1,6 +1,7 @@
 """Support for Honeywell Lyric climate platform."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from time import localtime, strftime, time
 
@@ -22,6 +23,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE
@@ -45,7 +47,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+# Only LCC models support presets
+SUPPORT_FLAGS_LCC = (
+    SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE_RANGE
+)
+SUPPORT_FLAGS_TCC = SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE
 
 LYRIC_HVAC_ACTION_OFF = "EquipmentOff"
 LYRIC_HVAC_ACTION_HEAT = "Heat"
@@ -166,7 +172,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
-        return SUPPORT_FLAGS
+        if self.device.changeableValues.thermostatSetpointStatus:
+            support_flags = SUPPORT_FLAGS_LCC
+        else:
+            support_flags = SUPPORT_FLAGS_TCC
+        return support_flags
 
     @property
     def temperature_unit(self) -> str:
@@ -200,25 +210,28 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         device = self.device
-        if not device.hasDualSetpointStatus:
+        if (
+            not device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+        ):
             if self.hvac_mode == HVAC_MODE_COOL:
                 return device.changeableValues.coolSetpoint
             return device.changeableValues.heatSetpoint
         return None
 
     @property
-    def target_temperature_low(self) -> float | None:
-        """Return the upper bound temperature we try to reach."""
+    def target_temperature_high(self) -> float | None:
+        """Return the highbound target temperature we try to reach."""
         device = self.device
-        if device.hasDualSetpointStatus:
+        if device.changeableValues.autoChangeoverActive:
             return device.changeableValues.coolSetpoint
         return None
 
     @property
-    def target_temperature_high(self) -> float | None:
-        """Return the upper bound temperature we try to reach."""
+    def target_temperature_low(self) -> float | None:
+        """Return the lowbound target temperature we try to reach."""
         device = self.device
-        if device.hasDualSetpointStatus:
+        if device.changeableValues.autoChangeoverActive:
             return device.changeableValues.heatSetpoint
         return None
 
@@ -256,11 +269,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
+        device = self.device
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
-        device = self.device
-        if device.hasDualSetpointStatus:
+        if device.changeableValues.autoChangeoverActive:
             if target_temp_low is None or target_temp_high is None:
                 raise HomeAssistantError(
                     "Could not find target_temp_low and/or target_temp_high in arguments"
@@ -270,11 +283,13 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                 await self._update_thermostat(
                     self.location,
                     device,
-                    coolSetpoint=target_temp_low,
-                    heatSetpoint=target_temp_high,
+                    coolSetpoint=target_temp_high,
+                    heatSetpoint=target_temp_low,
+                    mode=HVAC_MODES[device.changeableValues.heatCoolMode],
                 )
             except LYRIC_EXCEPTIONS as exception:
                 _LOGGER.error(exception)
+            await self.coordinator.async_refresh()
         else:
             temp = kwargs.get(ATTR_TEMPERATURE)
             _LOGGER.debug("Set temperature: %s", temp)
@@ -289,15 +304,58 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
                     )
             except LYRIC_EXCEPTIONS as exception:
                 _LOGGER.error(exception)
-        await self.coordinator.async_refresh()
+            await self.coordinator.async_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set hvac mode."""
-        _LOGGER.debug("Set hvac mode: %s", hvac_mode)
+        _LOGGER.debug("HVAC mode: %s", hvac_mode)
         try:
-            await self._update_thermostat(
-                self.location, self.device, mode=LYRIC_HVAC_MODES[hvac_mode]
-            )
+            if LYRIC_HVAC_MODES[hvac_mode] == LYRIC_HVAC_MODE_HEAT_COOL:
+                # If the system is off, turn it to Heat first then to Auto, otherwise it turns to
+                # Auto briefly and then reverts to Off (perhaps related to heatCoolMode). This is the
+                # behavior that happens with the native app as well, so likely a bug in the api itself
+
+                if HVAC_MODES[self.device.changeableValues.mode] == HVAC_MODE_OFF:
+                    _LOGGER.debug(
+                        "HVAC mode passed to lyric: %s",
+                        HVAC_MODES[LYRIC_HVAC_MODE_COOL],
+                    )
+                    await self._update_thermostat(
+                        self.location,
+                        self.device,
+                        mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                        autoChangeoverActive=False,
+                    )
+                    # Sleep 3 seconds before proceeding
+                    await asyncio.sleep(3)
+                    _LOGGER.debug(
+                        "HVAC mode passed to lyric: %s",
+                        HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                    )
+                    await self._update_thermostat(
+                        self.location,
+                        self.device,
+                        mode=HVAC_MODES[LYRIC_HVAC_MODE_HEAT],
+                        autoChangeoverActive=True,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "HVAC mode passed to lyric: %s",
+                        HVAC_MODES[self.device.changeableValues.mode],
+                    )
+                    await self._update_thermostat(
+                        self.location, self.device, autoChangeoverActive=True
+                    )
+            else:
+                _LOGGER.debug(
+                    "HVAC mode passed to lyric: %s", LYRIC_HVAC_MODES[hvac_mode]
+                )
+                await self._update_thermostat(
+                    self.location,
+                    self.device,
+                    mode=LYRIC_HVAC_MODES[hvac_mode],
+                    autoChangeoverActive=False,
+                )
         except LYRIC_EXCEPTIONS as exception:
             _LOGGER.error(exception)
         await self.coordinator.async_refresh()

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -243,7 +243,10 @@ class MatrixBot:
                 room.update_aliases()
                 self._aliases_fetched_for.add(room.room_id)
 
-            if room_id_or_alias in room.aliases:
+            if (
+                room_id_or_alias in room.aliases
+                or room_id_or_alias == room.canonical_alias
+            ):
                 _LOGGER.debug(
                     "Already in room %s (known as %s)", room.room_id, room_id_or_alias
                 )

--- a/homeassistant/components/opensensemap/air_quality.py
+++ b/homeassistant/components/opensensemap/air_quality.py
@@ -43,7 +43,7 @@ async def async_setup_platform(
     station_id = config[CONF_STATION_ID]
 
     session = async_get_clientsession(hass)
-    osm_api = OpenSenseMapData(OpenSenseMap(station_id, hass.loop, session))
+    osm_api = OpenSenseMapData(OpenSenseMap(station_id, session))
 
     await osm_api.async_update()
 

--- a/homeassistant/components/opensensemap/manifest.json
+++ b/homeassistant/components/opensensemap/manifest.json
@@ -2,7 +2,7 @@
   "domain": "opensensemap",
   "name": "openSenseMap",
   "documentation": "https://www.home-assistant.io/integrations/opensensemap",
-  "requirements": ["opensensemap-api==0.1.5"],
+  "requirements": ["opensensemap-api==0.2.0"],
   "codeowners": [],
   "iot_class": "cloud_polling",
   "loggers": ["opensensemap_api"]

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -97,6 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         token_saver=token_saver,
     )
     try:
+        # pylint: disable-next=fixme
+        # TODO Remove authlib constraint when refactoring this code
         await session.ensure_active_token()
     except ConnectTimeout as err:
         _LOGGER.debug("Connection Timeout")

--- a/homeassistant/components/renault/manifest.json
+++ b/homeassistant/components/renault/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/renault",
   "requirements": [
-    "renault-api==0.1.9"
+    "renault-api==0.1.10"
   ],
   "codeowners": [
     "@epenet"

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -319,8 +319,9 @@ class SamsungTVWSBridge(SamsungTVBridge):
     def _get_app_list(self) -> dict[str, str] | None:
         """Get installed app list."""
         if self._app_list is None and (remote := self._get_remote()):
-            with contextlib.suppress(WebSocketTimeoutException):
+            with contextlib.suppress(TypeError, WebSocketTimeoutException):
                 raw_app_list: list[dict[str, str]] = remote.app_list()
+                LOGGER.debug("Received app list: %s", raw_app_list)
                 self._app_list = {
                     app["name"]: app["appId"]
                     for app in sorted(raw_app_list, key=lambda app: app["name"])

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -88,7 +88,10 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
 
         # Handle turning to temp mode
         if ATTR_COLOR_TEMP in kwargs:
-            color_tmp = mired_to_kelvin(int(kwargs[ATTR_COLOR_TEMP]))
+            # Handle temp conversion mireds -> kelvin being slightly outside of valid range
+            kelvin = mired_to_kelvin(int(kwargs[ATTR_COLOR_TEMP]))
+            kelvin_range = self.device.valid_temperature_range
+            color_tmp = max(kelvin_range.min, min(kelvin_range.max, kelvin))
             _LOGGER.debug("Changing color temp to %s", color_tmp)
             await self.device.set_color_temp(
                 color_tmp, brightness=brightness, transition=transition

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -78,4 +78,4 @@ class VelbusCover(VelbusEntity, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        self._channel.set_position(100 - kwargs[ATTR_POSITION])
+        await self._channel.set_position(100 - kwargs[ATTR_POSITION])

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from .backports.enum import StrEnum
 
 MAJOR_VERSION: Final = 2022
 MINOR_VERSION: Final = 3
-PATCH_VERSION: Final = "5"
+PATCH_VERSION: Final = "6"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 9, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -95,3 +95,7 @@ python-socketio>=4.6.0,<5.0
 # Constrain multidict to avoid typing issues
 # https://github.com/home-assistant/core/pull/67046
 multidict>=6.0.2
+
+# Required for compatibility with point integration - ensure_active_token
+# https://github.com/home-assistant/core/pull/68176
+authlib<1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2097,7 +2097,7 @@ raspyrfm-client==1.2.8
 regenmaschine==2022.01.0
 
 # homeassistant.components.renault
-renault-api==0.1.9
+renault-api==0.1.10
 
 # homeassistant.components.python_script
 restrictedpython==5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1180,7 +1180,7 @@ openevsewifi==1.1.0
 openhomedevice==2.0.1
 
 # homeassistant.components.opensensemap
-opensensemap-api==0.1.5
+opensensemap-api==0.2.0
 
 # homeassistant.components.enigma2
 openwebifpy==3.2.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1301,7 +1301,7 @@ radios==0.1.1
 regenmaschine==2022.01.0
 
 # homeassistant.components.renault
-renault-api==0.1.9
+renault-api==0.1.10
 
 # homeassistant.components.python_script
 restrictedpython==5.2

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -124,6 +124,10 @@ python-socketio>=4.6.0,<5.0
 # Constrain multidict to avoid typing issues
 # https://github.com/home-assistant/core/pull/67046
 multidict>=6.0.2
+
+# Required for compatibility with point integration - ensure_active_token
+# https://github.com/home-assistant/core/pull/68176
+authlib<1.0
 """
 
 IGNORE_PRE_COMMIT_HOOK_ID = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name         = homeassistant
-version      = 2022.3.5
+version      = 2022.3.6
 author       = The Home Assistant Authors
 author_email = hello@home-assistant.io
 license      = Apache-2.0


### PR DESCRIPTION
- Fix TypeError in SamsungTV ([@epenet] - [#68235]) ([samsungtv docs])
- Fix lyric climate ([@nprez83] - [#67018]) ([lyric docs])
- Fix finding matrix room that is already joined ([@antlarr] - [#67967]) ([matrix docs])
- Respect disable_new_entities for new device_tracker entities ([@mib1185] - [#68148]) ([device_tracker docs])
- Add missing await [velbus] ([@cdce8p] - [#68153]) ([velbus docs])
- Fix point by adding authlib constraint ([@cdce8p] - [#68176]) ([point docs])
- Update opensensemap-api to 0.2.0 ([@frenck] - [#68193]) ([opensensemap docs])
- Bump renault-api to 0.1.10 ([@epenet] - [#68260]) ([renault docs])
- Hue integration: update errors that should be supressed ([@marcelveldt] - [#68337]) ([hue docs])
- Filter IPv6 addreses from enphase_envoy discovery ([@bdraco] - [#68362]) ([enphase_envoy docs])
- Handle Hue discovery errors ([@balloob] - [#68392]) ([hue docs])
- Fix tplink color temp conversion ([@bdraco] - [#68484]) ([tplink docs])

[#67018]: https://github.com/home-assistant/core/pull/67018
[#67967]: https://github.com/home-assistant/core/pull/67967
[#68148]: https://github.com/home-assistant/core/pull/68148
[#68153]: https://github.com/home-assistant/core/pull/68153
[#68176]: https://github.com/home-assistant/core/pull/68176
[#68193]: https://github.com/home-assistant/core/pull/68193
[#68235]: https://github.com/home-assistant/core/pull/68235
[#68260]: https://github.com/home-assistant/core/pull/68260
[#68337]: https://github.com/home-assistant/core/pull/68337
[#68362]: https://github.com/home-assistant/core/pull/68362
[#68392]: https://github.com/home-assistant/core/pull/68392
[#68484]: https://github.com/home-assistant/core/pull/68484
[@antlarr]: https://github.com/antlarr
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@cdce8p]: https://github.com/cdce8p
[@epenet]: https://github.com/epenet
[@frenck]: https://github.com/frenck
[@marcelveldt]: https://github.com/marcelveldt
[@mib1185]: https://github.com/mib1185
[@nprez83]: https://github.com/nprez83
[device_tracker docs]: https://www.home-assistant.io/integrations/device_tracker/
[enphase_envoy docs]: https://www.home-assistant.io/integrations/enphase_envoy/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[lyric docs]: https://www.home-assistant.io/integrations/lyric/
[matrix docs]: https://www.home-assistant.io/integrations/matrix/
[opensensemap docs]: https://www.home-assistant.io/integrations/opensensemap/
[point docs]: https://www.home-assistant.io/integrations/point/
[renault docs]: https://www.home-assistant.io/integrations/renault/
[samsungtv docs]: https://www.home-assistant.io/integrations/samsungtv/
[tplink docs]: https://www.home-assistant.io/integrations/tplink/
[velbus docs]: https://www.home-assistant.io/integrations/velbus/