### PR TITLE
Use callback to get app_list in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -443,6 +443,10 @@ class SamsungTVWSBridge(SamsungTVBridge):
         """Send the launch_app command using websocket protocol."""
         await self._async_send_commands([ChannelEmitCommand.launch_app(app_id)])
 
+    async def async_request_app_list(self) -> None:
+        """Send the get_installed_app command using websocket protocol."""
+        await self._async_send_commands([ChannelEmitCommand.get_installed_app()])
+
     async def async_send_keys(self, keys: list[str]) -> None:
         """Send a list of keys using websocket protocol."""
         await self._async_send_commands([SendRemoteKey.click(key) for key in keys])
@@ -519,7 +523,6 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 self._remote = None
             else:
                 LOGGER.debug("Created SamsungTVWSBridge for %s", self.host)
-                await self._remote.send_command(ChannelEmitCommand.get_installed_app())
                 if self._device_info is None:
                     # Initialise device info on first connect
                     await self.async_device_info()

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -165,9 +165,8 @@ class SamsungTVBridge(ABC):
     async def async_device_info(self) -> dict[str, Any] | None:
         """Try to gather infos of this TV."""
 
-    async def async_request_app_list(self) -> None:  # pylint:disable=[no-self-use]
+    async def async_request_app_list(self) -> None:
         """Request app list."""
-        return
 
     @abstractmethod
     async def async_is_on(self) -> bool:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -443,10 +443,6 @@ class SamsungTVWSBridge(SamsungTVBridge):
         """Send the launch_app command using websocket protocol."""
         await self._async_send_commands([ChannelEmitCommand.launch_app(app_id)])
 
-    async def async_request_app_list(self) -> None:
-        """Send the get_installed_app command using websocket protocol."""
-        await self._async_send_commands([ChannelEmitCommand.get_installed_app()])
-
     async def async_send_keys(self, keys: list[str]) -> None:
         """Send a list of keys using websocket protocol."""
         await self._async_send_commands([SendRemoteKey.click(key) for key in keys])
@@ -523,6 +519,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
                 self._remote = None
             else:
                 LOGGER.debug("Created SamsungTVWSBridge for %s", self.host)
+                await self._remote.send_command(ChannelEmitCommand.get_installed_app())
                 if self._device_info is None:
                     # Initialise device info on first connect
                     await self.async_device_info()

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -167,6 +167,11 @@ class SamsungTVBridge(ABC):
 
     async def async_request_app_list(self) -> None:
         """Request app list."""
+        LOGGER.debug(
+            "App list request is not supported on %s TV: %s",
+            self.method,
+            self.host,
+        )
 
     @abstractmethod
     async def async_is_on(self) -> bool:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -606,10 +606,6 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
         self._remote: SamsungTVEncryptedWSAsyncRemote | None = None
         self._remote_lock = asyncio.Lock()
 
-    async def async_get_app_list(self) -> dict[str, str]:
-        """Get installed app list."""
-        return {}
-
     async def async_is_on(self) -> bool:
         """Tells if the TV is on."""
         LOGGER.debug("Checking if TV %s is on using websocket", self.host)

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -167,6 +167,7 @@ class SamsungTVBridge(ABC):
 
     async def async_request_app_list(self) -> None:
         """Request app list."""
+        # Overridden in SamsungTVWSBridge
         LOGGER.debug(
             "App list request is not supported on %s TV: %s",
             self.method,

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -192,6 +192,10 @@ class SamsungTVDevice(MediaPlayerEntity):
 
         if self._attr_state == STATE_ON and not self._app_list_event.is_set():
             await self._bridge.async_request_app_list()
+            if self._app_list_event.is_set():
+                # The try+wait_for is a bit expensive so we should try not to
+                # enter it unless we have to (Python 3.11 will have zero cost try)
+                return
             try:
                 await asyncio.wait_for(self._app_list_event.wait(), APP_LIST_DELAY)
             except asyncio.TimeoutError as err:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -1,6 +1,7 @@
 """Support for interface with an Samsung TV."""
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -75,6 +76,9 @@ SCAN_INTERVAL_PLUS_OFF_TIME = entity_component.DEFAULT_SCAN_INTERVAL + timedelta
     seconds=5
 )
 
+# Delay app_list request for xx seconds after TV is initially turned on
+APP_LIST_DELAY = 3
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -119,6 +123,7 @@ class SamsungTVDevice(MediaPlayerEntity):
         self._attr_device_class = MediaPlayerDeviceClass.TV
         self._attr_source_list = list(SOURCES)
         self._app_list: dict[str, str] | None = None
+        self._app_list_requested: bool = False
 
         if config_entry.data.get(CONF_METHOD) != METHOD_ENCRYPTED_WEBSOCKET:
             # Encrypted websockets currently only support ON/OFF status
@@ -183,6 +188,21 @@ class SamsungTVDevice(MediaPlayerEntity):
             self._attr_state = (
                 STATE_ON if await self._bridge.async_is_on() else STATE_OFF
             )
+
+        if self._attr_state != STATE_ON or self._app_list_requested:
+            return
+        self._app_list_requested = True
+        if isinstance(self._bridge, SamsungTVWSBridge):
+            self.hass.add_job(self._async_request_app_list())
+
+    async def _async_request_app_list(self) -> None:
+        """Send launch_app to the tv."""
+        await asyncio.sleep(APP_LIST_DELAY)
+        if self._power_off_in_progress():
+            LOGGER.info("TV is powering off, not sending app_list request")
+            return
+        assert isinstance(self._bridge, SamsungTVWSBridge)
+        await self._bridge.async_request_app_list()
 
     async def _async_launch_app(self, app_id: str) -> None:
         """Send launch_app to the tv."""

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -32,7 +32,7 @@ def fake_host_fixture() -> None:
 @pytest.fixture(autouse=True)
 def app_list_delay_fixture() -> None:
     """Patch APP_LIST_DELAY."""
-    with patch("homeassistant.components.samsungtv.bridge.APP_LIST_DELAY", 0):
+    with patch("homeassistant.components.samsungtv.media_player.APP_LIST_DELAY", 0):
         yield
 
 

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -91,7 +91,7 @@ def remotews_fixture() -> Mock:
             remotews.ws_event_callback(event, response)
 
     remotews.start_listening.side_effect = _start_listening
-    remotews.send_command.side_effect = _send_commands
+    remotews.send_commands.side_effect = _send_commands
     remotews.raise_mock_ws_event_callback = Mock(side_effect=_mock_ws_event_callback)
 
     with patch(

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -26,13 +26,6 @@ def fake_host_fixture() -> None:
         yield
 
 
-@pytest.fixture(autouse=True)
-def app_list_delay_fixture() -> None:
-    """Patch APP_LIST_DELAY."""
-    with patch("homeassistant.components.samsungtv.media_player.APP_LIST_DELAY", 0):
-        yield
-
-
 @pytest.fixture(name="remote")
 def remote_fixture() -> Mock:
     """Patch the samsungctl Remote."""

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -26,6 +26,13 @@ def fake_host_fixture() -> None:
         yield
 
 
+@pytest.fixture(autouse=True)
+def app_list_delay_fixture() -> None:
+    """Patch APP_LIST_DELAY."""
+    with patch("homeassistant.components.samsungtv.media_player.APP_LIST_DELAY", 0):
+        yield
+
+
 @pytest.fixture(name="remote")
 def remote_fixture() -> Mock:
     """Patch the samsungctl Remote."""

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -13,7 +13,7 @@ from samsungtvws.encrypted.remote import SamsungTVEncryptedWSAsyncRemote
 
 import homeassistant.util.dt as dt_util
 
-from .const import SAMPLE_APP_LIST, SAMPLE_DEVICE_INFO_WIFI
+from .const import SAMPLE_DEVICE_INFO_WIFI
 
 
 @pytest.fixture(autouse=True)
@@ -56,7 +56,6 @@ def remotews_fixture() -> Mock:
     remotews = Mock(SamsungTVWSAsyncRemote)
     remotews.__aenter__ = AsyncMock(return_value=remotews)
     remotews.__aexit__ = AsyncMock()
-    remotews.app_list.return_value = SAMPLE_APP_LIST
     remotews.token = "FAKE_TOKEN"
 
     def _start_listening(

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from samsungctl import Remote
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
+from samsungtvws.command import SamsungTVCommand
 from samsungtvws.encrypted.remote import SamsungTVEncryptedWSAsyncRemote
+from samsungtvws.event import ED_INSTALLED_APP_EVENT
+from samsungtvws.remote import ChannelEmitCommand
 
 import homeassistant.util.dt as dt_util
 
@@ -23,6 +26,13 @@ def fake_host_fixture() -> None:
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
         return_value="fake_host",
     ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def app_list_delay_fixture() -> None:
+    """Patch APP_LIST_DELAY."""
+    with patch("homeassistant.components.samsungtv.bridge.APP_LIST_DELAY", 0):
         yield
 
 
@@ -57,17 +67,31 @@ def remotews_fixture() -> Mock:
     remotews.__aenter__ = AsyncMock(return_value=remotews)
     remotews.__aexit__ = AsyncMock()
     remotews.token = "FAKE_TOKEN"
+    remotews.app_list_data = None
 
-    def _start_listening(
+    async def _start_listening(
         ws_event_callback: Callable[[str, Any], Awaitable[None] | None] | None = None
     ):
         remotews.ws_event_callback = ws_event_callback
+
+    async def _send_commands(commands: list[SamsungTVCommand]):
+        if (
+            len(commands) == 1
+            and isinstance(commands[0], ChannelEmitCommand)
+            and commands[0].params["event"] == "ed.installedApp.get"
+            and remotews.app_list_data is not None
+        ):
+            remotews.raise_mock_ws_event_callback(
+                ED_INSTALLED_APP_EVENT,
+                remotews.app_list_data,
+            )
 
     def _mock_ws_event_callback(event: str, response: Any):
         if remotews.ws_event_callback:
             remotews.ws_event_callback(event, response)
 
     remotews.start_listening.side_effect = _start_listening
+    remotews.send_command.side_effect = _send_commands
     remotews.raise_mock_ws_event_callback = Mock(side_effect=_mock_ws_event_callback)
 
     with patch(

--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -1,4 +1,6 @@
 """Constants for the samsungtv tests."""
+from samsungtvws.event import ED_INSTALLED_APP_EVENT
+
 from homeassistant.components.samsungtv.const import CONF_SESSION_ID
 from homeassistant.const import (
     CONF_HOST,
@@ -23,30 +25,6 @@ MOCK_ENTRYDATA_ENCRYPTED_WS = {
     CONF_TOKEN: "037739871315caef138547b03e348b72",
     CONF_SESSION_ID: "2",
 }
-
-SAMPLE_APP_LIST = [
-    {
-        "appId": "111299001912",
-        "app_type": 2,
-        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/111299001912/250x250.png",
-        "is_lock": 0,
-        "name": "YouTube",
-    },
-    {
-        "appId": "3201608010191",
-        "app_type": 2,
-        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201608010191/250x250.png",
-        "is_lock": 0,
-        "name": "Deezer",
-    },
-    {
-        "appId": "3201606009684",
-        "app_type": 2,
-        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201606009684/250x250.png",
-        "is_lock": 0,
-        "name": "Spotify - Music and Podcasts",
-    },
-]
 
 SAMPLE_DEVICE_INFO_WIFI = {
     "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -126,4 +104,34 @@ SAMPLE_DEVICE_INFO_UE48JU6400 = {
     },
     "type": "Samsung SmartTV",
     "uri": "https://1.2.3.4:8002/api/v2/",
+}
+
+SAMPLE_EVENT_ED_INSTALLED_APP = {
+    "event": ED_INSTALLED_APP_EVENT,
+    "from": "host",
+    "data": {
+        "data": [
+            {
+                "appId": "111299001912",
+                "app_type": 2,
+                "icon": "/opt/share/webappservice/apps_icon/FirstScreen/111299001912/250x250.png",
+                "is_lock": 0,
+                "name": "YouTube",
+            },
+            {
+                "appId": "3201608010191",
+                "app_type": 2,
+                "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201608010191/250x250.png",
+                "is_lock": 0,
+                "name": "Deezer",
+            },
+            {
+                "appId": "3201606009684",
+                "app_type": 2,
+                "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201606009684/250x250.png",
+                "is_lock": 0,
+                "name": "Spotify - Music and Podcasts",
+            },
+        ]
+    },
 }

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -55,9 +55,9 @@ from . import setup_samsungtv_entry
 from .const import (
     MOCK_CONFIG_ENCRYPTED_WS,
     MOCK_ENTRYDATA_ENCRYPTED_WS,
-    SAMPLE_APP_LIST,
     SAMPLE_DEVICE_INFO_FRAME,
 )
+from .const import SAMPLE_DEVICE_INFO_FRAME
 
 from tests.common import MockConfigEntry
 
@@ -910,7 +910,6 @@ async def test_autodetect_websocket(hass: HomeAssistant) -> None:
         remote = Mock(SamsungTVWSAsyncRemote)
         remote.__aenter__ = AsyncMock(return_value=remote)
         remote.__aexit__ = AsyncMock(return_value=False)
-        remote.app_list.return_value = SAMPLE_APP_LIST
         rest_api_class.return_value.rest_device_info = AsyncMock(
             return_value={
                 "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
@@ -957,7 +956,6 @@ async def test_websocket_no_mac(hass: HomeAssistant, mac_address: Mock) -> None:
         remote = Mock(SamsungTVWSAsyncRemote)
         remote.__aenter__ = AsyncMock(return_value=remote)
         remote.__aexit__ = AsyncMock(return_value=False)
-        remote.app_list.return_value = SAMPLE_APP_LIST
         rest_api_class.return_value.rest_device_info = AsyncMock(
             return_value={
                 "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -57,7 +57,6 @@ from .const import (
     MOCK_ENTRYDATA_ENCRYPTED_WS,
     SAMPLE_DEVICE_INFO_FRAME,
 )
-from .const import SAMPLE_DEVICE_INFO_FRAME
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -71,7 +71,11 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from . import setup_samsungtv_entry
-from .const import MOCK_ENTRYDATA_ENCRYPTED_WS, SAMPLE_DEVICE_INFO_FRAME
+from .const import (
+    MOCK_ENTRYDATA_ENCRYPTED_WS,
+    SAMPLE_DEVICE_INFO_FRAME,
+    SAMPLE_EVENT_ED_INSTALLED_APP,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -741,28 +745,7 @@ async def test_turn_off_websocket(
 
     remotews.raise_mock_ws_event_callback(
         ED_INSTALLED_APP_EVENT,
-        {
-            "event": "ed.installedApp.get",
-            "from": "host",
-            "data": {
-                "data": [
-                    {
-                        "appId": "111299001912",
-                        "app_type": 2,
-                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/111299001912/250x250.png",
-                        "is_lock": 0,
-                        "name": "YouTube",
-                    },
-                    {
-                        "appId": "3201608010191",
-                        "app_type": 2,
-                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201608010191/250x250.png",
-                        "is_lock": 0,
-                        "name": "Deezer",
-                    },
-                ]
-            },
-        },
+        SAMPLE_EVENT_ED_INSTALLED_APP,
     )
     remotews.send_commands.reset_mock()
 
@@ -1201,28 +1184,7 @@ async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
     await setup_samsungtv(hass, MOCK_CONFIGWS)
     remotews.raise_mock_ws_event_callback(
         ED_INSTALLED_APP_EVENT,
-        {
-            "event": "ed.installedApp.get",
-            "from": "host",
-            "data": {
-                "data": [
-                    {
-                        "appId": "111299001912",
-                        "app_type": 2,
-                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/111299001912/250x250.png",
-                        "is_lock": 0,
-                        "name": "YouTube",
-                    },
-                    {
-                        "appId": "3201608010191",
-                        "app_type": 2,
-                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201608010191/250x250.png",
-                        "is_lock": 0,
-                        "name": "Deezer",
-                    },
-                ]
-            },
-        },
+        SAMPLE_EVENT_ED_INSTALLED_APP,
     )
     remotews.send_commands.reset_mock()
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -9,7 +9,6 @@ from samsungctl import exceptions
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
 from samsungtvws.command import SamsungTVSleepCommand
 from samsungtvws.encrypted.remote import SamsungTVEncryptedWSAsyncRemote
-from samsungtvws.event import ED_INSTALLED_APP_EVENT
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from samsungtvws.remote import ChannelEmitCommand, SendRemoteKey
 from websockets.exceptions import ConnectionClosedError, WebSocketException
@@ -737,16 +736,13 @@ async def test_turn_off_websocket(
     hass: HomeAssistant, remotews: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test for turn_off."""
+    remotews.app_list_data = SAMPLE_EVENT_ED_INSTALLED_APP
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=[OSError("Boom"), DEFAULT_MOCK],
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-    remotews.raise_mock_ws_event_callback(
-        ED_INSTALLED_APP_EVENT,
-        SAMPLE_EVENT_ED_INSTALLED_APP,
-    )
     remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
@@ -1181,11 +1177,8 @@ async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
 
 async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
     """Test for select_source."""
+    remotews.app_list_data = SAMPLE_EVENT_ED_INSTALLED_APP
     await setup_samsungtv(hass, MOCK_CONFIGWS)
-    remotews.raise_mock_ws_event_callback(
-        ED_INSTALLED_APP_EVENT,
-        SAMPLE_EVENT_ED_INSTALLED_APP,
-    )
     remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -9,6 +9,7 @@ from samsungctl import exceptions
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
 from samsungtvws.command import SamsungTVSleepCommand
 from samsungtvws.encrypted.remote import SamsungTVEncryptedWSAsyncRemote
+from samsungtvws.event import ED_INSTALLED_APP_EVENT
 from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from samsungtvws.remote import ChannelEmitCommand, SendRemoteKey
 from websockets.exceptions import ConnectionClosedError, WebSocketException
@@ -70,11 +71,7 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from . import setup_samsungtv_entry
-from .const import (
-    MOCK_ENTRYDATA_ENCRYPTED_WS,
-    SAMPLE_APP_LIST,
-    SAMPLE_DEVICE_INFO_FRAME,
-)
+from .const import MOCK_ENTRYDATA_ENCRYPTED_WS, SAMPLE_DEVICE_INFO_FRAME
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -175,7 +172,6 @@ async def test_setup_websocket(hass: HomeAssistant) -> None:
         remote = Mock(SamsungTVWSAsyncRemote)
         remote.__aenter__ = AsyncMock(return_value=remote)
         remote.__aexit__ = AsyncMock()
-        remote.app_list.return_value = SAMPLE_APP_LIST
         remote.token = "123456789"
         remote_class.return_value = remote
 
@@ -213,7 +209,6 @@ async def test_setup_websocket_2(hass: HomeAssistant, mock_now: datetime) -> Non
         remote = Mock(SamsungTVWSAsyncRemote)
         remote.__aenter__ = AsyncMock(return_value=remote)
         remote.__aexit__ = AsyncMock()
-        remote.app_list.return_value = SAMPLE_APP_LIST
         remote.token = "987654321"
         remote_class.return_value = remote
         assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
@@ -744,6 +739,31 @@ async def test_turn_off_websocket(
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
+    remotews.raise_mock_ws_event_callback(
+        ED_INSTALLED_APP_EVENT,
+        {
+            "event": "ed.installedApp.get",
+            "from": "host",
+            "data": {
+                "data": [
+                    {
+                        "appId": "111299001912",
+                        "app_type": 2,
+                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/111299001912/250x250.png",
+                        "is_lock": 0,
+                        "name": "YouTube",
+                    },
+                    {
+                        "appId": "3201608010191",
+                        "app_type": 2,
+                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201608010191/250x250.png",
+                        "is_lock": 0,
+                        "name": "Deezer",
+                    },
+                ]
+            },
+        },
+    )
     remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
@@ -1179,6 +1199,31 @@ async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
 async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
     """Test for select_source."""
     await setup_samsungtv(hass, MOCK_CONFIGWS)
+    remotews.raise_mock_ws_event_callback(
+        ED_INSTALLED_APP_EVENT,
+        {
+            "event": "ed.installedApp.get",
+            "from": "host",
+            "data": {
+                "data": [
+                    {
+                        "appId": "111299001912",
+                        "app_type": 2,
+                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/111299001912/250x250.png",
+                        "is_lock": 0,
+                        "name": "YouTube",
+                    },
+                    {
+                        "appId": "3201608010191",
+                        "app_type": 2,
+                        "icon": "/opt/share/webappservice/apps_icon/FirstScreen/3201608010191/250x250.png",
+                        "is_lock": 0,
+                        "name": "Deezer",
+                    },
+                ]
+            },
+        },
+    )
     remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After #66752 was merged, I discovered that some newer models no longer reply to the app_list request. They accept the request, but don't respond and we are waiting for the timeout to trigger in the media_player update method.

This PR moves the logic into a callback, so the app_list request is sent on connect, but we no longer wait for a response.
If a response does come, then the callback is triggered.

Follow-up to #66752, #68114, #68235

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
