### PR TITLE
Fix flaky datetime test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -797,6 +797,8 @@ def enable_nightly_purge():
 @pytest.fixture
 def hass_recorder(enable_nightly_purge, enable_statistics, hass_storage):
     """Home Assistant fixture with in-memory recorder."""
+    original_tz = dt_util.DEFAULT_TIME_ZONE
+
     hass = get_test_home_assistant()
     stats = recorder.Recorder.async_periodic_statistics if enable_statistics else None
     nightly = recorder.Recorder.async_nightly_tasks if enable_nightly_purge else None
@@ -820,6 +822,9 @@ def hass_recorder(enable_nightly_purge, enable_statistics, hass_storage):
 
         yield setup_recorder
         hass.stop()
+
+    # Restore timezone, it is set when creating the hass object
+    dt_util.DEFAULT_TIME_ZONE = original_tz
 
 
 @pytest.fixture

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -67,9 +67,13 @@ def test_repr_helper():
     assert util.repr_helper(5) == "5"
     assert util.repr_helper(True) == "True"
     assert util.repr_helper({"test": 1}) == "test=1"
-    assert (
-        util.repr_helper(datetime(1986, 7, 9, 12, 0, 0)) == "1986-07-09T12:00:00+00:00"
-    )
+
+    tz = dt_util.get_time_zone("Europe/Copenhagen")
+    with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", tz):
+        assert (
+            util.repr_helper(datetime(1986, 7, 9, 12, 0, 0))
+            == "1986-07-09T12:00:00+02:00"
+        )
 
 
 def test_convert():


### PR DESCRIPTION
## Proposed change
Fix flaky datetime test `util/test_init.py -> test_repr_helper`. The test case depends on the global `dt_util.DEFAULT_TIME_ZONE` variable which is frequently modified during test runs. Not all code resets it probably. In particular, I believe the `hass_recorder` fixture with the recently changed `recorder/test_statistics.py` file are part of the reason so many runs failed lately.

Although I've fixed `hass_recorder`, there might still be other functions which don't cleanup properly. To help isolate the test case, I've thus chosen to patch `DEFAULT_TIME_ZONE` inside `test_repr_helper`.

Example failed run: https://github.com/home-assistant/core/runs/5629726354?check_suite_focus=true#step:9:93

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
