### PR TITLE
Simplify Hue error handling a bit

### DIFF
--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -37,21 +37,6 @@ from .helpers import (
     normalize_hue_transition,
 )
 
-ALLOWED_ERRORS = [
-    "device (groupedLight) has communication issues, command (on) may not have effect",
-    'device (groupedLight) is "soft off", command (on) may not have effect',
-    "device (light) has communication issues, command (on) may not have effect",
-    'device (light) is "soft off", command (on) may not have effect',
-    "device (grouped_light) has communication issues, command (.on) may not have effect",
-    'device (grouped_light) is "soft off", command (.on) may not have effect'
-    "device (grouped_light) has communication issues, command (.on.on) may not have effect",
-    'device (grouped_light) is "soft off", command (.on.on) may not have effect'
-    "device (light) has communication issues, command (.on) may not have effect",
-    'device (light) is "soft off", command (.on) may not have effect',
-    "device (light) has communication issues, command (.on.on) may not have effect",
-    'device (light) is "soft off", command (.on.on) may not have effect',
-]
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -183,10 +168,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             and flash is None
         ):
             await self.bridge.async_request_call(
-                self.controller.set_state,
-                id=self.resource.id,
-                on=True,
-                allowed_errors=ALLOWED_ERRORS,
+                self.controller.set_state, id=self.resource.id, on=True
             )
             return
 
@@ -202,7 +184,6 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                     color_xy=xy_color if light.supports_color else None,
                     color_temp=color_temp if light.supports_color_temperature else None,
                     transition_time=transition,
-                    allowed_errors=ALLOWED_ERRORS,
                 )
                 for light in self.controller.get_lights(self.resource.id)
             ]
@@ -222,10 +203,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         # To set other features, you'll have to control the attached lights
         if transition is None:
             await self.bridge.async_request_call(
-                self.controller.set_state,
-                id=self.resource.id,
-                on=False,
-                allowed_errors=ALLOWED_ERRORS,
+                self.controller.set_state, id=self.resource.id, on=False
             )
             return
 
@@ -237,7 +215,6 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                     light.id,
                     on=False,
                     transition_time=transition,
-                    allowed_errors=ALLOWED_ERRORS,
                 )
                 for light in self.controller.get_lights(self.resource.id)
             ]

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -36,15 +36,6 @@ from .helpers import (
     normalize_hue_transition,
 )
 
-ALLOWED_ERRORS = [
-    "device (light) has communication issues, command (on) may not have effect",
-    'device (light) is "soft off", command (on) may not have effect',
-    "device (light) has communication issues, command (.on) may not have effect",
-    'device (light) is "soft off", command (.on) may not have effect',
-    "device (light) has communication issues, command (.on.on) may not have effect",
-    'device (light) is "soft off", command (.on.on) may not have effect',
-]
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -182,7 +173,6 @@ class HueLight(HueBaseEntity, LightEntity):
             color_xy=xy_color,
             color_temp=color_temp,
             transition_time=transition,
-            allowed_errors=ALLOWED_ERRORS,
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -202,7 +192,6 @@ class HueLight(HueBaseEntity, LightEntity):
             id=self.resource.id,
             on=False,
             transition_time=transition,
-            allowed_errors=ALLOWED_ERRORS,
         )
 
     async def async_set_flash(self, flash: str) -> None:

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -60,7 +60,7 @@ def create_mock_bridge(hass, api_version=1):
 
     bridge.async_initialize_bridge = async_initialize_bridge
 
-    async def async_request_call(task, *args, allowed_errors=None, **kwargs):
+    async def async_request_call(task, *args, **kwargs):
         await task(*args, **kwargs)
 
     bridge.async_request_call = async_request_call


### PR DESCRIPTION
## Proposed change
Simplify the error handling a bit so we do not have to keep track of all errors we want to ignore.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68231
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
