### PR TITLE
Filter IPv6 addresses from AppleTV zeroconf discovery

### DIFF
--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PIN
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.network import is_ipv6_address
 
 from .const import CONF_CREDENTIALS, CONF_IDENTIFIERS, CONF_START_OFF, DOMAIN
 
@@ -166,6 +167,8 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> data_entry_flow.FlowResult:
         """Handle device found via zeroconf."""
         host = discovery_info.host
+        if is_ipv6_address(host):
+            return self.async_abort(reason="ipv6_not_supported")
         self._async_abort_entries_match({CONF_ADDRESS: host})
         service_type = discovery_info.type[:-1]  # Remove leading .
         name = discovery_info.name.replace(f".{service_type}.", "")

--- a/homeassistant/components/apple_tv/strings.json
+++ b/homeassistant/components/apple_tv/strings.json
@@ -48,6 +48,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
+      "ipv6_not_supported": "IPv6 is not supported.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "device_did_not_pair": "No attempt to finish pairing process was made from the device.",

--- a/homeassistant/components/apple_tv/translations/en.json
+++ b/homeassistant/components/apple_tv/translations/en.json
@@ -2,13 +2,11 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "already_configured_device": "Device is already configured",
             "already_in_progress": "Configuration flow is already in progress",
             "backoff": "Device does not accept pairing requests at this time (you might have entered an invalid PIN code too many times), try again later.",
             "device_did_not_pair": "No attempt to finish pairing process was made from the device.",
             "device_not_found": "Device was not found during discovery, please try adding it again.",
             "inconsistent_device": "Expected protocols were not found during discovery. This normally indicates a problem with multicast DNS (Zeroconf). Please try adding the device again.",
-            "invalid_config": "The configuration for this device is incomplete. Please try adding it again.",
             "no_devices_found": "No devices found on the network",
             "reauth_successful": "Re-authentication was successful",
             "setup_failed": "Failed to set up device.",
@@ -18,7 +16,6 @@
             "already_configured": "Device is already configured",
             "invalid_auth": "Invalid authentication",
             "no_devices_found": "No devices found on the network",
-            "no_usable_service": "A device was found but could not identify any way to establish a connection to it. If you keep seeing this message, try specifying its IP address or restarting your Apple TV.",
             "unknown": "Unexpected error"
         },
         "flow_title": "{name} ({type})",
@@ -72,6 +69,5 @@
                 "description": "Configure general device settings"
             }
         }
-    },
-    "title": "Apple TV"
+    }
 }

--- a/homeassistant/components/apple_tv/translations/en.json
+++ b/homeassistant/components/apple_tv/translations/en.json
@@ -7,6 +7,7 @@
             "device_did_not_pair": "No attempt to finish pairing process was made from the device.",
             "device_not_found": "Device was not found during discovery, please try adding it again.",
             "inconsistent_device": "Expected protocols were not found during discovery. This normally indicates a problem with multicast DNS (Zeroconf). Please try adding the device again.",
+            "ipv6_not_supported": "IPv6 is not supported.",
             "no_devices_found": "No devices found on the network",
             "reauth_successful": "Re-authentication was successful",
             "setup_failed": "Failed to set up device.",

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -1066,3 +1066,22 @@ async def test_option_start_off(hass):
     assert result2["type"] == "create_entry"
 
     assert config_entry.options[CONF_START_OFF]
+
+
+async def test_zeroconf_rejects_ipv6(hass):
+    """Test zeroconf discovery rejects ipv6."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="fd00::b27c:63bb:cc85:4ea0",
+            addresses=["fd00::b27c:63bb:cc85:4ea0"],
+            hostname="mock_hostname",
+            port=None,
+            type="_touch-able._tcp.local.",
+            name="dmapid._touch-able._tcp.local.",
+            properties={"CtlN": "Apple TV"},
+        ),
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "ipv6_not_supported"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes
```
2022-03-21 23:33:49 ERROR (MainThread) [homeassistant.components.apple_tv.config_flow] Unexpected exception
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/components/apple_tv/config_flow.py", line 270, in async_find_device_wrapper
    await self.async_find_device(allow_exist)
  File "/Users/bdraco/home-assistant/homeassistant/components/apple_tv/config_flow.py", line 283, in async_find_device
    self.atv, self.atv_identifiers = await device_scan(
  File "/Users/bdraco/home-assistant/homeassistant/components/apple_tv/config_flow.py", line 57, in device_scan
    scan_result = await scan(loop, timeout=3, hosts=_host_filter(), aiozc=aiozc)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/pyatv/__init__.py", line 58, in scan
    aiozc, hosts=[IPv4Address(host) for host in hosts]
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/pyatv/__init__.py", line 58, in <listcomp>
    aiozc, hosts=[IPv4Address(host) for host in hosts]
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ipaddress.py", line 1307, in __init__
    self._ip = self._ip_int_from_string(addr_str)
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ipaddress.py", line 1194, in _ip_int_from_string
    raise AddressValueError("Expected 4 octets in %r" % ip_str)
ipaddress.AddressValueError: Expected 4 octets in fd50:34d1:48cc:4784:106f:b7b3:1dbe:649b
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
