### PR TITLE
Remove color temperature workaround in Hue integration

### DIFF
--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -123,7 +123,6 @@ class HueLight(HueBaseEntity, LightEntity):
         # fallback to on_off
         return COLOR_MODE_ONOFF
 
-
     @property
     def xy_color(self) -> tuple[float, float] | None:
         """Return the xy color."""
@@ -164,11 +163,6 @@ class HueLight(HueBaseEntity, LightEntity):
             "mode": self.resource.mode.value,
             "dynamics": self.resource.dynamics.status.value,
         }
-
-    @callback
-    def on_update(self) -> None:
-        """Call on update event."""
-        self._set_color_mode()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
@@ -224,4 +218,3 @@ class HueLight(HueBaseEntity, LightEntity):
             id=self.resource.id,
             short=flash == FLASH_SHORT,
         )
-

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -95,9 +95,6 @@ class HueLight(HueBaseEntity, LightEntity):
                 self._supported_color_modes.add(COLOR_MODE_BRIGHTNESS)
             # support transition if brightness control
             self._attr_supported_features |= SUPPORT_TRANSITION
-        self._last_xy: tuple[float, float] | None = self.xy_color
-        self._last_color_temp: int = self.color_temp
-        self._set_color_mode()
 
     @property
     def brightness(self) -> int | None:
@@ -111,6 +108,21 @@ class HueLight(HueBaseEntity, LightEntity):
     def is_on(self) -> bool:
         """Return true if device is on (brightness above 0)."""
         return self.resource.on.on
+
+    @property
+    def color_mode(self) -> str | None:
+        """Return the color mode of the light."""
+        if color_temp := self.resource.color_temperature:
+            # Hue lights return `mired_valid` to indicate CT is active
+            if color_temp.mirek_valid and color_temp.mirek is not None:
+                return COLOR_MODE_COLOR_TEMP
+        if self.resource.supports_color:
+            return COLOR_MODE_XY
+        if self.resource.supports_dimming:
+            return COLOR_MODE_BRIGHTNESS
+        # fallback to on_off
+        return COLOR_MODE_ONOFF
+
 
     @property
     def xy_color(self) -> tuple[float, float] | None:
@@ -213,42 +225,3 @@ class HueLight(HueBaseEntity, LightEntity):
             short=flash == FLASH_SHORT,
         )
 
-    @callback
-    def _set_color_mode(self) -> None:
-        """Set current colormode of light."""
-        last_xy = self._last_xy
-        last_color_temp = self._last_color_temp
-        self._last_xy = self.xy_color
-        self._last_color_temp = self.color_temp
-
-        # Certified Hue lights return `mired_valid` to indicate CT is active
-        if color_temp := self.resource.color_temperature:
-            if color_temp.mirek_valid and color_temp.mirek is not None:
-                self._attr_color_mode = COLOR_MODE_COLOR_TEMP
-                return
-
-        # Non-certified lights do not report their current color mode correctly
-        # so we keep track of the color values to determine which is active
-        if last_color_temp != self.color_temp:
-            self._attr_color_mode = COLOR_MODE_COLOR_TEMP
-            return
-        if last_xy != self.xy_color:
-            self._attr_color_mode = COLOR_MODE_XY
-            return
-
-        # if we didn't detect any changes, abort and use previous values
-        if self._attr_color_mode is not None:
-            return
-
-        # color mode not yet determined, work it out here
-        # Note that for lights that do not correctly report `mirek_valid`
-        # we might have an invalid startup state which will be auto corrected
-        if self.resource.supports_color:
-            self._attr_color_mode = COLOR_MODE_XY
-        elif self.resource.supports_color_temperature:
-            self._attr_color_mode = COLOR_MODE_COLOR_TEMP
-        elif self.resource.supports_dimming:
-            self._attr_color_mode = COLOR_MODE_BRIGHTNESS
-        else:
-            # fallback to on_off
-            self._attr_color_mode = COLOR_MODE_ONOFF


### PR DESCRIPTION
## Proposed change
Signify confirmed to us that the previous malfunction of "mirek_valid" (which we use to determine if the light is in the CT spectrum) was actually a firmware bug for some (3rd party) lights so the workaround can be removed. We can rely on the "mirek_valid" property to determine if the light is in CT colormode.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
