### PR TITLE
Fix tplink effect not being restored when turning back on

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -21,7 +21,7 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired,
@@ -43,11 +43,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches."""
     coordinator: TPLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    device = cast(SmartBulb, coordinator.device)
-    if device.is_light_strip:
-        async_add_entities([TPLinkSmartLightStrip(device, coordinator)])
-    elif device.is_bulb or device.is_dimmer:
-        async_add_entities([TPLinkSmartBulb(device, coordinator)])
+    if coordinator.device.is_light_strip:
+        async_add_entities(
+            [
+                TPLinkSmartLightStrip(
+                    cast(SmartLightStrip, coordinator.device), coordinator
+                )
+            ]
+        )
+    elif coordinator.device.is_bulb or coordinator.device.is_dimmer:
+        async_add_entities(
+            [TPLinkSmartBulb(cast(SmartBulb, coordinator.device), coordinator)]
+        )
 
 
 class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
@@ -72,9 +79,10 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         else:
             self._attr_unique_id = device.mac.replace(":", "").upper()
 
-    @async_refresh_after
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the light on."""
+    @callback
+    def _async_extract_brightness_transition(
+        self, **kwargs: Any
+    ) -> tuple[int | None, int | None]:
         if (transition := kwargs.get(ATTR_TRANSITION)) is not None:
             transition = int(transition * 1_000)
 
@@ -89,35 +97,48 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
             # except when transition is defined, so we leverage that here for now.
             transition = 1
 
-        # Handle turning to temp mode
-        if ATTR_COLOR_TEMP in kwargs:
-            # Handle temp conversion mireds -> kelvin being slightly outside of valid range
-            kelvin = mired_to_kelvin(int(kwargs[ATTR_COLOR_TEMP]))
-            kelvin_range = self.device.valid_temperature_range
-            color_tmp = max(kelvin_range.min, min(kelvin_range.max, kelvin))
-            _LOGGER.debug("Changing color temp to %s", color_tmp)
-            await self.device.set_color_temp(
-                color_tmp, brightness=brightness, transition=transition
-            )
-            return
+        return brightness, transition
 
-        # Handling turning to hs color mode
-        if ATTR_HS_COLOR in kwargs:
-            # TP-Link requires integers.
-            hue, sat = tuple(int(val) for val in kwargs[ATTR_HS_COLOR])
-            await self.device.set_hsv(hue, sat, brightness, transition=transition)
-            return
+    async def _async_set_color_temp(
+        self, color_temp_mireds: int, brightness: int | None, transition: int | None
+    ) -> None:
+        # Handle temp conversion mireds -> kelvin being slightly outside of valid range
+        kelvin = mired_to_kelvin(color_temp_mireds)
+        kelvin_range = self.device.valid_temperature_range
+        color_tmp = max(kelvin_range.min, min(kelvin_range.max, kelvin))
+        _LOGGER.debug("Changing color temp to %s", color_tmp)
+        await self.device.set_color_temp(
+            color_tmp, brightness=brightness, transition=transition
+        )
 
-        if ATTR_EFFECT in kwargs:
-            assert isinstance(self.device, SmartLightStrip)
-            await self.device.set_effect(kwargs[ATTR_EFFECT])
-            return
+    async def _async_set_hsv(
+        self, hs_color: tuple[int, int], brightness: int | None, transition: int | None
+    ) -> None:
+        # TP-Link requires integers.
+        hue, sat = tuple(int(val) for val in hs_color)
+        await self.device.set_hsv(hue, sat, brightness, transition=transition)
 
+    async def _async_turn_on_with_brightness(
+        self, brightness: int | None, transition: int | None
+    ) -> None:
         # Fallback to adjusting brightness or turning the bulb on
         if brightness is not None:
             await self.device.set_brightness(brightness, transition=transition)
+            return
+        await self.device.turn_on(transition=transition)  # type: ignore[arg-type]
+
+    @async_refresh_after
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        brightness, transition = self._async_extract_brightness_transition(**kwargs)
+        if ATTR_COLOR_TEMP in kwargs:
+            await self._async_set_color_temp(
+                int(kwargs[ATTR_COLOR_TEMP]), brightness, transition
+            )
+        if ATTR_HS_COLOR in kwargs:
+            await self._async_set_hsv(kwargs[ATTR_HS_COLOR], brightness, transition)
         else:
-            await self.device.turn_on(transition=transition)
+            await self._async_turn_on_with_brightness(brightness, transition)
 
     @async_refresh_after
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -191,6 +212,14 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
 
     device: SmartLightStrip
 
+    def __init__(
+        self,
+        device: SmartLightStrip,
+        coordinator: TPLinkDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(device, coordinator)
+
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
@@ -209,3 +238,30 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
         if (effect := self.device.effect) and effect["enable"]:
             return cast(str, effect["name"])
         return None
+
+    @async_refresh_after
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        brightness, transition = self._async_extract_brightness_transition(**kwargs)
+        if ATTR_COLOR_TEMP in kwargs:
+            await self._async_set_color_temp(
+                int(kwargs[ATTR_COLOR_TEMP]), brightness, transition
+            )
+        elif ATTR_HS_COLOR in kwargs:
+            await self._async_set_hsv(kwargs[ATTR_HS_COLOR], brightness, transition)
+        elif ATTR_EFFECT in kwargs:
+            await self.device.set_effect(kwargs[ATTR_EFFECT])
+        elif (
+            self.device.is_off
+            and self.device.effect
+            and self.device.effect["enable"] == 0
+            and self.device.effect["name"]
+        ):
+            if not self.device.effect["custom"]:
+                await self.device.set_effect(self.device.effect["name"])
+            # The device does not remember custom effects
+            # so we must set a default value or it can never turn back on
+            else:
+                await self.device.set_hsv(0, 0, 100, transition=transition)
+        else:
+            await self._async_turn_on_with_brightness(brightness, transition)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -217,7 +217,7 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
         device: SmartLightStrip,
         coordinator: TPLinkDataUpdateCoordinator,
     ) -> None:
-        """Initialize the switch."""
+        """Initialize the smart light strip."""
         super().__init__(device, coordinator)
 
     @property

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -480,7 +480,7 @@ async def test_smart_strip_custom_random_effect_at_start(hass: HomeAssistant) ->
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
-    # fallback to set HSV when custom effect is not know so it does turn back on
+    # fallback to set HSV when custom effect is not known so it does turn back on
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix tplink effect not being restored when turning back on.  If an effect is set and the device is turned off and back on it will appear to still be off because the effect is still running but disabled. We need to restart the effect to avoid this state or if it’s a custom one, set to an hsv value since we have no way of knowing the effect script that is running and restoring it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
