### PR TITLE
Switch sqlalchemy execute to use .all() instead of list() on the iterator

### DIFF
--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -17,6 +17,7 @@ from awesomeversion import (
 )
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
+from sqlalchemy.orm.query import Query
 from sqlalchemy.orm.session import Session
 
 from homeassistant.core import HomeAssistant
@@ -111,12 +112,13 @@ def commit(session, work):
     return False
 
 
-def execute(qry, to_native=False, validate_entity_ids=True) -> list | None:
+def execute(
+    qry: Query, to_native: bool = False, validate_entity_ids: bool = True
+) -> list | None:
     """Query the database and convert the objects to HA native form.
 
     This method also retries a few times in the case of stale connections.
     """
-
     for tryno in range(0, RETRIES):
         try:
             timer_start = time.perf_counter()
@@ -130,7 +132,7 @@ def execute(qry, to_native=False, validate_entity_ids=True) -> list | None:
                     if row is not None
                 ]
             else:
-                result = list(qry)
+                result = qry.all()
 
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 elapsed = time.perf_counter() - timer_start
@@ -427,6 +429,7 @@ def retryable_database_job(description: str) -> Callable:
             try:
                 return job(instance, *args, **kwargs)
             except OperationalError as err:
+                assert instance.engine is not None
                 if (
                     instance.engine.dialect.name == "mysql"
                     and err.orig.args[0] in RETRYABLE_MYSQL_ERRORS
@@ -453,7 +456,7 @@ def perodic_db_cleanups(instance: Recorder):
 
     These cleanups will happen nightly or after any purge.
     """
-
+    assert instance.engine is not None
     if instance.engine.dialect.name == "sqlite":
         # Execute sqlite to create a wal checkpoint and free up disk space
         _LOGGER.debug("WAL checkpoint")
@@ -464,7 +467,7 @@ def perodic_db_cleanups(instance: Recorder):
 @contextmanager
 def write_lock_db_sqlite(instance: Recorder):
     """Lock database for writes."""
-
+    assert instance.engine is not None
     with instance.engine.connect() as connection:
         # Execute sqlite to create a wal checkpoint
         # This is optional but makes sure the backup is going to be minimal


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In older versions of sqlalchemy .all() was the performance equivalent to
calling list(), but in newer version of sqlalchemy, there is a different
implementation for .all() which was faster in testing than iterating
all the rows into a list.

Same query, but the overhead is much higher in relation to the query with `iterrows`
![iter](https://user-images.githubusercontent.com/663432/159619312-58d23619-84c6-4ea6-8b9c-3a869c9b1edd.png)
![all](https://user-images.githubusercontent.com/663432/159619317-d9ac8d61-11b9-4eff-9be6-e1120ce71b5a.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
