### PR TITLE
Include has_mean + has_sum in statistics metadata WS response

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -174,6 +174,9 @@ async def ws_get_list_statistic_ids(
         None,
         msg.get("statistic_type"),
     )
+    for statistic_id in statistic_ids:
+        statistic_id.pop("has_mean")
+        statistic_id.pop("has_sum")
     connection.send_result(msg["id"], statistic_ids)
 
 

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -174,9 +174,6 @@ async def ws_get_list_statistic_ids(
         None,
         msg.get("statistic_type"),
     )
-    for statistic_id in statistic_ids:
-        statistic_id.pop("has_mean")
-        statistic_id.pop("has_sum")
     connection.send_result(msg["id"], statistic_ids)
 
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -744,6 +744,8 @@ def list_statistic_ids(
 
         result = {
             meta["statistic_id"]: {
+                "has_mean": meta["has_mean"],
+                "has_sum": meta["has_sum"],
                 "name": meta["name"],
                 "source": meta["source"],
                 "unit_of_measurement": meta["unit_of_measurement"],
@@ -772,6 +774,8 @@ def list_statistic_ids(
     return [
         {
             "statistic_id": _id,
+            "has_mean": info["has_mean"],
+            "has_sum": info["has_sum"],
             "name": info.get("name"),
             "source": info["source"],
             "unit_of_measurement": info["unit_of_measurement"],

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -720,7 +720,7 @@ def list_statistic_ids(
     hass: HomeAssistant,
     statistic_ids: list[str] | tuple[str] | None = None,
     statistic_type: Literal["mean"] | Literal["sum"] | None = None,
-) -> list[dict | None]:
+) -> list[dict]:
     """Return all statistic_ids (or filtered one) and unit of measurement.
 
     Queries the database for existing statistic_ids, as well as integrations with

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -627,6 +627,8 @@ def list_statistic_ids(
 
         if device_class not in UNIT_CONVERSIONS:
             result[state.entity_id] = {
+                "has_mean": "mean" in provided_statistics,
+                "has_sum": "sum" in provided_statistics,
                 "source": RECORDER_DOMAIN,
                 "unit_of_measurement": native_unit,
             }
@@ -637,6 +639,8 @@ def list_statistic_ids(
 
         statistics_unit = DEVICE_CLASS_UNITS[device_class]
         result[state.entity_id] = {
+            "has_mean": "mean" in provided_statistics,
+            "has_sum": "sum" in provided_statistics,
             "source": RECORDER_DOMAIN,
             "unit_of_measurement": statistics_unit,
         }

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -57,12 +57,16 @@ async def test_demo_statistics(hass, recorder_mock):
         list_statistic_ids, hass
     )
     assert {
+        "has_mean": True,
+        "has_sum": False,
         "name": None,
         "source": "demo",
         "statistic_id": "demo:temperature_outdoor",
         "unit_of_measurement": "°C",
     } in statistic_ids
     assert {
+        "has_mean": False,
+        "has_sum": True,
         "name": None,
         "source": "demo",
         "statistic_id": "demo:energy_consumption",

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -1038,6 +1038,8 @@ async def test_list_statistic_ids(hass, hass_ws_client, units, attributes, unit)
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": unit,
@@ -1056,6 +1058,8 @@ async def test_list_statistic_ids(hass, hass_ws_client, units, attributes, unit)
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": unit,
@@ -1076,6 +1080,8 @@ async def test_list_statistic_ids(hass, hass_ws_client, units, attributes, unit)
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": unit,

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -394,6 +394,8 @@ def test_external_statistics(hass_recorder, caplog):
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {
+            "has_mean": False,
+            "has_sum": True,
             "statistic_id": "test:total_energy_import",
             "name": "Total imported energy",
             "source": "test",

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -230,6 +230,8 @@ async def test_update_statistics_metadata(hass, hass_ws_client, new_unit):
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "W",
@@ -254,6 +256,8 @@ async def test_update_statistics_metadata(hass, hass_ws_client, new_unit):
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": new_unit,
@@ -525,6 +529,8 @@ async def test_get_statistics_metadata(hass, hass_ws_client, units, attributes, 
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": unit,
@@ -549,6 +555,8 @@ async def test_get_statistics_metadata(hass, hass_ws_client, units, attributes, 
     assert response["result"] == [
         {
             "statistic_id": "sensor.test",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": unit,

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -114,6 +114,8 @@ def test_compile_hourly_statistics(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -177,6 +179,8 @@ def test_compile_hourly_statistics_purged_state_changes(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -243,18 +247,24 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "°C",
         },
         {
             "statistic_id": "sensor.test6",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "°C",
         },
         {
             "statistic_id": "sensor.test7",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "°C",
@@ -361,6 +371,8 @@ def test_compile_hourly_sum_statistics_amount(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": display_unit,
@@ -503,6 +515,8 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -592,6 +606,8 @@ def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -665,6 +681,8 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -775,6 +793,8 @@ def test_compile_hourly_sum_statistics_negative_state(
     statistic_ids = list_statistic_ids(hass)
     assert {
         "name": None,
+        "has_mean": False,
+        "has_sum": True,
         "source": "recorder",
         "statistic_id": entity_id,
         "unit_of_measurement": native_unit,
@@ -851,6 +871,8 @@ def test_compile_hourly_sum_statistics_total_no_reset(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -942,6 +964,8 @@ def test_compile_hourly_sum_statistics_total_increasing(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1044,6 +1068,8 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1134,6 +1160,8 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "kWh",
@@ -1222,18 +1250,24 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "kWh",
         },
         {
             "statistic_id": "sensor.test2",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "kWh",
         },
         {
             "statistic_id": "sensor.test3",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "kWh",
@@ -1555,6 +1589,8 @@ def test_list_statistic_ids(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": statistic_type == "mean",
+            "has_sum": statistic_type == "sum",
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1566,6 +1602,8 @@ def test_list_statistic_ids(
             assert statistic_ids == [
                 {
                     "statistic_id": "sensor.test1",
+                    "has_mean": statistic_type == "mean",
+                    "has_sum": statistic_type == "sum",
                     "name": None,
                     "source": "recorder",
                     "unit_of_measurement": native_unit,
@@ -1643,6 +1681,8 @@ def test_compile_hourly_statistics_changing_units_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1675,6 +1715,8 @@ def test_compile_hourly_statistics_changing_units_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1738,6 +1780,8 @@ def test_compile_hourly_statistics_changing_units_2(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "cats",
@@ -1791,6 +1835,8 @@ def test_compile_hourly_statistics_changing_units_3(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1821,6 +1867,8 @@ def test_compile_hourly_statistics_changing_units_3(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": native_unit,
@@ -1874,6 +1922,8 @@ def test_compile_hourly_statistics_changing_device_class_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": state_unit,
@@ -1920,6 +1970,8 @@ def test_compile_hourly_statistics_changing_device_class_1(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": state_unit,
@@ -1974,6 +2026,8 @@ def test_compile_hourly_statistics_changing_device_class_2(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": statistic_unit,
@@ -2020,6 +2074,8 @@ def test_compile_hourly_statistics_changing_device_class_2(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": statistic_unit,
@@ -2077,6 +2133,8 @@ def test_compile_hourly_statistics_changing_statistics(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": None,
@@ -2109,6 +2167,8 @@ def test_compile_hourly_statistics_changing_statistics(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": None,
@@ -2305,24 +2365,32 @@ def test_compile_statistics_hourly_daily_monthly_summary(
     assert statistic_ids == [
         {
             "statistic_id": "sensor.test1",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "%",
         },
         {
             "statistic_id": "sensor.test2",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "%",
         },
         {
             "statistic_id": "sensor.test3",
+            "has_mean": True,
+            "has_sum": False,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "%",
         },
         {
             "statistic_id": "sensor.test4",
+            "has_mean": False,
+            "has_sum": True,
             "name": None,
             "source": "recorder",
             "unit_of_measurement": "EUR",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include `has_mean` + `has_sum` in statistics metadata WS response

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
