### PR TITLE
Adjust backup type of Update entity

### DIFF
--- a/homeassistant/components/demo/update.py
+++ b/homeassistant/components/demo/update.py
@@ -134,10 +134,7 @@ class DemoUpdate(UpdateEntity):
             self._attr_supported_features |= UpdateEntityFeature.PROGRESS
 
     async def async_install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
         if self.supported_features & UpdateEntityFeature.PROGRESS:

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -170,10 +170,7 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
         )
 
     async def async_install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
         try:
@@ -214,10 +211,7 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
         return "https://brands.home-assistant.io/hassio/icon.png"
 
     async def async_install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
         try:
@@ -262,10 +256,7 @@ class SupervisorCoreUpdateEntity(HassioCoreEntity, UpdateEntity):
         return f"https://{'rc' if version.beta else 'www'}.home-assistant.io/latest-release-notes/"
 
     async def async_install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
         try:

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -82,7 +82,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_INSTALL,
         {
             vol.Optional(ATTR_VERSION): cv.string,
-            vol.Optional(ATTR_BACKUP): cv.boolean,
+            vol.Optional(ATTR_BACKUP, default=False): cv.boolean,
         },
         async_install,
         [UpdateEntityFeature.INSTALL],
@@ -138,7 +138,7 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
             f"Update installation already in progress for {entity.name}"
         )
 
-    await entity.async_install_with_progress(version, backup)
+    await entity.async_install_with_progress(version, backup or False)
 
 
 @dataclass
@@ -245,10 +245,7 @@ class UpdateEntity(RestoreEntity):
         self.async_write_ha_state()
 
     async def async_install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update.
 
@@ -260,12 +257,7 @@ class UpdateEntity(RestoreEntity):
         """
         await self.hass.async_add_executor_job(self.install, version, backup)
 
-    def install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
-    ) -> None:
+    def install(self, version: str | None, backup: bool, **kwargs: Any) -> None:
         """Install an update.
 
         Version can be specified to install a specific version. When `None`, the
@@ -323,9 +315,7 @@ class UpdateEntity(RestoreEntity):
 
     @final
     async def async_install_with_progress(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
+        self, version: str | None, backup: bool
     ) -> None:
         """Install update and handle progress if needed.
 

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -128,7 +128,7 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
 
     # If backup is requested, but not supported by the entity.
     if (
-        backup := service_call.data.get(ATTR_BACKUP)
+        backup := service_call.data[ATTR_BACKUP]
     ) and not entity.supported_features & UpdateEntityFeature.BACKUP:
         raise HomeAssistantError(f"Backup is not supported for {entity.name}")
 
@@ -138,7 +138,7 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
             f"Update installation already in progress for {entity.name}"
         )
 
-    await entity.async_install_with_progress(version, backup or False)
+    await entity.async_install_with_progress(version, backup)
 
 
 @dataclass

--- a/homeassistant/components/wled/update.py
+++ b/homeassistant/components/wled/update.py
@@ -80,10 +80,7 @@ class WLEDUpdateEntity(WLEDEntity, UpdateEntity):
 
     @wled_exception_handler
     async def async_install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-        **kwargs: Any,
+        self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
         if version is None:

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -117,10 +117,10 @@ async def test_update(hass: HomeAssistant) -> None:
     assert update.entity_category is EntityCategory.DIAGNOSTIC
 
     with pytest.raises(NotImplementedError):
-        await update.async_install()
+        await update.async_install(version=None, backup=True)
 
     with pytest.raises(NotImplementedError):
-        update.install()
+        update.install(version=None, backup=False)
 
     update.install = MagicMock()
     await update.async_install(version="1.0.1", backup=True)

--- a/tests/testing_config/custom_components/test/update.py
+++ b/tests/testing_config/custom_components/test/update.py
@@ -6,6 +6,7 @@ Call init before using it in your tests to ensure clean test data.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 
@@ -49,11 +50,7 @@ class MockUpdateEntity(MockEntity, UpdateEntity):
         """Title of the software."""
         return self._handle("title")
 
-    def install(
-        self,
-        version: str | None = None,
-        backup: bool | None = None,
-    ) -> None:
+    def install(self, version: str | None, backup: bool, **kwargs: Any) -> None:
         """Install an update."""
         if backup:
             _LOGGER.info("Creating backup before installing update")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This change is breaking for `dev` only. Integrations in dev itself have been adjusted.
Possibly this affects integrations currently in development by contributors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With the updated entity, one either does backup... or not :)

This PR adjusts the typing to have the `backup` parameter to be always a boolean; making it more friendly to use for integrations as well, as they don't need to handle a `None` value in these cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1246

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
