### PR TITLE
Cleanup SamsungTV following dependency bump

### DIFF
--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -468,7 +468,7 @@ class SamsungTVWSBridge(SamsungTVBridge):
             for _ in range(retry_count + 1):
                 try:
                     if remote := await self._async_get_remote():
-                        await remote.send_command(commands)
+                        await remote.send_commands(commands)
                     break
                 except (
                     BrokenPipeError,

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -712,12 +712,7 @@ class SamsungTVEncryptedBridge(SamsungTVBridge):
                 timeout=TIMEOUT_WEBSOCKET,
             )
             try:
-                # pylint:disable=[fixme]
-                # TODO: remove secondary timeout when library is bumped
-                # See https://github.com/xchwarze/samsung-tv-ws-api/pull/82
-                await asyncio.wait_for(
-                    self._remote.start_listening(), TIMEOUT_WEBSOCKET
-                )
+                await self._remote.start_listening()
             except (WebSocketException, AsyncioTimeoutError, OSError) as err:
                 LOGGER.debug(
                     "Failed to get remote for %s: %s", self.host, err.__repr__()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -593,7 +593,7 @@ async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Mock) ->
 async def test_send_key_websocketexception(hass: HomeAssistant, remotews: Mock) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIGWS)
-    remotews.send_command = Mock(side_effect=WebSocketException("Boom"))
+    remotews.send_commands = Mock(side_effect=WebSocketException("Boom"))
     assert await hass.services.async_call(
         DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
@@ -619,7 +619,7 @@ async def test_send_key_websocketexception_encrypted(
 async def test_send_key_os_error_ws(hass: HomeAssistant, remotews: Mock) -> None:
     """Testing unhandled response exception."""
     await setup_samsungtv(hass, MOCK_CONFIGWS)
-    remotews.send_command = Mock(side_effect=OSError("Boom"))
+    remotews.send_commands = Mock(side_effect=OSError("Boom"))
     assert await hass.services.async_call(
         DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
@@ -744,20 +744,20 @@ async def test_turn_off_websocket(
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-    remotews.send_command.reset_mock()
+    remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
-    assert remotews.send_command.call_count == 1
-    commands = remotews.send_command.call_args_list[0].args[0]
+    assert remotews.send_commands.call_count == 1
+    commands = remotews.send_commands.call_args_list[0].args[0]
     assert len(commands) == 1
     assert isinstance(commands[0], SendRemoteKey)
     assert commands[0].params["DataOfCmd"] == "KEY_POWER"
 
     # commands not sent : power off in progress
-    remotews.send_command.reset_mock()
+    remotews.send_commands.reset_mock()
     assert await hass.services.async_call(
         DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
@@ -769,7 +769,7 @@ async def test_turn_off_websocket(
         True,
     )
     assert "TV is powering off, not sending launch_app command" in caplog.text
-    remotews.send_command.assert_not_called()
+    remotews.send_commands.assert_not_called()
 
 
 async def test_turn_off_websocket_frame(
@@ -783,14 +783,14 @@ async def test_turn_off_websocket_frame(
     ):
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-    remotews.send_command.reset_mock()
+    remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
-    assert remotews.send_command.call_count == 1
-    commands = remotews.send_command.call_args_list[0].args[0]
+    assert remotews.send_commands.call_count == 1
+    commands = remotews.send_commands.call_args_list[0].args[0]
     assert len(commands) == 3
     assert isinstance(commands[0], SendRemoteKey)
     assert commands[0].params["Cmd"] == "Press"
@@ -1157,7 +1157,7 @@ async def test_select_source_invalid_source(hass: HomeAssistant) -> None:
 async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
     """Test for play_media."""
     await setup_samsungtv(hass, MOCK_CONFIGWS)
-    remotews.send_command.reset_mock()
+    remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -1169,8 +1169,8 @@ async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
         },
         True,
     )
-    assert remotews.send_command.call_count == 1
-    commands = remotews.send_command.call_args_list[0].args[0]
+    assert remotews.send_commands.call_count == 1
+    commands = remotews.send_commands.call_args_list[0].args[0]
     assert len(commands) == 1
     assert isinstance(commands[0], ChannelEmitCommand)
     assert commands[0].params["data"]["appId"] == "3201608010191"
@@ -1179,7 +1179,7 @@ async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
 async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
     """Test for select_source."""
     await setup_samsungtv(hass, MOCK_CONFIGWS)
-    remotews.send_command.reset_mock()
+    remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -1187,8 +1187,8 @@ async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "Deezer"},
         True,
     )
-    assert remotews.send_command.call_count == 1
-    commands = remotews.send_command.call_args_list[0].args[0]
+    assert remotews.send_commands.call_count == 1
+    commands = remotews.send_commands.call_args_list[0].args[0]
     assert len(commands) == 1
     assert isinstance(commands[0], ChannelEmitCommand)
     assert commands[0].params["data"]["appId"] == "3201608010191"
@@ -1203,7 +1203,7 @@ async def test_websocket_unsupported_remote_control(
     assert entry.data[CONF_METHOD] == METHOD_WEBSOCKET
     assert entry.data[CONF_PORT] == 8001
 
-    remotews.send_command.reset_mock()
+    remotews.send_commands.reset_mock()
 
     assert await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
@@ -1217,8 +1217,8 @@ async def test_websocket_unsupported_remote_control(
     )
 
     # key called
-    assert remotews.send_command.call_count == 1
-    commands = remotews.send_command.call_args_list[0].args[0]
+    assert remotews.send_commands.call_count == 1
+    commands = remotews.send_commands.call_args_list[0].args[0]
     assert len(commands) == 1
     assert isinstance(commands[0], SendRemoteKey)
     assert commands[0].params["DataOfCmd"] == "KEY_POWER"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to https://github.com/home-assistant/core/pull/68542

See https://github.com/xchwarze/samsung-tv-ws-api/pull/82 and https://github.com/xchwarze/samsung-tv-ws-api/pull/83


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
