### PR TITLE
Hue aggregated control for grouped lights

### DIFF
--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -1,7 +1,6 @@
 """Support for Hue groups (room/zone)."""
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from aiohue.v2 import HueBridgeV2
@@ -146,7 +145,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         }
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the light on."""
+        """Turn the grouped_light on."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
         xy_color = kwargs.get(ATTR_XY_COLOR)
         color_temp = normalize_hue_colortemp(kwargs.get(ATTR_COLOR_TEMP))
@@ -155,38 +154,16 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
         if flash is not None:
             await self.async_set_flash(flash)
-            # flash can not be sent with other commands at the same time
             return
 
-        # NOTE: a grouped_light can only handle turn on/off
-        # To set other features, you'll have to control the attached lights
-        if (
-            brightness is None
-            and xy_color is None
-            and color_temp is None
-            and transition is None
-            and flash is None
-        ):
-            await self.bridge.async_request_call(
-                self.controller.set_state, id=self.resource.id, on=True
-            )
-            return
-
-        # redirect all other feature commands to underlying lights
-        # note that this silently ignores params sent to light that are not supported
-        await asyncio.gather(
-            *[
-                self.bridge.async_request_call(
-                    self.api.lights.set_state,
-                    light.id,
-                    on=True,
-                    brightness=brightness if light.supports_dimming else None,
-                    color_xy=xy_color if light.supports_color else None,
-                    color_temp=color_temp if light.supports_color_temperature else None,
-                    transition_time=transition,
-                )
-                for light in self.controller.get_lights(self.resource.id)
-            ]
+        await self.bridge.async_request_call(
+            self.controller.set_state,
+            id=self.resource.id,
+            on=True,
+            brightness=brightness,
+            color_xy=xy_color,
+            color_temp=color_temp,
+            transition_time=transition,
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -199,38 +176,19 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             # flash can not be sent with other commands at the same time
             return
 
-        # NOTE: a grouped_light can only handle turn on/off
-        # To set other features, you'll have to control the attached lights
-        if transition is None:
-            await self.bridge.async_request_call(
-                self.controller.set_state, id=self.resource.id, on=False
-            )
-            return
-
-        # redirect all other feature commands to underlying lights
-        await asyncio.gather(
-            *[
-                self.bridge.async_request_call(
-                    self.api.lights.set_state,
-                    light.id,
-                    on=False,
-                    transition_time=transition,
-                )
-                for light in self.controller.get_lights(self.resource.id)
-            ]
+        await self.bridge.async_request_call(
+            self.controller.set_state,
+            id=self.resource.id,
+            on=False,
+            transition_time=transition,
         )
 
     async def async_set_flash(self, flash: str) -> None:
         """Send flash command to light."""
-        await asyncio.gather(
-            *[
-                self.bridge.async_request_call(
-                    self.api.lights.set_flash,
-                    id=light.id,
-                    short=flash == FLASH_SHORT,
-                )
-                for light in self.controller.get_lights(self.resource.id)
-            ]
+        await self.bridge.async_request_call(
+            self.controller.set_flash,
+            id=self.resource.id,
+            short=flash == FLASH_SHORT,
         )
 
     @callback

--- a/tests/components/hue/fixtures/v2_resources.json
+++ b/tests/components/hue/fixtures/v2_resources.json
@@ -460,7 +460,7 @@
         "model_id": "BSB002",
         "product_archetype": "bridge_v2",
         "product_name": "Philips hue",
-        "software_version": "1.48.1948086000"
+        "software_version": "1.50.1950111030"
       },
       "services": [
         {

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -372,31 +372,24 @@ async def test_grouped_lights(hass, mock_bridge_v2, v2_resources_test_data):
         blocking=True,
     )
 
-    # PUT request should have been sent to ALL group lights with correct params
-    assert len(mock_bridge_v2.mock_requests) == 3
-    for index in range(0, 3):
-        assert mock_bridge_v2.mock_requests[index]["json"]["on"]["on"] is True
-        assert (
-            mock_bridge_v2.mock_requests[index]["json"]["dimming"]["brightness"] == 100
-        )
-        assert mock_bridge_v2.mock_requests[index]["json"]["color"]["xy"]["x"] == 0.123
-        assert mock_bridge_v2.mock_requests[index]["json"]["color"]["xy"]["y"] == 0.123
-        assert (
-            mock_bridge_v2.mock_requests[index]["json"]["dynamics"]["duration"] == 200
-        )
+    # PUT request should have been sent to group_light with correct params
+    assert len(mock_bridge_v2.mock_requests) == 1
+    assert mock_bridge_v2.mock_requests[0]["json"]["on"]["on"] is True
+    assert mock_bridge_v2.mock_requests[0]["json"]["dimming"]["brightness"] == 100
+    assert mock_bridge_v2.mock_requests[0]["json"]["color"]["xy"]["x"] == 0.123
+    assert mock_bridge_v2.mock_requests[0]["json"]["color"]["xy"]["y"] == 0.123
+    assert mock_bridge_v2.mock_requests[0]["json"]["dynamics"]["duration"] == 200
 
     # Now generate update events by emitting the json we've sent as incoming events
-    for index, light_id in enumerate(
-        [
-            "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1",
-            "b3fe71ef-d0ef-48de-9355-d9e604377df0",
-            "8015b17f-8336-415b-966a-b364bd082397",
-        ]
-    ):
+    for light_id in [
+        "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1",
+        "b3fe71ef-d0ef-48de-9355-d9e604377df0",
+        "8015b17f-8336-415b-966a-b364bd082397",
+    ]:
         event = {
             "id": light_id,
             "type": "light",
-            **mock_bridge_v2.mock_requests[index]["json"],
+            **mock_bridge_v2.mock_requests[0]["json"],
         }
         mock_bridge_v2.api.emit_event("update", event)
     await hass.async_block_till_done()
@@ -452,13 +445,10 @@ async def test_grouped_lights(hass, mock_bridge_v2, v2_resources_test_data):
         blocking=True,
     )
 
-    # PUT request should have been sent to ALL group lights with correct params
-    assert len(mock_bridge_v2.mock_requests) == 3
-    for index in range(0, 3):
-        assert mock_bridge_v2.mock_requests[index]["json"]["on"]["on"] is False
-        assert (
-            mock_bridge_v2.mock_requests[index]["json"]["dynamics"]["duration"] == 200
-        )
+    # PUT request should have been sent to group_light with correct params
+    assert len(mock_bridge_v2.mock_requests) == 1
+    assert mock_bridge_v2.mock_requests[0]["json"]["on"]["on"] is False
+    assert mock_bridge_v2.mock_requests[0]["json"]["dynamics"]["duration"] == 200
 
     # Test sending short flash effect to a grouped light
     mock_bridge_v2.mock_requests.clear()
@@ -494,12 +484,9 @@ async def test_grouped_lights(hass, mock_bridge_v2, v2_resources_test_data):
         blocking=True,
     )
 
-    # PUT request should have been sent to ALL group lights with correct params
-    assert len(mock_bridge_v2.mock_requests) == 3
-    for index in range(0, 3):
-        assert (
-            mock_bridge_v2.mock_requests[index]["json"]["alert"]["action"] == "breathe"
-        )
+    # PUT request should have been sent to grouped_light with correct params
+    assert len(mock_bridge_v2.mock_requests) == 1
+    assert mock_bridge_v2.mock_requests[0]["json"]["alert"]["action"] == "breathe"
 
     # Test sending flash effect in turn_off call
     mock_bridge_v2.mock_requests.clear()


### PR DESCRIPTION
## Proposed change
Long awaited and finally there... Native support for sending commands (e.g. color, brightness) to a light group in Hue.
On our request Signify added this to the Hue bridge and V2 API so now we can remove our workarounds from the core code.

This change makes sure that sending a command addresses all lights at once instead of one-by-one.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64015
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
