### PR TITLE
Fix Lyric temperature setting when off

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -211,35 +211,32 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Return the temperature we try to reach."""
         device = self.device
         if (
-            device.changeableValues.autoChangeoverActive
-            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
+            not device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
         ):
-            return None
-        if self.hvac_mode == HVAC_MODE_COOL:
-            return device.changeableValues.coolSetpoint
-        return device.changeableValues.heatSetpoint
+            if self.hvac_mode == HVAC_MODE_COOL:
+                return device.changeableValues.coolSetpoint
+            return device.changeableValues.heatSetpoint
 
     @property
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         device = self.device
         if (
-            not device.changeableValues.autoChangeoverActive
-            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
+            device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
         ):
-            return None
-        return device.changeableValues.coolSetpoint
+            return device.changeableValues.coolSetpoint
 
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         device = self.device
         if (
-            not device.changeableValues.autoChangeoverActive
-            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
+            device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
         ):
-            return None
-        return device.changeableValues.heatSetpoint
+            return device.changeableValues.heatSetpoint
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -211,32 +211,35 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Return the temperature we try to reach."""
         device = self.device
         if (
-            not device.changeableValues.autoChangeoverActive
-            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+            device.changeableValues.autoChangeoverActive
+            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
         ):
-            if self.hvac_mode == HVAC_MODE_COOL:
-                return device.changeableValues.coolSetpoint
-            return device.changeableValues.heatSetpoint
+            return None
+        if self.hvac_mode == HVAC_MODE_COOL:
+            return device.changeableValues.coolSetpoint
+        return device.changeableValues.heatSetpoint
 
     @property
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         device = self.device
         if (
-            device.changeableValues.autoChangeoverActive
-            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+            not device.changeableValues.autoChangeoverActive
+            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
         ):
-            return device.changeableValues.coolSetpoint
+            return None
+        return device.changeableValues.coolSetpoint
 
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         device = self.device
         if (
-            device.changeableValues.autoChangeoverActive
-            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+            not device.changeableValues.autoChangeoverActive
+            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
         ):
-            return device.changeableValues.heatSetpoint
+            return None
+        return device.changeableValues.heatSetpoint
 
     @property
     def preset_mode(self) -> str | None:
@@ -273,7 +276,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         if self.hvac_mode == HVAC_MODE_OFF:
-            return None
+            return
 
         device = self.device
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -223,16 +223,26 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         device = self.device
-        if device.changeableValues.autoChangeoverActive:
-            return device.changeableValues.coolSetpoint
+        if (
+            device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+        ):
+            if device.changeableValues.autoChangeoverActive:
+                return device.changeableValues.coolSetpoint
+            return None
         return None
 
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         device = self.device
-        if device.changeableValues.autoChangeoverActive:
-            return device.changeableValues.heatSetpoint
+        if (
+            device.changeableValues.autoChangeoverActive
+            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+        ):
+            if device.changeableValues.autoChangeoverActive:
+                return device.changeableValues.heatSetpoint
+            return None
         return None
 
     @property

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -211,39 +211,35 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Return the temperature we try to reach."""
         device = self.device
         if (
-            not device.changeableValues.autoChangeoverActive
-            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+            device.changeableValues.autoChangeoverActive
+            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
         ):
-            if self.hvac_mode == HVAC_MODE_COOL:
-                return device.changeableValues.coolSetpoint
-            return device.changeableValues.heatSetpoint
-        return None
+            return None
+        if self.hvac_mode == HVAC_MODE_COOL:
+            return device.changeableValues.coolSetpoint
+        return device.changeableValues.heatSetpoint
 
     @property
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         device = self.device
         if (
-            device.changeableValues.autoChangeoverActive
-            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+            not device.changeableValues.autoChangeoverActive
+            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
         ):
-            if device.changeableValues.autoChangeoverActive:
-                return device.changeableValues.coolSetpoint
             return None
-        return None
+        return device.changeableValues.coolSetpoint
 
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         device = self.device
         if (
-            device.changeableValues.autoChangeoverActive
-            and HVAC_MODES[device.changeableValues.mode] != HVAC_MODE_OFF
+            not device.changeableValues.autoChangeoverActive
+            or HVAC_MODES[device.changeableValues.mode] == HVAC_MODE_OFF
         ):
-            if device.changeableValues.autoChangeoverActive:
-                return device.changeableValues.heatSetpoint
             return None
-        return None
+        return device.changeableValues.heatSetpoint
 
     @property
     def preset_mode(self) -> str | None:
@@ -279,6 +275,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
+        if self.hvac_mode == HVAC_MODE_OFF:
+            return None
+
         device = self.device
         target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
         target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)


### PR DESCRIPTION
In PR #67018 I added an if statement to prevent the target_temperature to be transmitted if the HVAC was off, but I didn't do that for target_temperature_low and target_temperature_high, which means if you shut the system off from auto mode, change the temperature setting in the front end, and then turn the system on, the temperature setting will have been changed. I added two additional if statement to prevent that, now if the temperature is changed in any way when the system if off, it will have no effect.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None


## Proposed change
I added two if statement to prevent target_temperature_low and target_temperature_high from being transmitted when the device is off. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to PR #67018 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
