### PR TITLE
Motion allow changing ip

### DIFF
--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -138,7 +138,7 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             mac_address = motion_gateway.mac
 
             await self.async_set_unique_id(mac_address)
-            self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured(updates={CONF_HOST: self._host, CONF_API_KEY: key, CONF_INTERFACE: multicast_interface})
 
             return self.async_create_entry(
                 title=DEFAULT_GATEWAY_NAME,

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -138,7 +138,13 @@ class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             mac_address = motion_gateway.mac
 
             await self.async_set_unique_id(mac_address)
-            self._abort_if_unique_id_configured(updates={CONF_HOST: self._host, CONF_API_KEY: key, CONF_INTERFACE: multicast_interface})
+            self._abort_if_unique_id_configured(
+                updates={
+                    CONF_HOST: self._host,
+                    CONF_API_KEY: key,
+                    CONF_INTERFACE: multicast_interface,
+                }
+            )
 
             return self.async_create_entry(
                 title=DEFAULT_GATEWAY_NAME,

--- a/homeassistant/components/motion_blinds/strings.json
+++ b/homeassistant/components/motion_blinds/strings.json
@@ -29,7 +29,7 @@
       "invalid_interface": "Invalid network interface"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%], connection settings are updated",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "connection_error": "[%key:common::config_flow::error::cannot_connect%]"
     }

--- a/homeassistant/components/motion_blinds/translations/en.json
+++ b/homeassistant/components/motion_blinds/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured",
+            "already_configured": "Device is already configured, connection settings are updated",
             "already_in_progress": "Configuration flow is already in progress",
             "connection_error": "Failed to connect"
         },

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -383,13 +383,6 @@ async def test_change_connection_settings(hass):
     )
     config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert config_entry.data[CONF_HOST] == TEST_HOST
-    assert config_entry.data[CONF_API_KEY] == TEST_API_KEY
-    assert config_entry.data[const.CONF_INTERFACE] == TEST_HOST_HA
-
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -14,7 +14,9 @@ from tests.common import MockConfigEntry
 TEST_HOST = "1.2.3.4"
 TEST_HOST2 = "5.6.7.8"
 TEST_HOST_HA = "9.10.11.12"
+TEST_HOST_ANY = "any"
 TEST_API_KEY = "12ab345c-d67e-8f"
+TEST_API_KEY2 = "f8e76dc5-43ba-21"
 TEST_MAC = "ab:cd:ef:gh"
 TEST_MAC2 = "ij:kl:mn:op"
 TEST_DEVICE_LIST = {TEST_MAC: Mock()}
@@ -76,6 +78,9 @@ def motion_blinds_connect_fixture(mock_get_source_ip):
     ), patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.device_list",
         TEST_DEVICE_LIST,
+    ), patch(
+        "homeassistant.components.motion_blinds.gateway.MotionGateway.mac",
+        TEST_MAC,
     ), patch(
         "homeassistant.components.motion_blinds.config_flow.MotionDiscovery.discover",
         return_value=TEST_DISCOVERY_1,
@@ -362,3 +367,52 @@ async def test_options_flow(hass):
     assert config_entry.options == {
         const.CONF_WAIT_FOR_PUSH: False,
     }
+
+
+async def test_change_connection_settings(hass):
+    """Test changing connection settings by issueing a second user config flow."""
+    config_entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=TEST_MAC,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_API_KEY: TEST_API_KEY,
+            const.CONF_INTERFACE: TEST_HOST_HA,
+        },
+        title=DEFAULT_GATEWAY_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.data[CONF_HOST] == TEST_HOST
+    assert config_entry.data[CONF_API_KEY] == TEST_API_KEY
+    assert config_entry.data[const.CONF_INTERFACE] == TEST_HOST_HA
+
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: TEST_HOST2},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "connect"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_API_KEY: TEST_API_KEY2, const.CONF_INTERFACE: TEST_HOST_ANY},
+    )
+
+    assert result["type"] == "abort"
+    assert config_entry.data[CONF_HOST] == TEST_HOST2
+    assert config_entry.data[CONF_API_KEY] == TEST_API_KEY2
+    assert config_entry.data[const.CONF_INTERFACE] == TEST_HOST_ANY

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -370,7 +370,7 @@ async def test_options_flow(hass):
 
 
 async def test_change_connection_settings(hass):
-    """Test changing connection settings by issueing a second user config flow."""
+    """Test changing connection settings by issuing a second user config flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=TEST_MAC,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow for a second config flow to update the connection settings of a already configured Motion Blinds device.
This allows users to change the network_interface, IP adress or Acces Key, withouth having to delete the integration and losing the configured names/entity IDs/icons etc. of the devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/home-assistant.io/issues/22033
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
