### PR TITLE
Remove direct usage of concurrent.futures from recorder

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -735,14 +735,13 @@ class Recorder(threading.Thread):
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_FINAL_WRITE, _empty_queue)
 
-        @callback
-        def _async_shutdown(event: Event) -> None:
+        async def _async_shutdown(event: Event) -> None:
             """Shut down the Recorder."""
             if not self._hass_started.done():
                 self._hass_started.set_result(SHUTDOWN_TASK)
             self.queue.put(StopTask())
             self._async_stop_queue_watcher_and_event_listener()
-            self.hass.async_add_executor_job(self.join)
+            await self.hass.async_add_executor_job(self.join)
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_shutdown)
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import abc
 import asyncio
 from collections.abc import Callable, Iterable
-import concurrent.futures
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
@@ -148,6 +147,8 @@ EXPIRE_AFTER_COMMITS = 120
 # - How frequently states with overlapping attributes will change
 # - How much memory our low end hardware has
 STATE_ATTRIBUTES_ID_CACHE_SIZE = 2048
+
+SHUTDOWN_TASK = object()
 
 
 DB_LOCK_TIMEOUT = 30
@@ -298,6 +299,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         exclude_t=exclude_t,
     )
     instance.async_initialize()
+    instance.async_register()
     instance.start()
     _async_register_services(hass, instance)
     history.async_setup(hass)
@@ -566,6 +568,7 @@ class Recorder(threading.Thread):
         self.hass = hass
         self.auto_purge = auto_purge
         self.keep_days = keep_days
+        self._hass_started: asyncio.Future[object] = asyncio.Future()
         self.commit_interval = commit_interval
         self.queue: queue.SimpleQueue[RecorderTask] = queue.SimpleQueue()
         self.recording_start = dt_util.utcnow()
@@ -710,12 +713,10 @@ class Recorder(threading.Thread):
         self.queue.put(StatisticsTask(start))
 
     @callback
-    def async_register(
-        self, shutdown_task: object, hass_started: concurrent.futures.Future
-    ) -> None:
+    def async_register(self) -> None:
         """Post connection initialize."""
 
-        def _empty_queue(event):
+        def _empty_queue(event: Event) -> None:
             """Empty the queue if its still present at final write."""
 
             # If the queue is full of events to be processed because
@@ -734,26 +735,29 @@ class Recorder(threading.Thread):
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_FINAL_WRITE, _empty_queue)
 
-        def shutdown(event):
+        @callback
+        def _async_shutdown(event: Event) -> None:
             """Shut down the Recorder."""
-            if not hass_started.done():
-                hass_started.set_result(shutdown_task)
+            if not self._hass_started.done():
+                self._hass_started.set_result(SHUTDOWN_TASK)
             self.queue.put(StopTask())
-            self.hass.add_job(self._async_stop_queue_watcher_and_event_listener)
-            self.join()
+            self._async_stop_queue_watcher_and_event_listener()
+            self.hass.async_add_executor_job(self.join)
 
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_shutdown)
 
         if self.hass.state == CoreState.running:
-            hass_started.set_result(None)
+            self._hass_started.set_result(None)
             return
 
         @callback
-        def async_hass_started(event):
+        def _async_hass_started(event: Event) -> None:
             """Notify that hass has started."""
-            hass_started.set_result(None)
+            self._hass_started.set_result(None)
 
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, async_hass_started)
+        self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STARTED, _async_hass_started
+        )
 
     @callback
     def async_connection_failed(self) -> None:
@@ -833,13 +837,18 @@ class Recorder(threading.Thread):
             self.hass, self.async_periodic_statistics, minute=range(0, 60, 5), second=10
         )
 
+    async def _async_wait_for_started(self) -> object | None:
+        """Wait for the hass started future."""
+        return await self._hass_started
+
+    def _wait_startup_or_shutdown(self) -> object | None:
+        """Wait for startup or shutdown before starting."""
+        return asyncio.run_coroutine_threadsafe(
+            self._async_wait_for_started(), self.hass.loop
+        ).result()
+
     def run(self) -> None:
         """Start processing events to save."""
-        shutdown_task = object()
-        hass_started: concurrent.futures.Future = concurrent.futures.Future()
-
-        self.hass.add_job(self.async_register, shutdown_task, hass_started)
-
         current_version = self._setup_recorder()
 
         if current_version is None:
@@ -853,8 +862,9 @@ class Recorder(threading.Thread):
             self.migration_in_progress = True
 
         self.hass.add_job(self.async_connection_success)
+
         # If shutdown happened before Home Assistant finished starting
-        if hass_started.result() is shutdown_task:
+        if self._wait_startup_or_shutdown() is SHUTDOWN_TASK:
             self.migration_in_progress = False
             # Make sure we cleanly close the run if
             # we restart before startup finishes

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -299,7 +299,7 @@ async def test_schema_migrate(hass, start_version):
         assert recorder.util.async_migration_in_progress(hass) is True
         migration_stall.set()
         await hass.async_block_till_done()
-        migration_done.wait()
+        await hass.async_add_executor_job(migration_done.wait)
         await async_wait_recording_done_without_instance(hass)
         assert migration_version == models.SCHEMA_VERSION
         assert setup_run.called


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove direct usage of concurrent.futures from recorder

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
