### PR TITLE
Add unique_id to utility_meter sensors

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -5,6 +5,7 @@ import logging
 from croniter import croniter
 import voluptuous as vol
 
+from homeassistant.components.input_select import _unique
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -86,7 +87,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_METER_DELTA_VALUES, default=False): cv.boolean,
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_TARIFFS, default=[]): vol.All(
-                cv.ensure_list, [cv.string]
+                cv.ensure_list, _unique, [cv.string]
             ),
             vol.Optional(CONF_CRON_PATTERN): validate_cron_pattern,
         },

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -140,13 +140,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         if not conf[CONF_TARIFFS]:
             # only one entity is required
-            name = conf.get(CONF_NAME, meter)
             hass.async_create_task(
                 discovery.async_load_platform(
                     hass,
                     SENSOR_DOMAIN,
                     DOMAIN,
-                    {name: {CONF_METER: meter, CONF_NAME: name}},
+                    {meter: {CONF_METER: meter}},
                     config,
                 )
             )
@@ -172,7 +171,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 name = f"{meter} {tariff}"
                 tariff_confs[name] = {
                     CONF_METER: meter,
-                    CONF_NAME: name,
                     CONF_TARIFF: tariff,
                 }
 

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -5,7 +5,6 @@ import logging
 from croniter import croniter
 import voluptuous as vol
 
-from homeassistant.components.input_select import _unique
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -87,7 +86,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_METER_DELTA_VALUES, default=False): cv.boolean,
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_TARIFFS, default=[]): vol.All(
-                cv.ensure_list, _unique, [cv.string]
+                cv.ensure_list, vol.Unique, [cv.string]
             ),
             vol.Optional(CONF_CRON_PATTERN): validate_cron_pattern,
         },

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -76,10 +76,10 @@ def max_28_days(config):
 
 METER_CONFIG_SCHEMA = vol.Schema(
     vol.All(
-        cv.deprecated(CONF_NAME),
         {
             vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
             vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_UNIQUE_ID): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),
             vol.Optional(CONF_METER_OFFSET, default=DEFAULT_OFFSET): vol.All(
                 cv.time_period, cv.positive_timedelta, max_28_days

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -141,12 +141,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         if not conf[CONF_TARIFFS]:
             # only one entity is required
+            name = conf.get(CONF_NAME, meter)
             hass.async_create_task(
                 discovery.async_load_platform(
                     hass,
                     SENSOR_DOMAIN,
                     DOMAIN,
-                    {meter: {CONF_METER: meter}},
+                    {name: {CONF_METER: meter, CONF_NAME: name}},
                     config,
                 )
             )
@@ -172,6 +173,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 name = f"{meter} {tariff}"
                 tariff_confs[name] = {
                     CONF_METER: meter,
+                    CONF_NAME: name,
                     CONF_TARIFF: tariff,
                 }
 

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -86,7 +86,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_METER_DELTA_VALUES, default=False): cv.boolean,
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_TARIFFS, default=[]): vol.All(
-                cv.ensure_list, vol.Unique, [cv.string]
+                cv.ensure_list, [cv.string]
             ),
             vol.Optional(CONF_CRON_PATTERN): validate_cron_pattern,
         },

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME, CONF_UNIQUE_ID, Platform
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers import discovery, entity_registry as er
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -75,8 +75,10 @@ def max_28_days(config):
 
 METER_CONFIG_SCHEMA = vol.Schema(
     vol.All(
+        cv.deprecated(CONF_NAME),
         {
             vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
+            vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),
             vol.Optional(CONF_METER_OFFSET, default=DEFAULT_OFFSET): vol.All(
                 cv.time_period, cv.positive_timedelta, max_28_days

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME, Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers import discovery, entity_registry as er
 import homeassistant.helpers.config_validation as cv
@@ -77,7 +77,6 @@ METER_CONFIG_SCHEMA = vol.Schema(
     vol.All(
         {
             vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
-            vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),
             vol.Optional(CONF_METER_OFFSET, default=DEFAULT_OFFSET): vol.All(
                 cv.time_period, cv.positive_timedelta, max_28_days

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -86,6 +86,7 @@ class TariffSelect(SelectEntity, RestoreEntity):
         self._tariffs = tariffs
         self._attr_icon = TARIFF_ICON
         self._attr_should_poll = False
+        self._attr_unique_id = f"utility_meter {name}"
         self._add_legacy_entities = add_legacy_entities
 
     @property
@@ -123,7 +124,7 @@ class LegacyTariffSelect(Entity):
     def __init__(self, tracked_entity_id):
         """Initialize the entity."""
         self._attr_icon = TARIFF_ICON
-        # Set name to influence enity_id
+        # Set name to influence entity_id
         self._attr_name = split_entity_id(tracked_entity_id)[1]
         self.tracked_entity_id = tracked_entity_id
 

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -53,10 +53,14 @@ async def async_setup_entry(
 async def async_setup_platform(hass, conf, async_add_entities, discovery_info=None):
     """Set up the utility meter select."""
     legacy_component = hass.data[DATA_LEGACY_COMPONENT]
+    meter = discovery_info[CONF_METER]
+    conf_meter_unique_id = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
+
     async_add_entities(
         [
             TariffSelect(
                 discovery_info[CONF_METER],
+                conf_meter_unique_id,
                 discovery_info[CONF_TARIFFS],
                 legacy_component.async_add_entities,
                 None,
@@ -78,7 +82,7 @@ async def async_setup_platform(hass, conf, async_add_entities, discovery_info=No
 class TariffSelect(SelectEntity, RestoreEntity):
     """Representation of a Tariff selector."""
 
-    def __init__(self, name, tariffs, add_legacy_entities, unique_id):
+    def __init__(self, name, unique_id, tariffs, add_legacy_entities):
         """Initialize a tariff selector."""
         self._attr_name = name
         self._attr_unique_id = unique_id
@@ -86,7 +90,7 @@ class TariffSelect(SelectEntity, RestoreEntity):
         self._tariffs = tariffs
         self._attr_icon = TARIFF_ICON
         self._attr_should_poll = False
-        self._attr_unique_id = f"utility_meter {name}"
+        self._attr_unique_id = unique_id
         self._add_legacy_entities = add_legacy_entities
 
     @property

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -13,7 +13,12 @@ from homeassistant.components.select.const import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    CONF_UNIQUE_ID,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import Event, HomeAssistant, callback, split_entity_id
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -27,6 +32,7 @@ from .const import (
     CONF_METER,
     CONF_TARIFFS,
     DATA_LEGACY_COMPONENT,
+    DATA_UTILITY,
     SERVICE_SELECT_NEXT_TARIFF,
     SERVICE_SELECT_TARIFF,
     TARIFF_ICON,
@@ -60,10 +66,9 @@ async def async_setup_platform(hass, conf, async_add_entities, discovery_info=No
         [
             TariffSelect(
                 discovery_info[CONF_METER],
-                conf_meter_unique_id,
                 discovery_info[CONF_TARIFFS],
                 legacy_component.async_add_entities,
-                None,
+                conf_meter_unique_id,
             )
         ]
     )
@@ -82,7 +87,7 @@ async def async_setup_platform(hass, conf, async_add_entities, discovery_info=No
 class TariffSelect(SelectEntity, RestoreEntity):
     """Representation of a Tariff selector."""
 
-    def __init__(self, name, unique_id, tariffs, add_legacy_entities):
+    def __init__(self, name, tariffs, add_legacy_entities, unique_id):
         """Initialize a tariff selector."""
         self._attr_name = name
         self._attr_unique_id = unique_id
@@ -90,7 +95,6 @@ class TariffSelect(SelectEntity, RestoreEntity):
         self._tariffs = tariffs
         self._attr_icon = TARIFF_ICON
         self._attr_should_poll = False
-        self._attr_unique_id = unique_id
         self._add_legacy_entities = add_legacy_entities
 
     @property

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -60,7 +60,9 @@ async def async_setup_platform(hass, conf, async_add_entities, discovery_info=No
     """Set up the utility meter select."""
     legacy_component = hass.data[DATA_LEGACY_COMPONENT]
     meter: str = discovery_info[CONF_METER]
-    conf_meter_unique_id: str | None = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
+    conf_meter_unique_id: str | None = hass.data[DATA_UTILITY][meter].get(
+        CONF_UNIQUE_ID
+    )
 
     async_add_entities(
         [

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -59,7 +59,7 @@ async def async_setup_entry(
 async def async_setup_platform(hass, conf, async_add_entities, discovery_info=None):
     """Set up the utility meter select."""
     legacy_component = hass.data[DATA_LEGACY_COMPONENT]
-    meter = discovery_info[CONF_METER]
+    meter: str = discovery_info[CONF_METER]
     conf_meter_unique_id = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
 
     async_add_entities(

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -60,7 +60,7 @@ async def async_setup_platform(hass, conf, async_add_entities, discovery_info=No
     """Set up the utility meter select."""
     legacy_component = hass.data[DATA_LEGACY_COMPONENT]
     meter: str = discovery_info[CONF_METER]
-    conf_meter_unique_id = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
+    conf_meter_unique_id: str | None = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
 
     async_add_entities(
         [

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -185,7 +185,7 @@ async def async_setup_platform(
         meter = conf[CONF_METER]
         conf_meter_source = hass.data[DATA_UTILITY][meter][CONF_SOURCE_SENSOR]
         conf_meter_unique_id = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
-        conf_sensor_tariff = conf.get(CONF_TARIFF)
+        conf_sensor_tariff = conf.get(CONF_TARIFF, "single_tariff")
         conf_sensor_unique_id = (
             f"{conf_meter_unique_id}_{conf_sensor_tariff}"
             if conf_meter_unique_id

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
     STATE_UNAVAILABLE,
@@ -183,12 +184,16 @@ async def async_setup_platform(
     for conf in discovery_info.values():
         meter = conf[CONF_METER]
         conf_meter_source = hass.data[DATA_UTILITY][meter][CONF_SOURCE_SENSOR]
-        conf_meter_name = hass.data[DATA_UTILITY][meter].get(
-            CONF_NAME, meter
-        )  # to be deprecated in 2022.7 in favor of conf_meter_name = meter
+        conf_meter_name = hass.data[DATA_UTILITY][meter].get(CONF_NAME, meter)
+        conf_meter_unique_id = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
         conf_sensor_tariff = conf.get(CONF_TARIFF)
         conf_sensor_name = (
             f"{meter} {conf_sensor_tariff}" if conf_sensor_tariff else conf_meter_name
+        )
+        conf_sensor_unique_id = (
+            f"{conf_meter_unique_id}_{conf_sensor_tariff}"
+            if conf_meter_unique_id
+            else None
         )
         conf_meter_type = hass.data[DATA_UTILITY][meter].get(CONF_METER_TYPE)
         conf_meter_offset = hass.data[DATA_UTILITY][meter][CONF_METER_OFFSET]
@@ -273,7 +278,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._sensor_net_consumption = net_consumption
         self._tariff = tariff
         self._tariff_entity = tariff_entity
-        self._attr_unique_id = f"utility_meter_{parent_meter}_{tariff}"
+        self._attr_unique_id = unique_id
 
     def start(self, unit):
         """Initialize unit and state upon source initial update."""

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -213,7 +213,7 @@ async def async_setup_platform(
             parent_meter=meter,
             source_entity=conf_meter_source,
             tariff_entity=conf_meter_tariff_entity,
-            conf_sensor_tariff,
+            tariff=conf_sensor_tariff,
             unique_id=conf_sensor_unique_id,
         )
         meters.append(meter_sensor)

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -218,7 +218,7 @@ async def async_setup_platform(
             source_entity=conf_meter_source,
             tariff_entity=conf_meter_tariff_entity,
             tariff=conf.get(CONF_TARIFF),
-            unique_id=None,
+            unique_id=conf_sensor_unique_id,
         )
         meters.append(meter_sensor)
 
@@ -278,7 +278,6 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._sensor_net_consumption = net_consumption
         self._tariff = tariff
         self._tariff_entity = tariff_entity
-        self._attr_unique_id = unique_id
 
     def start(self, unit):
         """Initialize unit and state upon source initial update."""

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
     STATE_UNAVAILABLE,
@@ -182,9 +183,12 @@ async def async_setup_platform(
     for conf in discovery_info.values():
         meter = conf[CONF_METER]
         conf_meter_source = hass.data[DATA_UTILITY][meter][CONF_SOURCE_SENSOR]
+        conf_meter_name = hass.data[DATA_UTILITY][meter].get(
+            CONF_NAME, meter
+        )  # to be deprecated in 2022.7 in favor of conf_meter_name = meter
         conf_sensor_tariff = conf.get(CONF_TARIFF)
         conf_sensor_name = (
-            f"{meter} {conf_sensor_tariff}" if conf_sensor_tariff else meter
+            f"{meter} {conf_sensor_tariff}" if conf_sensor_tariff else conf_meter_name
         )
         conf_meter_type = hass.data[DATA_UTILITY][meter].get(CONF_METER_TYPE)
         conf_meter_offset = hass.data[DATA_UTILITY][meter][CONF_METER_OFFSET]

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -213,7 +213,7 @@ async def async_setup_platform(
             parent_meter=meter,
             source_entity=conf_meter_source,
             tariff_entity=conf_meter_tariff_entity,
-            tariff=conf.get(CONF_TARIFF),
+            conf_sensor_tariff,
             unique_id=conf_sensor_unique_id,
         )
         meters.append(meter_sensor)

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -208,7 +208,7 @@ async def async_setup_platform(
             delta_values=conf_meter_delta_values,
             meter_offset=conf_meter_offset,
             meter_type=conf_meter_type,
-            name=conf[CONF_NAME],
+            name=conf.get(CONF_NAME),
             net_consumption=conf_meter_net_consumption,
             parent_meter=meter,
             source_entity=conf_meter_source,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -184,12 +184,8 @@ async def async_setup_platform(
     for conf in discovery_info.values():
         meter = conf[CONF_METER]
         conf_meter_source = hass.data[DATA_UTILITY][meter][CONF_SOURCE_SENSOR]
-        conf_meter_name = hass.data[DATA_UTILITY][meter].get(CONF_NAME, meter)
         conf_meter_unique_id = hass.data[DATA_UTILITY][meter].get(CONF_UNIQUE_ID)
         conf_sensor_tariff = conf.get(CONF_TARIFF)
-        conf_sensor_name = (
-            f"{meter} {conf_sensor_tariff}" if conf_sensor_tariff else conf_meter_name
-        )
         conf_sensor_unique_id = (
             f"{conf_meter_unique_id}_{conf_sensor_tariff}"
             if conf_meter_unique_id
@@ -212,7 +208,7 @@ async def async_setup_platform(
             delta_values=conf_meter_delta_values,
             meter_offset=conf_meter_offset,
             meter_type=conf_meter_type,
-            name=conf_sensor_name,
+            name=conf[CONF_NAME],
             net_consumption=conf_meter_net_consumption,
             parent_meter=meter,
             source_entity=conf_meter_source,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -182,6 +182,10 @@ async def async_setup_platform(
     for conf in discovery_info.values():
         meter = conf[CONF_METER]
         conf_meter_source = hass.data[DATA_UTILITY][meter][CONF_SOURCE_SENSOR]
+        conf_sensor_tariff = conf.get(CONF_TARIFF)
+        conf_sensor_name = (
+            f"{meter} {conf_sensor_tariff}" if conf_sensor_tariff else meter
+        )
         conf_meter_type = hass.data[DATA_UTILITY][meter].get(CONF_METER_TYPE)
         conf_meter_offset = hass.data[DATA_UTILITY][meter][CONF_METER_OFFSET]
         conf_meter_delta_values = hass.data[DATA_UTILITY][meter][
@@ -199,7 +203,7 @@ async def async_setup_platform(
             delta_values=conf_meter_delta_values,
             meter_offset=conf_meter_offset,
             meter_type=conf_meter_type,
-            name=conf.get(CONF_NAME),
+            name=conf_sensor_name,
             net_consumption=conf_meter_net_consumption,
             parent_meter=meter,
             source_entity=conf_meter_source,
@@ -248,7 +252,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._last_period = Decimal(0)
         self._last_reset = dt_util.utcnow()
         self._collecting = None
-        self._name = f"{parent_meter} {tariff}" if tariff else parent_meter
+        self._name = name
         self._unit_of_measurement = None
         self._period = meter_type
         if meter_type is not None:
@@ -265,7 +269,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._sensor_net_consumption = net_consumption
         self._tariff = tariff
         self._tariff_entity = tariff_entity
-        self._attr_unique_id = f"utility_meter{parent_meter}{tariff}"
+        self._attr_unique_id = f"utility_meter_{parent_meter}_{tariff}"
 
     def start(self, unit):
         """Initialize unit and state upon source initial update."""

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
-    CONF_NAME,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
     STATE_UNAVAILABLE,
@@ -249,7 +248,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._last_period = Decimal(0)
         self._last_reset = dt_util.utcnow()
         self._collecting = None
-        self._name = name
+        self._name = f"{parent_meter} {tariff}" if tariff else parent_meter
         self._unit_of_measurement = None
         self._period = meter_type
         if meter_type is not None:
@@ -266,6 +265,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._sensor_net_consumption = net_consumption
         self._tariff = tariff
         self._tariff_entity = tariff_entity
+        self._attr_unique_id = f"{parent_meter} {tariff}"
 
     def start(self, unit):
         """Initialize unit and state upon source initial update."""

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -265,7 +265,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._sensor_net_consumption = net_consumption
         self._tariff = tariff
         self._tariff_entity = tariff_entity
-        self._attr_unique_id = f"{parent_meter} {tariff}"
+        self._attr_unique_id = f"utility_meter{parent_meter}{tariff}"
 
     def start(self, unit):
         """Initialize unit and state upon source initial update."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds unique_id configuration option to allow customisation of utility_meter name through the UI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22150

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
