### PR TITLE
Fix history queries while the database migration is in progress

### DIFF
--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from itertools import groupby
 import logging
 import time
+from typing import Any
 
 from sqlalchemy import Column, Text, and_, bindparam, func, or_
 from sqlalchemy.ext import baked
@@ -98,7 +99,7 @@ def query_and_join_attributes(
 
 def bake_query_and_join_attributes(
     hass: HomeAssistant, no_attributes: bool
-) -> tuple[baked.bakery, bool]:
+) -> tuple[Any, bool]:
     """Return the initial backed query and if StateAttributes should be joined.
 
     Because these are baked queries the values inside the lambdas need

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -7,7 +7,7 @@ from itertools import groupby
 import logging
 import time
 
-from sqlalchemy import Text, and_, bindparam, func, or_
+from sqlalchemy import Column, Text, and_, bindparam, func, or_
 from sqlalchemy.ext import baked
 from sqlalchemy.sql.expression import literal
 
@@ -59,13 +59,41 @@ QUERY_STATE_NO_ATTR = [
     literal(value=None, type_=Text).label("attributes"),
     literal(value=None, type_=Text).label("shared_attrs"),
 ]
-QUERY_STATES = [
+# Remove QUERY_STATES_PRE_SCHEMA_25
+# and the migration_in_progress check
+# once schema 26 is created
+QUERY_STATES_PRE_SCHEMA_25 = [
     *BASE_STATES,
     States.attributes,
+    literal(value="{}", type_=Text).label("shared_attrs"),
+]
+QUERY_STATES = [
+    *BASE_STATES,
+    States.attributes,  # Remove States.attributes once all attributes are in StateAttributes.shared_attrs
     StateAttributes.shared_attrs,
 ]
 
 HISTORY_BAKERY = "recorder_history_bakery"
+
+
+def query_and_join_attributes(
+    hass: HomeAssistant, no_attributes: bool
+) -> tuple[list[Column], bool]:
+    """Return the query keys and if StateAttributes should be joined."""
+    # If we in the process of migrating schema we do
+    # not want to join the state_attributes table as we
+    # do not know if it will be there yet
+    if recorder.get_instance(hass).migration_in_progress:
+        return QUERY_STATES_PRE_SCHEMA_25, False
+    # If no_attributes was requested we do the query
+    # without the attributes fields and do not join the
+    # state_attributes table
+    if no_attributes:
+        return QUERY_STATE_NO_ATTR, False
+    # Finally if no migration is in progress and no_attributes
+    # was not requested, we query both attributes columns and
+    # join state_attributes
+    return QUERY_STATES, True
 
 
 def async_setup(hass):
@@ -104,7 +132,7 @@ def get_significant_states_with_session(
     thermostat so that we get current temperature in our graphs).
     """
     timer_start = time.perf_counter()
-    query_keys = QUERY_STATE_NO_ATTR if no_attributes else QUERY_STATES
+    query_keys, join_attributes = query_and_join_attributes(hass, no_attributes)
     baked_query = hass.data[HISTORY_BAKERY](lambda session: session.query(*query_keys))
 
     if entity_ids is not None and len(entity_ids) == 1:
@@ -146,7 +174,7 @@ def get_significant_states_with_session(
     if end_time is not None:
         baked_query += lambda q: q.filter(States.last_updated < bindparam("end_time"))
 
-    if not no_attributes:
+    if join_attributes:
         baked_query += lambda q: q.outerjoin(
             StateAttributes, States.attributes_id == StateAttributes.attributes_id
         )
@@ -187,7 +215,7 @@ def state_changes_during_period(
 ) -> dict[str, list[State]]:
     """Return states changes during UTC period start_time - end_time."""
     with session_scope(hass=hass) as session:
-        query_keys = QUERY_STATE_NO_ATTR if no_attributes else QUERY_STATES
+        query_keys, join_attributes = query_and_join_attributes(hass, no_attributes)
         baked_query = hass.data[HISTORY_BAKERY](
             lambda session: session.query(*query_keys)
         )
@@ -206,7 +234,7 @@ def state_changes_during_period(
             baked_query += lambda q: q.filter_by(entity_id=bindparam("entity_id"))
             entity_id = entity_id.lower()
 
-        if not no_attributes:
+        if join_attributes:
             baked_query += lambda q: q.outerjoin(
                 StateAttributes, States.attributes_id == StateAttributes.attributes_id
             )
@@ -240,8 +268,9 @@ def get_last_state_changes(hass, number_of_states, entity_id):
     start_time = dt_util.utcnow()
 
     with session_scope(hass=hass) as session:
+        query_keys, join_attributes = query_and_join_attributes(hass, False)
         baked_query = hass.data[HISTORY_BAKERY](
-            lambda session: session.query(*QUERY_STATES)
+            lambda session: session.query(*query_keys)
         )
         baked_query += lambda q: q.filter(States.last_changed == States.last_updated)
 
@@ -249,9 +278,10 @@ def get_last_state_changes(hass, number_of_states, entity_id):
             baked_query += lambda q: q.filter_by(entity_id=bindparam("entity_id"))
             entity_id = entity_id.lower()
 
-        baked_query += lambda q: q.outerjoin(
-            StateAttributes, States.attributes_id == StateAttributes.attributes_id
-        )
+        if join_attributes:
+            baked_query += lambda q: q.outerjoin(
+                StateAttributes, States.attributes_id == StateAttributes.attributes_id
+            )
         baked_query += lambda q: q.order_by(
             States.entity_id, States.last_updated.desc()
         )
@@ -322,7 +352,7 @@ def _get_states_with_session(
 
     # We have more than one entity to look at so we need to do a query on states
     # since the last recorder run started.
-    query_keys = QUERY_STATE_NO_ATTR if no_attributes else QUERY_STATES
+    query_keys, join_attributes = query_and_join_attributes(hass, no_attributes)
     query = session.query(*query_keys)
 
     if entity_ids:
@@ -344,7 +374,7 @@ def _get_states_with_session(
             most_recent_state_ids,
             States.state_id == most_recent_state_ids.c.max_state_id,
         )
-        if not no_attributes:
+        if join_attributes:
             query = query.outerjoin(
                 StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
             )
@@ -386,7 +416,7 @@ def _get_states_with_session(
             query = query.filter(~States.entity_id.like(entity_domain))
         if filters:
             query = filters.apply(query)
-        if not no_attributes:
+        if join_attributes:
             query = query.outerjoin(
                 StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
             )
@@ -400,13 +430,13 @@ def _get_single_entity_states_with_session(
 ):
     # Use an entirely different (and extremely fast) query if we only
     # have a single entity id
-    query_keys = QUERY_STATE_NO_ATTR if no_attributes else QUERY_STATES
+    query_keys, join_attributes = query_and_join_attributes(hass, no_attributes)
     baked_query = hass.data[HISTORY_BAKERY](lambda session: session.query(*query_keys))
     baked_query += lambda q: q.filter(
         States.last_updated < bindparam("utc_point_in_time"),
         States.entity_id == bindparam("entity_id"),
     )
-    if not no_attributes:
+    if join_attributes:
         baked_query += lambda q: q.outerjoin(
             StateAttributes, States.attributes_id == StateAttributes.attributes_id
         )

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -70,7 +70,8 @@ QUERY_STATES_PRE_SCHEMA_25 = [
 ]
 QUERY_STATES = [
     *BASE_STATES,
-    States.attributes,  # Remove States.attributes once all attributes are in StateAttributes.shared_attrs
+    # Remove States.attributes once all attributes are in StateAttributes.shared_attrs
+    States.attributes,
     StateAttributes.shared_attrs,
 ]
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

cc @dgomes 

Fixes

```
2022-03-23 22:30:37 ERROR (MainThread) [homeassistant.components.sensor] Error adding entities for domain sensor with platform filter
Traceback (most recent call last):
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1808, in _execute_context
    self.dialect.do_execute(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
    cursor.execute(statement, parameters)
sqlite3.OperationalError: no such column: states.attributes_id

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/dgomes/Projects/home-assistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/Users/dgomes/Projects/home-assistant/homeassistant/helpers/entity_platform.py", line 614, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/Users/dgomes/Projects/home-assistant/homeassistant/helpers/entity.py", line 780, in add_to_platform_finish
    await self.async_added_to_hass()
  File "/Users/dgomes/Projects/home-assistant/homeassistant/components/filter/sensor.py", line 299, in async_added_to_hass
    filter_history = await self.hass.async_add_executor_job(
  File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/dgomes/Projects/home-assistant/homeassistant/components/recorder/history.py", line 261, in get_last_state_changes
    states = execute(
  File "/Users/dgomes/Projects/home-assistant/homeassistant/components/recorder/util.py", line 135, in execute
    result = qry.all()
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/ext/baked.py", line 498, in all
    return self._iter().all()
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/ext/baked.py", line 412, in _iter
    result = self.session.execute(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1692, in execute
    result = conn._execute_20(statement, params or {}, execution_options)
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1620, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 325, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1487, in _execute_clauseelement
    ret = self._execute_context(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1851, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2032, in _handle_dbapi_exception
    util.raise_(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 207, in raise_
    raise exception
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1808, in _execute_context
    self.dialect.do_execute(
  File "/Users/dgomes/Projects/home-assistant/venv/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: states.attributes_id
[SQL: SELECT states.entity_id AS states_entity_id, states.state AS states_state, states.last_changed AS states_last_changed, states.last_updated AS states_last_updated, states.attributes AS states_attributes, state_attributes.shared_attrs AS state_attributes_shared_attrs 
FROM states LEFT OUTER JOIN state_attributes ON states.attributes_id = state_attributes.attributes_id 
WHERE states.last_changed = states.last_updated AND states.entity_id = ? ORDER BY states.entity_id, states.last_updated DESC
 LIMIT ? OFFSET ?]
[parameters: ('sensor.teste', 30, 0)]
(Background on this error at: https://sqlalche.me/e/14/e3q8)
2022-03-23 22:30:37 ERROR (MainThread) [homeassistant.components.sensor] Error adding entities for domain sensor with platform filter
Traceback (most recent call last):
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
