### PR TITLE
Bump notifications-android-tv to 0.1.5

### DIFF
--- a/homeassistant/components/nfandroidtv/manifest.json
+++ b/homeassistant/components/nfandroidtv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nfandroidtv",
   "name": "Notifications for Android TV / Fire TV",
   "documentation": "https://www.home-assistant.io/integrations/nfandroidtv",
-  "requirements": ["notifications-android-tv==0.1.4"],
+  "requirements": ["notifications-android-tv==0.1.5"],
   "codeowners": ["@tkdrob"],
   "config_flow": true,
   "iot_class": "local_push",

--- a/homeassistant/components/nfandroidtv/manifest.json
+++ b/homeassistant/components/nfandroidtv/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nfandroidtv",
   "name": "Notifications for Android TV / Fire TV",
   "documentation": "https://www.home-assistant.io/integrations/nfandroidtv",
-  "requirements": ["notifications-android-tv==0.1.3"],
+  "requirements": ["notifications-android-tv==0.1.4"],
   "codeowners": ["@tkdrob"],
   "config_flow": true,
   "iot_class": "local_push",

--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -1,8 +1,9 @@
 """Notifications for Android TV notification service."""
 from __future__ import annotations
 
+from io import BufferedReader
 import logging
-from typing import Any, BinaryIO
+from typing import Any
 
 from notifications_android_tv import Notifications
 import requests
@@ -116,7 +117,7 @@ class NFAndroidTVNotificationService(BaseNotificationService):
         position = None
         transparency = None
         bkgcolor = None
-        interrupt = None
+        interrupt = False
         icon = None
         image_file = None
         if data:
@@ -203,7 +204,7 @@ class NFAndroidTVNotificationService(BaseNotificationService):
         username: str | None = None,
         password: str | None = None,
         auth: str | None = None,
-    ) -> bytes | BinaryIO | None:
+    ) -> BufferedReader | bytes | None:
         """Load image/document/etc from a local path or URL."""
         try:
             if url is not None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1074,7 +1074,7 @@ niluclient==0.1.2
 noaa-coops==0.1.8
 
 # homeassistant.components.nfandroidtv
-notifications-android-tv==0.1.4
+notifications-android-tv==0.1.5
 
 # homeassistant.components.notify_events
 notify-events==1.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1074,7 +1074,7 @@ niluclient==0.1.2
 noaa-coops==0.1.8
 
 # homeassistant.components.nfandroidtv
-notifications-android-tv==0.1.3
+notifications-android-tv==0.1.4
 
 # homeassistant.components.notify_events
 notify-events==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -710,7 +710,7 @@ nettigo-air-monitor==1.2.1
 nexia==0.9.13
 
 # homeassistant.components.nfandroidtv
-notifications-android-tv==0.1.4
+notifications-android-tv==0.1.5
 
 # homeassistant.components.notify_events
 notify-events==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -710,7 +710,7 @@ nettigo-air-monitor==1.2.1
 nexia==0.9.13
 
 # homeassistant.components.nfandroidtv
-notifications-android-tv==0.1.3
+notifications-android-tv==0.1.4
 
 # homeassistant.components.notify_events
 notify-events==1.0.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump notifications-android-tv to 0.1.5
https://github.com/engrbm87/notifications_android_tv/compare/0.1.3...0.1.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
