### PR TITLE
Move remove all light option from group config flow

### DIFF
--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -57,11 +57,6 @@ BINARY_SENSOR_CONFIG_SCHEMA = vol.Schema(
     {vol.Required("name"): selector.selector({"text": {}})}
 ).extend(BINARY_SENSOR_OPTIONS_SCHEMA.schema)
 
-LIGHT_CONFIG_SCHEMA = vol.Schema(
-    {vol.Required("name"): selector.selector({"text": {}})}
-).extend(LIGHT_OPTIONS_SCHEMA.schema)
-
-
 GROUP_TYPES = ["binary_sensor", "cover", "fan", "light", "media_player"]
 
 
@@ -91,7 +86,9 @@ CONFIG_FLOW: dict[str, HelperFlowFormStep | HelperFlowMenuStep] = {
         basic_group_config_schema("cover"), set_group_type("cover")
     ),
     "fan": HelperFlowFormStep(basic_group_config_schema("fan"), set_group_type("fan")),
-    "light": HelperFlowFormStep(LIGHT_CONFIG_SCHEMA, set_group_type("light")),
+    "light": HelperFlowFormStep(
+        basic_group_config_schema("light"), set_group_type("light")
+    ),
     "media_player": HelperFlowFormStep(
         basic_group_config_schema("media_player"), set_group_type("media_player")
     ),

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -109,7 +109,7 @@ async def async_setup_entry(
     entities = er.async_validate_entity_ids(
         registry, config_entry.options[CONF_ENTITIES]
     )
-    mode = config_entry.options[CONF_ALL]
+    mode = config_entry.options.get(CONF_ALL, False)
 
     async_add_entities(
         [LightGroup(config_entry.entry_id, config_entry.title, entities, mode)]

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -59,31 +59,38 @@
   },
   "options": {
     "step": {
-      "binary_sensor_options": {
+      "binary_sensor": {
+        "description": "[%key:component::group::config::step::binary_sensor::description%]",
         "data": {
           "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
-          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]"
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
         }
       },
-      "cover_options": {
+      "cover": {
         "data": {
-          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]"
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
         }
       },
-      "fan_options": {
+      "fan": {
         "data": {
-          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]"
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
         }
       },
-      "light_options": {
+      "light": {
+        "description": "[%key:component::group::config::step::binary_sensor::description%]",
         "data": {
           "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
-          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]"
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
         }
       },
-      "media_player_options": {
+      "media_player": {
         "data": {
-          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]"
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
         }
       }
     }

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -42,8 +42,8 @@
       "light": {
         "title": "[%key:component::group::config::step::user::title%]",
         "data": {
-          "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
           "name": "[%key:component::group::config::step::binary_sensor::data::name%]"
         }
       },

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -40,12 +40,10 @@
         }
       },
       "light": {
-        "description": "[%key:component::group::config::step::binary_sensor::description%]",
         "title": "[%key:component::group::config::step::user::title%]",
         "data": {
           "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
-          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
           "name": "[%key:component::group::config::step::binary_sensor::data::name%]"
         }
       },

--- a/homeassistant/components/group/translations/en.json
+++ b/homeassistant/components/group/translations/en.json
@@ -29,8 +29,8 @@
             },
             "light": {
                 "data": {
-                    "all": "All entities",
                     "entities": "Members",
+                    "hide_members": "Hide members",
                     "name": "Name"
                 },
                 "title": "New Group"

--- a/homeassistant/components/group/translations/en.json
+++ b/homeassistant/components/group/translations/en.json
@@ -58,31 +58,38 @@
     },
     "options": {
         "step": {
-            "binary_sensor_options": {
+            "binary_sensor": {
                 "data": {
                     "all": "All entities",
-                    "entities": "Members"
-                }
+                    "entities": "Members",
+                    "hide_members": "Hide members"
+                },
+                "description": "If \"all entities\" is enabled, the group's state is on only if all members are on. If \"all entities\" is disabled, the group's state is on if any member is on."
             },
-            "cover_options": {
+            "cover": {
                 "data": {
-                    "entities": "Members"
+                    "entities": "Members",
+                    "hide_members": "Hide members"
                 }
             },
-            "fan_options": {
+            "fan": {
                 "data": {
-                    "entities": "Members"
+                    "entities": "Members",
+                    "hide_members": "Hide members"
                 }
             },
-            "light_options": {
+            "light": {
                 "data": {
                     "all": "All entities",
-                    "entities": "Members"
-                }
+                    "entities": "Members",
+                    "hide_members": "Hide members"
+                },
+                "description": "If \"all entities\" is enabled, the group's state is on only if all members are on. If \"all entities\" is disabled, the group's state is on if any member is on."
             },
-            "media_player_options": {
+            "media_player": {
                 "data": {
-                    "entities": "Members"
+                    "entities": "Members",
+                    "hide_members": "Hide members"
                 }
             }
         }

--- a/homeassistant/components/group/translations/en.json
+++ b/homeassistant/components/group/translations/en.json
@@ -31,10 +31,8 @@
                 "data": {
                     "all": "All entities",
                     "entities": "Members",
-                    "hide_members": "Hide members",
                     "name": "Name"
                 },
-                "description": "If \"all entities\" is enabled, the group's state is on only if all members are on. If \"all entities\" is disabled, the group's state is on if any member is on.",
                 "title": "New Group"
             },
             "media_player": {

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -23,8 +23,7 @@ from tests.common import MockConfigEntry
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
         ("cover", "open", "open", {}, {}, {}, {}),
         ("fan", "on", "on", {}, {}, {}, {}),
-        ("light", "on", "on", {}, {}, {"all": False}, {}),
-        ("light", "on", "on", {}, {"all": True}, {"all": True}, {}),
+        ("light", "on", "on", {}, {}, {}, {}),
         ("media_player", "on", "on", {}, {}, {}, {}),
     ),
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Per review comment here:

<https://github.com/home-assistant/core/pull/68528#discussion_r832866799>

This PR moves the `all` option for light groups, to the options flow only.

I'm not sure about the advanced option here. We don't have real control for that in the current helper flows.

Additionally, fixed the missing translations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
