### PR TITLE
Clean up async_reproduce_state helper usage

### DIFF
--- a/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
+++ b/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -17,7 +18,8 @@ async def test_reproducing_states(
     turn_off_calls = async_mock_service(hass, "NEW_DOMAIN", "turn_off")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("NEW_DOMAIN.entity_off", "off"),
             State("NEW_DOMAIN.entity_on", "on", {"color": "red"}),
@@ -29,8 +31,8 @@ async def test_reproducing_states(
     assert len(turn_off_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("NEW_DOMAIN.entity_off", "not_supported")], blocking=True
+    await async_reproduce_state(
+        hass, [State("NEW_DOMAIN.entity_off", "not_supported")], blocking=True
     )
 
     assert "not_supported" in caplog.text
@@ -38,7 +40,8 @@ async def test_reproducing_states(
     assert len(turn_off_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("NEW_DOMAIN.entity_on", "off"),
             State("NEW_DOMAIN.entity_off", "on", {"color": "red"}),

--- a/tests/components/alarm_control_panel/test_reproduce_state.py
+++ b/tests/components/alarm_control_panel/test_reproduce_state.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -67,7 +68,8 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("alarm_control_panel.entity_armed_away", STATE_ALARM_ARMED_AWAY),
             State(
@@ -81,7 +83,7 @@ async def test_reproducing_states(hass, caplog):
             ),
             State("alarm_control_panel.entity_disarmed", STATE_ALARM_DISARMED),
             State("alarm_control_panel.entity_triggered", STATE_ALARM_TRIGGERED),
-        ]
+        ],
     )
 
     assert len(arm_away_calls) == 0
@@ -93,8 +95,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(trigger_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("alarm_control_panel.entity_triggered", "not_supported")]
+    await async_reproduce_state(
+        hass, [State("alarm_control_panel.entity_triggered", "not_supported")]
     )
 
     assert "not_supported" in caplog.text
@@ -107,7 +109,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(trigger_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("alarm_control_panel.entity_armed_away", STATE_ALARM_TRIGGERED),
             State(
@@ -122,7 +125,7 @@ async def test_reproducing_states(hass, caplog):
             State("alarm_control_panel.entity_triggered", STATE_ALARM_DISARMED),
             # Should not raise
             State("alarm_control_panel.non_existing", "on"),
-        ]
+        ],
     )
 
     assert len(arm_away_calls) == 1

--- a/tests/components/alert/test_reproduce_state.py
+++ b/tests/components/alert/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Alert."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -13,30 +14,29 @@ async def test_reproducing_states(hass, caplog):
     turn_off_calls = async_mock_service(hass, "alert", "turn_off")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
-        [State("alert.entity_off", "off"), State("alert.entity_on", "on")]
+    await async_reproduce_state(
+        hass, [State("alert.entity_off", "off"), State("alert.entity_on", "on")]
     )
 
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("alert.entity_off", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("alert.entity_off", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("alert.entity_on", "off"),
             State("alert.entity_off", "on"),
             # Should not raise
             State("alert.non_existing", "on"),
-        ]
+        ],
     )
 
     assert len(turn_on_calls) == 1

--- a/tests/components/automation/test_reproduce_state.py
+++ b/tests/components/automation/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Automation."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -13,30 +14,30 @@ async def test_reproducing_states(hass, caplog):
     turn_off_calls = async_mock_service(hass, "automation", "turn_off")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
-        [State("automation.entity_off", "off"), State("automation.entity_on", "on")]
+    await async_reproduce_state(
+        hass,
+        [State("automation.entity_off", "off"), State("automation.entity_on", "on")],
     )
 
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("automation.entity_off", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("automation.entity_off", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("automation.entity_on", "off"),
             State("automation.entity_off", "on"),
             # Should not raise
             State("automation.non_existing", "on"),
-        ]
+        ],
     )
 
     assert len(turn_on_calls) == 1

--- a/tests/components/counter/test_reproduce_state.py
+++ b/tests/components/counter/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Counter."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -16,7 +17,8 @@ async def test_reproducing_states(hass, caplog):
     configure_calls = async_mock_service(hass, "counter", "configure")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("counter.entity", "5"),
             State(
@@ -24,21 +26,20 @@ async def test_reproducing_states(hass, caplog):
                 "8",
                 {"initial": 12, "minimum": 5, "maximum": 15, "step": 3},
             ),
-        ]
+        ],
     )
 
     assert len(configure_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("counter.entity", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("counter.entity", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(configure_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("counter.entity", "2"),
             State(
@@ -48,7 +49,7 @@ async def test_reproducing_states(hass, caplog):
             ),
             # Should not raise
             State("counter.non_existing", "6"),
-        ]
+        ],
     )
 
     valid_calls = [

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_OPEN,
 )
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -61,7 +62,8 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("cover.entity_close", STATE_CLOSED),
             State(
@@ -93,7 +95,7 @@ async def test_reproducing_states(hass, caplog):
                 STATE_OPEN,
                 {ATTR_CURRENT_POSITION: 100, ATTR_CURRENT_TILT_POSITION: 100},
             ),
-        ]
+        ],
     )
 
     assert len(close_calls) == 0
@@ -104,9 +106,7 @@ async def test_reproducing_states(hass, caplog):
     assert len(position_tilt_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("cover.entity_close", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("cover.entity_close", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(close_calls) == 0
@@ -117,7 +117,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(position_tilt_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("cover.entity_close", STATE_OPEN),
             State(

--- a/tests/components/fan/test_reproduce_state.py
+++ b/tests/components/fan/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Fan."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -19,7 +20,8 @@ async def test_reproducing_states(hass, caplog):
     set_percentage_calls = async_mock_service(hass, "fan", "set_percentage")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("fan.entity_off", "off"),
             State("fan.entity_on", "on"),
@@ -35,9 +37,7 @@ async def test_reproducing_states(hass, caplog):
     assert len(oscillate_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("fan.entity_off", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("fan.entity_off", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
@@ -47,7 +47,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(set_percentage_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("fan.entity_on", "off"),
             State("fan.entity_off", "on"),

--- a/tests/components/humidifier/test_reproduce_state.py
+++ b/tests/components/humidifier/test_reproduce_state.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import Context, State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -38,7 +39,8 @@ async def test_reproducing_on_off_states(hass, caplog):
     humidity_calls = async_mock_service(hass, DOMAIN, SERVICE_SET_HUMIDITY)
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State(ENTITY_1, "off", {ATTR_MODE: MODE_NORMAL, ATTR_HUMIDITY: 45}),
             State(ENTITY_2, "on", {ATTR_MODE: MODE_NORMAL, ATTR_HUMIDITY: 45}),
@@ -51,7 +53,7 @@ async def test_reproducing_on_off_states(hass, caplog):
     assert len(humidity_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state([State(ENTITY_1, "not_supported")])
+    await async_reproduce_state(hass, [State(ENTITY_1, "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
@@ -60,13 +62,14 @@ async def test_reproducing_on_off_states(hass, caplog):
     assert len(humidity_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State(ENTITY_2, "off"),
             State(ENTITY_1, "on", {}),
             # Should not raise
             State("humidifier.non_existing", "on"),
-        ]
+        ],
     )
 
     assert len(turn_on_calls) == 1

--- a/tests/components/input_boolean/test_reproduce_state.py
+++ b/tests/components/input_boolean/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for input boolean."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
 
@@ -15,7 +16,8 @@ async def test_reproducing_states(hass):
             }
         },
     )
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_boolean.initial_on", "off"),
             State("input_boolean.initial_off", "on"),
@@ -26,7 +28,8 @@ async def test_reproducing_states(hass):
     assert hass.states.get("input_boolean.initial_off").state == "on"
     assert hass.states.get("input_boolean.initial_on").state == "off"
 
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             # Test invalid state
             State("input_boolean.initial_on", "invalid_state"),

--- a/tests/components/input_datetime/test_reproduce_state.py
+++ b/tests/components/input_datetime/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Input datetime."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -28,7 +29,8 @@ async def test_reproducing_states(hass, caplog):
     datetime_calls = async_mock_service(hass, "input_datetime", "set_datetime")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_datetime.entity_datetime", "2010-10-10 01:20:00"),
             State("input_datetime.entity_time", "01:20:00"),
@@ -39,7 +41,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(datetime_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_datetime.entity_datetime", "not_supported"),
             State("input_datetime.entity_datetime", "not-valid-date"),
@@ -55,7 +58,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(datetime_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_datetime.entity_datetime", "2011-10-10 02:20:00"),
             State("input_datetime.entity_time", "02:20:00"),

--- a/tests/components/input_number/test_reproduce_state.py
+++ b/tests/components/input_number/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Input number."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
 VALID_NUMBER1 = "19.0"
@@ -20,7 +21,8 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_number.test_number", VALID_NUMBER1),
             # Should not raise
@@ -31,7 +33,8 @@ async def test_reproducing_states(hass, caplog):
     assert hass.states.get("input_number.test_number").state == VALID_NUMBER1
 
     # Test reproducing with different state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_number.test_number", VALID_NUMBER2),
             # Should not raise
@@ -42,14 +45,13 @@ async def test_reproducing_states(hass, caplog):
     assert hass.states.get("input_number.test_number").state == VALID_NUMBER2
 
     # Test setting state to number out of range
-    await hass.helpers.state.async_reproduce_state(
-        [State("input_number.test_number", "150")]
-    )
+    await async_reproduce_state(hass, [State("input_number.test_number", "150")])
 
     # The entity states should be unchanged after trying to set them to out-of-range number
     assert hass.states.get("input_number.test_number").state == VALID_NUMBER2
 
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             # Test invalid state
             State("input_number.test_number", "invalid_state"),

--- a/tests/components/input_select/test_reproduce_state.py
+++ b/tests/components/input_select/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Input select."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
 VALID_OPTION1 = "Option A"
@@ -29,7 +30,8 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State(ENTITY, VALID_OPTION1),
             # Should not raise
@@ -41,7 +43,8 @@ async def test_reproducing_states(hass, caplog):
     assert hass.states.get(ENTITY).state == VALID_OPTION1
 
     # Try reproducing with different state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State(ENTITY, VALID_OPTION3),
             # Should not raise
@@ -53,14 +56,14 @@ async def test_reproducing_states(hass, caplog):
     assert hass.states.get(ENTITY).state == VALID_OPTION3
 
     # Test setting state to invalid state
-    await hass.helpers.state.async_reproduce_state([State(ENTITY, INVALID_OPTION)])
+    await async_reproduce_state(hass, [State(ENTITY, INVALID_OPTION)])
 
     # The entity state should be unchanged
     assert hass.states.get(ENTITY).state == VALID_OPTION3
 
     # Test setting a different option set
-    await hass.helpers.state.async_reproduce_state(
-        [State(ENTITY, VALID_OPTION5, {"options": VALID_OPTION_SET2})]
+    await async_reproduce_state(
+        hass, [State(ENTITY, VALID_OPTION5, {"options": VALID_OPTION_SET2})]
     )
 
     # These should fail if options weren't changed to VALID_OPTION_SET2

--- a/tests/components/input_text/test_reproduce_state.py
+++ b/tests/components/input_text/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Input text."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 from homeassistant.setup import async_setup_component
 
 VALID_TEXT1 = "Test text"
@@ -23,7 +24,8 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_text.test_text", VALID_TEXT1),
             # Should not raise
@@ -35,7 +37,8 @@ async def test_reproducing_states(hass, caplog):
     assert hass.states.get("input_text.test_text").state == VALID_TEXT1
 
     # Try reproducing with different state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("input_text.test_text", VALID_TEXT2),
             # Should not raise
@@ -47,17 +50,13 @@ async def test_reproducing_states(hass, caplog):
     assert hass.states.get("input_text.test_text").state == VALID_TEXT2
 
     # Test setting state to invalid state (length too long)
-    await hass.helpers.state.async_reproduce_state(
-        [State("input_text.test_text", INVALID_TEXT1)]
-    )
+    await async_reproduce_state(hass, [State("input_text.test_text", INVALID_TEXT1)])
 
     # The entity state should be unchanged
     assert hass.states.get("input_text.test_text").state == VALID_TEXT2
 
     # Test setting state to invalid state (length too short)
-    await hass.helpers.state.async_reproduce_state(
-        [State("input_text.test_text", INVALID_TEXT2)]
-    )
+    await async_reproduce_state(hass, [State("input_text.test_text", INVALID_TEXT2)])
 
     # The entity state should be unchanged
     assert hass.states.get("input_text.test_text").state == VALID_TEXT2

--- a/tests/components/lock/test_reproduce_state.py
+++ b/tests/components/lock/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Lock."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -13,7 +14,8 @@ async def test_reproducing_states(hass, caplog):
     unlock_calls = async_mock_service(hass, "lock", "unlock")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("lock.entity_locked", "locked"),
             State("lock.entity_unlocked", "unlocked", {}),
@@ -24,16 +26,15 @@ async def test_reproducing_states(hass, caplog):
     assert len(unlock_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("lock.entity_locked", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("lock.entity_locked", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(lock_calls) == 0
     assert len(unlock_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("lock.entity_locked", "unlocked"),
             State("lock.entity_unlocked", "locked"),

--- a/tests/components/number/test_reproduce_state.py
+++ b/tests/components/number/test_reproduce_state.py
@@ -6,6 +6,7 @@ from homeassistant.components.number.const import (
     SERVICE_SET_VALUE,
 )
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -21,7 +22,8 @@ async def test_reproducing_states(hass, caplog):
     )
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("number.test_number", VALID_NUMBER1),
             # Should not raise
@@ -33,7 +35,8 @@ async def test_reproducing_states(hass, caplog):
 
     # Test reproducing with different state
     calls = async_mock_service(hass, DOMAIN, SERVICE_SET_VALUE)
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("number.test_number", VALID_NUMBER2),
             # Should not raise
@@ -46,8 +49,6 @@ async def test_reproducing_states(hass, caplog):
     assert calls[0].data == {"entity_id": "number.test_number", "value": VALID_NUMBER2}
 
     # Test invalid state
-    await hass.helpers.state.async_reproduce_state(
-        [State("number.test_number", "invalid_state")]
-    )
+    await async_reproduce_state(hass, [State("number.test_number", "invalid_state")])
 
     assert len(calls) == 1

--- a/tests/components/remote/test_reproduce_state.py
+++ b/tests/components/remote/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Remote."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -13,7 +14,8 @@ async def test_reproducing_states(hass, caplog):
     turn_off_calls = async_mock_service(hass, "remote", "turn_off")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [State("remote.entity_off", "off"), State("remote.entity_on", "on")],
     )
 
@@ -21,16 +23,15 @@ async def test_reproducing_states(hass, caplog):
     assert len(turn_off_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("remote.entity_off", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("remote.entity_off", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("remote.entity_on", "off"),
             State("remote.entity_off", "on", {}),

--- a/tests/components/select/test_reproduce_state.py
+++ b/tests/components/select/test_reproduce_state.py
@@ -9,6 +9,7 @@ from homeassistant.components.select.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -24,7 +25,8 @@ async def test_reproducing_states(
         {ATTR_OPTIONS: ["option_one", "option_two", "option_three"]},
     )
 
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("select.test", "option_two"),
         ],
@@ -35,7 +37,8 @@ async def test_reproducing_states(
     assert calls[0].data == {ATTR_ENTITY_ID: "select.test", ATTR_OPTION: "option_two"}
 
     # Calling it again should not do anything
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("select.test", "option_one"),
         ],
@@ -43,15 +46,11 @@ async def test_reproducing_states(
     assert len(calls) == 1
 
     # Restoring an invalid state should not work either
-    await hass.helpers.state.async_reproduce_state(
-        [State("select.test", "option_four")]
-    )
+    await async_reproduce_state(hass, [State("select.test", "option_four")])
     assert len(calls) == 1
     assert "Invalid state specified" in caplog.text
 
     # Restoring an state for an invalid entity ID logs a warning
-    await hass.helpers.state.async_reproduce_state(
-        [State("select.non_existing", "option_three")]
-    )
+    await async_reproduce_state(hass, [State("select.non_existing", "option_three")])
     assert len(calls) == 1
     assert "Unable to find entity" in caplog.text

--- a/tests/components/switch/test_reproduce_state.py
+++ b/tests/components/switch/test_reproduce_state.py
@@ -1,5 +1,6 @@
 """Test reproduce state for Switch."""
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -13,7 +14,8 @@ async def test_reproducing_states(hass, caplog):
     turn_off_calls = async_mock_service(hass, "switch", "turn_off")
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [State("switch.entity_off", "off"), State("switch.entity_on", "on", {})],
     )
 
@@ -21,22 +23,21 @@ async def test_reproducing_states(hass, caplog):
     assert len(turn_off_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("switch.entity_off", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("switch.entity_off", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("switch.entity_on", "off"),
             State("switch.entity_off", "on", {}),
             # Should not raise
             State("switch.non_existing", "on"),
-        ]
+        ],
     )
 
     assert len(turn_on_calls) == 1

--- a/tests/components/timer/test_reproduce_state.py
+++ b/tests/components/timer/test_reproduce_state.py
@@ -9,6 +9,7 @@ from homeassistant.components.timer import (
     STATUS_PAUSED,
 )
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -27,7 +28,8 @@ async def test_reproducing_states(hass, caplog):
     cancel_calls = async_mock_service(hass, "timer", SERVICE_CANCEL)
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("timer.entity_idle", STATUS_IDLE),
             State("timer.entity_paused", STATUS_PAUSED),
@@ -43,9 +45,7 @@ async def test_reproducing_states(hass, caplog):
     assert len(cancel_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("timer.entity_idle", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("timer.entity_idle", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(start_calls) == 0
@@ -53,7 +53,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(cancel_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("timer.entity_idle", STATUS_ACTIVE, {ATTR_DURATION: "00:01:00"}),
             State("timer.entity_paused", STATUS_ACTIVE),

--- a/tests/components/vacuum/test_reproduce_state.py
+++ b/tests/components/vacuum/test_reproduce_state.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_PAUSED,
 )
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -48,7 +49,8 @@ async def test_reproducing_states(hass, caplog):
     fan_speed_calls = async_mock_service(hass, "vacuum", SERVICE_SET_FAN_SPEED)
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("vacuum.entity_off", STATE_OFF),
             State("vacuum.entity_on", STATE_ON),
@@ -70,9 +72,7 @@ async def test_reproducing_states(hass, caplog):
     assert len(fan_speed_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("vacuum.entity_off", "not_supported")]
-    )
+    await async_reproduce_state(hass, [State("vacuum.entity_off", "not_supported")])
 
     assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
@@ -84,7 +84,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(fan_speed_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("vacuum.entity_off", STATE_ON),
             State("vacuum.entity_on", STATE_OFF),

--- a/tests/components/water_heater/test_reproduce_state.py
+++ b/tests/components/water_heater/test_reproduce_state.py
@@ -11,6 +11,7 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_ON
 from homeassistant.core import State
+from homeassistant.helpers.state import async_reproduce_state
 
 from tests.common import async_mock_service
 
@@ -34,7 +35,8 @@ async def test_reproducing_states(hass, caplog):
     set_away_calls = async_mock_service(hass, "water_heater", SERVICE_SET_AWAY_MODE)
 
     # These calls should do nothing as entities already in desired state
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("water_heater.entity_off", STATE_OFF),
             State("water_heater.entity_on", STATE_ON, {ATTR_TEMPERATURE: 45}),
@@ -45,7 +47,7 @@ async def test_reproducing_states(hass, caplog):
                 STATE_ECO,
                 {ATTR_AWAY_MODE: True, ATTR_TEMPERATURE: 45},
             ),
-        ]
+        ],
     )
 
     assert len(turn_on_calls) == 0
@@ -55,8 +57,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(set_away_calls) == 0
 
     # Test invalid state is handled
-    await hass.helpers.state.async_reproduce_state(
-        [State("water_heater.entity_off", "not_supported")]
+    await async_reproduce_state(
+        hass, [State("water_heater.entity_off", "not_supported")]
     )
 
     assert "not_supported" in caplog.text
@@ -67,7 +69,8 @@ async def test_reproducing_states(hass, caplog):
     assert len(set_away_calls) == 0
 
     # Make sure correct services are called
-    await hass.helpers.state.async_reproduce_state(
+    await async_reproduce_state(
+        hass,
         [
             State("water_heater.entity_on", STATE_OFF),
             State("water_heater.entity_off", STATE_ON, {ATTR_TEMPERATURE: 45}),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Cleans up the `async_reproduce_state` helper usage via the `hass` object.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
