### PR TITLE
Implement "feed" command for CoolMasterNet as a service

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -203,8 +203,8 @@ build.json @home-assistant/supervisor
 /tests/components/control4/ @lawtancool
 /homeassistant/components/conversation/ @home-assistant/core
 /tests/components/conversation/ @home-assistant/core
-/homeassistant/components/coolmaster/ @OnFreund
-/tests/components/coolmaster/ @OnFreund
+/homeassistant/components/coolmaster/ @OnFreund @Rjevski
+/tests/components/coolmaster/ @OnFreund @Rjevski
 /homeassistant/components/coronavirus/ @home-assistant/core
 /tests/components/coronavirus/ @home-assistant/core
 /homeassistant/components/counter/ @fabaff

--- a/homeassistant/components/coolmaster/const.py
+++ b/homeassistant/components/coolmaster/const.py
@@ -8,3 +8,5 @@ DOMAIN = "coolmaster"
 DEFAULT_PORT = 10102
 
 CONF_SUPPORTED_MODES = "supported_modes"
+
+SERVICE_FEED = "suggest_ambient_temperature"

--- a/homeassistant/components/coolmaster/manifest.json
+++ b/homeassistant/components/coolmaster/manifest.json
@@ -3,8 +3,8 @@
   "name": "CoolMasterNet",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/coolmaster",
-  "requirements": ["pycoolmasternet-async==0.1.2"],
-  "codeowners": ["@OnFreund"],
+  "requirements": ["pycoolmasternet-async==0.1.3"],
+  "codeowners": ["@OnFreund", "@Rjevski"],
   "iot_class": "local_polling",
   "loggers": ["pycoolmasternet_async"]
 }

--- a/homeassistant/components/coolmaster/services.yaml
+++ b/homeassistant/components/coolmaster/services.yaml
@@ -1,0 +1,18 @@
+suggest_ambient_temperature:
+  name: Suggest ambient temperature
+  description: Sends the provided value as the ambient temperature to the HVAC device.
+  target:
+    entity:
+      integration: coolmaster
+      domain: climate
+  fields:
+    temperature:
+      name: Ambient temperature
+      description: The ambient temperature value to send to the unit.
+      selector:
+        number:
+          min: -70
+          max: 122
+          step: 0.1
+          mode: box
+          unit_of_measurement: '°'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1473,7 +1473,7 @@ pycocotools==2.0.1
 pycomfoconnect==0.4
 
 # homeassistant.components.coolmaster
-pycoolmasternet-async==0.1.2
+pycoolmasternet-async==0.1.3
 
 # homeassistant.components.microsoft
 pycsspeechtts==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1034,7 +1034,7 @@ pyclimacell==0.18.2
 pycomfoconnect==0.4
 
 # homeassistant.components.coolmaster
-pycoolmasternet-async==0.1.2
+pycoolmasternet-async==0.1.3
 
 # homeassistant.components.daikin
 pydaikin==2.7.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR implements a new service that allows Home Assistant to provide an ambient temperature value to CoolMasterNet-controlled HVAC units. This is useful in case your HVAC's built-in temperature sensor isn't optimally-located and is reporting inaccurate values and you want to replace it with a HA-connected one. You can set up an automation to react to your temperature sensor's state changes and call the new service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->

This PR upgrades `pycoolmasternet-async` to 0.1.3 for which I've [opened a PR](https://github.com/OnFreund/pycoolmasternet-async/pull/3) in its repo. This has now been merged & the resulting release published to PyPi, so we are good to go.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
