### PR TITLE
Revert "Take Abode camera snapshot before fetching latest image"

### DIFF
--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -88,8 +88,6 @@ class AbodeCamera(AbodeDevice, Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Get a camera image."""
-        if not self.capture():
-            return None
         self.refresh_image()
 
         if self._response:


### PR DESCRIPTION
Reverts home-assistant/core#67150

The addition is causing issues on certain Abode camera models: https://github.com/home-assistant/core/issues/67756
I will look into another way to fix the original problem but we should revert the PR for now. 