### PR TITLE
Rename set_wifi_led_* to set_led_* for xiaomi_miio

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -280,8 +280,8 @@ SERVICE_SET_REMOTE_LED_ON = "remote_set_led_on"
 SERVICE_SET_REMOTE_LED_OFF = "remote_set_led_off"
 
 # Switch Services
-SERVICE_SET_WIFI_LED_ON = "switch_set_wifi_led_on"
-SERVICE_SET_WIFI_LED_OFF = "switch_set_wifi_led_off"
+SERVICE_SET_LED_ON = "switch_set_led_on"
+SERVICE_SET_LED_OFF = "switch_set_led_off"
 SERVICE_SET_POWER_MODE = "switch_set_power_mode"
 SERVICE_SET_POWER_PRICE = "switch_set_power_price"
 

--- a/homeassistant/components/xiaomi_miio/services.yaml
+++ b/homeassistant/components/xiaomi_miio/services.yaml
@@ -173,9 +173,9 @@ remote_set_led_off:
       integration: xiaomi_miio
       domain: remote
 
-switch_set_wifi_led_on:
-  name: Switch set Wi-fi LED on
-  description: Turn the wifi led on.
+switch_set_led_on:
+  name: Switch set LED on
+  description: Turn the led on.
   fields:
     entity_id:
       description: Name of the xiaomi miio entity.
@@ -184,9 +184,9 @@ switch_set_wifi_led_on:
           integration: xiaomi_miio
           domain: switch
 
-switch_set_wifi_led_off:
-  name: Switch set Wi-fi LED off
-  description: Turn the wifi led off.
+switch_set_led_off:
+  name: Switch set LED off
+  description: Turn the led off.
   fields:
     entity_id:
       description: Name of the xiaomi miio entity.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
To consolidate the services to allow further extensions, the following changes have been made:
* Service `switch_set_wifi_led_on` is renamed to `switch_set_led_on`
* Service `switch_set_wifi_led_off` is renamed to `switch_set_led_off`
* State attribute `wifi_led` is renamed to `led`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The upstream is moving towards having common APIs which involves some renaming some existing properties and methods,
causing deprecation warnings at homeassistant's code.
This PR converts the switch platform to use the new names, and also takes the opportunity to consolidate the naming scheme to be consistent with upstream.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #68501
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
