### PR TITLE
Remove ipaddress check in AndroidTV config flow

### DIFF
--- a/homeassistant/components/androidtv/config_flow.py
+++ b/homeassistant/components/androidtv/config_flow.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import os
-import socket
 
 from androidtv import state_detection_rules_validator
 import voluptuous as vol
@@ -56,14 +55,6 @@ def _is_file(value):
     """Validate that the value is an existing file."""
     file_in = os.path.expanduser(str(value))
     return os.path.isfile(file_in) and os.access(file_in, os.R_OK)
-
-
-def _get_ip(host):
-    """Get the ip address from the host name."""
-    try:
-        return socket.gethostbyname(host)
-    except socket.gaierror:
-        return None
 
 
 class AndroidTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -137,24 +128,17 @@ class AndroidTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input[CONF_HOST]
             adb_key = user_input.get(CONF_ADBKEY)
-            adb_server = user_input.get(CONF_ADB_SERVER_IP)
-
-            if adb_key and adb_server:
-                return self._show_setup_form(user_input, "key_and_server")
+            if CONF_ADB_SERVER_IP in user_input:
+                if adb_key:
+                    return self._show_setup_form(user_input, "key_and_server")
+            else:
+                user_input.pop(CONF_ADB_SERVER_PORT, None)
 
             if adb_key:
-                isfile = await self.hass.async_add_executor_job(_is_file, adb_key)
-                if not isfile:
+                if not await self.hass.async_add_executor_job(_is_file, adb_key):
                     return self._show_setup_form(user_input, "adbkey_not_file")
 
-            ip_address = await self.hass.async_add_executor_job(_get_ip, host)
-            if not ip_address:
-                return self._show_setup_form(user_input, "invalid_host")
-
             self._async_abort_entries_match({CONF_HOST: host})
-            if ip_address != host:
-                self._async_abort_entries_match({CONF_HOST: ip_address})
-
             error, unique_id = await self._async_check_connection(user_input)
             if error is None:
                 if not unique_id:

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -1,6 +1,5 @@
 """Tests for the AndroidTV config flow."""
 import json
-from socket import gaierror
 from unittest.mock import patch
 
 import pytest
@@ -42,6 +41,7 @@ from tests.components.androidtv.patchers import isfile
 ADBKEY = "adbkey"
 ETH_MAC = "a1:b1:c1:d1:e1:f1"
 WIFI_MAC = "a2:b2:c2:d2:e2:f2"
+INVALID_MAC = "ff:ff:ff:ff:ff:ff"
 HOST = "127.0.0.1"
 VALID_DETECT_RULE = [{"paused": {"media_session_state": 3}}]
 
@@ -50,7 +50,6 @@ CONFIG_PYTHON_ADB = {
     CONF_HOST: HOST,
     CONF_PORT: DEFAULT_PORT,
     CONF_DEVICE_CLASS: "androidtv",
-    CONF_ADB_SERVER_PORT: DEFAULT_ADB_SERVER_PORT,
 }
 
 # Android TV device with ADB server
@@ -67,10 +66,6 @@ CONNECT_METHOD = (
 )
 PATCH_ACCESS = patch(
     "homeassistant.components.androidtv.config_flow.os.access", return_value=True
-)
-PATCH_GET_HOST_IP = patch(
-    "homeassistant.components.androidtv.config_flow.socket.gethostbyname",
-    return_value=HOST,
 )
 PATCH_ISFILE = patch(
     "homeassistant.components.androidtv.config_flow.os.path.isfile", isfile
@@ -117,7 +112,7 @@ async def test_user(hass, config, eth_mac, wifi_mac):
     with patch(
         CONNECT_METHOD,
         return_value=(MockConfigDevice(eth_mac, wifi_mac), None),
-    ), PATCH_SETUP_ENTRY as mock_setup_entry, PATCH_GET_HOST_IP:
+    ), PATCH_SETUP_ENTRY as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
             flow_result["flow_id"], user_input=config
         )
@@ -138,7 +133,7 @@ async def test_user_adbkey(hass):
     with patch(
         CONNECT_METHOD,
         return_value=(MockConfigDevice(), None),
-    ), PATCH_SETUP_ENTRY as mock_setup_entry, PATCH_GET_HOST_IP, PATCH_ISFILE, PATCH_ACCESS:
+    ), PATCH_SETUP_ENTRY as mock_setup_entry, PATCH_ISFILE, PATCH_ACCESS:
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -171,7 +166,7 @@ async def test_error_both_key_server(hass):
     with patch(
         CONNECT_METHOD,
         return_value=(MockConfigDevice(), None),
-    ), PATCH_SETUP_ENTRY, PATCH_GET_HOST_IP:
+    ), PATCH_SETUP_ENTRY:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=CONFIG_ADB_SERVER
         )
@@ -198,7 +193,7 @@ async def test_error_invalid_key(hass):
     with patch(
         CONNECT_METHOD,
         return_value=(MockConfigDevice(), None),
-    ), PATCH_SETUP_ENTRY, PATCH_GET_HOST_IP:
+    ), PATCH_SETUP_ENTRY:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=CONFIG_ADB_SERVER
         )
@@ -209,45 +204,27 @@ async def test_error_invalid_key(hass):
         assert result2["data"] == CONFIG_ADB_SERVER
 
 
-async def test_error_invalid_host(hass):
-    """Test we abort if host name is invalid."""
+@pytest.mark.parametrize(
+    ["config", "eth_mac", "wifi_mac"],
+    [
+        (CONFIG_ADB_SERVER, None, None),
+        (CONFIG_PYTHON_ADB, None, None),
+        (CONFIG_ADB_SERVER, INVALID_MAC, None),
+        (CONFIG_PYTHON_ADB, INVALID_MAC, None),
+        (CONFIG_ADB_SERVER, None, INVALID_MAC),
+        (CONFIG_PYTHON_ADB, None, INVALID_MAC),
+    ],
+)
+async def test_invalid_mac(hass, config, eth_mac, wifi_mac):
+    """Test for invalid mac address."""
     with patch(
-        "socket.gethostbyname",
-        side_effect=gaierror,
+        CONNECT_METHOD,
+        return_value=(MockConfigDevice(eth_mac, wifi_mac), None),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": SOURCE_USER, "show_advanced_options": True},
-            data=CONFIG_ADB_SERVER,
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "invalid_host"}
-
-    with patch(
-        CONNECT_METHOD,
-        return_value=(MockConfigDevice(), None),
-    ), PATCH_SETUP_ENTRY, PATCH_GET_HOST_IP:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=CONFIG_ADB_SERVER
-        )
-        await hass.async_block_till_done()
-
-        assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result2["title"] == HOST
-        assert result2["data"] == CONFIG_ADB_SERVER
-
-
-async def test_invalid_serial(hass):
-    """Test for invalid serialno."""
-    with patch(
-        CONNECT_METHOD,
-        return_value=(MockConfigDevice(eth_mac=None), None),
-    ), PATCH_GET_HOST_IP:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
             context={"source": SOURCE_USER},
-            data=CONFIG_ADB_SERVER,
+            data=config,
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -260,18 +237,16 @@ async def test_abort_if_host_exist(hass):
         domain=DOMAIN, data=CONFIG_ADB_SERVER, unique_id=ETH_MAC
     ).add_to_hass(hass)
 
-    config_data = CONFIG_ADB_SERVER.copy()
-    config_data[CONF_HOST] = "name"
-    # Should fail, same IP Address (by PATCH_GET_HOST_IP)
-    with PATCH_GET_HOST_IP:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-            data=config_data,
-        )
+    config_data = CONFIG_PYTHON_ADB
+    # Should fail, same HOST
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data=config_data,
+    )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_abort_if_unique_exist(hass):
@@ -286,7 +261,7 @@ async def test_abort_if_unique_exist(hass):
     with patch(
         CONNECT_METHOD,
         return_value=(MockConfigDevice(), None),
-    ), PATCH_GET_HOST_IP:
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -304,7 +279,7 @@ async def test_on_connect_failed(hass):
         context={"source": SOURCE_USER, "show_advanced_options": True},
     )
 
-    with patch(CONNECT_METHOD, return_value=(None, "Error")), PATCH_GET_HOST_IP:
+    with patch(CONNECT_METHOD, return_value=(None, "Error")):
         result = await hass.config_entries.flow.async_configure(
             flow_result["flow_id"], user_input=CONFIG_ADB_SERVER
         )
@@ -314,7 +289,7 @@ async def test_on_connect_failed(hass):
     with patch(
         CONNECT_METHOD,
         side_effect=TypeError,
-    ), PATCH_GET_HOST_IP:
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=CONFIG_ADB_SERVER
         )
@@ -324,7 +299,7 @@ async def test_on_connect_failed(hass):
     with patch(
         CONNECT_METHOD,
         return_value=(MockConfigDevice(), None),
-    ), PATCH_SETUP_ENTRY, PATCH_GET_HOST_IP:
+    ), PATCH_SETUP_ENTRY:
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"], user_input=CONFIG_ADB_SERVER
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In config flow there is a check to verify that the hostname is a valid ipv4 address and that the address is not already configured. Because the check for already configured device is done based on unique ID, this check is useless, and can create issue in case of host associated to ipv6 address. In case that hostname is invalid the error will occur during connection test. 
With this PR this check is removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #66630
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
